### PR TITLE
chore: bump viem to 2.43.5

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -163,8 +163,8 @@ catalogs:
       specifier: ^22.5.0
       version: 22.5.0
     viem:
-      specifier: ^2.43.4
-      version: 2.43.4
+      specifier: ^2.43.5
+      version: 2.43.5
     vite:
       specifier: npm:rolldown-vite@latest
       version: 7.3.0
@@ -226,10 +226,10 @@ importers:
         version: 7.7.3
       tempo.ts:
         specifier: 'catalog:'
-        version: 0.12.1(@remix-run/headers@0.17.2)(@remix-run/route-pattern@0.15.3)(@remix-run/session@0.4.1)(@tanstack/query-core@5.90.16)(@tanstack/react-query@5.90.16(react@19.2.3))(@wagmi/core@3.0.2(@tanstack/query-core@5.90.16)(@types/react@19.2.7)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.3))(viem@2.43.4(typescript@5.9.3)(zod@4.3.4)))(prool@0.2.2(testcontainers@11.11.0))(typescript@5.9.3)(viem@2.43.4(typescript@5.9.3)(zod@4.3.4))(wagmi@3.1.4(@tanstack/query-core@5.90.16)(@tanstack/react-query@5.90.16(react@19.2.3))(@types/react@19.2.7)(react@19.2.3)(typescript@5.9.3)(viem@2.43.4(typescript@5.9.3)(zod@4.3.4)))(zod@4.3.4)
+        version: 0.12.1(@remix-run/headers@0.17.2)(@remix-run/route-pattern@0.15.3)(@remix-run/session@0.4.1)(@tanstack/query-core@5.90.16)(@tanstack/react-query@5.90.16(react@19.2.3))(@wagmi/core@3.0.2(@tanstack/query-core@5.90.16)(@types/react@19.2.7)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.3))(viem@2.43.5(typescript@5.9.3)(zod@4.3.4)))(prool@0.2.2(testcontainers@11.11.0))(typescript@5.9.3)(viem@2.43.5(typescript@5.9.3)(zod@4.3.4))(wagmi@3.1.4(@tanstack/query-core@5.90.16)(@tanstack/react-query@5.90.16(react@19.2.3))(@types/react@19.2.7)(react@19.2.3)(typescript@5.9.3)(viem@2.43.5(typescript@5.9.3)(zod@4.3.4)))(zod@4.3.4)
       viem:
         specifier: 'catalog:'
-        version: 2.43.4(typescript@5.9.3)(zod@4.3.4)
+        version: 2.43.5(typescript@5.9.3)(zod@4.3.4)
     devDependencies:
       '@biomejs/biome':
         specifier: 'catalog:'
@@ -341,13 +341,13 @@ importers:
         version: 4.1.18
       tempo.ts:
         specifier: 'catalog:'
-        version: 0.12.1(@remix-run/headers@0.17.2)(@remix-run/route-pattern@0.15.3)(@remix-run/session@0.4.1)(@tanstack/query-core@5.90.16)(@tanstack/react-query@5.90.16(react@19.2.3))(@wagmi/core@3.0.2(@tanstack/query-core@5.90.16)(@types/react@19.2.7)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.3))(viem@2.43.4(typescript@5.9.3)(zod@4.3.4)))(prool@0.2.2(testcontainers@11.11.0))(typescript@5.9.3)(viem@2.43.4(typescript@5.9.3)(zod@4.3.4))(wagmi@3.1.4(@tanstack/query-core@5.90.16)(@tanstack/react-query@5.90.16(react@19.2.3))(@types/react@19.2.7)(react@19.2.3)(typescript@5.9.3)(viem@2.43.4(typescript@5.9.3)(zod@4.3.4)))(zod@4.3.4)
+        version: 0.12.1(@remix-run/headers@0.17.2)(@remix-run/route-pattern@0.15.3)(@remix-run/session@0.4.1)(@tanstack/query-core@5.90.16)(@tanstack/react-query@5.90.16(react@19.2.3))(@wagmi/core@3.0.2(@tanstack/query-core@5.90.16)(@types/react@19.2.7)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.3))(viem@2.43.5(typescript@5.9.3)(zod@4.3.4)))(prool@0.2.2(testcontainers@11.11.0))(typescript@5.9.3)(viem@2.43.5(typescript@5.9.3)(zod@4.3.4))(wagmi@3.1.4(@tanstack/query-core@5.90.16)(@tanstack/react-query@5.90.16(react@19.2.3))(@types/react@19.2.7)(react@19.2.3)(typescript@5.9.3)(viem@2.43.5(typescript@5.9.3)(zod@4.3.4)))(zod@4.3.4)
       viem:
         specifier: 'catalog:'
