### PR TITLE
fix(explorer): use gasUsed instead of cumulativeGasUsed for tx fee

### DIFF
--- a/apps/explorer/src/routes/_layout/address/$address.tsx
+++ b/apps/explorer/src/routes/_layout/address/$address.tsx
@@ -1084,7 +1084,7 @@ function TransactionFeeCellInner(props: { hash: Hex.Hex }) {
 		<span className="text-tertiary">
 			{PriceFormatter.format(
 				batchData.receipt.effectiveGasPrice *
-					batchData.receipt.cumulativeGasUsed,
+					batchData.receipt.gasUsed,
 				{ decimals: 18, format: 'short' },
 			)}
 		</span>


### PR DESCRIPTION
## Motivation

the "Fee" column on the address summary page shows inflated transaction fees. For example, tx `0x37f60fe...` displays $0.5 on the address page but the correct fee of $0.04 on the receipt page.

the reason is that `TransactionFeeCellInner` was using `cumulativeGasUsed` (total gas for all txs in the block up to that point) instead of `gasUsed` (gas for just that transaction).

## Solution

use `gasUsed`rather than `cumulativeGasUsed`

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

### Greptile Summary

This PR fixes a bug in the address transaction history page where transaction fees were displayed incorrectly. 

The issue was in the `TransactionFeeCellInner` component (line 1087), which was using `cumulativeGasUsed` instead of `gasUsed` when calculating transaction fees.

**The Problem:**
- `cumulativeGasUsed` is the total gas used by all transactions in a block up to and including the current transaction
- `gasUsed` is the gas used by just the individual transaction
- Using `cumulativeGasUsed` resulted in inflated fee amounts (e.g., showing $0.5 instead of the correct $0.04)

**The Fix:**
Changed the calculation from:
```typescript
batchData.receipt.effectiveGasPrice * batchData.receipt.cumulativeGasUsed
```
to:
```typescript
batchData.receipt.effectiveGasPrice * batchData.receipt.gasUsed
```

**Verified Consistency:**
I checked all other fee calculations in the codebase and confirmed they all correctly use `gasUsed`:
- Receipt page (`receipt/$hash.tsx` lines 262-267, 325)
- Transaction detail page (`tx/$hash.tsx` line 385)
- Transaction row component (`TxTransactionRow.tsx` line 45)
- OG image generation (`og.ts` lines 394-396)

This was the only place with this bug. The fix aligns the address page with how fees are calculated everywhere else in the application.

### Confidence Score: 5/5

- This PR is safe to merge - it's a straightforward one-line bug fix with no risk
- The change is a simple, correct bug fix that replaces an incorrect field (cumulativeGasUsed) with the correct one (gasUsed). I verified that all other fee calculations in the codebase already use gasUsed correctly, and this change aligns the address page with the rest of the application. The component already has proper error handling with null checks. No tests need updating as there are no test files in the explorer app.
- No files require special attention - this is a simple one-line fix

<details><summary><h3>Important Files Changed</h3></summary>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| apps/explorer/src/routes/_layout/address/$address.tsx | 5/5 | Fixed transaction fee calculation by replacing cumulativeGasUsed with gasUsed - a straightforward one-line bug fix |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant AddressPage as Address Page
    participant TransactionFeeCell
    participant BatchContext as Batch Data Context
    participant RPC as RPC Client
    
    User->>AddressPage: Visit /address/0x...
    AddressPage->>RPC: Fetch transaction list
    RPC-->>AddressPage: Returns transactions
    AddressPage->>BatchContext: useBatchTransactionData(transactions)
    BatchContext->>RPC: getTransactionReceipt(hash)
    RPC-->>BatchContext: Returns receipt with gasUsed & cumulativeGasUsed
    BatchContext-->>AddressPage: Provides transactionDataMap
    
    AddressPage->>TransactionFeeCell: Render fee for tx
    TransactionFeeCell->>BatchContext: useTransactionDataFromBatch(hash)
    BatchContext-->>TransactionFeeCell: Returns receipt data
    
    Note over TransactionFeeCell: BEFORE: effectiveGasPrice * cumulativeGasUsed ❌<br/>AFTER: effectiveGasPrice * gasUsed ✓
    
    TransactionFeeCell-->>User: Display correct fee (e.g., $0.04 not $0.5)
```
</details>


<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->