### PR TITLE
feat: known events

### DIFF
--- a/src/components/Receipt/Amount.tsx
+++ b/src/components/Receipt/Amount.tsx
@@ -1,0 +1,35 @@
+import { useQuery } from '@tanstack/react-query'
+import type { Address } from 'ox'
+import { Value } from 'ox'
+import { Actions } from 'tempo.ts/wagmi'
+import { formatAmount } from '#formatting.ts'
+import { config } from '#wagmi.config.ts'
+
+export function Amount(props: Amount.Props) {
+	const { value, token, decimals: decimals_ } = props
+
+	const { data: metadata } = useQuery({
+		queryKey: ['token-metadata', token],
+		queryFn: () => Actions.token.getMetadata(config, { token }),
+		enabled: decimals_ === undefined,
+	})
+	const decimals = decimals_ ?? metadata?.decimals
+	const rawFormatted =
+		decimals === undefined ? '…' : Value.format(value, decimals)
+	const formatted = rawFormatted === '…' ? '…' : formatAmount(rawFormatted)
+
+	return (
+		<span className="items-end whitespace-nowrap">
+			{formatted}{' '}
+			<span className="text-base-content-positive">{metadata?.symbol}</span>
+		</span>
+	)
+}
+
+export namespace Amount {
+	export interface Props {
+		value: bigint
+		token: Address.Address
+		decimals?: number
+	}
+}

--- a/src/components/Receipt/Receipt.tsx
+++ b/src/components/Receipt/Receipt.tsx
@@ -5,7 +5,9 @@ import {
 	formatTimestampTime,
 	shortenHex,
 } from '#formatting.ts'
+import type { KnownEvent } from '#known-events.ts'
 import { useCopy } from '#react-utils.ts'