-        version: 2.43.4(typescript@5.9.3)(zod@4.3.4)
+        version: 2.43.5(typescript@5.9.3)(zod@4.3.4)
       wagmi:
         specifier: 'catalog:'
-        version: 3.1.4(@tanstack/query-core@5.90.16)(@tanstack/react-query@5.90.16(react@19.2.3))(@types/react@19.2.7)(react@19.2.3)(typescript@5.9.3)(viem@2.43.4(typescript@5.9.3)(zod@4.3.4))
+        version: 3.1.4(@tanstack/query-core@5.90.16)(@tanstack/react-query@5.90.16(react@19.2.3))(@types/react@19.2.7)(react@19.2.3)(typescript@5.9.3)(viem@2.43.5(typescript@5.9.3)(zod@4.3.4))
       zod:
         specifier: 'catalog:'
         version: 4.3.4
@@ -444,10 +444,10 @@ importers:
         version: 0.11.1(typescript@5.9.3)(zod@4.3.4)
       tempo.ts:
         specifier: 'catalog:'
-        version: 0.12.1(@remix-run/headers@0.17.2)(@remix-run/route-pattern@0.15.3)(@remix-run/session@0.4.1)(@tanstack/query-core@5.90.16)(@tanstack/react-query@5.90.16(react@19.2.3))(@wagmi/core@3.0.2(@tanstack/query-core@5.90.16)(@types/react@19.2.7)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.3))(viem@2.43.4(typescript@5.9.3)(zod@4.3.4)))(prool@0.2.2(testcontainers@11.11.0))(typescript@5.9.3)(viem@2.43.4(typescript@5.9.3)(zod@4.3.4))(wagmi@3.1.4(@tanstack/query-core@5.90.16)(@tanstack/react-query@5.90.16(react@19.2.3))(@types/react@19.2.7)(react@19.2.3)(typescript@5.9.3)(viem@2.43.4(typescript@5.9.3)(zod@4.3.4)))(zod@4.3.4)
+        version: 0.12.1(@remix-run/headers@0.17.2)(@remix-run/route-pattern@0.15.3)(@remix-run/session@0.4.1)(@tanstack/query-core@5.90.16)(@tanstack/react-query@5.90.16(react@19.2.3))(@wagmi/core@3.0.2(@tanstack/query-core@5.90.16)(@types/react@19.2.7)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.3))(viem@2.43.5(typescript@5.9.3)(zod@4.3.4)))(prool@0.2.2(testcontainers@11.11.0))(typescript@5.9.3)(viem@2.43.5(typescript@5.9.3)(zod@4.3.4))(wagmi@3.1.4(@tanstack/query-core@5.90.16)(@tanstack/react-query@5.90.16(react@19.2.3))(@types/react@19.2.7)(react@19.2.3)(typescript@5.9.3)(viem@2.43.5(typescript@5.9.3)(zod@4.3.4)))(zod@4.3.4)
       viem:
         specifier: 'catalog:'
-        version: 2.43.4(typescript@5.9.3)(zod@4.3.4)
+        version: 2.43.5(typescript@5.9.3)(zod@4.3.4)
       zod:
         specifier: 'catalog:'
         version: 4.3.4
@@ -493,13 +493,13 @@ importers:
         version: 19.2.3(react@19.2.3)
       tempo.ts:
         specifier: 'catalog:'
