### PR TITLE
feat: add balance changes to /tx

### DIFF
--- a/apps/explorer/src/comps/TxBalanceChanges.tsx
+++ b/apps/explorer/src/comps/TxBalanceChanges.tsx
@@ -1,0 +1,163 @@
+import { Link } from '@tanstack/react-router'
+import type { Address as OxAddress } from 'ox'
+import { Value } from 'ox'
+import { Address } from '#comps/Address'
+import { DataGrid } from '#comps/DataGrid'
+import { isTip20Address } from '#lib/domain/tip20'
+import { PriceFormatter } from '#lib/formatting'
+import {
+	LIMIT,
+	type BalanceChangesData,
+	type TokenMetadata,
+} from '#lib/queries/balance-changes'
+
+export function TxBalanceChanges(props: TxBalanceChanges.Props) {
+	const { data, page } = props
+
+	if (data.total === 0)
+		return (
+			<div className="px-[18px] py-[24px] text-[13px] text-tertiary text-center">
+				No balance changes for this transaction.
+			</div>
+		)
+
+	const cols: DataGrid.Column[] = [
+		{ label: 'Address', align: 'start', width: '2fr' },
+		{ label: 'Token', align: 'start', width: '1fr' },
+		{ label: 'Before', align: 'end', width: '1.5fr' },
+		{ label: 'After', align: 'end', width: '1.5fr' },
+		{ label: 'Change', align: 'end', width: '1.5fr' },
+	]
+
+	return (
+		<DataGrid
+			columns={{ stacked: cols, tabs: cols }}
+			items={() =>
+				data.changes.map((change) => {
+					const metadata = data.tokenMetadata[change.token]
+					return {
+						link: {
+							href: `/token/${change.token}?a=${change.address}`,
+							title: `View ${change.token} transfers for ${change.address}`,
+						},
+						cells: [
+							<Address key="addr" address={change.address} />,
+							<TxBalanceChanges.TokenSymbol
+								key="token"
+								token={change.token}
+								metadata={metadata}
+							/>,
+							<TxBalanceChanges.BalanceCell
+								key="before"
+								value={change.balanceBefore}
+								metadata={metadata}
+							/>,
+							<TxBalanceChanges.BalanceCell
+								key="after"
+								value={change.balanceAfter}
+								metadata={metadata}
+							/>,
+							<TxBalanceChanges.DiffCell
+								key="diff"
+								diff={change.diff}
+								metadata={metadata}
+							/>,
+						],
+					}
+				})
+			}
+			totalItems={data.total}
+			page={page}
+			isPending={false}
+			itemsLabel="changes"
+			itemsPerPage={LIMIT}
+			emptyState="No balance changes detected."
+			pagination="simple"
+		/>
+	)
+}
+
+export namespace TxBalanceChanges {
+	export interface Props {
+		data: BalanceChangesData
+		page: number
+	}
+
+	export function TokenSymbol(props: TokenSymbol.Props) {
+		const { token, metadata } = props
+		const isTip20 = isTip20Address(token)
+
+		return (
+			<Link
+				className="text-base-content-positive press-down"
+				params={{ address: token }}
+				title={token}
+				to={isTip20 ? '/token/$address' : '/address/$address'}
+			>
+				{metadata?.symbol ?? '…'}
+			</Link>
+		)
+	}
+
+	export namespace TokenSymbol {
+		export interface Props {
+			token: OxAddress.Address
+			metadata: TokenMetadata | undefined
+		}
+	}
+
+	export function BalanceCell(props: BalanceCell.Props) {
+		const { value: valueStr, metadata } = props
+
+		if (!metadata) return <span>…</span>
+
+		let value: bigint
+		try {
+			value = BigInt(valueStr)
+		} catch {
+			return <span className="text-tertiary">Invalid</span>
+		}
+
+		const raw = Value.format(value, metadata.decimals)
+		const formatted = PriceFormatter.formatAmount(raw)
+
+		return <span className="text-secondary">{formatted}</span>
+	}
+
+	export namespace BalanceCell {
+		export interface Props {
+			value: string
+			metadata: TokenMetadata | undefined
+		}
+	}
+
+	export function DiffCell(props: DiffCell.Props) {
+		const { diff: diffStr, metadata } = props
+
+		if (!metadata) return <span>…</span>
+
+		let diff: bigint
+		try {
+			diff = BigInt(diffStr)
+		} catch {
+			return <span className="text-tertiary">Invalid</span>
+		}
+
+		const isPositive = diff > 0n
+		const raw = Value.format(diff, metadata.decimals)
+		const formatted = PriceFormatter.formatAmount(raw)
+
+		return (
+			<span className={isPositive ? 'text-base-content-positive' : undefined}>
+				{formatted}
+			</span>
+		)
+	}
+
+	export namespace DiffCell {
+		export interface Props {
+			diff: string
+			metadata: TokenMetadata | undefined
+		}
+	}
+}

