### PR TITLE
fix: expand addresses on the calls tab of /tx

### DIFF
--- a/apps/explorer/src/routes/_layout/tx/$hash.tsx
+++ b/apps/explorer/src/routes/_layout/tx/$hash.tsx
@@ -456,7 +456,7 @@ function CallItem(props: {
 					<Link
 						to="/address/$address"
 						params={{ address: call.to }}
-						className="text-accent hover:underline press-down"
+						className="flex-1 text-accent hover:underline press-down"
 					>
 						<Midcut value={call.to} prefix="0x" />
 					</Link>


### PR DESCRIPTION
demo
https://a9f40e78-explorer.porto.workers.dev/tx/0x6d6d8c102064e6dee44abad2024a8b1d37959230baab80e70efbf9b0c739c4fd?tab=calls

before
<img width="2880" height="1520" alt="image" src="https://github.com/user-attachments/assets/d8d02930-cdb2-4a0e-97f1-4ede1ba478d2" />

after
<img width="2880" height="1520" alt="image" src="https://github.com/user-attachments/assets/734e7d6a-68ab-4793-91c1-d0728318ffae" />

