### PR TITLE
feat: complete events parsing

### DIFF
--- a/apps/explorer/package.json
+++ b/apps/explorer/package.json
@@ -30,7 +30,7 @@
 		"react-dom": "^19.2.0",
 		"tailwind-merge": "^3.4.0",
 		"tailwindcss": "^4.1.17",
-		"tempo.ts": "^0.4.2",
+		"tempo.ts": "^0.5.4",
 		"viem": "^2.39.0",
 		"wagmi": "^2.19.3",
 		"zod": "^4.1.12"

--- a/apps/explorer/src/routes/_layout/account/$address.tsx
+++ b/apps/explorer/src/routes/_layout/account/$address.tsx
@@ -80,10 +80,10 @@ function transactionsQueryOptions(params: TransactionQuery) {
 							}),
 						),
 					])
-					const tokenMetadata = await TokenMetadata.fromLogs(receipt.logs)
+					const getTokenMetadata = await TokenMetadata.fromLogs(receipt.logs)
 					knownEvents[transaction.hash] = parseKnownEvents(receipt, {
 						transaction,
-						tokenMetadata,
+						getTokenMetadata,
 					})
 					return { ...transaction, block, receipt }
 				}),

--- a/apps/explorer/src/routes/_layout/block/$id.tsx
+++ b/apps/explorer/src/routes/_layout/block/$id.tsx
@@ -398,10 +398,12 @@ function BlockTransactionsCard(props: BlockTransactionsCardProps) {
 									hash: transaction.hash,
 								}),
 							)
-							const tokenMetadata = await TokenMetadata.fromLogs(receipt.logs)
+							const getTokenMetadata = await TokenMetadata.fromLogs(
+								receipt.logs,
+							)
 							const events = parseKnownEvents(receipt, {
 								transaction,
-								tokenMetadata,
+								getTokenMetadata,
 							})
 
 							return [transaction.hash, events] as const

--- a/apps/explorer/src/routes/_layout/demo/tx.tsx
+++ b/apps/explorer/src/routes/_layout/demo/tx.tsx
@@ -49,40 +49,82 @@ const registryAddress = `0x${'a'.repeat(40)}` as const
 const updaterAddress = `0x${'abcde'.repeat(8)}` as const
 const recipientAddress = `0x${'9'.repeat(40)}` as const
 const adminAddress = `0x${'b'.repeat(40)}` as const
