### PR TITLE
fix: fee-payer usage endpoint should be env aware

### DIFF
--- a/apps/fee-payer/src/index.ts
+++ b/apps/fee-payer/src/index.ts
@@ -5,22 +5,13 @@ import { cors } from 'hono/cors'
 import { Handler } from 'tempo.ts/server'
 import { http } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
-import { type Chain, tempoDevnet, tempoTestnet } from 'viem/chains'
+import type { Chain } from 'viem/chains'
 import * as z from 'zod'
-import { alphaUsd } from './lib/consts.js'
+import { tempoChain } from './lib/chain.js'
 import { rateLimitMiddleware } from './lib/rate-limit.js'
 import { getUsage } from './lib/usage.js'
 
 const app = new Hono()
-
-const tempoChain =
-	env.TEMPO_ENV === 'devnet'
-		? tempoDevnet.extend({
-				feeToken: alphaUsd,
-			})
-		: tempoTestnet.extend({
-				feeToken: alphaUsd,
-			})
 
 app.use(
 	'*',

--- a/apps/fee-payer/src/lib/chain.ts
+++ b/apps/fee-payer/src/lib/chain.ts
@@ -1,0 +1,8 @@
+import { env } from 'cloudflare:workers'
+import { tempoDevnet, tempoTestnet } from 'viem/chains'
+import { alphaUsd } from './consts.js'
+
+export const tempoChain =
+	env.TEMPO_ENV === 'devnet'
+		? tempoDevnet.extend({ feeToken: alphaUsd })
+		: tempoTestnet.extend({ feeToken: alphaUsd })

--- a/apps/fee-payer/src/lib/usage.ts
+++ b/apps/fee-payer/src/lib/usage.ts
@@ -3,8 +3,8 @@ import * as IDX from 'idxs'
 import { sql } from 'kysely'
 import type { Address } from 'ox'
 import { createPublicClient, formatUnits, http } from 'viem'
-import { tempoTestnet } from 'viem/chains'
 import { Actions, Addresses } from 'viem/tempo'
+import { tempoChain } from './chain.js'
 import { alphaUsd } from './consts.js'
 
 const IS = IDX.IndexSupply.create({
@@ -39,7 +39,7 @@ export async function getUsage(
 			sql<number>`min(transfer.block_timestamp)`.as('starting_at'),
 			eb.fn.count('tx_hash').as('n_transactions'),
 		])
-		.where('chain', '=', tempoTestnet.id)
+		.where('chain', '=', tempoChain.id)
 		.where('from', '=', feePayerAddress)
 		.where('to', '=', Addresses.feeManager)
 		.$if(blockTimestampFrom !== undefined, (eb) =>
@@ -62,7 +62,7 @@ export async function getUsage(
 	const feesPaid = result?.total_spent ? BigInt(result.total_spent) : 0n
 	const feeTokenMetadata = await Actions.token.getMetadata(
 		createPublicClient({
-			chain: tempoTestnet,
+			chain: tempoChain,
 			transport: http(),
 		}),
 		{ token: alphaUsd },


### PR DESCRIPTION
### motivation

The usage IS query was using a hardcoded testnet ID when instead it should be environment aware to pass the right chain ID through.

### change

- centralizes Tempo chain definition based on environment
- usage and fee payer handler pull Tempo chain from ^
