### PR TITLE
fix: disable input submit when no value

### DIFF
--- a/apps/explorer/src/components/ExploreInput.tsx
+++ b/apps/explorer/src/components/ExploreInput.tsx
@@ -36,24 +36,26 @@ export function ExploreInput(props: ExploreInput.Props) {
 			ref={formRef}
 			onSubmit={(event) => {
 				event.preventDefault()
-				if (!formRef.current) return
+				if (!formRef.current || disabled) return
+
 				const data = new FormData(formRef.current)
-				let value = data.get('value')
-				if (typeof value !== 'string') return
-				value = value.trim()
-				if (isAddress(value)) {
-					onActivate?.({ type: 'address', value })
+				let formValue = data.get('value')
+				if (!formValue || typeof formValue !== 'string') return
+
+				formValue = formValue.trim()
+				if (isAddress(formValue)) {
+					onActivate?.({ type: 'address', value: formValue })
 					return
 				}
-				if (isHash(value)) {
-					onActivate?.({ type: 'hash', value })
+				if (isHash(formValue)) {
+					onActivate?.({ type: 'hash', value: formValue })
 					return
 				}
-				if (Number.isSafeInteger(Number(value))) {
-					onActivate?.({ type: 'block', value })
+				if (Number.isSafeInteger(Number(formValue))) {
+					onActivate?.({ type: 'block', value: formValue })
 					return
 				}
-				onActivate?.({ type: 'text', value })
+				onActivate?.({ type: 'text', value: formValue })
 			}}
 			className="relative w-full max-w-[448px]"
 		>


### PR DESCRIPTION
Search bar submits when there's no value. It happens when not on landing page:

![CleanShot 2025-11-21 at 15 53 50](https://github.com/user-attachments/assets/9d6db324-2843-4c2a-b32e-f1480e08dc8b)