--- a/apps/explorer/src/lib/queries/balance-changes.ts
+++ b/apps/explorer/src/lib/queries/balance-changes.ts
@@ -1,0 +1,31 @@
+import { keepPreviousData, queryOptions } from '@tanstack/react-query'
+
+import type { BalanceChangesData } from '#routes/api/tx/balance-changes/$hash'
+
+export type {
+	BalanceChangesData,
+	TokenBalanceChange,
+	TokenMetadata,
+} from '#routes/api/tx/balance-changes/$hash'
+
+export const LIMIT = 20
+
+export function balanceChangesQueryOptions(params: {
+	hash: string
+	page: number
+}) {
+	const offset = (params.page - 1) * LIMIT
+	return queryOptions({
+		queryKey: ['balance-changes', params.hash, params.page],
+		queryFn: async (): Promise<BalanceChangesData> => {
+			const url = `${__BASE_URL__}/api/tx/balance-changes/${params.hash}?limit=${LIMIT}&offset=${offset}`
+			const response = await fetch(url)
+			const data: BalanceChangesData & { error?: string } =
+				await response.json()
+			if (data.error) throw new Error(data.error)
+			return data
+		},
+		staleTime: Infinity, // data is immutable
+		placeholderData: keepPreviousData,
+	})
+}

--- a/apps/explorer/src/lib/queries/index.ts
+++ b/apps/explorer/src/lib/queries/index.ts
@@ -1,4 +1,5 @@
 export * from './account'
+export * from './balance-changes'
 export * from './blocks'
 export * from './tokens'
 export * from './tx'

--- a/apps/explorer/src/routeTree.gen.ts
+++ b/apps/explorer/src/routeTree.gen.ts
@@ -27,6 +27,7 @@ import { Route as LayoutDemoEmptyStateRouteImport } from './routes/_layout/demo/
 import { Route as LayoutDemoAddressRouteImport } from './routes/_layout/demo/address'
 import { Route as LayoutBlockIdRouteImport } from './routes/_layout/block/$id'
 import { Route as LayoutAddressAddressRouteImport } from './routes/_layout/address/$address'
+import { Route as ApiTxBalanceChangesHashRouteImport } from './routes/api/tx/balance-changes/$hash'
 import { Route as ApiAddressTxsCountAddressRouteImport } from './routes/api/address/txs-count/$address'
 import { Route as ApiAddressTotalValueAddressRouteImport } from './routes/api/address/total-value/$address'
 
@@ -119,6 +120,11 @@ const LayoutAddressAddressRoute = LayoutAddressAddressRouteImport.update({
   path: '/address/$address',
   getParentRoute: () => LayoutRoute,
 } as any)
