### PR TITLE
fix: address & hash max-width in sidebars

### DIFF
--- a/apps/explorer/src/comps/AccountCard.tsx
+++ b/apps/explorer/src/comps/AccountCard.tsx
@@ -72,7 +72,8 @@ export function AccountCard(props: AccountCard.Props) {
 							)}
 						</div>
 					</div>
-					<p className="text-[14px] font-normal leading-[17px] text-primary break-all max-w-[22ch] font-mono">
+					{/* 42 chars / 2 lines = 21ch */}
+					<p className="text-[14px] font-normal leading-[17px] text-primary break-all max-w-[21ch] font-mono">
 						{address}
 					</p>
 				</button>,

--- a/apps/explorer/src/comps/BlockCard.tsx
+++ b/apps/explorer/src/comps/BlockCard.tsx
@@ -107,7 +107,7 @@ export function BlockCard(props: BlockCard.Props) {
 					/>
 					<BlockCard.TimeRow label="UNIX" value={String(timestamp)} />
 				</div>,
-				<div key="hash-parent" className="w-full flex flex-col gap-[8px]">
+				<div key="hash-parent" className="w-full flex flex-col gap-[12px]">
 					{hash && (
 						<button
 							type="button"
@@ -126,7 +126,9 @@ export function BlockCard(props: BlockCard.Props) {
 									)}
 								</div>
 							</div>
-							<div className="text-[14px] font-mono font-normal leading-[18px] text-primary break-all max-w-[calc(22ch+22px)]">
+							{/* the 15px font size needs to match the block number wrapper font size to make sure they align */}
+							{/* 22 chars/line * (1ch + 1px tracking) */}
+							<div className="text-[15px] font-mono font-normal leading-[18px] tracking-[1px] text-primary break-all max-w-[calc(22ch+22px)]">
 								{hash}
 							</div>
 						</button>
@@ -263,11 +265,11 @@ export namespace BlockCard {
 
 	export function BlockNumber(props: BlockNumber.Props) {
 		const { value } = props
-		const str = String(value).padStart(14, '0')
+		const str = String(value).padStart(15, '0')
 		const zerosEnd = str.match(/^0*/)?.[0].length ?? 0
 		return (
-			// the 14px font size is used to set the same width as the block hash
-			<div className="text-[14px] max-w-[calc(22ch+22px)] font-mono">
+			// the 15px font size is used to set the same width as the block hash
+			<div className="text-[15px] max-w-[calc(22ch+22px)] font-mono">
 				<span className="flex justify-between gap-px text-[22px] text-tertiary">
 					{str.split('').map((char, index) => (
 						<span

--- a/apps/explorer/src/comps/TxTransactionCard.tsx
+++ b/apps/explorer/src/comps/TxTransactionCard.tsx
@@ -40,7 +40,8 @@ export function TxTransactionCard(props: TxTransactionCard.Props) {
 							)}
 						</div>
 					</div>
-					<p className="text-[14px] font-normal leading-[17px] text-primary break-all max-w-[23ch] font-mono">
+					{/* 66 chars / 3 lines = 22ch */}
+					<p className="text-[14px] font-normal leading-[17px] text-primary break-all max-w-[22ch] font-mono">
 						{hash}
 					</p>
 				</button>,

--- a/apps/explorer/src/routes/_layout/demo/address.tsx
+++ b/apps/explorer/src/routes/_layout/demo/address.tsx
@@ -896,7 +896,7 @@ function Component() {
 								)}
 							</div>
 						</div>
-						<p className="text-[14px] font-normal leading-[17px] tracking-[0.02em] text-primary break-all max-w-[22ch]">
+						<p className="text-[14px] font-normal leading-[17px] tracking-[0.02em] text-primary break-all max-w-[21ch]">
 							{accountAddress}
 						</p>
 					</button>,

--- a/apps/explorer/src/routes/_layout/token/$address.tsx
+++ b/apps/explorer/src/routes/_layout/token/$address.tsx
@@ -353,7 +353,7 @@ function TokenCard(props: {
 							)}
 						</div>
 					</div>
-					<p className="text-[14px] font-mono font-normal leading-4.25 text-primary break-all max-w-[22ch]">
+					<p className="text-[14px] font-mono font-normal leading-4.25 text-primary break-all max-w-[21ch]">
 						{address}
 					</p>
 				</button>,


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

### Greptile Summary

This PR fixes max-width CSS values for addresses and hashes displayed in sidebar cards to ensure proper text wrapping.

**Changes made:**
- **Address displays** (42 chars): Changed from `max-w-[22ch]` to `max-w-[21ch]` for correct 2-line wrapping (42 ÷ 2 = 21)
- **Transaction hash** (66 chars): Changed from `max-w-[23ch]` to `max-w-[22ch]` for correct 3-line wrapping (66 ÷ 3 = 22)
- **Block card alignment**: Adjusted font size (14px → 15px), tracking (added 1px), gap spacing (8px → 12px), and block number padding (14 → 15 digits) to ensure block hash and block number have matching visual widths

The calculations are mathematically correct and the changes are consistently applied across all relevant components (AccountCard, TxTransactionCard, BlockCard) and routes (demo/address, token/$address).

**Impact:** Purely cosmetic CSS adjustments that improve visual consistency. No functional logic changes.

### Confidence Score: 5/5

- This PR is safe to merge with no risk
- All changes are purely CSS adjustments with correct mathematical calculations (42÷2=21ch, 66÷3=22ch). No JavaScript logic was modified, no edge cases exist for static styling values, and changes are consistently applied across all affected components.
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| apps/explorer/src/comps/AccountCard.tsx | 5/5 | Updated address max-width from 22ch to 21ch for proper 2-line wrapping (42 chars / 2 = 21ch) |
| apps/explorer/src/comps/TxTransactionCard.tsx | 5/5 | Updated transaction hash max-width from 23ch to 22ch for proper 3-line wrapping (66 chars / 3 = 22ch) |
| apps/explorer/src/comps/BlockCard.tsx | 5/5 | Adjusted font size (14px to 15px), tracking (1px), gap (8px to 12px), and block number padding (14 to 15 digits) to align block hash and number widths |
| apps/explorer/src/routes/_layout/demo/address.tsx | 5/5 | Updated address max-width from 22ch to 21ch to match AccountCard component |
| apps/explorer/src/routes/_layout/token/$address.tsx | 5/5 | Updated address max-width from 22ch to 21ch to match AccountCard component |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant Browser
    participant Component
    participant CSS

    User->>Browser: Navigate to page with sidebar
    Browser->>Component: Render AccountCard/TxTransactionCard/BlockCard
    Component->>CSS: Apply max-width styling
    
    Note over CSS: Before PR:<br/>Address: max-w-[22ch]<br/>Tx Hash: max-w-[23ch]
    
    CSS-->>Component: Text wraps incorrectly
    Component-->>Browser: Display with improper alignment
    
    Note over Component,CSS: PR Changes Applied
    
    Component->>CSS: Apply corrected max-width
    
    Note over CSS: After PR:<br/>Address: max-w-[21ch] (42÷2=21)<br/>Tx Hash: max-w-[22ch] (66÷3=22)<br/>Block: 15px font + tracking
    
    CSS-->>Component: Text wraps at correct width
    Component-->>Browser: Display with proper alignment
    Browser-->>User: Show correctly formatted sidebar
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->