### PR TITLE
fix: spotlight links

### DIFF
--- a/apps/explorer/src/routes/_layout/index.tsx
+++ b/apps/explorer/src/routes/_layout/index.tsx
@@ -22,7 +22,7 @@ import UserIcon from '~icons/lucide/user'
 import ZapIcon from '~icons/lucide/zap'
 
 const SPOTLIGHT_DATA: Record<
-	number,
+	string,
 	{
 		accountAddress: Address.Address
 		contractAddress: Address.Address
@@ -32,7 +32,7 @@ const SPOTLIGHT_DATA: Record<
 		mintHash: Hex.Hex
 	}
 > = {
-	42429: {
+	testnet: {
 		accountAddress: '0x5bc1473610754a5ca10749552b119df90c1a1877',
 		contractAddress: '0xe4b10A2a727D0f4863CEBca743a8dAb84cf65b2d',
 		receiptHash:
@@ -44,7 +44,7 @@ const SPOTLIGHT_DATA: Record<
 		mintHash:
 			'0xe5c909ef42674965a8b805118f08b58f215a98661838ae187737841531097b70',
 	},
-	42431: {
+	moderato: {
 		accountAddress: '0xa726a1CD723409074DF9108A2187cfA19899aCF8',
 		contractAddress: '0x0cb37634841784a6ef44aeba9bd6cf82c7143f86',
 		receiptHash:
@@ -58,8 +58,7 @@ const SPOTLIGHT_DATA: Record<
 	},
 }
 
-const chainId = Number(import.meta.env.VITE_TEMPO_CHAIN_ID)
-const spotlightData = SPOTLIGHT_DATA[chainId]
+const spotlightData = SPOTLIGHT_DATA[import.meta.env.VITE_TEMPO_ENV]
 
 export const Route = createFileRoute('/_layout/')({
 	component: Component,


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h2>Greptile Overview</h2>

### Greptile Summary

This PR refactors the spotlight data lookup mechanism to use environment names (`testnet`, `moderato`) instead of numeric chain IDs (42429, 42431). This change aligns with the broader pattern in the codebase where `VITE_TEMPO_ENV` is used for environment detection.

**Changes made:**
- Changed `SPOTLIGHT_DATA` keys from `number` to `string` type
- Updated object keys from chain IDs to environment names (`42429` → `testnet`, `42431` → `moderato`)
- Simplified data access from `Number(import.meta.env.VITE_TEMPO_CHAIN_ID)` to direct string lookup using `import.meta.env.VITE_TEMPO_ENV`

**Safety notes:**
- The code properly handles missing spotlight data (e.g., for `devnet` environment) through conditional checks on lines 250 and 264
- This matches the previous behavior where devnet (chain ID 31318) also had no spotlight data
- No other source files reference `VITE_TEMPO_CHAIN_ID`, so this change is isolated to this file

### Confidence Score: 4/5

- This PR is safe to merge with minimal risk - it's a straightforward refactoring that maintains existing behavior
- Score of 4 reflects a clean, well-handled refactoring. The code properly handles missing data scenarios, maintains backward compatibility with environments that lack spotlight data, and follows existing patterns in the codebase. Minor point deducted for a type safety improvement opportunity (Record&lt;string, ...&gt; could be more specific), but this doesn't affect runtime behavior.
- No files require special attention - this is a single-file refactoring with proper null checks

<details><summary><h3>Important Files Changed</h3></summary>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| apps/explorer/src/routes/_layout/index.tsx | 4/5 | Changes spotlight data lookup from chain ID numbers to environment names (testnet/moderato); properly handles missing devnet data |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant ENV as Environment Config
    participant DATA as SPOTLIGHT_DATA
    participant Component as SpotlightLinks
    participant UI as User Interface

    ENV->>DATA: VITE_TEMPO_ENV (testnet/moderato/devnet)
    DATA->>Component: spotlightData lookup [testnet/moderato exists, devnet → undefined]
    
    alt spotlightData exists
        Component->>UI: Render Account, Contract, Receipt pills
        Component->>UI: Render Action dropdown (Payment/Swap/Mint)
    else spotlightData is undefined
        Component->>UI: Skip spotlight-specific pills
    end
    
    Component->>UI: Always render Blocks and Tokens pills
```
</details>


<details><summary><h3>Important Files Changed</h3></summary>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| apps/explorer/src/routes/_layout/index.tsx | 4/5 | Changes spotlight data lookup from chain ID numbers to environment names (testnet/moderato); properly handles missing devnet data |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant ENV as Environment Config
    participant DATA as SPOTLIGHT_DATA
    participant Component as SpotlightLinks
    participant UI as User Interface

    ENV->>DATA: VITE_TEMPO_ENV (testnet/moderato/devnet)
    DATA->>Component: spotlightData lookup [testnet/moderato exists, devnet → undefined]
    
    alt spotlightData exists
        Component->>UI: Render Account, Contract, Receipt pills
        Component->>UI: Render Action dropdown (Payment/Swap/Mint)
    else spotlightData is undefined
        Component->>UI: Skip spotlight-specific pills
    end
    
    Component->>UI: Always render Blocks and Tokens pills
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->