### PR TITLE
fix: support multiple chains on apps/og

### DIFF
--- a/apps/explorer/src/lib/og-params.ts
+++ b/apps/explorer/src/lib/og-params.ts
@@ -41,6 +41,7 @@ export interface TxOgParams {
 
 export interface TokenOgParams {
 	address: string
+	chainId: number
 	name?: string
 	symbol?: string
 	currency?: string
@@ -135,6 +136,7 @@ export function buildTokenOgUrl(
 	if (params.quoteToken)
 		search.set('quoteToken', truncateText(params.quoteToken, 24))
 	if (params.isFeeToken) search.set('isFeeToken', 'true')
+	search.set('chainId', String(params.chainId))
 
 	return `${baseUrl}/token/${params.address}?${search.toString()}`
 }

--- a/apps/explorer/src/lib/og.ts
+++ b/apps/explorer/src/lib/og.ts
@@ -306,6 +306,7 @@ export function buildAddressDescription(
 
 export function buildTokenOgImageUrl(params: {
 	address: string
+	chainId: number
 	name?: string
 	symbol?: string
 	currency?: string
@@ -316,6 +317,7 @@ export function buildTokenOgImageUrl(params: {
 }): string {
 	const ogParams: TokenOgParams = {
 		address: params.address,
+		chainId: params.chainId,
 		name: params.name,
 		symbol: params.symbol,
 		currency: params.currency,

--- a/apps/explorer/src/routes/_layout/token/$address.tsx
+++ b/apps/explorer/src/routes/_layout/token/$address.tsx
@@ -13,7 +13,7 @@ import * as React from 'react'
 import { formatUnits } from 'viem'
 import { Abis } from 'viem/tempo'
 import type { Config } from 'wagmi'
-import { getPublicClient } from 'wagmi/actions'
+import { getChainId, getPublicClient } from 'wagmi/actions'
 import { Actions, Hooks } from 'wagmi/tempo'
 import * as z from 'zod/mini'
 import { AddressCell } from '#comps/AddressCell'
@@ -51,6 +51,8 @@ const defaultSearchValues = {
 } as const
 
 const tabOrder = ['transfers', 'holders', 'contract'] as const
+
+const chainId = getChainId(getWagmiConfig())
 
 type TokenMetadata = Actions.token.getMetadata.ReturnValue
 
@@ -173,15 +175,18 @@ export const Route = createFileRoute('/_layout/token/$address')({
 				: null,
 		)
 
-		const ogImageUrl = buildTokenOgImageUrl({
-			address: params.address,
-			name: metadata?.name,
-			symbol: metadata?.symbol,
-			currency,
-			holders: formatHolders(ogStats?.holders),
-			supply,
-			created: ogStats?.created ?? undefined,
-		})
+		const ogImageUrl = loaderData
+			? buildTokenOgImageUrl({
+					address: params.address,
+					chainId,
+					name: metadata?.name,
+					symbol: metadata?.symbol,
+					currency,
+					holders: formatHolders(ogStats?.holders),
+					supply,
+					created: ogStats?.created ?? undefined,
+				})
+			: undefined
 
 		return {
 			title,

--- a/apps/og/src/index.tsx
+++ b/apps/og/src/index.tsx
@@ -169,7 +169,9 @@ app.get(
 		const [fonts, images, tokenIcon] = await Promise.all([
 			loadFonts(),
 			loadImages(context.env),
-			fetchTokenIcon(address),
+			tokenParams.chainId
+				? fetchTokenIcon(address, tokenParams.chainId)
+				: null,
 		])
 
 		const imageResponse = new ImageResponse(

--- a/apps/og/src/params.ts
+++ b/apps/og/src/params.ts
@@ -155,6 +155,7 @@ export const tokenOgQuerySchema = z.pipe(
 		created: sanitizedWithDefault(32),
 		quoteToken: sanitized(24),
 		isFeeToken: booleanString,
+		chainId: z.optional(z.coerce.number()),
 	}),
 	z.transform((data) => ({
 		name: data.name,
@@ -165,6 +166,7 @@ export const tokenOgQuerySchema = z.pipe(
 		created: data.created,
 		quoteToken: data.quoteToken,
 		isFeeToken: data.isFeeToken,
+		chainId: data.chainId,
 	})),
 )
 

--- a/apps/og/src/utilities.ts
+++ b/apps/og/src/utilities.ts
@@ -5,7 +5,6 @@ const FONT_MONO_URL =
 const FONT_INTER_URL =
 	'https://unpkg.com/@fontsource/inter/files/inter-latin-500-normal.woff2'
 const TOKENLIST_ICON_URL = 'https://tokenlist.tempo.xyz/icon'
-const TESTNET_CHAIN_ID = 42429
 
 interface ImageCache {
 	bgTx: ArrayBuffer
@@ -85,10 +84,13 @@ export async function loadImages(env: Cloudflare.Env): Promise<ImageCache> {
 	return imagesInFlight
 }
 
-export async function fetchTokenIcon(address: string): Promise<string | null> {
+export async function fetchTokenIcon(
+	address: string,
+	chainId: number,
+): Promise<string | null> {
 	try {
 		const response = await fetch(
-			`${TOKENLIST_ICON_URL}/${TESTNET_CHAIN_ID}/${address}`,
+			`${TOKENLIST_ICON_URL}/${chainId}/${address}`,
 			{ cf: { cacheTtl: 3600 } },
 		)
 		if (!response.ok) return null


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

### Greptile Summary

This PR adds multi-chain support to the Open Graph (OG) image generation system for token pages. Previously, the OG worker hardcoded `TESTNET_CHAIN_ID = 42429` when fetching token icons. Now, the explorer passes the current chain ID through the OG URL parameters, allowing the worker to fetch icons from the correct chain.

**Key changes:**
- Added `chainId` field to `TokenOgParams` interface (required field)
- Explorer now retrieves chain ID at module level using `getChainId(getWagmiConfig())` 
- Chain ID is passed through the entire OG URL generation pipeline
- OG worker conditionally fetches token icon only when `chainId` is provided
- Removed hardcoded `TESTNET_CHAIN_ID` constant from utilities

The implementation properly threads the chain ID through all layers: from the explorer's token page → OG library → URL parameters → OG worker → token list API. This enables correct token icon fetching across devnet (31318), testnet/andantino (42429), and moderato (42431) chains.

### Confidence Score: 5/5

- Safe to merge - clean refactoring that properly threads chain ID through the OG system
- The changes are straightforward and well-structured. The chainId is properly added to interfaces, passed through all layers consistently, and the OG worker handles the optional parameter safely. The module-level initialization of chainId follows an existing pattern in the codebase (seen in txs-count route). No breaking changes or edge cases detected.
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| apps/explorer/src/lib/og-params.ts | 5/5 | Added chainId field to TokenOgParams interface and included it in buildTokenOgUrl function |
| apps/explorer/src/lib/og.ts | 5/5 | Added chainId parameter to buildTokenOgImageUrl function and passed it through to OG params |
| apps/explorer/src/routes/_layout/token/$address.tsx | 5/5 | Added module-level chainId constant and passed it to buildTokenOgImageUrl; conditionally builds OG URL only when loaderData exists |
| apps/og/src/index.tsx | 5/5 | Updated fetchTokenIcon call to conditionally fetch icon only when chainId is provided |
| apps/og/src/params.ts | 5/5 | Added optional chainId field to tokenOgQuerySchema as z.coerce.number() |
| apps/og/src/utilities.ts | 5/5 | Updated fetchTokenIcon to accept chainId parameter and removed hardcoded TESTNET_CHAIN_ID constant |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Explorer as Explorer (token/$address.tsx)
    participant OgLib as OG Library (og.ts)
    participant OgParams as OG Params Builder
    participant OgWorker as OG Worker (apps/og)
    participant TokenList as Token List API
    
    Note over Explorer: Module initialization
    Explorer->>Explorer: getChainId(getWagmiConfig())
    
    Note over Explorer: Page head() function
    Explorer->>OgLib: buildTokenOgImageUrl({chainId, address, ...})
    OgLib->>OgParams: buildTokenOgUrl(baseUrl, {chainId, ...})
    OgParams->>OgParams: Add chainId to URL params
    OgParams-->>Explorer: Return OG image URL with chainId
    
    Note over OgWorker: Image generation request
    OgWorker->>OgWorker: Parse chainId from query params
    alt chainId provided
        OgWorker->>TokenList: fetchTokenIcon(address, chainId)
        TokenList-->>OgWorker: Return token icon or null
    else chainId not provided
        OgWorker->>OgWorker: Use null icon
    end
    OgWorker->>OgWorker: Generate OG image with token data
    OgWorker-->>Explorer: Return PNG image
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->