### PR TITLE
fix: replace unsafe type cast with type-safe check in rate limiter

### DIFF
--- a/apps/fee-payer/src/lib/rate-limit.ts
+++ b/apps/fee-payer/src/lib/rate-limit.ts
@@ -16,7 +16,12 @@ export async function rateLimitMiddleware(c: Context, next: Next) {
 	const serialized = request.params?.[0] as `0x76${string}`
 
 	const transaction = Transaction.deserialize(serialized)
-	const from = (transaction as any).from
+	
+	// Type-safe access to 'from' address
+	const from = 'from' in transaction ? transaction.from : null
+	if (!from) {
+		return c.json({ error: 'Invalid transaction: missing from address' }, 400)
+	}
 
 	const { success } = await env.AddressRateLimiter.limit({
 		key: from,


### PR DESCRIPTION
Replaces 'as any' type assertion with proper type checking using 'in' operator. Adds validation to return 400 error if 'from' address is missing, preventing potential runtime crashes from undefined values.

Fixes: Unsafe type casting in rate limiter middleware
Impact: Improved type safety and error handling