### PR TITLE
chore: remove tempoDevnet patch in fee-payer app

### DIFF
--- a/apps/fee-payer/package.json
+++ b/apps/fee-payer/package.json
@@ -20,9 +20,9 @@
 		"hono": "catalog:",
 		"idxs": "catalog:",
 		"kysely": "catalog:",
-		"ox": "catalog:",
+		"ox": "^0.11.1",
 		"tempo.ts": "catalog:",
-		"viem": "catalog:",
+		"viem": "^2.43.3",
 		"zod": "catalog:"
 	},
 	"devDependencies": {

--- a/apps/fee-payer/src/index.ts
+++ b/apps/fee-payer/src/index.ts
@@ -2,11 +2,12 @@ import { env } from 'cloudflare:workers'
 import { zValidator } from '@hono/zod-validator'
 import { Hono } from 'hono'
 import { cors } from 'hono/cors'
-import { tempoDevnet, tempoTestnet } from 'tempo.ts/chains'
 import { Handler } from 'tempo.ts/server'
 import { http } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
+import { type Chain, tempoDevnet, tempoTestnet } from 'viem/chains'
 import * as z from 'zod'
+import { alphaUsd } from './lib/consts.js'
 import { rateLimitMiddleware } from './lib/rate-limit.js'
 import { getUsage } from './lib/usage.js'
 
@@ -14,20 +15,12 @@ const app = new Hono()
 
 const tempoChain =
 	env.TEMPO_ENV === 'devnet'
-		? {
-				...tempoDevnet({
-					feeToken: '0x20c0000000000000000000000000000000000001',
-				}),
-				// todo: following is a patch until we consume https://github.com/wevm/viem/pull/4189
-				id: 42429,
-				rpcUrls: {
-					default: {
-						http: ['https://rpc.devnet.tempoxyz.dev'],
-						webSocket: ['wss://rpc.devnet.tempoxyz.dev'],
-					},
-				},
-			}
-		: tempoTestnet({ feeToken: '0x20c0000000000000000000000000000000000001' })
+		? tempoDevnet.extend({
+				feeToken: alphaUsd,
+			})
+		: tempoTestnet.extend({
+				feeToken: alphaUsd,
+			})
 
 app.use(
 	'*',
@@ -70,7 +63,7 @@ app.get(
 app.all('*', rateLimitMiddleware, async (c) => {
 	const handler = Handler.feePayer({
 		account: privateKeyToAccount(env.SPONSOR_PRIVATE_KEY as `0x${string}`),
-		chain: tempoChain,
+		chain: tempoChain as Chain,
 		transport: http(env.TEMPO_RPC_URL),
 		async onRequest(request) {
 			console.log(`Sponsoring transaction: ${request.method}`)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -449,14 +449,14 @@ importers:
         specifier: 'catalog:'
         version: 0.28.9
       ox:
-        specifier: 'catalog:'
-        version: 0.10.5(typescript@5.9.3)(zod@4.2.1)
+        specifier: ^0.11.1
+        version: 0.11.1(typescript@5.9.3)(zod@4.2.1)
       tempo.ts:
         specifier: 'catalog:'
-        version: 0.11.1(@remix-run/headers@0.17.2)(@remix-run/route-pattern@0.15.3)(@remix-run/session@0.4.1)(@tanstack/query-core@5.90.12)(@tanstack/react-query@5.90.12(react@19.2.3))(@wagmi/core@3.0.0(@tanstack/query-core@5.90.12)(@types/react@19.2.7)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.3))(viem@2.43.1(typescript@5.9.3)(zod@4.2.1)))(typescript@5.9.3)(viem@2.43.1(typescript@5.9.3)(zod@4.2.1))(wagmi@3.1.0(@tanstack/query-core@5.90.12)(@tanstack/react-query@5.90.12(react@19.2.3))(@types/react@19.2.7)(react@19.2.3)(typescript@5.9.3)(viem@2.43.1(typescript@5.9.3)(zod@4.2.1)))(zod@4.2.1)
+        version: 0.11.1(@remix-run/headers@0.17.2)(@remix-run/route-pattern@0.15.3)(@remix-run/session@0.4.1)(@tanstack/query-core@5.90.12)(@tanstack/react-query@5.90.12(react@19.2.3))(@wagmi/core@3.0.0(@tanstack/query-core@5.90.12)(@types/react@19.2.7)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.3))(viem@2.43.3(typescript@5.9.3)(zod@4.2.1)))(typescript@5.9.3)(viem@2.43.3(typescript@5.9.3)(zod@4.2.1))(wagmi@3.1.0(@tanstack/query-core@5.90.12)(@tanstack/react-query@5.90.12(react@19.2.3))(@types/react@19.2.7)(react@19.2.3)(typescript@5.9.3)(viem@2.43.3(typescript@5.9.3)(zod@4.2.1)))(zod@4.2.1)
       viem:
-        specifier: 'catalog:'
-        version: 2.43.1(typescript@5.9.3)(zod@4.2.1)
+        specifier: ^2.43.3
+        version: 2.43.3(typescript@5.9.3)(zod@4.2.1)
       zod:
         specifier: 'catalog:'
         version: 4.2.1
@@ -4945,6 +4945,14 @@ packages:
       typescript:
         optional: true
 
+  ox@0.11.1:
+    resolution: {integrity: sha512-1l1gOLAqg0S0xiN1dH5nkPna8PucrZgrIJOfS49MLNiMevxu07Iz4ZjuJS9N+xifvT+PsZyIptS7WHM8nC+0+A==}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   ox@0.9.17:
     resolution: {integrity: sha512-rKAnhzhRU3Xh3hiko+i1ZxywZ55eWQzeS/Q4HRKLx2PqfHOolisZHErSsJVipGlmQKHW5qwOED/GighEw9dbLg==}
     peerDependencies:
@@ -5726,6 +5734,14 @@ packages:
 
   viem@2.43.1:
     resolution: {integrity: sha512-S33pBNlRvOlVv4+L94Z8ydCMDB1j0cuHFUvaC28i6OTxw3uY1P4M3h1YDFK8YC1H9/lIbeBTTvCRhi0FqU/2iw==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  viem@2.43.3:
+    resolution: {integrity: sha512-zM251fspfSjENCtfmT7cauuD+AA/YAlkFU7cksdEQJxj7wDuO0XFRWRH+RMvfmTFza88B9kug5cKU+Wk2nAjJg==}
     peerDependencies:
       typescript: '>=5.0.4'
     peerDependenciesMeta:
@@ -9085,6 +9101,14 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
+  '@wagmi/connectors@7.0.2(@wagmi/core@3.0.0(@tanstack/query-core@5.90.12)(@types/react@19.2.7)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.3))(viem@2.43.3(typescript@5.9.3)(zod@4.2.1)))(typescript@5.9.3)(viem@2.43.3(typescript@5.9.3)(zod@4.2.1))':
+    dependencies:
+      '@wagmi/core': 3.0.0(@tanstack/query-core@5.90.12)(@types/react@19.2.7)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.3))(viem@2.43.3(typescript@5.9.3)(zod@4.2.1))
+      viem: 2.43.3(typescript@5.9.3)(zod@4.2.1)
+    optionalDependencies:
+      typescript: 5.9.3
+    optional: true
+
   '@wagmi/core@3.0.0(@tanstack/query-core@5.90.12)(@types/react@19.2.7)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.3))(viem@2.43.1(typescript@5.9.3)(zod@4.2.1))':
     dependencies:
       eventemitter3: 5.0.1
@@ -9100,6 +9124,22 @@ snapshots:
       - react
       - use-sync-external-store
 
+  '@wagmi/core@3.0.0(@tanstack/query-core@5.90.12)(@types/react@19.2.7)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.3))(viem@2.43.3(typescript@5.9.3)(zod@4.2.1))':
+    dependencies:
+      eventemitter3: 5.0.1
+      mipd: 0.0.7(typescript@5.9.3)
+      viem: 2.43.3(typescript@5.9.3)(zod@4.2.1)
+      zustand: 5.0.0(@types/react@19.2.7)(react@19.2.3)(use-sync-external-store@1.4.0(react@19.2.3))
+    optionalDependencies:
+      '@tanstack/query-core': 5.90.12
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+      - react
+      - use-sync-external-store
+    optional: true
+
   '@wagmi/core@3.0.0(@tanstack/query-core@5.90.12)(@types/react@19.2.7)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.3))(viem@2.43.1(typescript@5.9.3)(zod@4.2.1))':
     dependencies:
       eventemitter3: 5.0.1
@@ -9114,6 +9154,22 @@ snapshots:
       - immer
       - react
       - use-sync-external-store
+
+  '@wagmi/core@3.0.0(@tanstack/query-core@5.90.12)(@types/react@19.2.7)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.3))(viem@2.43.3(typescript@5.9.3)(zod@4.2.1))':
+    dependencies:
+      eventemitter3: 5.0.1
+      mipd: 0.0.7(typescript@5.9.3)
+      viem: 2.43.3(typescript@5.9.3)(zod@4.2.1)
+      zustand: 5.0.0(@types/react@19.2.7)(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
+    optionalDependencies:
+      '@tanstack/query-core': 5.90.12
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+      - react
+      - use-sync-external-store
+    optional: true
 
   abitype@1.2.3(typescript@5.9.3)(zod@4.2.1):
     optionalDependencies:
@@ -10728,6 +10784,21 @@ snapshots:
     transitivePeerDependencies:
       - zod
 
+  ox@0.11.1(typescript@5.9.3)(zod@4.2.1):
+    dependencies:
+      '@adraffy/ens-normalize': 1.11.1
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@5.9.3)(zod@4.2.1)
+      eventemitter3: 5.0.1
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - zod
+
   ox@0.9.17(typescript@5.9.3)(zod@4.2.1):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
@@ -11378,6 +11449,24 @@ snapshots:
       - typescript
       - zod
 
+  tempo.ts@0.11.1(@remix-run/headers@0.17.2)(@remix-run/route-pattern@0.15.3)(@remix-run/session@0.4.1)(@tanstack/query-core@5.90.12)(@tanstack/react-query@5.90.12(react@19.2.3))(@wagmi/core@3.0.0(@tanstack/query-core@5.90.12)(@types/react@19.2.7)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.3))(viem@2.43.3(typescript@5.9.3)(zod@4.2.1)))(typescript@5.9.3)(viem@2.43.3(typescript@5.9.3)(zod@4.2.1))(wagmi@3.1.0(@tanstack/query-core@5.90.12)(@tanstack/react-query@5.90.12(react@19.2.3))(@types/react@19.2.7)(react@19.2.3)(typescript@5.9.3)(viem@2.43.3(typescript@5.9.3)(zod@4.2.1)))(zod@4.2.1):
+    dependencies:
+      '@remix-run/fetch-router': 0.12.0(@remix-run/headers@0.17.2)(@remix-run/route-pattern@0.15.3)(@remix-run/session@0.4.1)
+      idb-keyval: 6.2.2
+      ox: 0.10.5(typescript@5.9.3)(zod@4.2.1)
+    optionalDependencies:
+      '@tanstack/query-core': 5.90.12
+      '@tanstack/react-query': 5.90.12(react@19.2.3)
+      '@wagmi/core': 3.0.0(@tanstack/query-core@5.90.12)(@types/react@19.2.7)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.3))(viem@2.43.3(typescript@5.9.3)(zod@4.2.1))
+      viem: 2.43.3(typescript@5.9.3)(zod@4.2.1)
+      wagmi: 3.1.0(@tanstack/query-core@5.90.12)(@tanstack/react-query@5.90.12(react@19.2.3))(@types/react@19.2.7)(react@19.2.3)(typescript@5.9.3)(viem@2.43.3(typescript@5.9.3)(zod@4.2.1))
+    transitivePeerDependencies:
+      - '@remix-run/headers'
+      - '@remix-run/route-pattern'
+      - '@remix-run/session'
+      - typescript
+      - zod
+
   text-decoder@1.2.3:
     dependencies:
       b4a: 1.7.3
