### PR TITLE
fix(explorer): hide category buttons when search dropdown is open

### DIFF
--- a/apps/explorer/src/comps/ExploreInput.tsx
+++ b/apps/explorer/src/comps/ExploreInput.tsx
@@ -22,6 +22,7 @@ export function ExploreInput(props: ExploreInput.Props) {
 		size = 'medium',
 		disabled,
 		className,
+		onDropdownVisibilityChange,
 	} = props
 	const formRef = React.useRef<HTMLFormElement>(null)
 	const resultsRef = React.useRef<HTMLDivElement>(null)
@@ -87,6 +88,10 @@ export function ExploreInput(props: ExploreInput.Props) {
 	React.useEffect(() => {
 		setShowResults(disabled ? false : query.length > 0)
 	}, [query, disabled])
+
+	React.useEffect(() => {
+		onDropdownVisibilityChange?.(showResults)
+	}, [showResults, onDropdownVisibilityChange])
 
 	const lastResultsKey = React.useRef('')
 	const resultsKey = JSON.stringify(flatSuggestions)
@@ -365,6 +370,7 @@ export namespace ExploreInput {
 		size?: 'large' | 'medium'
 		disabled?: boolean
 		className?: string
+		onDropdownVisibilityChange?: (visible: boolean) => void
 	}
 
 	export type SuggestionGroup = {

--- a/apps/explorer/src/routes/_layout/index.tsx
+++ b/apps/explorer/src/routes/_layout/index.tsx
@@ -27,6 +27,7 @@ function Component() {
 	const [inputValue, setInputValue] = useState('')
 	const [isMounted, setIsMounted] = useState(false)
 	const [introPhase, setIntroPhase] = useState<IntroPhase>('initial')
+	const [isDropdownOpen, setIsDropdownOpen] = useState(false)
 	const isNavigating = useRouterState({
 		select: (state) => state.status === 'pending',
 	})
@@ -62,6 +63,7 @@ function Component() {
 						onChange={setInputValue}
 						disabled={isMounted && isNavigating}
 						className={introPhase === 'search' ? 'border-accent/50' : undefined}
+						onDropdownVisibilityChange={setIsDropdownOpen}
 						onActivate={(data) => {
 							if (data.type === 'hash') {
 								navigate({
@@ -87,13 +89,19 @@ function Component() {
 						}}
 					/>
 				</div>
-				<SpotlightLinks introPhase={introPhase} />
+				<SpotlightLinks introPhase={introPhase} hidden={isDropdownOpen} />
 			</div>
 		</div>
 	)
 }
 
-function SpotlightLinks({ introPhase }: { introPhase: IntroPhase }) {
+function SpotlightLinks({
+	introPhase,
+	hidden,
+}: {
+	introPhase: IntroPhase
+	hidden?: boolean
+}) {
 	const navigate = useNavigate()
 	const [actionOpen, setActionOpen] = useState(false)
 	const dropdownRef = useRef<HTMLDivElement>(null)
@@ -146,7 +154,10 @@ function SpotlightLinks({ introPhase }: { introPhase: IntroPhase }) {
 	const showDiscover = ['discover', 'done'].includes(introPhase)
 
 	return (
-		<section className="text-center max-w-[500px] px-4">
+		<section
+			className="text-center max-w-[500px] px-4 transition-opacity duration-150"
+			style={{ opacity: hidden ? 0 : 1 }}
+		>
 			<div className="group/pills flex items-center gap-2 text-[13px] flex-wrap justify-center">
 				{/* Explore pills - animate in with "Explore" */}
 				<div


### PR DESCRIPTION
Hides the spotlight buttons when the search dropdown is showing.

Was noticing the Account/Contract/Receipt buttons showing through the dropdown while typing - made it hard to read the results. Now they hide consistently whether you're typing a partial query or pasting a full address.

![tempo_pr_hq](https://github.com/user-attachments/assets/cfd449a1-b88e-4a67-b6b0-f67c77d8837f)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>


Prevents spotlight buttons from showing through search dropdown by adding visibility callback. The `ExploreInput` component now notifies its parent when the dropdown opens/closes, allowing the parent to fade out the spotlight buttons with a smooth opacity transition.

- Added `onDropdownVisibilityChange` callback prop to `ExploreInput` component
- Wired up effect to call callback when `showResults` state changes
- Parent component tracks dropdown state and applies `opacity: 0` to spotlight section when open
- Added transition CSS for smooth fade effect


</details>
<details><summary><h3>Confidence Score: 5/5</h3></summary>


- Safe to merge - clean UI fix with proper React patterns
- Simple, well-implemented change using standard React callback pattern. Optional prop preserves backward compatibility, effect properly manages callback lifecycle, and CSS transition provides smooth UX.
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/explorer/src/comps/ExploreInput.tsx | Added optional callback prop `onDropdownVisibilityChange` with effect to notify parent of dropdown state changes |
| apps/explorer/src/routes/_layout/index.tsx | Tracks dropdown state and applies opacity transition to hide spotlight buttons when search dropdown is open |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant IndexRoute as Index Route
    participant ExploreInput
    participant SpotlightLinks

    User->>ExploreInput: Types in search input
    ExploreInput->>ExploreInput: Updates query state
    ExploreInput->>ExploreInput: Sets showResults = true
    ExploreInput->>ExploreInput: useEffect triggers
    ExploreInput->>IndexRoute: onDropdownVisibilityChange(true)
    IndexRoute->>IndexRoute: setIsDropdownOpen(true)
    IndexRoute->>SpotlightLinks: Renders with hidden=true
    SpotlightLinks->>SpotlightLinks: Applies opacity: 0
    Note over SpotlightLinks: Buttons fade out

    User->>ExploreInput: Clicks outside or selects result
    ExploreInput->>ExploreInput: Sets showResults = false
    ExploreInput->>ExploreInput: useEffect triggers
    ExploreInput->>IndexRoute: onDropdownVisibilityChange(false)
    IndexRoute->>IndexRoute: setIsDropdownOpen(false)
    IndexRoute->>SpotlightLinks: Renders with hidden=false
    SpotlightLinks->>SpotlightLinks: Applies opacity: 1
    Note over SpotlightLinks: Buttons fade back in
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->