### PR TITLE
feat: Decode TIP-20 roles

### DIFF
--- a/apps/explorer/src/comps/TxEventDescription.tsx
+++ b/apps/explorer/src/comps/TxEventDescription.tsx
@@ -6,7 +6,12 @@ import { Address } from '#comps/Address'
 import { Amount } from '#comps/Amount'
 import { cx } from '#cva.config.ts'
 import type { KnownEvent, KnownEventPart } from '#lib/domain/known-events.ts'
-import { DateFormatter, HexFormatter, PriceFormatter } from '#lib/formatting.ts'
+import {
+	DateFormatter,
+	HexFormatter,
+	PriceFormatter,
+	RoleFormatter,
+} from '#lib/formatting.ts'
 
 export function TxEventDescription(props: TxEventDescription.Props) {
 	const { event, seenAs, className } = props
@@ -70,6 +75,13 @@ export namespace TxEventDescription {
 								? Value.format(...part.value)
 								: Value.format(BigInt(part.value)),
 						)}
+					</span>
+				)
+			case 'role':
+				return (
+					<span className="items-end whitespace-nowrap" title={part.value}>
+						{RoleFormatter.getRoleName(part.value) ||
+							HexFormatter.shortenHex(part.value)}
 					</span>
 				)
 			case 'text':

--- a/apps/explorer/src/lib/domain/known-events.ts
+++ b/apps/explorer/src/lib/domain/known-events.ts
@@ -121,7 +121,7 @@ function createDetectors(
 							type: 'action',
 							value: args.hasRole ? 'Grant Role' : 'Revoke Role',
 						},
-						{ type: 'hex', value: args.role },
+						{ type: 'role', value: args.role },
 						{ type: 'text', value: 'to' },
 						{ type: 'account', value: args.account },
 					],
@@ -316,9 +316,9 @@ function createDetectors(
 					type: 'role admin updated',
 					parts: [
 						{ type: 'action', value: 'Update Role Admin' },
-						{ type: 'hex', value: args.role },
+						{ type: 'role', value: args.role },
 						{ type: 'text', value: 'to' },
-						{ type: 'hex', value: args.newAdminRole },
+						{ type: 'role', value: args.newAdminRole },
 					],
 					note: [['Sender', { type: 'account', value: args.sender }]],
 				}
@@ -689,6 +689,7 @@ export type KnownEventPart =
 			type: 'number'
 			value: bigint | number | [value: bigint, decimals: number]
 	  }
+	| { type: 'role'; value: Hex.Hex }
 	| { type: 'text'; value: string }
 	| { type: 'tick'; value: number }
 	| { type: 'token'; value: Token }

--- a/apps/explorer/src/lib/formatting.ts
+++ b/apps/explorer/src/lib/formatting.ts
@@ -1,4 +1,4 @@
-import { type Hex, Value } from 'ox'
+import { Hash, Hex, Value } from 'ox'
 
 export namespace HexFormatter {
 	export function truncate(value: Hex.Hex, chars = 4) {
@@ -12,6 +12,24 @@ export namespace HexFormatter {
 		return hex.length < chars * 2 + 2
 			? hex
 			: `${hex.slice(0, chars + 2)}…${hex.slice(-chars)}`
+	}
+}
+
+export namespace RoleFormatter {
+	const KNOWN_ROLES = [
+		'DEFAULT_ADMIN_ROLE',
+		'ISSUER_ROLE',
+		'PAUSE_ROLE',
+		'UNPAUSE_ROLE',
+		'BURN_BLOCKED_ROLE',
+	] as const
+
+	const roleHashMap = new Map<Hex.Hex, string>(
+		KNOWN_ROLES.map((role) => [Hash.keccak256(Hex.fromString(role)), role]),
+	)
+
+	export function getRoleName(roleHash: Hex.Hex): string | undefined {
+		return roleHashMap.get(roleHash)
 	}
 }
 


### PR DESCRIPTION
Fixes #207 

- Adds new `KnownEventPart` called `role` for `Hex` fields we know refer to roles
- Adds `RoleFormatter` to do a lookup against the `keccak256` of the role names

Decided to add a new `role` part instead of changing `hex` behavior in case future events need a part to be shown as hex