@@ -11592,6 +11681,23 @@ snapshots:
       - utf-8-validate
       - zod
 
+  viem@2.43.3(typescript@5.9.3)(zod@4.2.1):
+    dependencies:
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@5.9.3)(zod@4.2.1)
+      isows: 1.0.7(ws@8.18.3)
+      ox: 0.11.1(typescript@5.9.3)(zod@4.2.1)
+      ws: 8.18.3
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - zod
+
   vite-node@3.2.4(@types/node@24.10.4)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       cac: 6.7.14
@@ -11732,6 +11838,30 @@ snapshots:
       - '@walletconnect/ethereum-provider'
       - immer
       - porto
+
+  wagmi@3.1.0(@tanstack/query-core@5.90.12)(@tanstack/react-query@5.90.12(react@19.2.3))(@types/react@19.2.7)(react@19.2.3)(typescript@5.9.3)(viem@2.43.3(typescript@5.9.3)(zod@4.2.1)):
+    dependencies:
+      '@tanstack/react-query': 5.90.12(react@19.2.3)
+      '@wagmi/connectors': 7.0.2(@wagmi/core@3.0.0(@tanstack/query-core@5.90.12)(@types/react@19.2.7)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.3))(viem@2.43.3(typescript@5.9.3)(zod@4.2.1)))(typescript@5.9.3)(viem@2.43.3(typescript@5.9.3)(zod@4.2.1))
+      '@wagmi/core': 3.0.0(@tanstack/query-core@5.90.12)(@types/react@19.2.7)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.3))(viem@2.43.3(typescript@5.9.3)(zod@4.2.1))
+      react: 19.2.3
+      use-sync-external-store: 1.4.0(react@19.2.3)
+      viem: 2.43.3(typescript@5.9.3)(zod@4.2.1)
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@base-org/account'
+      - '@coinbase/wallet-sdk'
+      - '@gemini-wallet/core'
+      - '@metamask/sdk'
+      - '@safe-global/safe-apps-provider'
+      - '@safe-global/safe-apps-sdk'
+      - '@tanstack/query-core'
+      - '@types/react'
+      - '@walletconnect/ethereum-provider'
+      - immer
+      - porto
+    optional: true
 
   web-namespaces@2.0.1: {}
 


### PR DESCRIPTION
**changes**
- bumps viem and ox in fee-payer app
- removes `tempoDevnet` patch post https://github.com/wevm/viem/pull/4189

**testing**
- `cd apps/fee-payer && pnpm dev`
- pointed localhost docs at dev fee-payer localhost:8787 and sponsorship still works