### PR TITLE
fix: double header on 404s + url params on /blocks

### DIFF
--- a/apps/explorer/src/router.tsx
+++ b/apps/explorer/src/router.tsx
@@ -4,7 +4,6 @@ import { createRouter } from '@tanstack/react-router'
 import { setupRouterSsrQueryIntegration } from '@tanstack/react-router-ssr-query'
 import { hashFn } from 'wagmi/query'
 import { NotFound } from '#comps/NotFound'
-import { Layout } from '#routes/_layout.tsx'
 import { routeTree } from '#routeTree.gen.ts'
 
 export const getRouter = () => {
@@ -25,11 +24,7 @@ export const getRouter = () => {
 		context: { queryClient },
 		defaultPreload: 'intent',
 		defaultPreloadDelay: 150,
-		defaultNotFoundComponent: () => (
-			<Layout>
-				<NotFound />
-			</Layout>
-		),
+		defaultNotFoundComponent: () => <NotFound />,
 	})
 
 	// @see https://tanstack.com/router/latest/docs/integrations/query

--- a/apps/explorer/src/routes/_layout/blocks.tsx
+++ b/apps/explorer/src/routes/_layout/blocks.tsx
@@ -19,16 +19,21 @@ const recentlyAddedBlocks = new Set<string>()
 export const Route = createFileRoute('/_layout/blocks')({
 	component: RouteComponent,
 	validateSearch: z.object({
-		page: z.prefault(z.coerce.number(), 1),
-		live: z.prefault(z.coerce.boolean(), true),
+		page: z.optional(z.coerce.number()),
+		live: z.optional(z.coerce.boolean()),
 	}),
-	loaderDeps: ({ search: { page, live } }) => ({ page, live }),
+	loaderDeps: ({ search: { page, live } }) => ({
+		page: page ?? 1,
+		live: live ?? (page ?? 1) === 1,
+	}),
 	loader: async ({ deps, context }) =>
 		context.queryClient.ensureQueryData(blocksQueryOptions(deps.page)),
 })
 
 function RouteComponent() {
-	const { page = 1, live = true } = Route.useSearch()
+	const search = Route.useSearch()
+	const page = search.page ?? 1
+	const live = search.live ?? page === 1
 	const loaderData = Route.useLoaderData()
 
 	const { data: queryData } = useQuery({


### PR DESCRIPTION
- remove `<Layout>` from `defaultNotFoundComponent` in `router.tsx` to prevent a double header.
- move from `z.prefault` to `z.optional` for the /blocks search params, to prevent default values from being added to the url.
- default `live` to `true` on page 1, `false` on other pages.

|before|after|
|-|-|
| <img width="2880" height="1530" alt="image" src="https://github.com/user-attachments/assets/b9c13570-b300-4fc7-913d-47f33fafc2da" />|<img width="2880" height="1530" alt="image" src="https://github.com/user-attachments/assets/5ee92fb0-36b7-4cef-8f5a-9107fcbc280f" />|