### PR TITLE
fix: use the token address for the TokenCreated known event

### DIFF
--- a/apps/explorer/src/lib/domain/known-events.ts
+++ b/apps/explorer/src/lib/domain/known-events.ts
@@ -338,14 +338,17 @@ function createDetectors(
 		},
 
 		tip20Factory(event: ParsedEvent) {
-			const { eventName, args, address } = event
+			const { eventName, args } = event
 
 			if (eventName === 'TokenCreated')
 				return {
 					type: 'create token',
 					parts: [
 						{ type: 'action', value: 'Create Token' },
-						{ type: 'token', value: { address, symbol: args.symbol } },
+						{
+							type: 'token',
+							value: { address: args.token, symbol: args.symbol },
+						},
 					],
 				}
 


### PR DESCRIPTION
It was wrongly pointing to the factory address.
