### PR TITLE
feat(explorer): key "t" to toggle between transaction and receipt views

### DIFF
--- a/apps/explorer/src/lib/hooks.ts
+++ b/apps/explorer/src/lib/hooks.ts
@@ -124,7 +124,7 @@ export declare namespace useDownload {
 	}
 }
 
-export function useKeyboardShortcut(key: string, callback: () => void) {
+export function useKeyboardShortcut(shortcuts: Record<string, () => void>) {
 	React.useEffect(() => {
 		const handleKeyDown = (event: KeyboardEvent) => {
 			const target = event.target as HTMLElement
@@ -135,17 +135,18 @@ export function useKeyboardShortcut(key: string, callback: () => void) {
 			) {
 				return
 			}
+			const key = event.key.toLowerCase()
 			if (
-				event.key.toLowerCase() === key.toLowerCase() &&
 				!event.metaKey &&
 				!event.ctrlKey &&
-				!event.altKey
+				!event.altKey &&
+				key in shortcuts
 			) {
 				event.preventDefault()
-				callback()
+				shortcuts[key]()
 			}
 		}
 		window.addEventListener('keydown', handleKeyDown)
 		return () => window.removeEventListener('keydown', handleKeyDown)
-	}, [key, callback])
+	}, [shortcuts])
 }

--- a/apps/explorer/src/routes/_layout/receipt/$hash.tsx
+++ b/apps/explorer/src/routes/_layout/receipt/$hash.tsx
@@ -312,9 +312,9 @@ function Component() {
 		initialData: loaderData,
 	})
 
-	useKeyboardShortcut('t', () =>
-		navigate({ to: '/tx/$hash', params: { hash } }),
-	)
+	useKeyboardShortcut({
+		t: () => navigate({ to: '/tx/$hash', params: { hash } }),
+	})
 
 	const { block, knownEvents, lineItems, receipt } = data
 

--- a/apps/explorer/src/routes/_layout/tx/$hash.tsx
+++ b/apps/explorer/src/routes/_layout/tx/$hash.tsx
@@ -163,12 +163,13 @@ function RouteComponent() {
 	const isMobile = useMediaQuery('(max-width: 799px)')
 	const mode = isMobile ? 'stacked' : 'tabs'
 
-	useKeyboardShortcut('t', () =>
-		navigate({
-			to: '/receipt/$hash',
-			params: { hash: receipt.transactionHash },
-		}),
-	)
+	useKeyboardShortcut({
+		t: () =>
+			navigate({
+				to: '/receipt/$hash',
+				params: { hash: receipt.transactionHash },
+			}),
+	})
 
 	const calls = 'calls' in transaction ? transaction.calls : undefined
 	const hasCalls = Boolean(calls && calls.length > 0)


### PR DESCRIPTION
### motivation

When looking at transactions I toggle to the receipt view a fair amount.

### change

Adds a key listener on "t" for the tx and receipt pages to toggle between them

### testing

https://github.com/user-attachments/assets/dbcb0332-c076-44be-bbbf-918d062f2e92

### what's next?

What other keybindings would be nice to have?

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>


Implements keyboard shortcut "t" to toggle between transaction and receipt views in the explorer. Added a reusable `useKeyboardShortcut` hook that prevents activation when typing in input fields or when modifier keys are pressed. Also includes a bug fix for `ALLOWED_HOSTS` env variable handling and reformatted an SVG icon.

- Introduced `useKeyboardShortcut` hook in `hooks.ts` with input field detection and modifier key filtering
- Integrated "t" key shortcut on both `/tx/$hash` and `/receipt/$hash` routes to navigate between views
- Fixed optional chaining for `ALLOWED_HOSTS` environment variable to handle undefined values
- Reformatted pathUSD token SVG icon (changed from blue to black fill)


</details>
<details><summary><h3>Confidence Score: 3/5</h3></summary>


- Safe to merge after fixing the stale closure bug in useKeyboardShortcut hook
- The keyboard shortcut implementation is straightforward and well-designed with proper input field detection. However, the missing `callback` dependency in the useEffect causes a stale closure bug that could lead to incorrect navigation behavior. The fix is simple but critical.
- Pay attention to `apps/explorer/src/lib/hooks.ts` - the dependency array bug must be fixed
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/explorer/src/lib/hooks.ts | Added `useKeyboardShortcut` hook with missing dependency causing stale closure bug |
| apps/explorer/src/routes/_layout/receipt/$hash.tsx | Integrated keyboard shortcut to navigate to tx view using "t" key |
| apps/explorer/src/routes/_layout/tx/$hash.tsx | Integrated keyboard shortcut to navigate to receipt view using "t" key |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant Browser
    participant TxPage as /tx/$hash
    participant ReceiptPage as /receipt/$hash
    participant Hook as useKeyboardShortcut

    User->>Browser: Press "t" key
    Browser->>Hook: keydown event
    Hook->>Hook: Check if target is INPUT/TEXTAREA
    Hook->>Hook: Check if key is "t" (no modifiers)
    Hook->>Hook: event.preventDefault()
    
    alt From Transaction Page
        Hook->>TxPage: Execute callback
        TxPage->>Browser: navigate({ to: '/receipt/$hash' })
        Browser->>ReceiptPage: Navigate to receipt view
    else From Receipt Page
        Hook->>ReceiptPage: Execute callback
        ReceiptPage->>Browser: navigate({ to: '/tx/$hash' })
        Browser->>TxPage: Navigate to transaction view
    end
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->