### PR TITLE
fix: receipt pdf search param

### DIFF
--- a/apps/explorer/src/routes/_layout/tx/$hash.tsx
+++ b/apps/explorer/src/routes/_layout/tx/$hash.tsx
@@ -168,11 +168,13 @@ export const Route = createFileRoute('/_layout/tx/$hash')({
 							Authorization: authHeader,
 						})
 
-					// Get the current URL without .pdf extension
-					const htmlUrl = `${url.href.replace(/\.pdf$/, '')}?plain`
+					// Build the equivalent HTML URL, preserving existing query params
+					const htmlUrl = new URL(url.href)
+					htmlUrl.pathname = htmlUrl.pathname.replace(/\.pdf$/, '')
+					htmlUrl.searchParams.set('plain', '')
 
 					// Navigate to the HTML version of the receipt
-					await page.goto(htmlUrl, { waitUntil: 'domcontentloaded' })
+					await page.goto(htmlUrl.toString(), { waitUntil: 'domcontentloaded' })
 
 					// Generate PDF
 					const pdf = await page.pdf({


### PR DESCRIPTION
the PDF handler builds `htmlUrl` with `url.href.replace(/\.pdf$/, '') + '?plain'`. If the request includes query params (e.g., `/tx/<hash>.pdf?r=...`), replace doesn’t strip `.pdf` because of the trailing query string, and the code appends a second `?`, yielding a malformed URL like `...hash.pdf?r=foo?plain`.
The custom `r` RPC override is also lost, so PDF requests hit the default RPC and may fail.