### PR TITLE
fix(Pagination): use aria-disabled instead of disabled for Link styles

### DIFF
--- a/apps/explorer/src/comps/Pagination.tsx
+++ b/apps/explorer/src/comps/Pagination.tsx
@@ -242,7 +242,7 @@ export namespace Pagination {
 					search={(prev) => ({ ...prev, page: 1, live: true })}
 					disabled={page <= 1 || isPending}
 					className={cx(
-						'rounded-full border border-base-border hover:bg-alt flex items-center justify-center cursor-pointer active:translate-y-[0.5px] disabled:cursor-not-allowed disabled:opacity-50 size-[24px] text-primary',
+						'rounded-full border border-base-border hover:bg-alt flex items-center justify-center cursor-pointer active:translate-y-[0.5px] aria-disabled:cursor-not-allowed aria-disabled:opacity-50 size-[24px] text-primary',
 					)}
 					title="First page"
 				>
@@ -257,7 +257,7 @@ export namespace Pagination {
 					}}
 					disabled={page <= 1 || isPending}
 					className={cx(
-						'rounded-full border border-base-border hover:bg-alt flex items-center justify-center cursor-pointer active:translate-y-[0.5px] disabled:cursor-not-allowed disabled:opacity-50 size-[24px] text-primary',
+						'rounded-full border border-base-border hover:bg-alt flex items-center justify-center cursor-pointer active:translate-y-[0.5px] aria-disabled:cursor-not-allowed aria-disabled:opacity-50 size-[24px] text-primary',
 					)}
 					title="Previous page"
 				>
@@ -277,7 +277,7 @@ export namespace Pagination {
 					})}
 					disabled={page >= totalPages || isPending}
 					className={cx(
-						'rounded-full border border-base-border hover:bg-alt flex items-center justify-center cursor-pointer active:translate-y-[0.5px] disabled:cursor-not-allowed disabled:opacity-50 size-[24px] text-primary',
+						'rounded-full border border-base-border hover:bg-alt flex items-center justify-center cursor-pointer active:translate-y-[0.5px] aria-disabled:cursor-not-allowed aria-disabled:opacity-50 size-[24px] text-primary',
 					)}
 					title="Next page"
 				>
@@ -289,7 +289,7 @@ export namespace Pagination {
 					search={(prev) => ({ ...prev, page: totalPages, live: false })}
 					disabled={page >= totalPages || isPending}
 					className={cx(
-						'rounded-full border border-base-border hover:bg-alt flex items-center justify-center cursor-pointer active:translate-y-[0.5px] disabled:cursor-not-allowed disabled:opacity-50 size-[24px] text-primary',
+						'rounded-full border border-base-border hover:bg-alt flex items-center justify-center cursor-pointer active:translate-y-[0.5px] aria-disabled:cursor-not-allowed aria-disabled:opacity-50 size-[24px] text-primary',
 					)}
 					title="Last page"
 				>


### PR DESCRIPTION
Quick fix for the pagination component to correctly display the disabled state. Its super minor but I couldn't help but send a PR to fix! Expect more to come :)

Before:
<img width="270" height="55" alt="Screenshot 2025-12-12 at 4 39 37 pm" src="https://github.com/user-attachments/assets/2ba429ad-5ae9-4a7e-8cd3-7545e5d97a66" />

After:
<img width="259" height="47" alt="Screenshot 2025-12-12 at 4 39 56 pm" src="https://github.com/user-attachments/assets/5de629d9-191f-47bd-bb70-b9106e900f74" />

BTW I sent an email to @gakonst explaining who I am and my background so you guys have more context.