+const ApiTxBalanceChangesHashRoute = ApiTxBalanceChangesHashRouteImport.update({
+  id: '/api/tx/balance-changes/$hash',
+  path: '/api/tx/balance-changes/$hash',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiAddressTxsCountAddressRoute =
   ApiAddressTxsCountAddressRouteImport.update({
     id: '/api/address/txs-count/$address',
@@ -152,6 +158,7 @@ export interface FileRoutesByFullPath {
   '/demo': typeof LayoutDemoIndexRoute
   '/api/address/total-value/$address': typeof ApiAddressTotalValueAddressRoute
   '/api/address/txs-count/$address': typeof ApiAddressTxsCountAddressRoute
+  '/api/tx/balance-changes/$hash': typeof ApiTxBalanceChangesHashRoute
 }
 export interface FileRoutesByTo {
   '/blocks': typeof LayoutBlocksRoute
@@ -173,6 +180,7 @@ export interface FileRoutesByTo {
   '/demo': typeof LayoutDemoIndexRoute
   '/api/address/total-value/$address': typeof ApiAddressTotalValueAddressRoute
   '/api/address/txs-count/$address': typeof ApiAddressTxsCountAddressRoute
+  '/api/tx/balance-changes/$hash': typeof ApiTxBalanceChangesHashRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -196,6 +204,7 @@ export interface FileRoutesById {
   '/_layout/demo/': typeof LayoutDemoIndexRoute
   '/api/address/total-value/$address': typeof ApiAddressTotalValueAddressRoute
   '/api/address/txs-count/$address': typeof ApiAddressTxsCountAddressRoute
+  '/api/tx/balance-changes/$hash': typeof ApiTxBalanceChangesHashRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -219,6 +228,7 @@ export interface FileRouteTypes {
     | '/demo'
     | '/api/address/total-value/$address'
     | '/api/address/txs-count/$address'
+    | '/api/tx/balance-changes/$hash'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/blocks'
@@ -240,6 +250,7 @@ export interface FileRouteTypes {
     | '/demo'
     | '/api/address/total-value/$address'
     | '/api/address/txs-count/$address'
+    | '/api/tx/balance-changes/$hash'
   id:
     | '__root__'
     | '/_layout'
@@ -262,6 +273,7 @@ export interface FileRouteTypes {
     | '/_layout/demo/'
     | '/api/address/total-value/$address'
     | '/api/address/txs-count/$address'
+    | '/api/tx/balance-changes/$hash'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -272,6 +284,7 @@ export interface RootRouteChildren {
   ApiAddressAddressRoute: typeof ApiAddressAddressRoute
   ApiAddressTotalValueAddressRoute: typeof ApiAddressTotalValueAddressRoute
   ApiAddressTxsCountAddressRoute: typeof ApiAddressTxsCountAddressRoute
+  ApiTxBalanceChangesHashRoute: typeof ApiTxBalanceChangesHashRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -402,6 +415,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof LayoutAddressAddressRouteImport
       parentRoute: typeof LayoutRoute
     }
+    '/api/tx/balance-changes/$hash': {
+      id: '/api/tx/balance-changes/$hash'
+      path: '/api/tx/balance-changes/$hash'
+      fullPath: '/api/tx/balance-changes/$hash'
+      preLoaderRoute: typeof ApiTxBalanceChangesHashRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/address/txs-count/$address': {
       id: '/api/address/txs-count/$address'
       path: '/api/address/txs-count/$address'
@@ -462,6 +482,7 @@ const rootRouteChildren: RootRouteChildren = {
   ApiAddressAddressRoute: ApiAddressAddressRoute,
   ApiAddressTotalValueAddressRoute: ApiAddressTotalValueAddressRoute,
   ApiAddressTxsCountAddressRoute: ApiAddressTxsCountAddressRoute,
+  ApiTxBalanceChangesHashRoute: ApiTxBalanceChangesHashRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/apps/explorer/src/routes/api/tx/balance-changes/$hash.ts
+++ b/apps/explorer/src/routes/api/tx/balance-changes/$hash.ts
@@ -1,0 +1,212 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { json } from '@tanstack/react-start'
+import type { Address } from 'ox'
+import { Abis } from 'tempo.ts/viem'
+import type { Log } from 'viem'
+import { getAbiItem, parseEventLogs, zeroAddress } from 'viem'
+import { getTransactionReceipt, readContract } from 'viem/actions'
+import * as z from 'zod/mini'
+
+import { zHash } from '#lib/zod'
+import { getConfig } from '#wagmi.config'
+
+const DEFAULT_LIMIT = 20
+const MAX_LIMIT = 100
+
+export interface TokenBalanceChange {
+	address: Address.Address
+	token: Address.Address
+	balanceBefore: string
+	balanceAfter: string
+	diff: string
+}
+
+export interface TokenMetadata {
+	decimals: number
+	symbol: string
+}
+
+export interface BalanceChangesData {
+	changes: TokenBalanceChange[]
+	tokenMetadata: Record<Address.Address, TokenMetadata>
+	total: number
+}
+
+const transferAbi = [getAbiItem({ abi: Abis.tip20, name: 'Transfer' })]
+
+function computeBalanceChanges(logs: Log[]) {
+	const events = parseEventLogs({
+		abi: transferAbi,
+		logs,
+		strict: false,
+	})
+
+	const changes = new Map<
+		string,
+		{
+			address: Address.Address
+			token: Address.Address
+			diff: bigint
+		}
+	>()
+
+	const addChange = (
+		address: Address.Address,
+		token: Address.Address,
+		amount: bigint,
+	) => {
+		if (address === zeroAddress) return
+		const key = `${address}:${token}`
+		const change = changes.get(key)
+		if (change) change.diff += amount
+		else changes.set(key, { address, token, diff: amount })
+	}
+
+	for (const event of events) {
+		if (event.eventName !== 'Transfer') continue
+		const { from, to, amount } = event.args
+		if (!amount) continue
+		if (from) addChange(from, event.address, -amount)
+		if (to) addChange(to, event.address, amount)
+	}
+
+	return Array.from(changes.values()).filter(({ diff }) => diff !== 0n)
+}
+
+async function getBalanceAtBlock(
+	client: ReturnType<ReturnType<typeof getConfig>['getClient']>,
+	token: Address.Address,
+	account: Address.Address,
+	blockNumber: bigint,
+): Promise<bigint | null> {
+	try {
+		return await readContract(client, {
+			address: token,
+			abi: Abis.tip20,
+			functionName: 'balanceOf',
+			args: [account],
+			blockNumber,
+		})
+	} catch {
+		return null
+	}
+}
+
+async function getTokenMetadata(
+	client: ReturnType<ReturnType<typeof getConfig>['getClient']>,
+	token: Address.Address,
+) {
+	const [decimals, symbol] = await Promise.all([
+		readContract(client, {
+			address: token,
+			abi: Abis.tip20,
+			functionName: 'decimals',
+		}).catch(() => null),
+		readContract(client, {
+			address: token,
+			abi: Abis.tip20,
+			functionName: 'symbol',
+		}).catch(() => null),
+	])
+	if (decimals === null || symbol === null) return null
+	return { decimals, symbol }
+}
+
+const querySchema = z.object({
+	limit: z.optional(z.coerce.number()),
+	offset: z.optional(z.coerce.number()),
+})
+
+export const Route = createFileRoute('/api/tx/balance-changes/$hash')({
+	server: {
+		handlers: {
+			GET: async ({ params, request }) => {
+				try {
+					const hash = zHash().parse(params.hash)
+					const url = new URL(request.url)
+					const query = querySchema.parse({
+						limit: url.searchParams.get('limit') ?? undefined,
+						offset: url.searchParams.get('offset') ?? undefined,
+					})
+					const limit = Math.min(MAX_LIMIT, query.limit ?? DEFAULT_LIMIT)
+					const offset = query.offset ?? 0
+
+					const config = getConfig()
+					const client = config.getClient()
+
+					const receipt = await getTransactionReceipt(client, { hash }).catch(
+						() => null,
+					)
+
+					if (!receipt)
+						return json({ error: 'Transaction not found' }, { status: 404 })
+
+					const balanceChanges = computeBalanceChanges(receipt.logs)
+
+					if (balanceChanges.length === 0)
+						return json<BalanceChangesData>({
+							changes: [],
+							tokenMetadata: {},
+							total: 0,
+						})
+
+					const uniqueTokens = [
+						...new Set(balanceChanges.map(({ token }) => token)),
+					]
+
+					const [tokenMetadataEntries, balanceAfterResults] = await Promise.all(
+						[
+							Promise.all(
+								uniqueTokens.map(async (token) => [
+									token,
+									await getTokenMetadata(client, token),
+								]),
+							),
+							Promise.all(
+								balanceChanges.map(async (change) => ({
+									...change,
+									balanceAfter: await getBalanceAtBlock(
+										client,
+										change.token,
+										change.address,
+										receipt.blockNumber,
+									),
+								})),
+							),
+						],
+					)
+
+					const tokenMetadata = Object.fromEntries(
+						tokenMetadataEntries.filter(([, meta]) => meta !== null),
+					)
+
+					const allChanges = balanceAfterResults
+						.filter(
+							(change): change is typeof change & { balanceAfter: bigint } =>
+								change.balanceAfter !== null &&
+								Boolean(tokenMetadata[change.token]),
+						)
+						.map((change) => ({
+							address: change.address,
+							token: change.token,
+							balanceBefore: String(change.balanceAfter - change.diff),
+							balanceAfter: String(change.balanceAfter),
+							diff: String(change.diff),
+						}))
+
+					return json<BalanceChangesData>({
+						changes: allChanges.slice(offset, offset + limit),
+						tokenMetadata,
+						total: allChanges.length,
+					})
+				} catch (error) {
+					console.error('Balance changes error:', error)
+					return json(
+						{ error: 'Failed to fetch balance changes' },
+						{ status: 500 },
+					)
+				}
+			},
+		},
+	},
+})


### PR DESCRIPTION
https://github.com/tempoxyz/tempo-apps/issues/142 progress (4/5)

Changes

- Add `/api/tx/balance-changes/$hash` endpoint to compute TIP20 balance diffs from Transfer events.
- Add "Changes" tab to the tx screen, showing balance diffs per address + token.

<img width="2880" height="1482" alt="image" src="https://github.com/user-attachments/assets/cea486dc-a02b-4ec3-9e82-b040f72747fb" />
