### PR TITLE
fix: replace unsafe type cast with type-safe check in rate limiter

### DIFF
--- a/apps/fee-payer/src/lib/rate-limit.ts
+++ b/apps/fee-payer/src/lib/rate-limit.ts
@@ -16,7 +16,12 @@ export async function rateLimitMiddleware(c: Context, next: Next) {
 	const serialized = request.params?.[0] as `0x76${string}`
 
 	const transaction = Transaction.deserialize(serialized)
-	const from = (transaction as any).from
+	
+	// Type-safe access to 'from' address
+	const from = 'from' in transaction ? transaction.from : null
+	if (!from) {
+		return c.json({ error: 'Invalid transaction: missing from address' }, 400)
+	}
 
 	const { success } = await env.AddressRateLimiter.limit({
 		key: from,


### PR DESCRIPTION
---

### ✅ **BUG #3: Unsafe type cast in rate-limit.ts**
- **Branch:** `fix/unsafe-type-cast-rate-limiter`
- **PR Link:** https://github.com/deseti/tempo-apps/pull/new/fix/unsafe-type-cast-rate-limiter
- **Status:** ✅ Pushed and ready

**Issue to post:**
```markdown
Title: 🐛 Unsafe type casting in rate limiter middleware

## Description
Line 18 in `apps/fee-payer/src/lib/rate-limit.ts` uses unsafe `as any` type assertion that could cause runtime crashes.

## Current Code
```typescript
const from = (transaction as any).from  // ❌ Unsafe