### PR TITLE
fix: remove duplicate line items in `mint`/`burn` receipts

### DIFF
--- a/apps/explorer/src/routes/_layout/demo/tx.tsx
+++ b/apps/explorer/src/routes/_layout/demo/tx.tsx
@@ -366,6 +366,7 @@ function loader() {
 				}) as [Hex.Hex, ...Hex.Hex[]],
 				data: encodeAbiParameters([{ type: 'uint256' }], [250000n]),
 			}),
+			// Test case: Mint without memo (just Mint event)
 			mockLog({
 				address: tokenAddress,
 				topics: encodeEventTopics({
@@ -377,6 +378,7 @@ function loader() {
 				}) as [Hex.Hex, ...Hex.Hex[]],
 				data: encodeAbiParameters([{ type: 'uint256' }], [500000n]),
 			}),
+			// Test case: Burn without memo (just Burn event)
 			mockLog({
 				address: tokenAddress,
 				topics: encodeEventTopics({
@@ -387,6 +389,56 @@ function loader() {
 					},
 				}) as [Hex.Hex, ...Hex.Hex[]],
 				data: encodeAbiParameters([{ type: 'uint256' }], [100000n]),
+			}),
+			// Test case: Mint WITH memo (Mint + TransferWithMemo pair - should dedupe to just Mint with memo)
+			mockLog({
+				address: tokenAddress,
+				topics: encodeEventTopics({
+					abi: Abis.tip20,
+					eventName: 'Mint',
+					args: {
+						to: accountAddress,
+					},
+				}) as [Hex.Hex, ...Hex.Hex[]],
+				data: encodeAbiParameters([{ type: 'uint256' }], [200000n]),
+			}),
+			mockLog({
+				address: tokenAddress,
+				topics: encodeEventTopics({
+					abi: Abis.tip20,
+					eventName: 'TransferWithMemo',
+					args: {
+						from: zeroAddress,
+						to: accountAddress,
+						memo: Hex.padLeft(Hex.fromString('Minted for you!'), 32),
+					},
+				}) as [Hex.Hex, ...Hex.Hex[]],
+				data: encodeAbiParameters([{ type: 'uint256' }], [200000n]),
+			}),
+			// Test case: Burn WITH memo (Burn + TransferWithMemo pair - should dedupe to just Burn with memo)
+			mockLog({
+				address: tokenAddress,
+				topics: encodeEventTopics({
+					abi: Abis.tip20,
+					eventName: 'Burn',
+					args: {
+						from: adminAddress,
+					},
+				}) as [Hex.Hex, ...Hex.Hex[]],
+				data: encodeAbiParameters([{ type: 'uint256' }], [75000n]),
+			}),
+			mockLog({
+				address: tokenAddress,
+				topics: encodeEventTopics({
+					abi: Abis.tip20,
+					eventName: 'TransferWithMemo',
+					args: {
+						from: adminAddress,
+						to: zeroAddress,
+						memo: Hex.padLeft(Hex.fromString('Burned by admin'), 32),
+					},
+				}) as [Hex.Hex, ...Hex.Hex[]],
+				data: encodeAbiParameters([{ type: 'uint256' }], [75000n]),
 			}),
 			mockLog({
 				address: tokenAddress,


### PR DESCRIPTION
Before: 
`Mint`/`Burn` with memo showed 2 line items (e.g., "Mint 100 FDR" + "Send 100 FDR" with memo)

After:
`Mint`/`Burn` with memo shows 1 line item (e.g., "Mint 100 FDR" with memo attached)

`Mint` before
<img width="392" height="372" alt="CleanShot 2025-11-25 at 09 44 24" src="https://github.com/user-attachments/assets/6349c370-fa91-432b-b80d-487cf4f500b6" />

`Mint` after
<img width="382" height="325" alt="CleanShot 2025-11-25 at 09 44 38" src="https://github.com/user-attachments/assets/1ec3ffc9-ee3f-447a-a463-e9555aea73c7" />

`Burn` before
<img width="383" height="368" alt="CleanShot 2025-11-25 at 09 45 07" src="https://github.com/user-attachments/assets/e18846bd-214d-4ce0-905a-c92c3a3c094e" />

`Burn` after
<img width="382" height="325" alt="CleanShot 2025-11-25 at 09 44 54" src="https://github.com/user-attachments/assets/c85f0f3f-f7e1-415e-b381-503da46c1904" />