-        version: 0.12.1(@remix-run/headers@0.17.2)(@remix-run/route-pattern@0.15.3)(@remix-run/session@0.4.1)(@tanstack/query-core@5.90.16)(@tanstack/react-query@5.90.16(react@19.2.3))(@wagmi/core@3.0.2(@tanstack/query-core@5.90.16)(@types/react@19.2.7)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.3))(viem@2.43.4(typescript@5.9.3)(zod@4.3.4)))(prool@0.2.2(testcontainers@11.11.0))(typescript@5.9.3)(viem@2.43.4(typescript@5.9.3)(zod@4.3.4))(wagmi@3.1.4(@tanstack/query-core@5.90.16)(@tanstack/react-query@5.90.16(react@19.2.3))(@types/react@19.2.7)(react@19.2.3)(typescript@5.9.3)(viem@2.43.4(typescript@5.9.3)(zod@4.3.4)))(zod@4.3.4)
+        version: 0.12.1(@remix-run/headers@0.17.2)(@remix-run/route-pattern@0.15.3)(@remix-run/session@0.4.1)(@tanstack/query-core@5.90.16)(@tanstack/react-query@5.90.16(react@19.2.3))(@wagmi/core@3.0.2(@tanstack/query-core@5.90.16)(@types/react@19.2.7)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.3))(viem@2.43.5(typescript@5.9.3)(zod@4.3.4)))(prool@0.2.2(testcontainers@11.11.0))(typescript@5.9.3)(viem@2.43.5(typescript@5.9.3)(zod@4.3.4))(wagmi@3.1.4(@tanstack/query-core@5.90.16)(@tanstack/react-query@5.90.16(react@19.2.3))(@types/react@19.2.7)(react@19.2.3)(typescript@5.9.3)(viem@2.43.5(typescript@5.9.3)(zod@4.3.4)))(zod@4.3.4)
       viem:
         specifier: 'catalog:'
-        version: 2.43.4(typescript@5.9.3)(zod@4.3.4)
+        version: 2.43.5(typescript@5.9.3)(zod@4.3.4)
       wagmi:
         specifier: 'catalog:'
-        version: 3.1.4(@tanstack/query-core@5.90.16)(@tanstack/react-query@5.90.16(react@19.2.3))(@types/react@19.2.7)(react@19.2.3)(typescript@5.9.3)(viem@2.43.4(typescript@5.9.3)(zod@4.3.4))
+        version: 3.1.4(@tanstack/query-core@5.90.16)(@tanstack/react-query@5.90.16(react@19.2.3))(@types/react@19.2.7)(react@19.2.3)(typescript@5.9.3)(viem@2.43.5(typescript@5.9.3)(zod@4.3.4))
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -542,10 +542,10 @@ importers:
         version: 0.11.1(typescript@5.9.3)(zod@4.3.4)
       tempo.ts:
         specifier: 'catalog:'
-        version: 0.12.1(@remix-run/headers@0.17.2)(@remix-run/route-pattern@0.15.3)(@remix-run/session@0.4.1)(@tanstack/query-core@5.90.16)(@tanstack/react-query@5.90.16(react@19.2.3))(@wagmi/core@3.0.2(@tanstack/query-core@5.90.16)(@types/react@19.2.7)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.3))(viem@2.43.4(typescript@5.9.3)(zod@4.3.4)))(prool@0.2.2(testcontainers@11.11.0))(typescript@5.9.3)(viem@2.43.4(typescript@5.9.3)(zod@4.3.4))(wagmi@3.1.4(@tanstack/query-core@5.90.16)(@tanstack/react-query@5.90.16(react@19.2.3))(@types/react@19.2.7)(react@19.2.3)(typescript@5.9.3)(viem@2.43.4(typescript@5.9.3)(zod@4.3.4)))(zod@4.3.4)
+        version: 0.12.1(@remix-run/headers@0.17.2)(@remix-run/route-pattern@0.15.3)(@remix-run/session@0.4.1)(@tanstack/query-core@5.90.16)(@tanstack/react-query@5.90.16(react@19.2.3))(@wagmi/core@3.0.2(@tanstack/query-core@5.90.16)(@types/react@19.2.7)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.3))(viem@2.43.5(typescript@5.9.3)(zod@4.3.4)))(prool@0.2.2(testcontainers@11.11.0))(typescript@5.9.3)(viem@2.43.5(typescript@5.9.3)(zod@4.3.4))(wagmi@3.1.4(@tanstack/query-core@5.90.16)(@tanstack/react-query@5.90.16(react@19.2.3))(@types/react@19.2.7)(react@19.2.3)(typescript@5.9.3)(viem@2.43.5(typescript@5.9.3)(zod@4.3.4)))(zod@4.3.4)
       viem:
         specifier: 'catalog:'
