### PR TITLE
fix: moderato ABIs

### DIFF
--- a/apps/explorer/scripts/generate-tokens-index.ts
+++ b/apps/explorer/scripts/generate-tokens-index.ts
@@ -1,11 +1,11 @@
 import { writeFileSync } from 'node:fs'
 import { resolve } from 'node:path'
+import * as ABIS from '../src/lib/abis'
 
 const indexSupplyEndpoint = 'https://api.tempo.xyz/indexer/query'
 const chainId = 42429
 
-const eventSignature =
-	'TokenCreated(address indexed token, uint256 indexed tokenId, string name, string symbol, string currency, address quoteToken, address admin)'
+const eventSignature = ABIS.getTokenCreatedEvent(chainId).replace(/^event /, '')
 
 const query =
 	`SELECT token, symbol, name FROM tokencreated ` +

--- a/apps/explorer/src/routes/api/tokens/count.ts
+++ b/apps/explorer/src/routes/api/tokens/count.ts
@@ -1,6 +1,7 @@
 import { createFileRoute } from '@tanstack/react-router'
 import * as IDX from 'idxs'
 import { getChainId } from 'wagmi/actions'
+import * as ABIS from '#lib/abis'
 import { TOKEN_COUNT_MAX } from '#lib/constants'
 import { getWagmiConfig } from '#wagmi.config.ts'
 
@@ -10,9 +11,6 @@ const IS = IDX.IndexSupply.create({
 
 const QB = IDX.QueryBuilder.from(IS)
 
-const EVENT_SIGNATURE =
-	'event TokenCreated(address indexed token, uint256 indexed tokenId, string name, string symbol, string currency, address quoteToken, address admin)'
-
 export const Route = createFileRoute('/api/tokens/count')({
 	server: {
 		handlers: {
@@ -20,9 +18,10 @@ export const Route = createFileRoute('/api/tokens/count')({
 				try {
 					const config = getWagmiConfig()
 					const chainId = getChainId(config)
+					const eventSignature = ABIS.getTokenCreatedEvent(chainId)
 
 					const countResult = await QB.selectFrom(
-						QB.withSignatures([EVENT_SIGNATURE])
+						QB.withSignatures([eventSignature])
 							.selectFrom('tokencreated')
 							.select((eb) => eb.lit(1).as('x'))
 							.where('chain', '=', chainId)


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h2>Greptile Overview</h2>

### Greptile Summary

This PR attempts to fix moderato ABI handling by introducing dynamic event signature retrieval based on chain ID. However, **the PR is incomplete and will cause critical failures**.

## Critical Issue

All three modified files import from `#lib/abis` (or `../src/lib/abis` in the script), which **does not exist** in the repository. The function `getTokenCreatedEvent(chainId)` is called but never defined anywhere in the codebase.

## What the PR Tries to Accomplish

The PR replaces hardcoded `TokenCreated` event signatures with dynamic retrieval via `ABIS.getTokenCreatedEvent(chainId)`. This makes sense given that:
- The repository supports multiple chain environments (Andantino/42429, Moderato/42431, Devnet/31318)
- Different chains may have different ABI versions for the same contract

The old hardcoded signature was:
```
TokenCreated(address indexed token, uint256 indexed tokenId, string name, string symbol, string currency, address quoteToken, address admin)
```

## Impact

Without the missing `abis` module:
- **Build failure**: TypeScript compilation will fail
- **Runtime errors**: All token-related functionality breaks
  - Token listing API (`tokens.server.ts`)
  - Token count API (`count.ts`)  
  - Token index generation script (`generate-tokens-index.ts`)

## Required Fix

The PR author needs to either:
1. Add the missing `apps/explorer/src/lib/abis.ts` file with the `getTokenCreatedEvent` function
2. Use an alternative approach (e.g., import from `viem/tempo` if such functionality exists there)
3. Revert to a working solution

### Confidence Score: 0/5

- This PR cannot be merged - it references a non-existent module causing guaranteed build/runtime failures
- Score of 0 (critical issues) because all three modified files import from a module that doesn't exist in the repository. This will cause immediate build failures and break all token-related functionality. The PR appears incomplete - missing the core abis module that implements getTokenCreatedEvent()
- All files require immediate attention - every changed file references the missing '#lib/abis' module

<details><summary><h3>Important Files Changed</h3></summary>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| apps/explorer/scripts/generate-tokens-index.ts | 0/5 | Imports from non-existent module '../src/lib/abis' causing critical failure. Script will not execute. |
| apps/explorer/src/lib/server/tokens.server.ts | 0/5 | Imports from non-existent module '#lib/abis' causing build/runtime failure in token fetching API. |
| apps/explorer/src/routes/api/tokens/count.ts | 0/5 | Imports from non-existent module '#lib/abis' breaking the tokens count API endpoint. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant TokensAPI as Tokens API
    participant CountAPI as Count API
    participant Script as generate-tokens-index
    participant ABIS as lib/abis (MISSING)
    participant IndexSupply as IndexSupply Service
    
    Note over ABIS: This module does not exist!
    
    Client->>TokensAPI: Request tokens list
    TokensAPI->>ABIS: getTokenCreatedEvent(chainId)
    ABIS--xTokensAPI: ERROR: Module not found
    
    Client->>CountAPI: Request token count
    CountAPI->>ABIS: getTokenCreatedEvent(chainId)
    ABIS--xCountAPI: ERROR: Module not found
    
    Script->>ABIS: getTokenCreatedEvent(chainId)
    ABIS--xScript: ERROR: Module not found
    Script->>IndexSupply: Query with eventSignature
    IndexSupply--xScript: Cannot execute (missing signature)
```
</details>


<details><summary><h3>Important Files Changed</h3></summary>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| apps/explorer/scripts/generate-tokens-index.ts | 0/5 | Imports from non-existent module '../src/lib/abis' causing critical failure. Script will not execute. |
| apps/explorer/src/lib/server/tokens.server.ts | 0/5 | Imports from non-existent module '#lib/abis' causing build/runtime failure in token fetching API. |
| apps/explorer/src/routes/api/tokens/count.ts | 0/5 | Imports from non-existent module '#lib/abis' breaking the tokens count API endpoint. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant TokensAPI as Tokens API
    participant CountAPI as Count API
    participant Script as generate-tokens-index
    participant ABIS as lib/abis (MISSING)
    participant IndexSupply as IndexSupply Service
    
    Note over ABIS: This module does not exist!
    
    Client->>TokensAPI: Request tokens list
    TokensAPI->>ABIS: getTokenCreatedEvent(chainId)
    ABIS--xTokensAPI: ERROR: Module not found
    
    Client->>CountAPI: Request token count
    CountAPI->>ABIS: getTokenCreatedEvent(chainId)
    ABIS--xCountAPI: ERROR: Module not found
    
    Script->>ABIS: getTokenCreatedEvent(chainId)
    ABIS--xScript: ERROR: Module not found
    Script->>IndexSupply: Query with eventSignature
    IndexSupply--xScript: Cannot execute (missing signature)
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->