### PR TITLE
Update link for network upgrades documentation

### DIFF
--- a/apps/explorer/src/routes/_layout.tsx
+++ b/apps/explorer/src/routes/_layout.tsx
@@ -44,7 +44,7 @@ export function Layout(props: Layout.Props) {
 					</time>
 					.{' '}
 					<a
-						href="https://docs.tempo.xyz/#testnet-migration"
+						href="https://docs.tempo.xyz/network-upgrades"
 						className="underline press-down-inline"
 						target="_blank"
 						rel="noopener noreferrer"


### PR DESCRIPTION
<h2>Greptile Overview</h2>

### Greptile Summary

Updated documentation link in the testnet migration banner from the old anchor-based URL (`#testnet-migration`) to a new dedicated page path (`/network-upgrades`).

- Simple URL change to align with documentation restructuring
- No functional or logical issues found
- Link points to the same domain with improved URL structure

### Confidence Score: 5/5

- This PR is completely safe to merge with no risk
- This is a trivial documentation link update with no code logic changes, no syntax issues, and no security implications. The change is well-scoped and aligns with the companion PR in the main repository.
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| apps/explorer/src/routes/_layout.tsx | 5/5 | Updated documentation link from `#testnet-migration` to `/network-upgrades` path |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant ExplorerUI as Explorer UI
    participant Layout as _layout.tsx
    participant Docs as docs.tempo.xyz
    
    User->>ExplorerUI: Visits explorer page
    ExplorerUI->>Layout: Render layout with banner
    Layout->>Layout: Display testnet migration warning
    User->>Layout: Clicks "Checkout our docs" link
    Layout->>Docs: Navigate to /network-upgrades
    Docs-->>User: Display network upgrades documentation
```
</details>