-        version: 2.43.4(typescript@5.9.3)(zod@4.3.4)
+        version: 2.43.5(typescript@5.9.3)(zod@4.3.4)
       zod:
         specifier: 'catalog:'
         version: 4.3.4
@@ -570,10 +570,10 @@ importers:
         version: 4.0.0
       tempo.ts:
         specifier: 'catalog:'
-        version: 0.12.1(@remix-run/headers@0.17.2)(@remix-run/route-pattern@0.15.3)(@remix-run/session@0.4.1)(@tanstack/query-core@5.90.16)(@tanstack/react-query@5.90.16(react@19.2.3))(@wagmi/core@3.0.2(@tanstack/query-core@5.90.16)(@types/react@19.2.7)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.3))(viem@2.43.4(typescript@5.9.3)(zod@4.3.4)))(prool@0.2.2(testcontainers@11.11.0))(typescript@5.9.3)(viem@2.43.4(typescript@5.9.3)(zod@4.3.4))(wagmi@3.1.4(@tanstack/query-core@5.90.16)(@tanstack/react-query@5.90.16(react@19.2.3))(@types/react@19.2.7)(react@19.2.3)(typescript@5.9.3)(viem@2.43.4(typescript@5.9.3)(zod@4.3.4)))(zod@4.3.4)
+        version: 0.12.1(@remix-run/headers@0.17.2)(@remix-run/route-pattern@0.15.3)(@remix-run/session@0.4.1)(@tanstack/query-core@5.90.16)(@tanstack/react-query@5.90.16(react@19.2.3))(@wagmi/core@3.0.2(@tanstack/query-core@5.90.16)(@types/react@19.2.7)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.3))(viem@2.43.5(typescript@5.9.3)(zod@4.3.4)))(prool@0.2.2(testcontainers@11.11.0))(typescript@5.9.3)(viem@2.43.5(typescript@5.9.3)(zod@4.3.4))(wagmi@3.1.4(@tanstack/query-core@5.90.16)(@tanstack/react-query@5.90.16(react@19.2.3))(@types/react@19.2.7)(react@19.2.3)(typescript@5.9.3)(viem@2.43.5(typescript@5.9.3)(zod@4.3.4)))(zod@4.3.4)
       viem:
         specifier: 'catalog:'
-        version: 2.43.4(typescript@5.9.3)(zod@4.3.4)
+        version: 2.43.5(typescript@5.9.3)(zod@4.3.4)
     devDependencies:
       '@biomejs/biome':
         specifier: 'catalog:'
@@ -5476,8 +5476,8 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
-  viem@2.43.4:
-    resolution: {integrity: sha512-PSoML7uG5es/SA1v2988grfcHdMDIogqC0LftdX74q8ZUHj3E7uiAXypNQiUxRZBuyoD5LO1nGEgTU9AGRvuHA==}
+  viem@2.43.5:
+    resolution: {integrity: sha512-QuJpuEMEPM3EreN+vX4mVY68Sci0+zDxozYfbh/WfV+SSy/Gthm74PH8XmitXdty1xY54uTCJ+/Gbbd1IiMPSA==}
     peerDependencies:
       typescript: '>=5.0.4'
     peerDependenciesMeta:
@@ -8270,18 +8270,18 @@ snapshots:
     dependencies:
       vue: 3.5.26(typescript@5.9.3)
 
-  '@wagmi/connectors@7.0.6(@wagmi/core@3.0.2(@tanstack/query-core@5.90.16)(@types/react@19.2.7)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.3))(viem@2.43.4(typescript@5.9.3)(zod@4.3.4)))(typescript@5.9.3)(viem@2.43.4(typescript@5.9.3)(zod@4.3.4))':
+  '@wagmi/connectors@7.0.6(@wagmi/core@3.0.2(@tanstack/query-core@5.90.16)(@types/react@19.2.7)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.3))(viem@2.43.5(typescript@5.9.3)(zod@4.3.4)))(typescript@5.9.3)(viem@2.43.5(typescript@5.9.3)(zod@4.3.4))':
     dependencies:
