### PR TITLE
fix: show memo in tx view if present

### DIFF
--- a/apps/explorer/src/routes/_layout/tx/$hash.tsx
+++ b/apps/explorer/src/routes/_layout/tx/$hash.tsx
@@ -216,38 +216,38 @@ function OverviewSection(props: {
 	const positionInBlock = receipt.transactionIndex
 	const input = transaction.input
 
-        const memoNotes = knownEvents
-                .map((event) => event.note)
-                .filter((note): note is string => typeof note === 'string' && note.trim().length > 0)
+	const memos = knownEvents
+		.map((event) => event.note)
+		.filter((note): note is string => typeof note === 'string' && !!note.trim())
 
-        return (
-                <div className="flex flex-col">
-                        {knownEvents.length > 0 && (
-                                <InfoRow label="Description">
-                                        <div className="flex flex-col gap-[6px]">
-                                                <TxEventDescription.ExpandGroup
-                                                        events={knownEvents}
-                                                        limit={5}
-                                                        limitFilter={(event) =>
-                                                                event.type !== 'active key count changed' &&
-                                                                event.type !== 'nonce incremented'
-                                                        }
-                                                />
-                                                {memoNotes.length > 0 && (
-                                                        <div className="flex flex-row items-center gap-[11px] overflow-hidden">
-                                                                <div className="border-l border-base-border pl-[10px] w-full">
-                                                                        <span
-                                                                                className="text-tertiary items-end overflow-hidden text-ellipsis whitespace-nowrap"
-                                                                                title={memoNotes[0]}
-                                                                        >
-                                                                                {memoNotes[0]}
-                                                                        </span>
-                                                                </div>
-                                                        </div>
-                                                )}
-                                        </div>
-                                </InfoRow>
-                        )}
+	return (
+		<div className="flex flex-col">
+			{knownEvents.length > 0 && (
+				<InfoRow label="Description">
+					<div className="flex flex-col gap-[6px]">
+						<TxEventDescription.ExpandGroup
+							events={knownEvents}
+							limit={5}
+							limitFilter={(event) =>
+								event.type !== 'active key count changed' &&
+								event.type !== 'nonce incremented'
+							}
+						/>
+						{memos.length > 0 && (
+							<div className="flex flex-row items-center gap-[11px] overflow-hidden">
+								<div className="border-l border-base-border pl-[10px] w-full">
+									<span
+										className="text-tertiary items-end overflow-hidden text-ellipsis whitespace-nowrap"
+										title={memos[0]}
+									>
+										{memos[0]}
+									</span>
+								</div>
+							</div>
+						)}
+					</div>
+				</InfoRow>
+			)}
 			<InfoRow label="Value">
 				<span className="text-primary">
 					{Value.format(value, decimals)} {symbol}


### PR DESCRIPTION
## Summary
- surface memo notes below the transaction description when present
- align transaction overview memo display with receipt view styling

## Context
https://tempoxyz.slack.com/archives/C09K91ETGRY/p1765576321927799

## Testing
| Before | After |
| --- | --- |
| <img width="3480" height="2094" alt="CleanShot 2025-12-12 at 17 08 32@2x" src="https://github.com/user-attachments/assets/041fb6c1-811a-4637-ac31-b51e57f8883b" /> | <img width="3220" height="1980" alt="CleanShot 2025-12-12 at 17 06 23@2x" src="https://github.com/user-attachments/assets/aac62dcd-4d1e-4b6d-ae91-75fe52dc83f7" /> |





------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693c903da02c8329a38c9d82b29cd8b8)