### PR TITLE
feat: add contract call event parsing

### DIFF
--- a/apps/explorer/src/comps/TxEventDescription.tsx
+++ b/apps/explorer/src/comps/TxEventDescription.tsx
@@ -7,10 +7,7 @@ import { Address } from '#comps/Address'
 import { Amount } from '#comps/Amount'
 import { Midcut } from '#comps/Midcut'
 import { cx } from '#cva.config.ts'
-import {
-	extractContractAbi,
-	getContractAbi,
-} from '#lib/domain/contracts.ts'
+import { extractContractAbi, getContractAbi } from '#lib/domain/contracts.ts'
 import type { KnownEvent, KnownEventPart } from '#lib/domain/known-events.ts'
 import {
 	DateFormatter,
@@ -23,7 +20,10 @@ import {
  * Renders a contract call with decoded function name.
  * Fetches ABI from registry or extracts from bytecode using whatsabi.
  */
-function ContractCallPart(props: { address: AddressType.Address; input: Hex.Hex }) {
+function ContractCallPart(props: {
+	address: AddressType.Address
+	input: Hex.Hex
+}) {
 	const { address, input } = props
 	const selector = Hex.slice(input, 0, 4)
 
@@ -51,20 +51,17 @@ function ContractCallPart(props: { address: AddressType.Address; input: Hex.Hex 
 	})
 
 	// Show selector while loading or if we couldn't decode
-	const displayText = isLoading
-		? selector
-		: functionName ?? selector
+	const displayText = isLoading ? selector : (functionName ?? selector)
 
 	return (
 		<Link
 			to="/address/$address"
 			params={{ address }}
+			search={{ tab: 'contract' }}
 			title={`${address} - ${functionName ?? selector}`}
 			className="press-down whitespace-nowrap"
 		>
-			<span className="text-accent items-end">
-				{displayText}
-			</span>
+			<span className="text-accent items-end">{displayText}</span>
 		</Link>
 	)
 }

--- a/apps/explorer/src/lib/domain/known-events.ts
+++ b/apps/explorer/src/lib/domain/known-events.ts
@@ -855,8 +855,7 @@ function detectContractCall(
 	return {
 		type: 'contract call',
 		parts: [
-			{ type: 'account', value: receipt.from },
-			{ type: 'action', value: 'Called' },
+			{ type: 'action', value: 'Call To' },
 			{
 				type: 'contractCall',
 				value: { address: contractAddress, input: callInput },


### PR DESCRIPTION
 Adds a "contract call" event detecor for the address page when viewing transactions from a contract's perspective.

  - Added a new `contractCall` part type that carries the contract address and transaction input data
  - When no known events involve the viewer contract, detect if it was the call target and show a "Called" event
  - The `ContractCallPart` component asynchronously decodes the function name using the contract's ABI (from registry or extracted via whatsabi)
  - Falls back to showing the 4-byte selector if decoding fails