### PR TITLE
replace empty catch block with comment in calldata decoding

### DIFF
--- a/apps/explorer/src/comps/TxDecodedCalldata.tsx
+++ b/apps/explorer/src/comps/TxDecodedCalldata.tsx
@@ -72,7 +72,9 @@ export function TxDecodedCalldata(props: TxDecodedCalldata.Props) {
 				return {
 					args: decodeAbiParameters(abiItem.inputs, rawArgs),
 				}
-			} catch {}
+			} catch {
+				// Failed to decode - return undefined to display raw calldata
+			}
 		}
 		return { args: undefined }
 	}, [abiItem, rawArgs])


### PR DESCRIPTION
---

### ✅ **BUG #2: Empty catch in TxDecodedCalldata.tsx**
- **Branch:** `fix/empty-catch-block-calldata-decoding`
- **PR Link:** https://github.com/deseti/tempo-apps/pull/new/fix/empty-catch-block-calldata-decoding
- **Status:** ✅ Pushed and ready

**Issue to post:**
```markdown
Title: 🐛 Empty catch block in calldata decoding component

## Description
Empty catch block at line 75 in `apps/explorer/src/comps/TxDecodedCalldata.tsx` makes error handling intent unclear.

## Current Code
```typescript
} catch {}  // ❌ Silent failure