### PR TITLE
fix: use `process.env.INDEXER_API_KEY`

### DIFF
--- a/apps/explorer/src/routes/api/address/total-value/$address.ts
+++ b/apps/explorer/src/routes/api/address/total-value/$address.ts
@@ -1,4 +1,3 @@
-import { env } from 'cloudflare:workers'
 import { createFileRoute } from '@tanstack/react-router'
 import { json } from '@tanstack/react-start'
 import * as IDX from 'idxs'
@@ -11,7 +10,7 @@ import { zAddress } from '#lib/zod.ts'
 import { config, getConfig } from '#wagmi.config.ts'
 
 const IS = IDX.IndexSupply.create({
-	apiKey: env.INDEXER_API_KEY,
+	apiKey: process.env.INDEXER_API_KEY,
 })
 
 const QB = IDX.QueryBuilder.from(IS)


### PR DESCRIPTION
Noticed `apps/explorer/src/routes/api/address/total-value/$address.ts` wasn't grabbing `INDEXER_API_KEY` from `process.env` like the other files. Showed up as an error in `pnpm check:types`