-      '@wagmi/core': 3.0.2(@tanstack/query-core@5.90.16)(@types/react@19.2.7)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.3))(viem@2.43.4(typescript@5.9.3)(zod@4.3.4))
-      viem: 2.43.4(typescript@5.9.3)(zod@4.3.4)
+      '@wagmi/core': 3.0.2(@tanstack/query-core@5.90.16)(@types/react@19.2.7)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.3))(viem@2.43.5(typescript@5.9.3)(zod@4.3.4))
+      viem: 2.43.5(typescript@5.9.3)(zod@4.3.4)
     optionalDependencies:
       typescript: 5.9.3
 
-  '@wagmi/core@3.0.2(@tanstack/query-core@5.90.16)(@types/react@19.2.7)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.3))(viem@2.43.4(typescript@5.9.3)(zod@4.3.4))':
+  '@wagmi/core@3.0.2(@tanstack/query-core@5.90.16)(@types/react@19.2.7)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.3))(viem@2.43.5(typescript@5.9.3)(zod@4.3.4))':
     dependencies:
       eventemitter3: 5.0.1
       mipd: 0.0.7(typescript@5.9.3)
-      viem: 2.43.4(typescript@5.9.3)(zod@4.3.4)
+      viem: 2.43.5(typescript@5.9.3)(zod@4.3.4)
       zustand: 5.0.0(@types/react@19.2.7)(react@19.2.3)(use-sync-external-store@1.4.0(react@19.2.3))
     optionalDependencies:
       '@tanstack/query-core': 5.90.16
@@ -8292,11 +8292,11 @@ snapshots:
       - react
       - use-sync-external-store
 
-  '@wagmi/core@3.0.2(@tanstack/query-core@5.90.16)(@types/react@19.2.7)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.3))(viem@2.43.4(typescript@5.9.3)(zod@4.3.4))':
+  '@wagmi/core@3.0.2(@tanstack/query-core@5.90.16)(@types/react@19.2.7)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.3))(viem@2.43.5(typescript@5.9.3)(zod@4.3.4))':
     dependencies:
       eventemitter3: 5.0.1
       mipd: 0.0.7(typescript@5.9.3)
-      viem: 2.43.4(typescript@5.9.3)(zod@4.3.4)
+      viem: 2.43.5(typescript@5.9.3)(zod@4.3.4)
       zustand: 5.0.0(@types/react@19.2.7)(react@19.2.3)(use-sync-external-store@1.6.0(react@19.2.3))
     optionalDependencies:
       '@tanstack/query-core': 5.90.16
@@ -10696,7 +10696,7 @@ snapshots:
       mkdirp: 3.0.1
       yallist: 5.0.0
 
-  tempo.ts@0.12.1(@remix-run/headers@0.17.2)(@remix-run/route-pattern@0.15.3)(@remix-run/session@0.4.1)(@tanstack/query-core@5.90.16)(@tanstack/react-query@5.90.16(react@19.2.3))(@wagmi/core@3.0.2(@tanstack/query-core@5.90.16)(@types/react@19.2.7)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.3))(viem@2.43.4(typescript@5.9.3)(zod@4.3.4)))(prool@0.2.2(testcontainers@11.11.0))(typescript@5.9.3)(viem@2.43.4(typescript@5.9.3)(zod@4.3.4))(wagmi@3.1.4(@tanstack/query-core@5.90.16)(@tanstack/react-query@5.90.16(react@19.2.3))(@types/react@19.2.7)(react@19.2.3)(typescript@5.9.3)(viem@2.43.4(typescript@5.9.3)(zod@4.3.4)))(zod@4.3.4):
+  tempo.ts@0.12.1(@remix-run/headers@0.17.2)(@remix-run/route-pattern@0.15.3)(@remix-run/session@0.4.1)(@tanstack/query-core@5.90.16)(@tanstack/react-query@5.90.16(react@19.2.3))(@wagmi/core@3.0.2(@tanstack/query-core@5.90.16)(@types/react@19.2.7)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.3))(viem@2.43.5(typescript@5.9.3)(zod@4.3.4)))(prool@0.2.2(testcontainers@11.11.0))(typescript@5.9.3)(viem@2.43.5(typescript@5.9.3)(zod@4.3.4))(wagmi@3.1.4(@tanstack/query-core@5.90.16)(@tanstack/react-query@5.90.16(react@19.2.3))(@types/react@19.2.7)(react@19.2.3)(typescript@5.9.3)(viem@2.43.5(typescript@5.9.3)(zod@4.3.4)))(zod@4.3.4):
     dependencies:
       '@remix-run/fetch-router': 0.12.0(@remix-run/headers@0.17.2)(@remix-run/route-pattern@0.15.3)(@remix-run/session@0.4.1)
       idb-keyval: 6.2.2
