### PR TITLE
fix: check if address is tip20 in receipt

### DIFF
--- a/apps/explorer/src/components/Receipt/Amount.tsx
+++ b/apps/explorer/src/components/Receipt/Amount.tsx
@@ -2,6 +2,7 @@ import { Link } from '@tanstack/react-router'
 import { type Address, Value } from 'ox'
 import { Hooks } from 'tempo.ts/wagmi'
 import { PriceFormatter } from '#lib/formatting.ts'
+import { isTip20Address } from '#lib/tip20.ts'
 
 export function Amount(props: Amount.Props) {
 	const { value, token, decimals, symbol } = props
@@ -28,7 +29,7 @@ export function Amount(props: Amount.Props) {
 				className="text-base-content-positive press-down inline-flex"
 				params={{ address: token }}
 				title={token}
-				to="/token/$address"
+				to={isTip20Address(token) ? '/token/$address' : '/address/$address'}
 			>
 				{symbol_}
 			</Link>


### PR DESCRIPTION
right now if someone views a transaction that involves 0x20fc... (e.g., a fee payment or system operation), clicking the token symbol links to /token/0x20fc... which is why we get this page:

<img width="532" height="319" alt="CleanShot 2025-12-06 at 10 01 18" src="https://github.com/user-attachments/assets/3590e8bf-b8e2-4525-bf4c-09815699b7ba" />

this adds a check if the address is tip20 to decide whether to link to /address or /token