### PR TITLE
replace empty catch block with explicit continue in event log decoding

### DIFF
--- a/apps/explorer/src/lib/abi.ts
+++ b/apps/explorer/src/lib/abi.ts
@@ -150,7 +150,10 @@ export function decodeEventLog_guessed(args: {
 					topics: topics as [Hex, ...Hex[]],
 					data,
 				})
-			} catch {}
+			} catch {
+				// Continue trying different indexed input combinations
+				continue
+			}
 		}
 	}
 }


### PR DESCRIPTION
## 🐛 Bug Fix
Replaces empty catch block with explicit `continue` statement in `decodeEventLog_guessed` function.

## Location
`apps/explorer/src/lib/abi.ts`, line 153

## Changes
- Added explicit `continue` statement in catch block
- Added comment explaining intent (trying different indexed input combinations)

## Why This Matters
- Empty catch blocks silently swallow errors
- Obscures developer intent
- Anti-pattern flagged by linters

## Impact
- ✅ No breaking changes
- ✅ Same behavior, better documentation
- ✅ Improved code maintainability