@@ -10704,10 +10704,10 @@ snapshots:
     optionalDependencies:
       '@tanstack/query-core': 5.90.16
       '@tanstack/react-query': 5.90.16(react@19.2.3)
-      '@wagmi/core': 3.0.2(@tanstack/query-core@5.90.16)(@types/react@19.2.7)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.3))(viem@2.43.4(typescript@5.9.3)(zod@4.3.4))
+      '@wagmi/core': 3.0.2(@tanstack/query-core@5.90.16)(@types/react@19.2.7)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.3))(viem@2.43.5(typescript@5.9.3)(zod@4.3.4))
       prool: 0.2.2(testcontainers@11.11.0)
-      viem: 2.43.4(typescript@5.9.3)(zod@4.3.4)
-      wagmi: 3.1.4(@tanstack/query-core@5.90.16)(@tanstack/react-query@5.90.16(react@19.2.3))(@types/react@19.2.7)(react@19.2.3)(typescript@5.9.3)(viem@2.43.4(typescript@5.9.3)(zod@4.3.4))
+      viem: 2.43.5(typescript@5.9.3)(zod@4.3.4)
+      wagmi: 3.1.4(@tanstack/query-core@5.90.16)(@tanstack/react-query@5.90.16(react@19.2.3))(@types/react@19.2.7)(react@19.2.3)(typescript@5.9.3)(viem@2.43.5(typescript@5.9.3)(zod@4.3.4))
     transitivePeerDependencies:
       - '@remix-run/headers'
       - '@remix-run/route-pattern'
@@ -10715,7 +10715,7 @@ snapshots:
       - typescript
       - zod
 
-  tempo.ts@0.12.1(@remix-run/headers@0.17.2)(@remix-run/route-pattern@0.15.3)(@remix-run/session@0.4.1)(@tanstack/query-core@5.90.16)(@tanstack/react-query@5.90.16(react@19.2.3))(@wagmi/core@3.0.2(@tanstack/query-core@5.90.16)(@types/react@19.2.7)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.3))(viem@2.43.4(typescript@5.9.3)(zod@4.3.4)))(prool@0.2.2(testcontainers@11.11.0))(typescript@5.9.3)(viem@2.43.4(typescript@5.9.3)(zod@4.3.4))(wagmi@3.1.4(@tanstack/query-core@5.90.16)(@tanstack/react-query@5.90.16(react@19.2.3))(@types/react@19.2.7)(react@19.2.3)(typescript@5.9.3)(viem@2.43.4(typescript@5.9.3)(zod@4.3.4)))(zod@4.3.4):
+  tempo.ts@0.12.1(@remix-run/headers@0.17.2)(@remix-run/route-pattern@0.15.3)(@remix-run/session@0.4.1)(@tanstack/query-core@5.90.16)(@tanstack/react-query@5.90.16(react@19.2.3))(@wagmi/core@3.0.2(@tanstack/query-core@5.90.16)(@types/react@19.2.7)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.3))(viem@2.43.5(typescript@5.9.3)(zod@4.3.4)))(prool@0.2.2(testcontainers@11.11.0))(typescript@5.9.3)(viem@2.43.5(typescript@5.9.3)(zod@4.3.4))(wagmi@3.1.4(@tanstack/query-core@5.90.16)(@tanstack/react-query@5.90.16(react@19.2.3))(@types/react@19.2.7)(react@19.2.3)(typescript@5.9.3)(viem@2.43.5(typescript@5.9.3)(zod@4.3.4)))(zod@4.3.4):
     dependencies:
       '@remix-run/fetch-router': 0.12.0(@remix-run/headers@0.17.2)(@remix-run/route-pattern@0.15.3)(@remix-run/session@0.4.1)
       idb-keyval: 6.2.2
