### PR TITLE
chore(explorer): remove unused ClientOnly import

### DIFF
--- a/apps/explorer/src/comps/AccountCard.tsx
+++ b/apps/explorer/src/comps/AccountCard.tsx
@@ -1,4 +1,4 @@
-import { ClientOnly, getRouteApi } from '@tanstack/react-router'
+import { getRouteApi } from '@tanstack/react-router'
 import type { Address } from 'ox'
 import { InfoCard } from '#comps/InfoCard'
 import { RelativeTime } from '#comps/RelativeTime'


### PR DESCRIPTION
Remove unused ClientOnly import

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>


- Removes `ClientOnly` import from `@tanstack/react-router` in `apps/explorer/src/comps/AccountCard.tsx` while leaving multiple component usages intact, creating a critical runtime error


</details>
<details><summary><h3>Important Files Changed</h3></summary>


| Filename | Overview |
|----------|----------|
| apps/explorer/src/comps/AccountCard.tsx | Critical error: removed `ClientOnly` import but left 3 component usages intact (lines 87, 106, 123) causing undefined reference |


</details>
<details><summary><h3>Confidence score: 0/5</h3></summary>


- This PR will immediately break the application with undefined reference errors and should not be merged under any circumstances
- Score reflects critical breaking changes that remove imports while leaving component usage intact, creating immediate runtime failures
- Pay immediate attention to `apps/explorer/src/comps/AccountCard.tsx` which has broken `ClientOnly` references that will crash the component
</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant AccountCard
    participant Route
    participant InfoCard
    participant CopyHook

    User->>AccountCard: "Render account details"
    AccountCard->>Route: "useParams()"
    Route-->>AccountCard: "address parameter"
    AccountCard->>CopyHook: "useCopy()"
    CopyHook-->>AccountCard: "copy function and notifying state"
    AccountCard->>InfoCard: "Render with title and sections"
    User->>AccountCard: "Click address to copy"
    AccountCard->>CopyHook: "copy(address)"
    CopyHook-->>AccountCard: "Update notifying state"
    AccountCard->>User: "Show 'copied' notification"
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->