### PR TITLE
fix: asset tab inaccessible when no txs

### DIFF
--- a/apps/explorer/src/components/Receipt/Receipt.tsx
+++ b/apps/explorer/src/components/Receipt/Receipt.tsx
@@ -22,6 +22,10 @@ export function Receipt(props: Receipt.Props) {
 	const [hashExpanded, setHashExpanded] = useState(false)
 	const { copy, notifying } = useCopy()
 	const formattedTime = DateFormatter.formatTimestampTime(timestamp)
+	const hasFee = feeDisplay !== undefined || (fee !== undefined && fee !== null)
+	const hasTotal =
+		totalDisplay !== undefined || (total !== undefined && total !== null)
+
 	return (
 		<div className="flex flex-col w-[360px] bg-base-plane border border-base-border shadow-[0px_4px_44px_rgba(0,0,0,0.05)] rounded-[10px] text-base-content">
 			<div className="flex gap-[40px] px-[20px] pt-[24px] pb-[16px]">
@@ -162,25 +166,25 @@ export function Receipt(props: Receipt.Props) {
 					</div>
 				</>
 			)}
-			{(fee || total) && (
+			{(hasFee || hasTotal) && (
 				<>
 					<div className="border-t border-dashed border-base-border" />
 					<div className="flex flex-col gap-2 px-[20px] py-[16px] font-mono text-[13px] leading-4">
-						{fee && (
+						{hasFee && (
 							<div className="flex justify-between items-center">
 								<span className="text-tertiary">Fee</span>
 								<span className="text-right">
 									{feeDisplay ??
-										PriceFormatter.format(fee, { format: 'short' })}
+										PriceFormatter.format(fee ?? 0, { format: 'short' })}
 								</span>
 							</div>
 						)}
-						{total && (
+						{hasTotal && (
 							<div className="flex justify-between items-center">
 								<span className="text-tertiary">Total</span>
 								<span className="text-right">
 									{totalDisplay ??
-										PriceFormatter.format(total, { format: 'short' })}
+										PriceFormatter.format(total ?? 0, { format: 'short' })}
 								</span>
 							</div>
 						)}

--- a/apps/explorer/src/components/Sections.tsx
+++ b/apps/explorer/src/components/Sections.tsx
@@ -69,7 +69,7 @@ export function Sections(props: Sections.Props) {
 							</button>
 
 							{!isCollapsed && (
-								<div className="rounded-t-[10px] border-t border border-card-border bg-card -mb-[1px] -mx-[1px]">
+								<div className="rounded-t-[10px] border-t border border-card-border bg-card -mb-[1px] -mx-[1px] flex flex-col min-h-0">
 									<Sections.SectionContent
 										section={section}
 										totalPages={totalPages}
@@ -95,7 +95,7 @@ export function Sections(props: Sections.Props) {
 	return (
 		<section
 			className={cx(
-				'flex flex-col font-mono w-full overflow-hidden',
+				'flex flex-col font-mono w-full overflow-hidden h-full min-h-0',
 				'rounded-[10px] border border-card-border bg-card-header',
 				'shadow-[0px_4px_44px_rgba(0,0,0,0.05)]',
 				className,
@@ -123,7 +123,7 @@ export function Sections(props: Sections.Props) {
 				))}
 			</div>
 
-			<div className="rounded-t-[10px] border-t border border-card-border bg-card -mb-[1px] -mx-[1px]">
+			<div className="rounded-t-[10px] border-t border border-card-border bg-card -mb-[1px] -mx-[1px] flex-1 flex flex-col min-h-0">
 				<Sections.SectionContent
 					section={currentSection}
 					totalPages={totalPages}
@@ -175,7 +175,7 @@ export namespace Sections {
 		const items = section.items(mode)
 
 		return (
-			<>
+			<div className="flex flex-col h-full min-h-0">
 				<div className="rounded-t-lg relative w-full">
 					<ClientOnly>
 						{isPending && (
@@ -233,16 +233,18 @@ export namespace Sections {
 						</tbody>
 					</table>
 				</div>
-				<Pagination
-					page={page}
-					totalPages={totalPages}
-					totalItems={totalItems}
-					itemsLabel={itemsLabel}
-					isPending={isPending}
-					onPageChange={onPageChange}
-					compact={mode === 'stacked'}
-				/>
-			</>
+				<div className="mt-auto">
+					<Pagination
+						page={page}
+						totalPages={totalPages}
+						totalItems={totalItems}
+						itemsLabel={itemsLabel}
+						isPending={isPending}
+						onPageChange={onPageChange}
+						compact={mode === 'stacked'}
+					/>
+				</div>
+			</div>
 		)
 	}
 

--- a/apps/explorer/src/routes/_layout/account/$address.tsx
+++ b/apps/explorer/src/routes/_layout/account/$address.tsx
@@ -375,7 +375,8 @@ function SectionsWrapper(props: {
 	const isMobile = useMediaQuery('(max-width: 1239px)')
 	const mode = isMobile ? 'stacked' : 'tabs'
 
-	if (transactions.length === 0) return <SectionsSkeleton totalItems={total} />
+	if (transactions.length === 0 && isLoadingPage)
+		return <SectionsSkeleton totalItems={total} />
 	return (
 		<Sections
 			mode={mode}


### PR DESCRIPTION
- asset tab inaccessible when no txs,
- receipt missing fee and total when $0