### PR TITLE
fix: temporarily use testnet instead of prool for fee-payer CI test

### DIFF
--- a/.github/workflows/test-fee-payer.yml
+++ b/.github/workflows/test-fee-payer.yml
@@ -35,5 +35,6 @@ jobs:
         uses: ./.github/actions/install-dependencies
 
       - name: Run tests
-        run: pnpm test
+        # TODO(struong): use prool instance once Moderato hardfork lands
+        run: pnpm test:testnet
         working-directory: apps/fee-payer


### PR DESCRIPTION
### motivation

fee-payer CI test is failing with liquidity issues. Debugged and found that a changed ABI also breaks the test. Upstream changes to viem will fix in https://github.com/wevm/viem/pull/4201 but we can get CI to pass for the time being by pointing to testnet instead

### change

Run `pnpm test:testnet` for CI tests

### testing

""

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>


Temporarily switches CI tests to use testnet instead of prool local instance to work around liquidity issues and ABI breaking changes. Once the Moderato hardfork lands in viem ([wevm/viem#4201](https://github.com/wevm/viem/pull/4201)), this should be reverted to use the prool instance again.

- Changed test command from `pnpm test` to `pnpm test:testnet` in fee-payer CI workflow
- Added TODO comment indicating this is temporary until Moderato hardfork support lands
- Minor style issue: `TEMPO_ENV` env var in workflow still set to `localnet` (the test script overrides this, but could cause confusion)


</details>
<details><summary><h3>Confidence Score: 4/5</h3></summary>


- Safe temporary workaround with clear TODO for reverting once upstream fix lands
- Simple change that switches test environment. The TODO comment makes it clear this is temporary. Only minor style issue with env var inconsistency that doesn't affect functionality.
- No files require special attention - straightforward test environment change
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/test-fee-payer.yml | Changed test command from `pnpm test` to `pnpm test:testnet` as temporary workaround for liquidity issues and ABI changes. Minor inconsistency with `TEMPO_ENV` env var still set to localnet. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant GH as GitHub Actions
    participant WF as test-fee-payer.yml
    participant PKG as package.json
    participant VC as vitest.config.ts
    participant TS as Test Suite

    GH->>WF: Trigger workflow
    WF->>WF: Set TEMPO_ENV=localnet (env var)
    WF->>PKG: Run pnpm test:testnet
    PKG->>PKG: Set TEMPO_ENV=testnet (overrides)
    PKG->>VC: Execute vitest --run
    VC->>VC: Read TEMPO_ENV=testnet
    VC->>VC: Set RPC URL to https://rpc.testnet.tempo.xyz
    VC->>VC: Skip prool local setup (line 33)
    VC->>TS: Run tests against testnet
    TS->>TS: Execute fee-payer integration tests
    TS-->>GH: Return test results
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->