### PR TITLE
chore: make token table scrollable

### DIFF
--- a/apps/explorer/src/routeTree.gen.ts
+++ b/apps/explorer/src/routeTree.gen.ts
@@ -15,7 +15,7 @@ import { Route as LayoutBlocksRouteImport } from './routes/_layout/blocks'
 import { Route as LayoutTxHashRouteImport } from './routes/_layout/tx/$hash'
 import { Route as LayoutTokenAddressRouteImport } from './routes/_layout/token/$address'
 import { Route as LayoutDemoTxRouteImport } from './routes/_layout/demo/tx'
-import { Route as LayoutDemoAccountRouteImport } from './routes/_layout/demo/account'
+import { Route as LayoutDemoAddressRouteImport } from './routes/_layout/demo/address'
 import { Route as LayoutBlockIdRouteImport } from './routes/_layout/block/$id'
 import { Route as LayoutAddressAddressRouteImport } from './routes/_layout/address/$address'
 
@@ -48,9 +48,9 @@ const LayoutDemoTxRoute = LayoutDemoTxRouteImport.update({
   path: '/demo/tx',
   getParentRoute: () => LayoutRoute,
 } as any)
-const LayoutDemoAccountRoute = LayoutDemoAccountRouteImport.update({
-  id: '/demo/account',
-  path: '/demo/account',
+const LayoutDemoAddressRoute = LayoutDemoAddressRouteImport.update({
+  id: '/demo/address',
+  path: '/demo/address',
   getParentRoute: () => LayoutRoute,
 } as any)
 const LayoutBlockIdRoute = LayoutBlockIdRouteImport.update({
@@ -69,7 +69,7 @@ export interface FileRoutesByFullPath {
   '/': typeof LayoutIndexRoute
   '/address/$address': typeof LayoutAddressAddressRoute
   '/block/$id': typeof LayoutBlockIdRoute
-  '/demo/account': typeof LayoutDemoAccountRoute
+  '/demo/address': typeof LayoutDemoAddressRoute
   '/demo/tx': typeof LayoutDemoTxRoute
   '/token/$address': typeof LayoutTokenAddressRoute
   '/tx/$hash': typeof LayoutTxHashRoute
@@ -79,7 +79,7 @@ export interface FileRoutesByTo {
   '/': typeof LayoutIndexRoute
   '/address/$address': typeof LayoutAddressAddressRoute
   '/block/$id': typeof LayoutBlockIdRoute
-  '/demo/account': typeof LayoutDemoAccountRoute
+  '/demo/address': typeof LayoutDemoAddressRoute
   '/demo/tx': typeof LayoutDemoTxRoute
   '/token/$address': typeof LayoutTokenAddressRoute
   '/tx/$hash': typeof LayoutTxHashRoute
@@ -91,7 +91,7 @@ export interface FileRoutesById {
   '/_layout/': typeof LayoutIndexRoute
   '/_layout/address/$address': typeof LayoutAddressAddressRoute
   '/_layout/block/$id': typeof LayoutBlockIdRoute
-  '/_layout/demo/account': typeof LayoutDemoAccountRoute
+  '/_layout/demo/address': typeof LayoutDemoAddressRoute
   '/_layout/demo/tx': typeof LayoutDemoTxRoute
   '/_layout/token/$address': typeof LayoutTokenAddressRoute
   '/_layout/tx/$hash': typeof LayoutTxHashRoute
@@ -103,7 +103,7 @@ export interface FileRouteTypes {
     | '/'
     | '/address/$address'
     | '/block/$id'
-    | '/demo/account'
+    | '/demo/address'
     | '/demo/tx'
     | '/token/$address'
     | '/tx/$hash'
@@ -113,7 +113,7 @@ export interface FileRouteTypes {
     | '/'
     | '/address/$address'
     | '/block/$id'
-    | '/demo/account'
+    | '/demo/address'
     | '/demo/tx'
     | '/token/$address'
     | '/tx/$hash'
@@ -124,7 +124,7 @@ export interface FileRouteTypes {
     | '/_layout/'
     | '/_layout/address/$address'
     | '/_layout/block/$id'
-    | '/_layout/demo/account'
+    | '/_layout/demo/address'
     | '/_layout/demo/tx'
     | '/_layout/token/$address'
     | '/_layout/tx/$hash'
@@ -178,11 +178,11 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof LayoutDemoTxRouteImport
       parentRoute: typeof LayoutRoute
     }
-    '/_layout/demo/account': {
-      id: '/_layout/demo/account'
-      path: '/demo/account'
-      fullPath: '/demo/account'
-      preLoaderRoute: typeof LayoutDemoAccountRouteImport
+    '/_layout/demo/address': {
+      id: '/_layout/demo/address'
+      path: '/demo/address'
+      fullPath: '/demo/address'
+      preLoaderRoute: typeof LayoutDemoAddressRouteImport
       parentRoute: typeof LayoutRoute
     }
     '/_layout/block/$id': {
@@ -207,7 +207,7 @@ interface LayoutRouteChildren {
   LayoutIndexRoute: typeof LayoutIndexRoute
   LayoutAddressAddressRoute: typeof LayoutAddressAddressRoute
   LayoutBlockIdRoute: typeof LayoutBlockIdRoute
-  LayoutDemoAccountRoute: typeof LayoutDemoAccountRoute
+  LayoutDemoAddressRoute: typeof LayoutDemoAddressRoute
   LayoutDemoTxRoute: typeof LayoutDemoTxRoute
   LayoutTokenAddressRoute: typeof LayoutTokenAddressRoute
   LayoutTxHashRoute: typeof LayoutTxHashRoute
@@ -218,7 +218,7 @@ const LayoutRouteChildren: LayoutRouteChildren = {
   LayoutIndexRoute: LayoutIndexRoute,
   LayoutAddressAddressRoute: LayoutAddressAddressRoute,
   LayoutBlockIdRoute: LayoutBlockIdRoute,
-  LayoutDemoAccountRoute: LayoutDemoAccountRoute,
+  LayoutDemoAddressRoute: LayoutDemoAddressRoute,
   LayoutDemoTxRoute: LayoutDemoTxRoute,
   LayoutTokenAddressRoute: LayoutTokenAddressRoute,
   LayoutTxHashRoute: LayoutTxHashRoute,

--- a/apps/explorer/src/routes/_layout/address/$address.tsx
+++ b/apps/explorer/src/routes/_layout/address/$address.tsx
@@ -297,7 +297,7 @@ function SectionsSkeleton({ totalItems }: { totalItems: number }) {
 							totalItems={0}
 							page={1}
 							isPending={false}
-							itemsLabel='assets'
+							itemsLabel="assets"
 						/>
 					),
 				},
@@ -491,36 +491,36 @@ function SectionsWrapper(props: {
 										mode === 'stacked'
 											? [
 													<TokenName
-														key='name'
+														key="name"
 														contractAddress={assetAddress}
 													/>,
 													<AssetContract
-														key='contract'
+														key="contract"
 														contractAddress={assetAddress}
 													/>,
 													<AssetAmount
-														key='amount'
+														key="amount"
 														contractAddress={assetAddress}
 														accountAddress={address}
 													/>,
 												]
 											: [
 													<TokenName
-														key='name'
+														key="name"
 														contractAddress={assetAddress}
 													/>,
 													<TokenSymbol
-														key='symbol'
+														key="symbol"
 														contractAddress={assetAddress}
 													/>,
-													<span key='currency'>USD</span>,
+													<span key="currency">USD</span>,
 													<AssetAmount
-														key='amount'
+														key="amount"
 														contractAddress={assetAddress}
 														accountAddress={address}
 													/>,
 													<AssetValue
-														key='value'
+														key="value"
 														contractAddress={assetAddress}
 														accountAddress={address}
 													/>,
@@ -534,7 +534,7 @@ function SectionsWrapper(props: {
 							totalItems={assets.length}
 							page={1}
 							isPending={false}
-							itemsLabel='assets'
+							itemsLabel="assets"
 							itemsPerPage={assets.length}
 						/>
 					),
@@ -724,7 +724,7 @@ function TransactionDescription(props: {
 					/>
 					{index === 0 && remainingCount > 0 && (
 						<button
-							type='button'
+							type="button"
 							onClick={() => setExpanded(true)}
 							className="ml-1 text-base-content-secondary cursor-pointer press-down shrink-0"
 						>

--- a/apps/explorer/src/routes/_layout/index.tsx
+++ b/apps/explorer/src/routes/_layout/index.tsx
@@ -63,43 +63,52 @@ function Component() {
 function SpotlightLinks(props: { recentTransactions?: Hex.Hex[] }) {
 	const { recentTransactions = [] } = props
 	return (
-		<div className="flex items-center gap-[8px] mt-[24px] text-[14px] text-base-content-tertiary">
-			<span>Try:</span>
-			<SpotlightLink
-				to="/address/$address"
-				params={{ address: '0x5bc1473610754a5ca10749552b119df90c1a1877' }}
-			>
-				Account
-			</SpotlightLink>
-			<span>·</span>
-			<SpotlightLink
-				to="/token/$address"
-				params={{ address: '0x20c0000000000000000000000000000000000002' }}
-			>
-				Token
-			</SpotlightLink>
-			<span>·</span>
-			{recentTransactions[0] ? (
-				<SpotlightLink to="/tx/$hash" params={{ hash: recentTransactions[0] }}>
-					Receipt
+		<section className="text-center">
+			<span className="text-sm font-medium text-base-content-tertiary">
+				Try
+			</span>
+			<div className="flex items-center gap-[8px] mt-2 text-[14px] text-base-content-tertiary">
+				<SpotlightLink
+					to="/address/$address"
+					params={{ address: '0x5bc1473610754a5ca10749552b119df90c1a1877' }}
+				>
+					Account
 				</SpotlightLink>
-			) : (
-				<span className="opacity-50">Receipt</span>
-			)}
-		</div>
+				<span>·</span>
+				<SpotlightLink to="/blocks">Blocks</SpotlightLink>
+				<span>·</span>
+				<SpotlightLink
+					to="/token/$address"
+					params={{ address: '0x20c0000000000000000000000000000000000002' }}
+				>
+					Token
+				</SpotlightLink>
+				<span>·</span>
+				{recentTransactions[0] ? (
+					<SpotlightLink
+						to="/tx/$hash"
+						params={{ hash: recentTransactions[0] }}
+					>
+						Receipt
+					</SpotlightLink>
+				) : (
+					<span className="opacity-50">Receipt</span>
+				)}
+			</div>
+		</section>
 	)
 }
 
 function SpotlightLink(props: {
 	to: string
-	params: Record<string, string>
+	params?: Record<string, string>
 	children: React.ReactNode
 }) {
 	const { to, params, children } = props
 	return (
 		<Link
 			to={to}
-			params={params}
+			{...(params ? { params } : {})}
 			className="text-base-content-secondary hover:text-base-content transition-colors duration-150 underline underline-offset-2 decoration-base-border hover:decoration-base-content-secondary"
 		>
 			{children}

--- a/apps/explorer/src/routes/_layout/token/$address.tsx
+++ b/apps/explorer/src/routes/_layout/token/$address.tsx
@@ -20,6 +20,7 @@ import { InfoCard } from '#components/InfoCard'
 import { NotFound } from '#components/NotFound'
 import { RelativeTime } from '#components/RelativeTime'
 import { Sections } from '#components/Sections'
+import { cx } from '#cva.config.ts'
 import { HexFormatter, PriceFormatter } from '#lib/formatting'
 import { useCopy, useMediaQuery } from '#lib/hooks'
 import { fetchHolders, fetchTransfers } from '#lib/token.server'
@@ -299,7 +300,22 @@ function TokenCard(props: {
 }
 
 function SectionsSkeleton({ totalItems }: { totalItems: number }) {
-	const isMobile = useMediaQuery('(max-width: 1239px)')
+	const isMobile = useMediaQuery('(max-width: 799px)')
+
+	const transfersColumns: DataGrid.Column[] = [
+		{ label: 'Time', align: 'start', minWidth: 100 },
+		{ label: 'Transaction', align: 'start', minWidth: 120 },
+		{ label: 'From', align: 'start', minWidth: 140 },
+		{ label: 'To', align: 'start', minWidth: 140 },
+		{ label: 'Amount', align: 'end', minWidth: 100 },
+	]
+
+	const holdersColumns: DataGrid.Column[] = [
+		{ label: 'Address', align: 'start', minWidth: 140 },
+		{ label: 'Balance', align: 'end', minWidth: 120 },
+		{ label: 'Percentage', align: 'end', minWidth: 100 },
+	]
+
 	return (
 		<Sections
 			mode={isMobile ? 'stacked' : 'tabs'}
@@ -311,18 +327,8 @@ function SectionsSkeleton({ totalItems }: { totalItems: number }) {
 					content: (
 						<DataGrid
 							columns={{
-								stacked: [
-									{ label: 'Time', align: 'start', minWidth: 100 },
-									{ label: 'From', align: 'start' },
-									{ label: 'To', align: 'start' },
-								],
-								tabs: [
-									{ label: 'Time', align: 'start', minWidth: 100 },
-									{ label: 'Transaction', align: 'start' },
-									{ label: 'From', align: 'start' },
-									{ label: 'To', align: 'start' },
-									{ label: 'Amount', align: 'end' },
-								],
+								stacked: transfersColumns,
+								tabs: transfersColumns,
 							}}
 							items={() =>
 								Array.from(
@@ -332,8 +338,10 @@ function SectionsSkeleton({ totalItems }: { totalItems: number }) {
 										return {
 											cells: [
 												<div key={`${key}-time`} className="h-5" />,
+												<div key={`${key}-tx`} className="h-5" />,
 												<div key={`${key}-from`} className="h-5" />,
 												<div key={`${key}-to`} className="h-5" />,
+												<div key={`${key}-amount`} className="h-5" />,
 											],
 										}
 									},
@@ -354,15 +362,8 @@ function SectionsSkeleton({ totalItems }: { totalItems: number }) {
 					content: (
 						<DataGrid
 							columns={{
-								stacked: [
-									{ label: 'Address', align: 'start' },
-									{ label: 'Balance', align: 'end' },
-								],
-								tabs: [
-									{ label: 'Address', align: 'start' },
-									{ label: 'Balance', align: 'end' },
-									{ label: 'Percentage', align: 'end' },
-								],
+								stacked: holdersColumns,
+								tabs: holdersColumns,
 							}}
 							items={() => []}
 							totalItems={0}
@@ -442,7 +443,12 @@ function RouteComponent() {
 	const activeSection = tab === 'transfers' ? 0 : 1
 
 	return (
-		<div className="flex flex-col min-[1240px]:grid max-w-[1080px] w-full min-[1240px]:pt-20 pt-10 min-[1240px]:pb-16 pb-8 px-4 gap-[14px] min-w-0 min-[1240px]:grid-cols-[auto_1fr]">
+		<div
+			className={cx(
+				'max-[800px]:flex max-[800px]:flex-col max-w-[800px]:pt-10 max-w-[800px]:pb-8 w-full',
+				'grid w-full pt-20 pb-16 px-4 gap-[14px] min-w-0 grid-cols-[auto_1fr] min-[1240px]:max-w-[1080px]',
+			)}
+		>
 			<TokenCard
 				address={address}
 				className="self-start"
@@ -533,11 +539,25 @@ function SectionsWrapper(props: {
 		isLoadingTransfers ||
 		isLoadingHolders
 
-	const isMobile = useMediaQuery('(max-width: 1239px)')
+	const isMobile = useMediaQuery('(max-width: 799px)')
 	const mode = isMobile ? 'stacked' : 'tabs'
 
 	if (transfers.length === 0 && isLoadingPage && activeSection === 0)
 		return <SectionsSkeleton totalItems={transfersTotal} />
+
+	const transfersColumns: DataGrid.Column[] = [
+		{ label: 'Time', align: 'start', minWidth: 100 },
+		{ label: 'Transaction', align: 'start', minWidth: 120 },
+		{ label: 'From', align: 'start', minWidth: 140 },
+		{ label: 'To', align: 'start', minWidth: 140 },
+		{ label: 'Amount', align: 'end', minWidth: 100 },
+	]
+
+	const holdersColumns: DataGrid.Column[] = [
+		{ label: 'Address', align: 'start', minWidth: 140 },
+		{ label: 'Balance', align: 'end', minWidth: 120 },
+		{ label: 'Percentage', align: 'end', minWidth: 100 },
+	]
 
 	return (
 		<Sections
@@ -553,72 +573,39 @@ function SectionsWrapper(props: {
 					content: (
 						<DataGrid
 							columns={{
-								stacked: [
-									{ label: 'Time', align: 'start', minWidth: 100 },
-									{ label: 'From', align: 'start' },
-									{ label: 'To', align: 'start' },
-								],
-								tabs: [
-									{ label: 'Time', align: 'start', minWidth: 100 },
-									{ label: 'Transaction', align: 'start' },
-									{ label: 'From', align: 'start' },
-									{ label: 'To', align: 'start' },
-									{ label: 'Amount', align: 'end' },
-								],
+								stacked: transfersColumns,
+								tabs: transfersColumns,
 							}}
-							items={(mode) => {
+							items={() => {
 								const validTransfers = transfers.filter(
 									(t): t is typeof t & { timestamp: string; value: string } =>
 										t.timestamp !== null && t.value !== null,
 								)
 
 								return validTransfers.map((transfer) => ({
-									cells:
-										mode === 'stacked'
-											? [
-													<TransferTime
-														key="time"
-														timestamp={BigInt(transfer.timestamp)}
-														link={`/tx/${transfer.transactionHash}`}
-													/>,
-													<AddressLink
-														key="from"
-														address={transfer.from}
-														label="From"
-													/>,
-													<AddressLink
-														key="to"
-														address={transfer.to}
-														label="To"
-													/>,
-												]
-											: [
-													<TransferTime
-														key="time"
-														timestamp={BigInt(transfer.timestamp)}
-														link={`/tx/${transfer.transactionHash}`}
-													/>,
-													<TransactionLink
-														key="tx"
-														hash={transfer.transactionHash}
-													/>,
-													<AddressLink
-														key="from"
-														address={transfer.from}
-														label="From"
-													/>,
-													<AddressLink
-														key="to"
-														address={transfer.to}
-														label="To"
-													/>,
-													<TransferAmount
-														key="amount"
-														value={BigInt(transfer.value)}
-														decimals={metadata?.decimals}
-														symbol={metadata?.symbol}
-													/>,
-												],
+									cells: [
+										<TransferTime
+											key="time"
+											timestamp={BigInt(transfer.timestamp)}
+											link={`/tx/${transfer.transactionHash}`}
+										/>,
+										<TransactionLink
+											key="tx"
+											hash={transfer.transactionHash}
+										/>,
+										<AddressLink
+											key="from"
+											address={transfer.from}
+											label="From"
+										/>,
+										<AddressLink key="to" address={transfer.to} label="To" />,
+										<TransferAmount
+											key="amount"
+											value={BigInt(transfer.value)}
+											decimals={metadata?.decimals}
+											symbol={metadata?.symbol}
+										/>,
+									],
 									link: {
 										href: `/tx/${transfer.transactionHash}`,
 										title: `View receipt ${transfer.transactionHash}`,
@@ -640,48 +627,22 @@ function SectionsWrapper(props: {
 					content: (
 						<DataGrid
 							columns={{
-								stacked: [
-									{ label: 'Address', align: 'start' },
-									{ label: 'Balance', align: 'end' },
-								],
-								tabs: [
-									{ label: 'Address', align: 'start' },
-									{ label: 'Balance', align: 'end' },
-									{ label: 'Percentage', align: 'end' },
-								],
+								stacked: holdersColumns,
+								tabs: holdersColumns,
 							}}
-							items={(mode) =>
+							items={() =>
 								holders.map((holder) => ({
-									cells:
-										mode === 'stacked'
-											? [
-													<AddressLink
-														key="address"
-														address={holder.address}
-													/>,
-													<HolderBalance
-														key="balance"
-														balance={holder.balance}
-														decimals={metadata?.decimals}
-													/>,
-												]
-											: [
-													<AddressLink
-														key="address"
-														address={holder.address}
-													/>,
-													<HolderBalance
-														key="balance"
-														balance={holder.balance}
-														decimals={metadata?.decimals}
-													/>,
-													<span
-														key="percentage"
-														className="text-[12px] text-primary"
-													>
-														{holder.percentage.toFixed(2)}%
-													</span>,
-												],
+									cells: [
+										<AddressLink key="address" address={holder.address} />,
+										<HolderBalance
+											key="balance"
+											balance={holder.balance}
+											decimals={metadata?.decimals}
+										/>,
+										<span key="percentage" className="text-[12px] text-primary">
+											{holder.percentage.toFixed(2)}%
+										</span>,
+									],
 									link: {
 										href: `/token/${address}?a=${holder.address}`,
 										title: `View transfers for ${holder.address}`,
@@ -725,7 +686,7 @@ function FilterIndicator(props: {
 				className="text-tertiary press-down"
 				title="Clear filter"
 			>
-				<XIcon className="w-[14px] h-[14px] translate-y-[1px]" />
+				<XIcon className="w-[14px] h-[14px] translate-y-px" />
 			</Link>
 		</div>
 	)


### PR DESCRIPTION
we already made tables in address and block/s routes scrollable. This does the same for the token route table.

also adds blocks demo link.