### PR TITLE
fix: add rate limiter to Privy env

### DIFF
--- a/apps/fee-payer/wrangler.jsonc
+++ b/apps/fee-payer/wrangler.jsonc
@@ -33,7 +33,17 @@
 			"routes": [
 				{ "pattern": "privy-sponsor.testnet.tempo.xyz", "custom_domain": true }
 			],
-			"workers_dev": false
+			"workers_dev": false,
+			"ratelimits": [
+				{
+					"name": "AddressRateLimiter",
+					"namespace_id": "888",
+					"simple": {
+						"limit": 1000,
+						"period": 60
+					}
+				}
+			]
 		}
 	}
 }


### PR DESCRIPTION
Privy env does not inherit rate limit binding[0] so the Privy fee payer was throwing 500s on requests

[0] https://developers.cloudflare.com/workers/wrangler/environments/#:~:text=For%20example%2C%20bindings%20and%20environment%20variables%20are%20non%2Dinheritable%2C%20and%20must%20be%20specified%20per%20environment%20in%20your%20Wrangler%20configuration%20file.