### PR TITLE
fix: exclude devtools from prod

### DIFF
--- a/apps/explorer/package.json
+++ b/apps/explorer/package.json
@@ -16,7 +16,6 @@
 	"dependencies": {
 		"@tailwindcss/vite": "^4.1.17",
 		"@tanstack/query-async-storage-persister": "^5.90.12",
-		"@tanstack/react-devtools": "^0.8.1",
 		"@tanstack/react-query": "^5.90.10",
 		"@tanstack/react-query-persist-client": "^5.90.12",
 		"@tanstack/react-router": "^1.136.11",
@@ -41,6 +40,8 @@
 		"@iconify/json": "^2.2.408",
 		"@svgr/core": "^8.1.0",
 		"@svgr/plugin-jsx": "^8.1.0",
+		"@tanstack/devtools-vite": "^0.3.11",
+		"@tanstack/react-devtools": "^0.8.1",
 		"@tanstack/react-query-devtools": "^5.90.2",
 		"@tanstack/react-router-devtools": "^1.136.11",
 		"@types/node": "^24.10.1",

--- a/apps/explorer/src/lib/env.ts
+++ b/apps/explorer/src/lib/env.ts
@@ -1,0 +1,20 @@
+import * as z from 'zod/mini'
+
+const ServerEnvSchema = z.object({
+	INDEXSUPPLY_API_KEY: z.string(),
+	INDEXSUPPLY_ENDPOINT: z.prefault(
+		z.url(),
+		'https://api.indexsupply.net/v2/query',
+	),
+})
+
+const ClientEnvSchema = z.object({
+	VITE_ENABLE_COLOR_SCHEME_TOGGLE: z.prefault(z.coerce.boolean(), false),
+	VITE_ENABLE_ERUDA: z.prefault(z.coerce.boolean(), false),
+})
+
+export const server = ServerEnvSchema.parse(process.env)
+
+export const client = ClientEnvSchema.parse(import.meta.env)
+
+export const env = { server, client }

--- a/apps/explorer/src/routes/api/health.ts
+++ b/apps/explorer/src/routes/api/health.ts
@@ -1,9 +1,17 @@
 import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
 
 export const Route = createFileRoute('/api/health')({
 	server: {
 		handlers: {
-			GET: async () => new Response('OK', { status: 200 }),
+			GET: async () =>
+				json({
+					status: 'healthy',
+					timestamp: new Date().toISOString(),
+					uptime: process.uptime(),
+					memory: process.memoryUsage(),
+					version: process.env.npm_package_version,
+				}),
 		},
 	},
 })

--- a/apps/explorer/vite.config.ts
+++ b/apps/explorer/vite.config.ts
@@ -1,5 +1,6 @@
 import { cloudflare } from '@cloudflare/vite-plugin'
 import tailwind from '@tailwindcss/vite'
+import { devtools } from '@tanstack/devtools-vite'
 import { tanstackStart as tanstack } from '@tanstack/react-start/plugin/vite'
 import react from '@vitejs/plugin-react'
 import Icons from 'unplugin-icons/vite'
@@ -11,6 +12,7 @@ export default defineConfig((config) => {
 
 	return {
 		plugins: [
+			devtools(),
 			cloudflare({ viteEnvironment: { name: 'ssr' } }),
 			tsconfigPaths({
 				projects: ['./tsconfig.json'],


### PR DESCRIPTION
now:
```sh
rolldown-vite v7.2.6 building ssr environment for production...
transforming (140) ../../node_modules/.pnpm/react@19.2.0/node_modules/react/cjs/react.production.js
[@tanstack/devtools-vite] Removed devtools code from: /src/routes/__root.tsx
```

previously:
<img width="732" height="71" alt="CleanShot 2025-11-19 at 09 21 26" src="https://github.com/user-attachments/assets/ea882c83-8d5b-4369-8f30-45dbfab87294" />