### PR TITLE
fix: `.pdf` endpoint

### DIFF
--- a/apps/explorer/src/index.server.ts
+++ b/apps/explorer/src/index.server.ts
@@ -14,12 +14,6 @@ export default {
 
 /** @deprecated TODO: remove once we go public */
 function basicAuth(request: Request): Response | null {
-	// Allow requests from Cloudflare Browser Worker (for PDF generation)
-	const signatureAgent = request.headers.get('signature-agent')
-	if (signatureAgent?.includes('cloudflare-browser-rendering')) {
-		return null
-	}
-
 	const authHeader = request.headers.get('Authorization')
 
 	if (!authHeader)

--- a/apps/explorer/src/routes/_layout/tx/$hash.tsx
+++ b/apps/explorer/src/routes/_layout/tx/$hash.tsx
@@ -151,6 +151,13 @@ export const Route = createFileRoute('/_layout/tx/$hash')({
 					const browser = await puppeteer.launch(env.BROWSER)
 					const page = await browser.newPage()
 
+					// Pass through authentication if present
+					const authHeader = request.headers.get('Authorization')
+					if (authHeader)
+						await page.setExtraHTTPHeaders({
+							Authorization: authHeader,
+						})
+
 					// Get the current URL without .pdf extension
 					const htmlUrl = `${url.href.replace(/\.pdf$/, '')}?plain`
 


### PR DESCRIPTION
bug cause was Puppeteer blocked from accessing `/tx` endpoint since it's behind basic auth wall. 

demo: 

https://5fdb395f-explorer.porto.workers.dev/tx/0x7921c06f4059318863761bbafe8684ea80b64c46f5e2674f62109321196cfed1.pdf