### PR TITLE
feat: show failed status on receipt view

### DIFF
--- a/apps/explorer/src/comps/Receipt.tsx
+++ b/apps/explorer/src/comps/Receipt.tsx
@@ -17,6 +17,7 @@ export function Receipt(props: Receipt.Props) {
 		sender,
 		hash,
 		timestamp,
+		status,
 		events = [],
 		fee,
 		total,
@@ -46,7 +47,7 @@ export function Receipt(props: Receipt.Props) {
 					</div>
 					<div className="flex flex-col gap-[8px] font-mono text-[13px] leading-[16px] flex-1">
 						<div className="flex justify-between items-end">
-							<span className="text-tertiary capitalize">Block</span>
+							<span className="text-tertiary">Block</span>
 							<Link
 								to="/block/$id"
 								params={{ id: blockNumber.toString() }}
@@ -56,7 +57,7 @@ export function Receipt(props: Receipt.Props) {
 							</Link>
 						</div>
 						<div className="flex justify-between items-end gap-4">
-							<span className="text-tertiary capitalize shrink-0">Sender</span>
+							<span className="text-tertiary shrink-0">Sender</span>
 							<Link
 								to="/address/$address"
 								params={{ address: sender }}
@@ -67,7 +68,7 @@ export function Receipt(props: Receipt.Props) {
 						</div>
 						<div className="flex justify-between items-start gap-4">
 							<div className="relative shrink-0">
-								<span className="text-tertiary capitalize">Hash</span>
+								<span className="text-tertiary">Hash</span>
 								{copyHash.notifying && (
 									<span className="absolute left-[calc(100%+8px)] text-[13px] leading-[16px] text-accent">
 										copied
@@ -93,18 +94,26 @@ export function Receipt(props: Receipt.Props) {
 							)}
 						</div>
 						<div className="flex justify-between items-end">
-							<span className="text-tertiary capitalize">Date</span>
+							<span className="text-tertiary">Date</span>
 							<span className="text-right">
 								{DateFormatter.formatTimestampDate(timestamp)}
 							</span>
 						</div>
 						<div className="flex justify-between items-end">
-							<span className="text-tertiary capitalize">Time</span>
+							<span className="text-tertiary">Time</span>
 							<span className="text-right">
 								{formattedTime.time} {formattedTime.timezone}
 								<span className="text-tertiary">{formattedTime.offset}</span>
 							</span>
 						</div>
+						{status === 'reverted' && (
+							<div className="flex justify-between items-end">
+								<span className="text-tertiary">Status</span>
+								<span className="text-base-content-negative uppercase text-[11px]">
+									Failed
+								</span>
+							</div>
+						)}
 					</div>
 				</div>
 				{filteredEvents.length > 0 && (
@@ -301,6 +310,7 @@ export namespace Receipt {
 		sender: Address.Address
 		hash: Hex.Hex
 		timestamp: bigint
+		status?: 'success' | 'reverted'
 		events?: KnownEvent[]
 		fee?: number
 		feeDisplay?: string

--- a/apps/explorer/src/routes/_layout/receipt/$hash.tsx
+++ b/apps/explorer/src/routes/_layout/receipt/$hash.tsx
@@ -331,6 +331,7 @@ function Component() {
 				feeDisplay={feeDisplay}
 				hash={receipt.transactionHash}
 				sender={receipt.from}
+				status={receipt.status}
 				timestamp={block.timestamp}
 				total={total}
 				totalDisplay={totalDisplay}


### PR DESCRIPTION
demo

[/receipt (current)](https://explore.tempo.xyz/receipt/0xa83ff8ec36fdf7e68ff27e68e0ab7d68ed0581a14ce9ce9146d53164fd03ea7d)
[/receipt (updated)](https://808814e9-explorer.porto.workers.dev/receipt/0xa83ff8ec36fdf7e68ff27e68e0ab7d68ed0581a14ce9ce9146d53164fd03ea7d)

preview

<img width="2880" height="1528" alt="image" src="https://github.com/user-attachments/assets/3593f760-96fa-4b79-84c1-a08a2ed12db8" />
