### PR TITLE
feat: moderato spotlight links

### DIFF
--- a/apps/explorer/src/routes/_layout/index.tsx
+++ b/apps/explorer/src/routes/_layout/index.tsx
@@ -50,6 +50,18 @@ const SPOTLIGHT_DATA: Record<
 		mintHash:
 			'0xe5c909ef42674965a8b805118f08b58f215a98661838ae187737841531097b70',
 	},
+	42431: {
+		accountAddress: '0xa726a1CD723409074DF9108A2187cfA19899aCF8',
+		contractAddress: '0x0cb37634841784a6ef44aeba9bd6cf82c7143f86',
+		receiptHash:
+			'0x429eb0d8a4565138aec97fe11c8f2f4e56f26725e3a428881bbeba6c4e8ecdc9',
+		paymentHash:
+			'0x429eb0d8a4565138aec97fe11c8f2f4e56f26725e3a428881bbeba6c4e8ecdc9',
+		swapHash:
+			'0xc61b40cfc6714a893e3d758f2db3e19cd54f175369e17c48591654b294332cf9',
+		mintHash:
+			'0x58fcdd78477f7ee402320984e990e7a1623d80b768afb03f9b27fd2eac395032',
+	},
 }
 
 const chainId = Number(import.meta.env.VITE_TEMPO_CHAIN_ID)


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h2>Greptile Overview</h2>

### Greptile Summary

This PR adds spotlight data configuration for the Moderato testnet (chain ID 42431) to the explorer's home page. The spotlight data includes sample addresses and transaction hashes that power the quick-access links on the landing page, allowing users to explore example accounts, contracts, receipts, and actions (Payment, Swap, Mint).

The implementation follows the existing pattern used for Andantino (chain ID 42429), where spotlight data is keyed by chain ID and conditionally rendered based on the `VITE_TEMPO_CHAIN_ID` environment variable.

**Key additions:**
- Account address for spotlight account link
- Contract address for spotlight contract link  
- Receipt, payment, swap, and mint transaction hashes for various spotlight actions

**Potential issue identified:** The `receiptHash` and `paymentHash` values are identical, which differs from the Andantino configuration where these are distinct. This may be a copy-paste error or could be intentional if Moderato's transaction structure differs.

### Confidence Score: 3/5

- This PR is generally safe but contains a potential data issue that should be verified
- The code change is straightforward (adding configuration data) with no logic modifications. However, the identical receiptHash and paymentHash values suggest a possible copy-paste error. Score is 3 (moderate confidence) rather than higher because the duplicate hash could lead to confusing user experience where "Receipt" and "Payment" links navigate to different routes but with the same underlying data
- The spotlight data in apps/explorer/src/routes/_layout/index.tsx needs verification - specifically whether receiptHash and paymentHash should be identical

<details><summary><h3>Important Files Changed</h3></summary>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| apps/explorer/src/routes/_layout/index.tsx | 3/5 | Adds spotlight data for Moderato chain (42431), but receiptHash and paymentHash are identical which may be unintentional |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant HomePage as Home Page Component
    participant Config as SPOTLIGHT_DATA
    participant Router as Router/Navigator
    participant Routes as Route Pages

    User->>HomePage: Visits explorer home page
    HomePage->>Config: Get spotlightData[chainId]
    
    alt chainId is 42431 (Moderato)
        Config-->>HomePage: Return Moderato spotlight data
        HomePage->>HomePage: Render spotlight pills
        HomePage-->>User: Display Account, Contract, Receipt, Action pills
        
        alt User clicks Receipt pill
            User->>HomePage: Click Receipt
            HomePage->>Router: Navigate to /receipt/0x429eb0d...
            Router->>Routes: Load receipt page
            Routes-->>User: Display receipt details
        end
        
        alt User clicks Action → Payment
            User->>HomePage: Click Payment action
            HomePage->>Router: Navigate to /tx/0x429eb0d...
            Router->>Routes: Load transaction page
            Routes-->>User: Display transaction details
        end
        
        Note over Router,Routes: ⚠️ Both use same hash (potential issue)
    else chainId is other value
        Config-->>HomePage: Return null or other chain data
        HomePage->>HomePage: Conditionally render available pills
        HomePage-->>User: Display available spotlight options
    end
```
</details>


<details><summary><h3>Important Files Changed</h3></summary>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| apps/explorer/src/routes/_layout/index.tsx | 3/5 | Adds spotlight data for Moderato chain (42431), but receiptHash and paymentHash are identical which may be unintentional |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant HomePage as Home Page Component
    participant Config as SPOTLIGHT_DATA
    participant Router as Router/Navigator
    participant Routes as Route Pages

    User->>HomePage: Visits explorer home page
    HomePage->>Config: Get spotlightData[chainId]
    
    alt chainId is 42431 (Moderato)
        Config-->>HomePage: Return Moderato spotlight data
        HomePage->>HomePage: Render spotlight pills
        HomePage-->>User: Display Account, Contract, Receipt, Action pills
        
        alt User clicks Receipt pill
            User->>HomePage: Click Receipt
            HomePage->>Router: Navigate to /receipt/0x429eb0d...
            Router->>Routes: Load receipt page
            Routes-->>User: Display receipt details
        end
        
        alt User clicks Action → Payment
            User->>HomePage: Click Payment action
            HomePage->>Router: Navigate to /tx/0x429eb0d...
            Router->>Routes: Load transaction page
            Routes-->>User: Display transaction details
        end
        
        Note over Router,Routes: ⚠️ Both use same hash (potential issue)
    else chainId is other value
        Config-->>HomePage: Return null or other chain data
        HomePage->>HomePage: Conditionally render available pills
        HomePage-->>User: Display available spotlight options
    end
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->