### PR TITLE
fix: display main event in block viewer

### DIFF
--- a/apps/explorer/src/routes/_layout/block/$id.tsx
+++ b/apps/explorer/src/routes/_layout/block/$id.tsx
@@ -313,7 +313,6 @@ function ExpandableEvents(props: { events: KnownEvent[] }) {
 
 	if (events.length === 0) return null
 
-	
 	const [firstEvent, ...rest] = events
 	const preferredEvents = events.filter(preferredEventsFilter)
 


### PR DESCRIPTION
Displays main event in tx rows in block viewer as well

https://github.com/user-attachments/assets/49d8c845-6088-41e9-bb64-2060b5e05b9a