@@ -10723,10 +10723,10 @@ snapshots:
     optionalDependencies:
       '@tanstack/query-core': 5.90.16
       '@tanstack/react-query': 5.90.16(react@19.2.3)
-      '@wagmi/core': 3.0.2(@tanstack/query-core@5.90.16)(@types/react@19.2.7)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.3))(viem@2.43.4(typescript@5.9.3)(zod@4.3.4))
+      '@wagmi/core': 3.0.2(@tanstack/query-core@5.90.16)(@types/react@19.2.7)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.3))(viem@2.43.5(typescript@5.9.3)(zod@4.3.4))
       prool: 0.2.2(testcontainers@11.11.0)
-      viem: 2.43.4(typescript@5.9.3)(zod@4.3.4)
-      wagmi: 3.1.4(@tanstack/query-core@5.90.16)(@tanstack/react-query@5.90.16(react@19.2.3))(@types/react@19.2.7)(react@19.2.3)(typescript@5.9.3)(viem@2.43.4(typescript@5.9.3)(zod@4.3.4))
+      viem: 2.43.5(typescript@5.9.3)(zod@4.3.4)
+      wagmi: 3.1.4(@tanstack/query-core@5.90.16)(@tanstack/react-query@5.90.16(react@19.2.3))(@types/react@19.2.7)(react@19.2.3)(typescript@5.9.3)(viem@2.43.5(typescript@5.9.3)(zod@4.3.4))
     transitivePeerDependencies:
       - '@remix-run/headers'
       - '@remix-run/route-pattern'
@@ -10942,7 +10942,7 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  viem@2.43.4(typescript@5.9.3)(zod@4.3.4):
+  viem@2.43.5(typescript@5.9.3)(zod@4.3.4):
     dependencies:
       '@noble/curves': 1.9.1
       '@noble/hashes': 1.8.0
@@ -11072,14 +11072,14 @@ snapshots:
 
   w3c-keyname@2.2.8: {}
 
-  wagmi@3.1.4(@tanstack/query-core@5.90.16)(@tanstack/react-query@5.90.16(react@19.2.3))(@types/react@19.2.7)(react@19.2.3)(typescript@5.9.3)(viem@2.43.4(typescript@5.9.3)(zod@4.3.4)):
+  wagmi@3.1.4(@tanstack/query-core@5.90.16)(@tanstack/react-query@5.90.16(react@19.2.3))(@types/react@19.2.7)(react@19.2.3)(typescript@5.9.3)(viem@2.43.5(typescript@5.9.3)(zod@4.3.4)):
     dependencies:
       '@tanstack/react-query': 5.90.16(react@19.2.3)
-      '@wagmi/connectors': 7.0.6(@wagmi/core@3.0.2(@tanstack/query-core@5.90.16)(@types/react@19.2.7)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.3))(viem@2.43.4(typescript@5.9.3)(zod@4.3.4)))(typescript@5.9.3)(viem@2.43.4(typescript@5.9.3)(zod@4.3.4))
-      '@wagmi/core': 3.0.2(@tanstack/query-core@5.90.16)(@types/react@19.2.7)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.3))(viem@2.43.4(typescript@5.9.3)(zod@4.3.4))
+      '@wagmi/connectors': 7.0.6(@wagmi/core@3.0.2(@tanstack/query-core@5.90.16)(@types/react@19.2.7)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.6.0(react@19.2.3))(viem@2.43.5(typescript@5.9.3)(zod@4.3.4)))(typescript@5.9.3)(viem@2.43.5(typescript@5.9.3)(zod@4.3.4))
+      '@wagmi/core': 3.0.2(@tanstack/query-core@5.90.16)(@types/react@19.2.7)(react@19.2.3)(typescript@5.9.3)(use-sync-external-store@1.4.0(react@19.2.3))(viem@2.43.5(typescript@5.9.3)(zod@4.3.4))
       react: 19.2.3
       use-sync-external-store: 1.4.0(react@19.2.3)
-      viem: 2.43.4(typescript@5.9.3)(zod@4.3.4)
+      viem: 2.43.5(typescript@5.9.3)(zod@4.3.4)
     optionalDependencies:
       typescript: 5.9.3
     transitivePeerDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -56,7 +56,7 @@ catalog:
   typed-query-selector: ^2.12.0
   typescript: ^5.9.3
   unplugin-icons: ^22.5.0
