### PR TITLE
fix: token transfers query

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -53,7 +53,7 @@
 	"files.exclude": {
 		"**/.tanstack": true,
 		"**/*.wrangler": true,
-		"**/_/**": true
+		"**/.pnpm-store/**": true
 	},
 	"tailwindCSS.experimental.classRegex": [
 		"cx\\(([^)]+)\\)",


### PR DESCRIPTION
new query:

```sql
SELECT "from" AS holder, SUM(tokens) AS sent
FROM transfer
WHERE "chain" = $1
  AND "address" = $2
  AND "from" <> '0x0000000000000000000000000000000000000000'
GROUP BY "from";
```

Changes made to stop the ~2M-row stream for token holders:

In `fetchHoldersData`, replaced the “select all transfers and sum in Node” approach with two grouped SQL queries:
1. sum incoming per to for the token/chain,
2. sum outgoing per from (excluding zero-address mints), then merge the two small result sets in memory to compute balances, filter > 0, sort, and sum for total supply.