### PR TITLE
chore: pnpm dev => pnpm dev:moderato

### DIFF
--- a/apps/explorer/package.json
+++ b/apps/explorer/package.json
@@ -7,9 +7,10 @@
 		"#wrangler.json": "./wrangler.jsonc"
 	},
 	"scripts": {
-		"dev": "CLOUDFLARE_ENV='testnet' vite dev --port 3000",
-		"dev:devnet": "CLOUDFLARE_ENV='devnet' vite dev",
-		"dev:moderato": "CLOUDFLARE_ENV='moderato' vite dev",
+		"dev": "pnpm dev:moderato",
+		"dev:devnet": "CLOUDFLARE_ENV='devnet' vite dev --port 3000",
+		"dev:andantino": "CLOUDFLARE_ENV='testnet' vite dev --port 3000",
+		"dev:moderato": "CLOUDFLARE_ENV='moderato' vite dev --port 3000",
 		"build": "vite build",
 		"check": "pnpm check:biome && pnpm check:types",
 		"check:biome": "biome check --write --unsafe",


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h2>Greptile Overview</h2>

### Greptile Summary

This PR reorganizes the development scripts in the explorer app's package.json. The changes consolidate environment configurations and add port consistency across all dev scripts. 

**Key changes:**
- `pnpm dev` now delegates to `pnpm dev:moderato` instead of directly running testnet
- New `dev:andantino` script created to preserve the original testnet behavior (aligning with wrangler environment naming)
- Port 3000 is now consistently applied to all dev scripts (previously only testnet had it)

**Concerns:**
- This represents a breaking change in default behavior - developers expecting `pnpm dev` to start testnet will now get moderato instead
- README.md documentation is now outdated and incorrectly claims the default is testnet
- The change appears intentional based on the PR title and wrangler configuration setup, but lacks accompanying documentation updates

**Positive aspects:**
- The new naming scheme (`dev:andantino` for testnet) aligns with wrangler environment domains (explore.andantino.tempo.xyz)
- Port consistency improves developer experience
- All three environments remain easily accessible via distinct npm scripts

### Confidence Score: 2/5

- This PR introduces a breaking change to the default development environment without accompanying documentation updates, creating risk for developer confusion and potential testing against unintended chains.
- The confidence score is low (2/5) due to a critical breaking change in default behavior. While the technical implementation is sound (delegation to moderato, consistent port configuration), the change fundamentally alters how developers interact with the default `pnpm dev` command. Without updated documentation, developers unfamiliar with the change will experience unexpected behavior. The README still claims testnet is the default, creating a documentation/implementation mismatch.
- README.md needs immediate update to reflect the new default environment (moderato instead of testnet) and document the new dev:andantino script for accessing testnet

<details><summary><h3>Important Files Changed</h3></summary>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| apps/explorer/package.json | 2/5 | Script commands reorganized with breaking change: `pnpm dev` now runs moderato instead of testnet (previously the default). Added dev:andantino for testnet, made port 3000 consistent across all dev scripts. README documentation is now outdated. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant NPM as npm/pnpm
    participant Script as Script Command
    participant Vite as Vite Dev Server
    participant Env as Environment Config

    rect rgb(200, 150, 255)
    Note over Dev,Env: OLD BEHAVIOR (Before PR)
    Dev->>NPM: pnpm dev
    NPM->>Script: CLOUDFLARE_ENV='testnet' vite dev --port 3000
    Script->>Vite: Start dev server (testnet)
    Vite->>Env: Load CLOUDFLARE_ENV=testnet
    Env-->>Vite: VITE_TEMPO_ENV=testnet, Chain 42429
    end

    rect rgb(150, 200, 255)
    Note over Dev,Env: NEW BEHAVIOR (After PR)
    Dev->>NPM: pnpm dev
    NPM->>Script: pnpm dev:moderato
    Script->>NPM: Execute dev:moderato script
    NPM->>Vite: CLOUDFLARE_ENV='moderato' vite dev --port 3000
    Vite->>Env: Load CLOUDFLARE_ENV=moderato
    Env-->>Vite: VITE_TEMPO_ENV=moderato, Chain 42431
    end

    rect rgb(150, 255, 200)
    Note over Dev,Env: ACCESSING OLD DEFAULT (After PR)
    Dev->>NPM: pnpm dev:andantino
    NPM->>Vite: CLOUDFLARE_ENV='testnet' vite dev --port 3000
    Vite->>Env: Load CLOUDFLARE_ENV=testnet
    Env-->>Vite: VITE_TEMPO_ENV=testnet, Chain 42429
    end
```
</details>


<details><summary><h3>Important Files Changed</h3></summary>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| apps/explorer/package.json | 2/5 | Script commands reorganized with breaking change: `pnpm dev` now runs moderato instead of testnet (previously the default). Added dev:andantino for testnet, made port 3000 consistent across all dev scripts. README documentation is now outdated. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant NPM as npm/pnpm
    participant Script as Script Command
    participant Vite as Vite Dev Server
    participant Env as Environment Config

    rect rgb(200, 150, 255)
    Note over Dev,Env: OLD BEHAVIOR (Before PR)
    Dev->>NPM: pnpm dev
    NPM->>Script: CLOUDFLARE_ENV='testnet' vite dev --port 3000
    Script->>Vite: Start dev server (testnet)
    Vite->>Env: Load CLOUDFLARE_ENV=testnet
    Env-->>Vite: VITE_TEMPO_ENV=testnet, Chain 42429
    end

    rect rgb(150, 200, 255)
    Note over Dev,Env: NEW BEHAVIOR (After PR)
    Dev->>NPM: pnpm dev
    NPM->>Script: pnpm dev:moderato
    Script->>NPM: Execute dev:moderato script
    NPM->>Vite: CLOUDFLARE_ENV='moderato' vite dev --port 3000
    Vite->>Env: Load CLOUDFLARE_ENV=moderato
    Env-->>Vite: VITE_TEMPO_ENV=moderato, Chain 42431
    end

    rect rgb(150, 255, 200)
    Note over Dev,Env: ACCESSING OLD DEFAULT (After PR)
    Dev->>NPM: pnpm dev:andantino
    NPM->>Vite: CLOUDFLARE_ENV='testnet' vite dev --port 3000
    Vite->>Env: Load CLOUDFLARE_ENV=testnet
    Env-->>Vite: VITE_TEMPO_ENV=testnet, Chain 42429
    end
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->