### PR TITLE
fix: only rate limit sponsorship endpoint

### DIFF
--- a/apps/fee-payer/src/index.ts
+++ b/apps/fee-payer/src/index.ts
@@ -24,7 +24,6 @@ app.use(
 		allowHeaders: ['Content-Type', 'Authorization'],
 		maxAge: 86400,
 	}),
-	rateLimitMiddleware,
 )
 
 app.get(
@@ -51,7 +50,7 @@ app.get(
 	},
 )
 
-app.all('*', async (c) => {
+app.all('*', rateLimitMiddleware, async (c) => {
 	const handler = Handler.feePayer({
 		account: privateKeyToAccount(env.SPONSOR_PRIVATE_KEY as `0x${string}`),
 		chain: tempo({ feeToken: '0x20c0000000000000000000000000000000000001' }),


### PR DESCRIPTION
The rate limiting logic is only relevant to the sponsorship endpoint as it uses the `from` field from a transaction. The middleware was being applied to all routes so it'd break `GET /usage` path.