### PR TITLE
fix(`contract`): avoid including `+commit.*` in Solidity compiler link so it points to a correct release

### DIFF
--- a/apps/explorer/src/comps/ContractSource.tsx
+++ b/apps/explorer/src/comps/ContractSource.tsx
@@ -10,7 +10,14 @@ import SolidityIcon from '~icons/vscode-icons/file-type-solidity'
 import VyperIcon from '~icons/vscode-icons/file-type-vyper'
 
 function getCompilerVersionUrl(compiler: string, version: string) {
-	return `https://github.com/${compiler.toLowerCase() === 'vyper' ? 'vyperlang/vyper' : 'argotorg/solidity'}/releases/tag/v${version}`
+	const isVyper = compiler.toLowerCase() === "vyper"
+	const repo = isVyper ? "vyperlang/vyper" : "argotorg/solidity"
+
+	const tag = isVyper
+		? version.trim()
+		: version.trim().split("+commit.", 1)[0]
+
+	return `https://github.com/${repo}/releases/tag/v${tag}`
 }
 
 function getOptimizerText(compilation: ContractSource['compilation']) {


### PR DESCRIPTION
To reproduce:

`0.8.33+commit.64118f21 (solc)` points to https://github.com/argotorg/solidity/releases/tag/v0.8.33+commit.64118f21, instead it should point to https://github.com/argotorg/solidity/releases/tag/v0.8.33.

Alternatively could use regex to extract semver but then you have to deal with edge cases like: https://github.com/argotorg/solidity/releases/tag/v0.8.31-pre.1; I think this works well enough.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h2>Greptile Overview</h2>

### Greptile Summary

Fixed broken GitHub release links for Solidity compiler versions. Previously, version strings like `0.8.33+commit.64118f21` were used directly in URLs, creating invalid links. Now the code strips the `+commit.*` suffix to generate correct release tag URLs.

- Refactored `getCompilerVersionUrl` function to handle Solidity and Vyper differently
- Solidity versions now have commit hash stripped via `.split("+commit.", 1)[0]`
- Vyper versions remain unchanged (no commit hash stripping needed)
- Code is more readable with explicit variable names (`isVyper`, `repo`, `tag`)

### Confidence Score: 5/5

- This PR is safe to merge with no risk
- The change is a simple, well-isolated fix that correctly handles the version string parsing. The `.split("+commit.", 1)[0]` approach safely handles both versions with and without the commit suffix. The refactoring improves code clarity without changing behavior for Vyper versions.
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| apps/explorer/src/comps/ContractSource.tsx | 5/5 | Fixed Solidity compiler version URL by stripping `+commit.*` suffix to correctly link to release tags |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant SourceSection
    participant getCompilerVersionUrl
    participant GitHub

    User->>SourceSection: View contract source
    SourceSection->>getCompilerVersionUrl: compilation.compiler, compilation.version
    
    alt Compiler is Vyper
        getCompilerVersionUrl->>getCompilerVersionUrl: Use version as-is (trim only)
        getCompilerVersionUrl->>getCompilerVersionUrl: repo = "vyperlang/vyper"
    else Compiler is Solidity
        getCompilerVersionUrl->>getCompilerVersionUrl: Strip "+commit.*" suffix
        Note over getCompilerVersionUrl: "0.8.33+commit.64118f21" → "0.8.33"
        getCompilerVersionUrl->>getCompilerVersionUrl: repo = "argotorg/solidity"
    end
    
    getCompilerVersionUrl-->>SourceSection: GitHub URL with correct tag
    SourceSection->>User: Display link with compiler version
    User->>GitHub: Click compiler version link
    GitHub-->>User: Show correct release page
```
</details>


<details><summary><h3>Important Files Changed</h3></summary>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| apps/explorer/src/comps/ContractSource.tsx | 5/5 | Fixed Solidity compiler version URL by stripping `+commit.*` suffix to correctly link to release tags |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant SourceSection
    participant getCompilerVersionUrl
    participant GitHub

    User->>SourceSection: View contract source
    SourceSection->>getCompilerVersionUrl: compilation.compiler, compilation.version
    
    alt Compiler is Vyper
        getCompilerVersionUrl->>getCompilerVersionUrl: Use version as-is (trim only)
        getCompilerVersionUrl->>getCompilerVersionUrl: repo = "vyperlang/vyper"
    else Compiler is Solidity
        getCompilerVersionUrl->>getCompilerVersionUrl: Strip "+commit.*" suffix
        Note over getCompilerVersionUrl: "0.8.33+commit.64118f21" → "0.8.33"
        getCompilerVersionUrl->>getCompilerVersionUrl: repo = "argotorg/solidity"
    end
    
    getCompilerVersionUrl-->>SourceSection: GitHub URL with correct tag
    SourceSection->>User: Display link with compiler version
    User->>GitHub: Click compiler version link
    GitHub-->>User: Show correct release page
```
</details>


<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->