### PR TITLE
fix?: prevent memo from being clipped in `TransactionRow`

### DIFF
--- a/apps/explorer/src/routes/_layout/account/$address.tsx
+++ b/apps/explorer/src/routes/_layout/account/$address.tsx
@@ -548,15 +548,15 @@ function TransactionRow(props: {
 	const { transaction, address } = props
 
 	return (
-		<tr key={transaction.hash} className="transition-colors hover:bg-alt h-12">
+		<tr key={transaction.hash} className="transition-colors hover:bg-alt min-h-12">
 			<td className="px-5 py-3 text-primary text-xs align-middle whitespace-nowrap overflow-hidden h-12">
 				<div className="h-5 flex items-center overflow-hidden">
 					<TransactionTimestamp blockNumber={transaction.blockNumber} />
 				</div>
 			</td>
 
-			<td className="px-4 py-3 text-primary text-sm align-middle text-left whitespace-nowrap overflow-hidden h-12">
-				<div className="h-5 flex items-center overflow-hidden">
+			<td className="px-4 py-3 text-primary text-sm align-middle text-left h-12">
+				<div className="flex items-center">
 					<TransactionDescription transaction={transaction} address={address} />
 				</div>
 			</td>


### PR DESCRIPTION
I was clicking around and sent some AlphaUSD with a memo in this transaction: https://explore.tempo.xyz/receipt/0x080f2daa621b99f3ec7877bc450be2c865ffc6141a23103ae9dad81d9963fe9b

**Before**
When looking at the sender account view I noticed some content in `TransactionRow` was being clipped: https://explore.tempo.xyz/account/0x7758a73f26ed00ff655093c673a20a5e79faefdf?page=1&tab=history
<img width="1060" height="189" alt="image" src="https://github.com/user-attachments/assets/6b2d62db-699e-4313-9fe2-4ff882b9dd9f" />

**After**
I'm not sure what the intended design is based on the [explorer Figma's account view](https://www.figma.com/design/jy6mqhO31W8asUMS2VuUHv/Tempo-%E2%80%BA-Explorer?node-id=4002-1207&t=BuEeLN9BdcNNZQ0f-1)

Putting up this fix PR as an onboarding exercise for myself, fft close if not needed
- Allows `TransactionRow` to grow taller if there's more stacked content
- Allows for content overflow
<img width="1150" height="247" alt="image" src="https://github.com/user-attachments/assets/9a48e9b6-583b-43e1-ace7-0f09580b363c" />
