### PR TITLE
fix: blinking ExploreInput during navigation

### DIFF
--- a/apps/explorer/src/comps/Header.tsx
+++ b/apps/explorer/src/comps/Header.tsx
@@ -40,6 +40,7 @@ export namespace Header {
 		const navigate = useNavigate()
 		const [inputValue, setInputValue] = React.useState('')
 		const [isMounted, setIsMounted] = React.useState(false)
+		const [delayedNavigating, setDelayedNavigating] = React.useState(false)
 		const { currentPathname, isNavigating } = useRouterState({
 			select: (state) => ({
 				currentPathname:
@@ -57,13 +58,23 @@ export namespace Header {
 			})
 		}, [router])
 
+		// delay disabling the input to avoid blinking on fast navigations
+		React.useEffect(() => {
+			if (!isNavigating) {
+				setDelayedNavigating(false)
+				return
+			}
+			const timer = setTimeout(() => setDelayedNavigating(true), 100)
+			return () => clearTimeout(timer)
+		}, [isNavigating])
+
 		return (
 			showSearch && (
 				<div className="absolute left-0 right-0 justify-center hidden @min-[1240px]:flex z-1 h-0 items-center">
 					<ExploreInput
 						value={inputValue}
 						onChange={setInputValue}
-						disabled={isMounted && isNavigating}
+						disabled={isMounted && delayedNavigating}
 						onActivate={({ value, type }) => {
 							if (type === 'hash') {
 								navigate({ to: '/receipt/$hash', params: { hash: value } })


### PR DESCRIPTION
even when a URL update is near instant, it’s enough to trigger the `pending` router state and see the explore input in a disabled state. this gets solved by adding a 100ms delay before showing the disabled state.

before

https://github.com/user-attachments/assets/8f007dc2-6821-469c-a5b5-0c63506b55a7

after

https://github.com/user-attachments/assets/1baa849f-e528-43f4-838f-7af70798ee24



