### PR TITLE
fix: parse token symbol for FeeManger events

### DIFF
--- a/apps/explorer/src/lib/domain/known-events.ts
+++ b/apps/explorer/src/lib/domain/known-events.ts
@@ -485,27 +485,37 @@ function createDetectors(
 		feeManager(event: ParsedEvent) {
 			const { eventName, args } = event
 
-			if (eventName === 'UserTokenSet')
+			if (eventName === 'UserTokenSet') {
+				const metadata = getTokenMetadata?.(args.token)
 				return {
 					type: 'user token set',
 					parts: [
 						{ type: 'action', value: 'Set Fee Token' },
-						{ type: 'token', value: { address: args.token } },
+						{
+							type: 'token',
+							value: { address: args.token, symbol: metadata?.symbol },
+						},
 						{ type: 'text', value: 'for' },
 						{ type: 'account', value: args.user },
 					],
 				}
+			}
 
-			if (eventName === 'ValidatorTokenSet')
+			if (eventName === 'ValidatorTokenSet') {
+				const metadata = getTokenMetadata?.(args.token)
 				return {
 					type: 'validator token set',
 					parts: [
 						{ type: 'action', value: 'Set Fee Token' },
-						{ type: 'token', value: { address: args.token } },
+						{
+							type: 'token',
+							value: { address: args.token, symbol: metadata?.symbol },
+						},
 						{ type: 'text', value: 'for' },
 						{ type: 'account', value: args.validator },
 					],
 				}
+			}
 
 			return null
 		},


### PR DESCRIPTION
Follows pattern in `known-events.ts` to populate token symbol for fee manager transaction events

https://f8e91630-explorer.porto.workers.dev/address/0x63eFAf61756bC63c7D86Df0C323DDe4E14d8ADc0
<img width="2982" height="1414" alt="CleanShot 2025-12-09 at 17 16 16@2x" src="https://github.com/user-attachments/assets/74a34a2a-2ac0-4428-b330-4df9a533bf0a" />