-  viem: ^2.43.4
+  viem: ^2.43.5
   vite: npm:rolldown-vite@latest
   vite-plugin-devtools-json: ^1.0.0
   vitest: 3.2.4


### PR DESCRIPTION
### motivation

Devnet ID changed
```
$ cast chain-id -r https://rpc.devnet.tempoxyz.dev
31318
```

### change
Bumps viem to 2.43.5 that has devnet ID set to 31318

### testing
Tested with `pnpm dev` locally and pointed docs _Sponsor User Fees_ guide to test devnet fee payer works as expected

```
$ cast receipt 0x81eb701c9bff23c8ba52f18ff5216bb596a1d02915833d105ee5843193256c9b --rpc-url https://rpc.devnet.tempoxyz.dev

feeToken             0x20C0000000000000000000000000000000000000
feePayer             0x58Aa7CE42E1D13B2919E2ac7E006c4fBC171442c
blockHash            0x8b09f2c8e5b19fa8a027c53c7b16f5d33567e9c9239e6c5693eda1ea6800585c
blockNumber          78750
contractAddress
cumulativeGasUsed    59887
effectiveGasPrice    10000000000
from                 0xBF2dd0bed0632efeba903cF4BA8d78AF6F12b90F
gasUsed              59887
logs                 [{"address":"0x20c0000000000000000000000000000000000000","topics":["0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef","0x00000000000000000000000058aa7ce42e1d13b2919e2ac7e006c4fbc171442c","0x000000000000000000000000feec000000000000000000000000000000000000"],"data":"0x0000000000000000000000000000000000000000000000000000000000000257","blockHash":"0x8b09f2c8e5b19fa8a027c53c7b16f5d33567e9c9239e6c5693eda1ea6800585c","blockNumber":"0x1339e","blockTimestamp":"0x6958b0bc","transactionHash":"0x81eb701c9bff23c8ba52f18ff5216bb596a1d02915833d105ee5843193256c9b","transactionIndex":"0x0","logIndex":"0x0","removed":false}]
logsBloom            0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000100000000000000000000080000000000000000000004000000000000000008000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000020000000000020800000000000000000000000000020000000000000000000000000002000000000000000000000000000000000000002000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
root
status               false
transactionHash      0x81eb701c9bff23c8ba52f18ff5216bb596a1d02915833d105ee5843193256c9b
transactionIndex     0
type                 AA
to                   0x20C0000000000000000000000000000000000001
```

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>


Bumps viem from 2.43.4 to 2.43.5 to support the updated Tempo devnet chain ID (31318). The devnet ID changed from the default 31337 to 31318, and this viem version includes the updated `tempoDevnet` chain configuration.

- Updated viem specifier in catalog from ^2.43.4 to ^2.43.5
- Lock file updated with new viem version and all transitive dependencies
- Code imports `tempoDevnet` from `viem/chains`, so this update is necessary for devnet compatibility
- Author tested locally with devnet and confirmed fee payer functionality works as expected


</details>
<details><summary><h3>Confidence Score: 5/5</h3></summary>


- This PR is safe to merge with minimal risk - it's a straightforward patch version bump
- This is a simple dependency update to align with infrastructure changes. The change is isolated to dependency files, the version bump is minor (patch), and the author has tested the functionality locally with successful results. No code changes are required since the app already imports the chain configuration from viem.
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| pnpm-workspace.yaml | Bumped viem catalog version from ^2.43.4 to ^2.43.5 |
| pnpm-lock.yaml | Updated viem dependency and all transitive references from 2.43.4 to 2.43.5 |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant App as Tempo Apps
    participant Viem as Viem Library
    participant RPC as Devnet RPC

    Dev->>App: Update viem to 2.43.5
    App->>Viem: Import tempoDevnet chain
    Viem-->>App: Returns chain config (ID: 31318)
    App->>RPC: Connect to devnet with chain ID 31318
    RPC-->>App: Connection successful
    App->>RPC: Execute fee payer transaction
    RPC-->>App: Transaction receipt with fee payer
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->