+import { Amount } from './Amount.tsx'
 import { ReceiptMark } from './ReceiptMark.tsx'
 
 export function Receipt(props: Receipt.Props) {
@@ -14,7 +16,7 @@ export function Receipt(props: Receipt.Props) {
 		sender,
 		hash,
 		timestamp,
-		displayEvents = [],
+		events = [],
 		fee,
 		total,
 	} = props
@@ -26,7 +28,7 @@ export function Receipt(props: Receipt.Props) {
 				<div className="flex-shrink-0">
 					<ReceiptMark />
 				</div>
-				<div className="flex flex-col gap-[9px] font-mono text-[13px] [line-height:16px] flex-1">
+				<div className="flex flex-col gap-[8px] font-mono text-[13px] [line-height:16px] flex-1">
 					<div className="flex justify-between items-end">
 						<span className="text-tertiary capitalize">Block</span>
 						<a
@@ -92,33 +94,99 @@ export function Receipt(props: Receipt.Props) {
 			</div>
 			<div className="border-t border-dashed border-border-base" />
 			<div className="flex flex-col gap-3 px-[20px] py-[16px] font-mono text-[13px] leading-4 [counter-reset:event]">
-				{displayEvents.map((event, index) => (
-					// only 'send' events for now
+				{events.map((event, index) => (
 					<div
-						key={`event-${event.type}-${index}`}
+						key={`${event.type}-${index}`}
 						className="flex flex-col gap-[8px] [counter-increment:event]"
 					>
-						<div className="flex flex-row justify-between items-center gap-[10px]">
-							<div className="flex flex-row items-center gap-[4px] flex-grow min-w-0">
-								<div className="flex flex-row justify-center items-center text-tertiary before:content-[counter(event)_'.']"></div>
-								<div className="flex flex-row items-center pl-[4px] gap-[4px] flex-grow">
-									<div className="flex flex-row justify-center items-center px-[5px] py-[4px] bg-base-alt">
-										<span className="capitalize items-end">Send</span>
-									</div>
-									<span className="text-base-content-positive items-end">
-										{event.token}
-									</span>
-									<span className="items-end">to</span>
-									<a
-										href={`/explore/account/${event.receiver}`}
-										className="text-accent items-end active:translate-y-[0.5px]"
-										title={event.receiver}
-									>
-										{shortenHex(event.receiver)}
-									</a>
+						<div className="flex flex-row justify-between items-start gap-[10px]">
+							<div className="flex flex-row items-start gap-[4px] flex-grow min-w-0 [line-height:24px]">
+								<div className="flex flex-row justify-center text-tertiary before:content-[counter(event)_'.'] flex-shrink-0 [line-height:24px]"></div>
+								<div className="flex flex-row flex-wrap items-center pl-[4px] gap-[4px] flex-grow">
+									{event.parts.map((part, partIndex) => {
+										const partKey = `${part.type}-${partIndex}`
+										switch (part.type) {
+											case 'action':
+												return (
+													<div
+														key={partKey}
+														className="flex flex-row justify-center items-center px-[5px] py-[4px] bg-base-alt [line-height:16px]"
+													>
+														<span className="capitalize items-end">
+															{part.value}
+														</span>
+													</div>
+												)
+											case 'amount':
+												return (
+													<Amount
+														key={partKey}
+														value={part.value.value}
+														token={part.value.token}
+														decimals={part.value.decimals}
+													/>
+												)
+											case 'token':
+												return (
+													<span
+														key={partKey}
+														className="text-base-content-positive items-end"
+													>
+														{part.value.symbol ||
+															shortenHex(part.value.address)}
+													</span>
+												)
+											case 'account':
+												return (
+													<a
+														key={partKey}
+														href={`/explore/account/${part.value}`}
+														className="text-accent items-end active:translate-y-[0.5px] whitespace-nowrap"
+														title={part.value}
+													>
+														{shortenHex(part.value)}
+													</a>
+												)
+											case 'hex':
+												return (
+													<span
+														key={partKey}
+														className="items-end whitespace-nowrap"
+														title={part.value}
+													>
+														{shortenHex(part.value)}
+													</span>
+												)
+											case 'primary':
+												return (
+													<span key={partKey} className="items-end">
+														{part.value}
+													</span>
+												)
+											case 'secondary':
+												return (
+													<span
+														key={partKey}
+														className="items-end text-secondary"
+													>
+														{part.value}
+													</span>
+												)
+											case 'tick':
+												return (
+													<span key={partKey} className="items-end">
+														{part.value}
+													</span>
+												)
+											default:
+												return null
+										}
+									})}
 								</div>
 							</div>
-							<span className="text-right flex-shrink-0">{event.amount}</span>
+							<div className="flex text-right flex-shrink-0 [line-height:24px]">
+								($0.1)
+							</div>
 						</div>
 						{event.note && (
 							<div className="flex flex-row items-center pl-[24px] gap-[11px] overflow-hidden">
@@ -138,11 +206,11 @@ export function Receipt(props: Receipt.Props) {
 			<div className="flex flex-col gap-2 px-[20px] py-[16px] font-mono text-[13px] leading-4">
 				<div className="flex justify-between items-center">
 					<span className="text-tertiary">Fee</span>
-					<span className="text-right">{fee}</span>
+					<span className="text-right">({fee})</span>
 				</div>
 				<div className="flex justify-between items-center">
 					<span className="text-tertiary">Total</span>
-					<span className="text-right">{total}</span>
+					<span className="text-right">({total})</span>
 				</div>
 			</div>
 		</div>
@@ -155,18 +223,8 @@ export namespace Receipt {
 		sender: Address.Address
 		hash: Hex.Hex
 		timestamp: bigint
-		displayEvents?: DisplayEvent[]
+		events?: KnownEvent[]
 		fee?: string
 		total?: string
 	}
-
-	export interface SendDisplayEvent {
-		type: 'send'
-		token: string
-		receiver: Address.Address
-		amount: string
-		note?: string
-	}
-
-	export type DisplayEvent = SendDisplayEvent
 }

--- a/src/formatting.ts
+++ b/src/formatting.ts
@@ -48,3 +48,14 @@ export function formatTimestampTime(timestamp: bigint): {
 
 	return { time: timeFormatter.format(date), timezone, offset }
 }
+
+const amountFormatter = new Intl.NumberFormat('en-US', {
+	minimumFractionDigits: 0,
+	maximumFractionDigits: 18,
+})
+
+export function formatAmount(value: string): string {
+	const number = Number(value)
+	if (number > 0 && number < 0.01) return '<0.01'
+	return amountFormatter.format(number)
+}

--- a/src/known-events.ts
+++ b/src/known-events.ts
@@ -1,0 +1,212 @@
+import { type Address, Hex } from 'ox'
+import { Abis } from 'tempo.ts/viem'
+import type { TransactionReceipt } from 'viem'
+import { parseEventLogs } from 'viem'
+
+const abi = Object.values(Abis).flat()
+
+type Amount = {
+	decimals?: number
+	token: Address.Address
+	value: bigint
+}
+
+type Token = {
+	address: Address.Address
+	symbol?: string
+}
+
+export type KnownEventPart =
+	| { type: 'account'; value: Address.Address }
+	| { type: 'action'; value: string }
+	| { type: 'amount'; value: Amount }
+	| { type: 'hex'; value: Hex.Hex }
+	| { type: 'primary'; value: string }
+	| { type: 'secondary'; value: string }
+	| { type: 'tick'; value: number }
+	| { type: 'token'; value: Token }
+
+export interface KnownEvent {
+	type: string
+	parts: KnownEventPart[]
+	note?: string
+}
+
+export function parseKnownEvents(receipt: TransactionReceipt): KnownEvent[] {
+	const { logs } = receipt
+	const events = parseEventLogs({ abi, logs })
+
+	const preferenceMap = new Map<string, string>()
+
+	for (const event of events) {
+		let key: string | undefined
+
+		// `TransferWithMemo` and `Transfer` events are paired with each other,
+		// we will need to take preference on `TransferWithMemo` for those instances.
+		if (event.eventName === 'TransferWithMemo') {
+			const [_, from, to] = event.topics
+			key = `${from}${to}`
+		}
+
+		// `Mint` and `Transfer` events are paired with each other,
+		// we will need to take preference on `Mint` for those instances.
+		if (event.eventName === 'Mint') {
+			const [_, to] = event.topics
+			key = `${event.address}${event.data}${to}`
+		}
+
+		// `Burn` and `Transfer` events are paired with each other,
+		// we will need to take preference on `Burn` for those instances.
+		if (event.eventName === 'Burn') {
+			const [_, from] = event.topics
+			key = `${event.address}${event.data}${from}`
+		}
+
+		if (key) preferenceMap.set(key, event.eventName)
+	}
+
+	const dedupedEvents = events.filter((event) => {
+		let include = true
+
+		if (event.eventName === 'Transfer') {
+			{
+				// Check TransferWithMemo dedup
+				const [_, from, to] = event.topics
+				const key = `${from}${to}`
+				if (preferenceMap.get(key)?.includes('TransferWithMemo'))
+					include = false
+			}
+
+			{
+				// Check Mint dedup
+				const [_, __, to] = event.topics
+				const key = `${event.address}${event.data}${to}`
+				if (preferenceMap.get(key)?.includes('Mint')) include = false
+			}
+
+			{
+				// Check Burn dedup
+				const [_, from] = event.topics
+				const key = `${event.address}${event.data}${from}`
+				if (preferenceMap.get(key)?.includes('Burn')) include = false
+			}
+		}
+
+		return include
+	})
+
+	const knownEvents: KnownEvent[] = []
+
+	// Map log events to known events.
+	for (const event of dedupedEvents) {
+		switch (event.eventName) {
+			case 'TransferWithMemo':
+			case 'Transfer': {
+				const { amount, to } = event.args
+				const isFee = to.toLowerCase().startsWith('0xfeec00000')
+				if (isFee) break
+
+				const memo =
+					'memo' in event.args
+						? Hex.toString(Hex.trimLeft(event.args.memo))
+						: undefined
+
+				knownEvents.push({
+					type: 'send',
+					note: memo,
+					parts: [
+						{ type: 'action', value: 'Send' },
+						{
+							type: 'amount',
+							value: {
+								value: amount,
+								token: event.address,
+							},
+						},
+						{ type: 'secondary', value: 'to' },
+						{ type: 'account', value: to },
+					],
+				})
+				break
+			}
+
+			case 'Mint': {
+				if ('amount' in event.args) {
+					const { amount, to } = event.args
+
+					knownEvents.push({
+						type: 'mint',
+						parts: [
+							{ type: 'action', value: 'Mint' },
+							{
+								type: 'amount',
+								value: {
+									value: amount,
+									token: event.address,
+								},
+							},
+							{ type: 'secondary', value: 'to' },
+							{ type: 'account', value: to },
+						],
+					})
+					break
+				}
+
+				break
+			}
+
+			case 'Burn': {
+				if ('amount' in event.args) {
+					const { amount, from } = event.args
+
+					knownEvents.push({
+						type: 'burn',
+						parts: [
+							{ type: 'action', value: 'Burn' },
+							{
+								type: 'amount',
+								value: {
+									value: amount,
+									token: event.address,
+								},
+							},
+							{ type: 'secondary', value: 'from' },
+							{ type: 'account', value: from },
+						],
+					})
+					break
+				}
+
+				break
+			}
+
+			case 'TokenCreated': {
+				const { symbol } = event.args
+				knownEvents.push({
+					type: 'create token',
+					parts: [
+						{ type: 'action', value: 'Create Token' },
+						{ type: 'token', value: { address: event.address, symbol } },
+					],
+				})
+				break
+			}
+
+			case 'RoleMembershipUpdated': {
+				const { account, hasRole, role } = event.args
+				knownEvents.push({
+					type: hasRole ? 'grant role' : 'revoke role',
+					parts: [
+						{ type: 'action', value: hasRole ? 'Grant Role' : 'Revoke Role' },
+						{ type: 'hex', value: role },
+						{ type: 'secondary', value: 'to' },
+						{ type: 'account', value: account },
+					],
+				})
+				break
+			}
+		}
+	}
+
+	return knownEvents
+}


### PR DESCRIPTION
[demo](https://d34645ae-tempo-app.porto.workers.dev/receipt/0xc7d31abecd0c86f780fe86d75604fc6e4e6cd789ae46f82d9a22800d7ba4c27e)

Add `src/known-events.ts` (mostly taken from `LineItem` in `$hash`, which will be updated after), which allows to parse some some known events into parts that can be rendered easily.

Only used in `Receipt.tsx` for now.

Also:

- Add an `Amount` component (in `components/Receipt/` for now, will be moved later).
- Add `formatAmount()`.

Preview:

<img width="1982" height="1804" alt="image_2025-11-11_01-40-24" src="https://github.com/user-attachments/assets/78af87ab-8a18-4da4-8956-d5a35de0f991" />