-
-const transferWithMemoEvent = Abis.tip20.find(
-	(e) => e.type === 'event' && e.name === 'TransferWithMemo',
-)
-if (!transferWithMemoEvent) throw new Error()
-
-const supplyCapUpdateEvent = Abis.tip20.find(
-	(e) => e.type === 'event' && e.name === 'SupplyCapUpdate',
-)
-if (!supplyCapUpdateEvent) throw new Error()
-
-const rewardScheduledEvent = Abis.tip20.find(
-	(e) => e.type === 'event' && e.name === 'RewardScheduled',
-)
-if (!rewardScheduledEvent) throw new Error()
-
-const policyAdminUpdatedEvent = Abis.tip403Registry.find(
-	(e) => e.type === 'event' && e.name === 'PolicyAdminUpdated',
-)
-if (!policyAdminUpdatedEvent) throw new Error()
+const spenderAddress = `0x${'c'.repeat(40)}` as const
+const userTokenAddress = `0x${'d'.repeat(40)}` as const
+const validatorTokenAddress = `0x${'e'.repeat(40)}` as const
+const accountAddress = `0x${'f'.repeat(40)}` as const
+const feeAmmAddress = `0x${'1'.repeat(40)}` as const
+const factoryAddress = `0x${'2'.repeat(40)}` as const
+const exchangeAddress = `0x${'3'.repeat(40)}` as const
+const makerAddress = `0x${'4'.repeat(40)}` as const
+const baseTokenAddress = `0x${'5'.repeat(40)}` as const
+const quoteTokenAddress = `0x${'6'.repeat(40)}` as const
+const validatorAddress = `0x${'7'.repeat(40)}` as const
 
 function loader() {
 	if (import.meta.env.VITE_ENABLE_DEMO !== 'true') throw notFound()
 
-	const tokenMetadata = new Map([
-		[tokenAddress, { decimals: 2, symbol: 'TEST2' }],
+	const metadataMap = new Map([
+		[
+			tokenAddress.toLowerCase(),
+			{
+				currency: 'USD',
+				decimals: 2,
+				symbol: 'TEST2',
+				name: 'Test Token 2',
+				totalSupply: 1000000n,
+			},
+		],
+		[
+			userTokenAddress.toLowerCase(),
+			{
+				currency: 'USD',
+				decimals: 6,
+				symbol: 'USDC',
+				name: 'USD Coin',
+				totalSupply: 1000000000000n,
+			},
+		],
+		[
+			validatorTokenAddress.toLowerCase(),
+			{
+				currency: 'USD',
+				decimals: 6,
+				symbol: 'LINK',
+				name: 'Chainlink',
+				totalSupply: 1000000000000n,
+			},
+		],
+		[
+			baseTokenAddress.toLowerCase(),
+			{
+				currency: 'USD',
+				decimals: 6,
+				symbol: 'DAI',
+				name: 'Dai Stablecoin',
+				totalSupply: 1000000000000n,
+			},
+		],
+		[
+			quoteTokenAddress.toLowerCase(),
+			{
+				currency: 'USD',
+				decimals: 6,
+				symbol: 'USDT',
+				name: 'Tether USD',
+				totalSupply: 1000000000000n,
+			},
+		],
 	])
+	const getTokenMetadata = (address: Address.Address) =>
+		metadataMap.get(address.toLowerCase())
 
 	const receipt = mockReceipt(
 		[
 			mockLog({
 				address: tokenAddress,
 				topics: encodeEventTopics({
-					abi: [transferWithMemoEvent],
+					abi: Abis.tip20,
 					eventName: 'TransferWithMemo',
 					args: {
 						from: updaterAddress,
@@ -95,7 +137,7 @@ function loader() {
 			mockLog({
 				address: registryAddress,
 				topics: encodeEventTopics({
-					abi: [policyAdminUpdatedEvent],
+					abi: Abis.tip403Registry,
 					eventName: 'PolicyAdminUpdated',
 					args: {
 						policyId: 20n,
@@ -107,7 +149,7 @@ function loader() {
 			mockLog({
 				address: tokenAddress,
 				topics: encodeEventTopics({
-					abi: [supplyCapUpdateEvent],
+					abi: Abis.tip20,
 					eventName: 'SupplyCapUpdate',
 					args: {
 						updater: updaterAddress,
@@ -118,7 +160,7 @@ function loader() {
 			mockLog({
 				address: tokenAddress,
 				topics: encodeEventTopics({
-					abi: [rewardScheduledEvent],
+					abi: Abis.tip20,
 					eventName: 'RewardScheduled',
 					args: {
 						funder: updaterAddress,
@@ -130,11 +172,401 @@ function loader() {
 					[5000000n, 604800],
 				),
 			}),
+			mockLog({
+				address: zeroAddress,
+				topics: encodeEventTopics({
+					abi: Abis.nonce,
+					eventName: 'NonceIncremented',
+					args: {
+						account: accountAddress,
+						nonceKey: 42n,
+					},
+				}) as [Hex.Hex, ...Hex.Hex[]],
+				data: encodeAbiParameters([{ type: 'uint64' }], [7n]),
+			}),
+			mockLog({
+				address: zeroAddress,
+				topics: encodeEventTopics({
+					abi: Abis.nonce,
+					eventName: 'ActiveKeyCountChanged',
+					args: {
+						account: accountAddress,
+					},
+				}) as [Hex.Hex, ...Hex.Hex[]],
+				data: encodeAbiParameters([{ type: 'uint256' }], [3n]),
+			}),
+			mockLog({
+				address: tokenAddress,
+				topics: encodeEventTopics({
+					abi: Abis.tip20,
+					eventName: 'Approval',
+					args: {
+						owner: updaterAddress,
+						spender: spenderAddress,
+					},
+				}) as [Hex.Hex, ...Hex.Hex[]],
+				data: encodeAbiParameters([{ type: 'uint256' }], [1000000n]),
+			}),
+			mockLog({
+				address: tokenAddress,
+				topics: encodeEventTopics({
+					abi: Abis.tip20,
+					eventName: 'BurnBlocked',
+					args: {
+						from: accountAddress,
+					},
+				}) as [Hex.Hex, ...Hex.Hex[]],
+				data: encodeAbiParameters([{ type: 'uint256' }], [50000n]),
+			}),
+			mockLog({
+				address: tokenAddress,
+				topics: encodeEventTopics({
+					abi: Abis.tip20,
+					eventName: 'TransferPolicyUpdate',
+					args: {
+						updater: updaterAddress,
+						newPolicyId: 5n,
+					},
+				}) as [Hex.Hex, ...Hex.Hex[]],
+			}),
+			mockLog({
+				address: tokenAddress,
+				topics: encodeEventTopics({
+					abi: Abis.tip20,
+					eventName: 'NextQuoteTokenSet',
+					args: {
+						updater: updaterAddress,
+						nextQuoteToken: userTokenAddress,
+					},
+				}) as [Hex.Hex, ...Hex.Hex[]],
+			}),
+			mockLog({
+				address: tokenAddress,
+				topics: encodeEventTopics({
+					abi: Abis.tip20,
+					eventName: 'QuoteTokenUpdate',
+					args: {
+						updater: updaterAddress,
+						newQuoteToken: userTokenAddress,
+					},
+				}) as [Hex.Hex, ...Hex.Hex[]],
+			}),
+			mockLog({
+				address: tokenAddress,
+				topics: encodeEventTopics({
+					abi: Abis.tip20,
+					eventName: 'RewardCanceled',
+					args: {
+						funder: updaterAddress,
+						id: 99n,
+					},
+				}) as [Hex.Hex, ...Hex.Hex[]],
+				data: encodeAbiParameters([{ type: 'uint256' }], [2500000n]),
+			}),
+			mockLog({
+				address: tokenAddress,
+				topics: encodeEventTopics({
+					abi: Abis.tip20,
+					eventName: 'RewardRecipientSet',
+					args: {
+						holder: updaterAddress,
+						recipient: recipientAddress,
+					},
+				}) as [Hex.Hex, ...Hex.Hex[]],
+			}),
+			mockLog({
+				address: tokenAddress,
+				topics: encodeEventTopics({
+					abi: Abis.tip20,
+					eventName: 'RoleAdminUpdated',
+					args: {
+						role: Hex.padLeft('0x01', 32),
+						newAdminRole: Hex.padLeft('0x02', 32),
+						sender: adminAddress,
+					},
+				}) as [Hex.Hex, ...Hex.Hex[]],
+			}),
+			mockLog({
+				address: feeAmmAddress,
+				topics: encodeEventTopics({
+					abi: Abis.feeAmm,
+					eventName: 'Mint',
+					args: {
+						sender: updaterAddress,
+						userToken: userTokenAddress,
+						validatorToken: validatorTokenAddress,
+					},
+				}) as [Hex.Hex, ...Hex.Hex[]],
+				data: encodeAbiParameters(
+					[{ type: 'uint256' }, { type: 'uint256' }, { type: 'uint256' }],
+					[1000000000n, 500000000n, 707106781n],
+				),
+			}),
+			mockLog({
+				address: feeAmmAddress,
+				topics: encodeEventTopics({
+					abi: Abis.feeAmm,
+					eventName: 'Burn',
+					args: {
+						sender: updaterAddress,
+						userToken: userTokenAddress,
+						validatorToken: validatorTokenAddress,
+					},
+				}) as [Hex.Hex, ...Hex.Hex[]],
+				data: encodeAbiParameters(
+					[
+						{ type: 'uint256' },
+						{ type: 'uint256' },
+						{ type: 'uint256' },
+						{ type: 'address' },
+					],
+					[250000000n, 125000000n, 176776695n, recipientAddress],
+				),
+			}),
+			mockLog({
+				address: feeAmmAddress,
+				topics: encodeEventTopics({
+					abi: Abis.feeAmm,
+					eventName: 'RebalanceSwap',
+					args: {
+						userToken: userTokenAddress,
+						validatorToken: validatorTokenAddress,
+						swapper: updaterAddress,
+					},
+				}) as [Hex.Hex, ...Hex.Hex[]],
+				data: encodeAbiParameters(
+					[{ type: 'uint256' }, { type: 'uint256' }],
+					[100000000n, 95000000n],
+				),
+			}),
+			mockLog({
+				address: feeAmmAddress,
+				topics: encodeEventTopics({
+					abi: Abis.feeAmm,
+					eventName: 'FeeSwap',
+					args: {
+						userToken: userTokenAddress,
+						validatorToken: validatorTokenAddress,
+					},
+				}) as [Hex.Hex, ...Hex.Hex[]],
+				data: encodeAbiParameters(
+					[{ type: 'uint256' }, { type: 'uint256' }],
+					[50000000n, 48500000n],
+				),
+			}),
+			mockLog({
+				address: tokenAddress,
+				topics: encodeEventTopics({
+					abi: Abis.tip20,
+					eventName: 'Transfer',
+					args: {
+						from: updaterAddress,
+						to: recipientAddress,
+					},
+				}) as [Hex.Hex, ...Hex.Hex[]],
+				data: encodeAbiParameters([{ type: 'uint256' }], [250000n]),
+			}),
+			mockLog({
+				address: tokenAddress,
+				topics: encodeEventTopics({
+					abi: Abis.tip20,
+					eventName: 'Mint',
+					args: {
+						to: recipientAddress,
+					},
+				}) as [Hex.Hex, ...Hex.Hex[]],
+				data: encodeAbiParameters([{ type: 'uint256' }], [500000n]),
+			}),
+			mockLog({
+				address: tokenAddress,
+				topics: encodeEventTopics({
+					abi: Abis.tip20,
+					eventName: 'Burn',
+					args: {
+						from: updaterAddress,
+					},
+				}) as [Hex.Hex, ...Hex.Hex[]],
+				data: encodeAbiParameters([{ type: 'uint256' }], [100000n]),
+			}),
+			mockLog({
+				address: tokenAddress,
+				topics: encodeEventTopics({
+					abi: Abis.tip20,
+					eventName: 'RoleMembershipUpdated',
+					args: {
+						role: Hex.padLeft('0x03', 32),
+						account: accountAddress,
+						sender: adminAddress,
+					},
+				}) as [Hex.Hex, ...Hex.Hex[]],
+				data: encodeAbiParameters([{ type: 'bool' }], [true]),
+			}),
+			mockLog({
+				address: tokenAddress,
+				topics: encodeEventTopics({
+					abi: Abis.tip20,
+					eventName: 'PauseStateUpdate',
+					args: {
+						updater: adminAddress,
+					},
+				}) as [Hex.Hex, ...Hex.Hex[]],
+				data: encodeAbiParameters([{ type: 'bool' }], [true]),
+			}),
+			mockLog({
+				address: factoryAddress,
+				topics: encodeEventTopics({
+					abi: Abis.tip20Factory,
+					eventName: 'TokenCreated',
+					args: {
+						token: tokenAddress,
+						tokenId: 1n,
+					},
+				}) as [Hex.Hex, ...Hex.Hex[]],
+				data: encodeAbiParameters(
+					[
+						{ type: 'string' },
+						{ type: 'string' },
+						{ type: 'string' },
+						{ type: 'address' },
+						{ type: 'address' },
+					],
+					['Test Token 2', 'TEST2', 'USD', userTokenAddress, adminAddress],
+				),
+			}),
+			mockLog({
+				address: exchangeAddress,
+				topics: encodeEventTopics({
+					abi: Abis.stablecoinExchange,
+					eventName: 'PairCreated',
+					args: {
+						key: Hex.padLeft('0xabc', 32),
+						base: baseTokenAddress,
+						quote: quoteTokenAddress,
+					},
+				}) as [Hex.Hex, ...Hex.Hex[]],
+			}),
+			mockLog({
+				address: exchangeAddress,
+				topics: encodeEventTopics({
+					abi: Abis.stablecoinExchange,
+					eventName: 'OrderPlaced',
+					args: {
+						orderId: 123n,
+						maker: makerAddress,
+						token: baseTokenAddress,
+					},
+				}) as [Hex.Hex, ...Hex.Hex[]],
+				data: encodeAbiParameters(
+					[{ type: 'uint128' }, { type: 'bool' }, { type: 'int16' }],
+					[1000000n, true, 100],
+				),
+			}),
+			mockLog({
+				address: exchangeAddress,
+				topics: encodeEventTopics({
+					abi: Abis.stablecoinExchange,
+					eventName: 'FlipOrderPlaced',
+					args: {
+						orderId: 124n,
+						maker: makerAddress,
+						token: baseTokenAddress,
+					},
+				}) as [Hex.Hex, ...Hex.Hex[]],
+				data: encodeAbiParameters(
+					[{ type: 'uint128' }, { type: 'bool' }, { type: 'int16' }, { type: 'int16' }],
+					[2000000n, false, 105, 95],
+				),
+			}),
+			mockLog({
+				address: exchangeAddress,
+				topics: encodeEventTopics({
+					abi: Abis.stablecoinExchange,
+					eventName: 'OrderFilled',
+					args: {
+						orderId: 123n,
+						maker: makerAddress,
+					},
+				}) as [Hex.Hex, ...Hex.Hex[]],
+				data: encodeAbiParameters(
+					[{ type: 'uint128' }, { type: 'bool' }],
+					[500000n, false],
+				),
+			}),
+			mockLog({
+				address: exchangeAddress,
+				topics: encodeEventTopics({
+					abi: Abis.stablecoinExchange,
+					eventName: 'OrderCancelled',
+					args: {
+						orderId: 124n,
+					},
+				}) as [Hex.Hex, ...Hex.Hex[]],
+			}),
+			mockLog({
+				address: registryAddress,
+				topics: encodeEventTopics({
+					abi: Abis.tip403Registry,
+					eventName: 'WhitelistUpdated',
+					args: {
+						policyId: 10n,
+						updater: adminAddress,
+						account: accountAddress,
+					},
+				}) as [Hex.Hex, ...Hex.Hex[]],
+				data: encodeAbiParameters([{ type: 'bool' }], [true]),
+			}),
+			mockLog({
+				address: registryAddress,
+				topics: encodeEventTopics({
+					abi: Abis.tip403Registry,
+					eventName: 'BlacklistUpdated',
+					args: {
+						policyId: 10n,
+						updater: adminAddress,
+						account: spenderAddress,
+					},
+				}) as [Hex.Hex, ...Hex.Hex[]],
+				data: encodeAbiParameters([{ type: 'bool' }], [true]),
+			}),
+			mockLog({
+				address: registryAddress,
+				topics: encodeEventTopics({
+					abi: Abis.tip403Registry,
+					eventName: 'PolicyCreated',
+					args: {
+						policyId: 15n,
+						updater: adminAddress,
+					},
+				}) as [Hex.Hex, ...Hex.Hex[]],
+				data: encodeAbiParameters([{ type: 'uint8' }], [1]),
+			}),
+			mockLog({
+				address: zeroAddress,
+				topics: encodeEventTopics({
+					abi: Abis.feeManager,
+					eventName: 'UserTokenSet',
+					args: {
+						user: updaterAddress,
+						token: userTokenAddress,
+					},
+				}) as [Hex.Hex, ...Hex.Hex[]],
+			}),
+			mockLog({
+				address: zeroAddress,
+				topics: encodeEventTopics({
+					abi: Abis.feeManager,
+					eventName: 'ValidatorTokenSet',
+					args: {
+						validator: validatorAddress,
+						token: validatorTokenAddress,
+					},
+				}) as [Hex.Hex, ...Hex.Hex[]],
+			}),
 		],
 		updaterAddress,
 	)
 
-	const knownEvents = parseKnownEvents(receipt, { tokenMetadata })
+	const knownEvents = parseKnownEvents(receipt, { getTokenMetadata })
 
 	return {
 		blockNumber,


### PR DESCRIPTION
changes

- Update tempo.ts to 0.5.
- Add nonce events (NonceIncremented, ActiveKeyCountChanged).
- Add feeAmm events (Mint, Burn, RebalanceSwap, FeeSwap).
- Add new tip20 events (Approval, BurnBlocked, TransferPolicyUpdate, NextQuoteTokenSet, QuoteTokenUpdate, RewardCanceled, RewardRecipientSet, RoleAdminUpdated).
- Add a demo for each supported event (/demo/tx).
- Update lib/token-metadata to allow checksum or non-checksum addresses to be used.

preview

<img width="2880" height="4489" alt="image" src="https://github.com/user-attachments/assets/cacf67c7-37b5-44e0-9ccc-e3eb9ac99e58" />

