### PR TITLE
chore: deploy worker only when its files change (prod)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,9 +21,9 @@ jobs:
       matrix:
         include:
           - app: explorer
-          - app: fee-payer
+          - app: fee-payer # default
+          - app: fee-payer # privy
             env: privy
-          - app: index-supply
 
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
same as https://github.com/tempoxyz/tempo-apps/pull/162 but for `main` / prod