### PR TITLE
perf(explorer): code split heavy contract and trace components

### DIFF
--- a/apps/explorer/src/comps/Contract.tsx
+++ b/apps/explorer/src/comps/Contract.tsx
@@ -3,11 +3,27 @@ import * as React from 'react'
 import type { Abi } from 'viem'
 import { useBytecode } from 'wagmi'
 import { ConnectWallet } from '#comps/ConnectWallet.tsx'
-import { AbiViewer } from '#comps/ContractAbi.tsx'
-import { ContractReader } from '#comps/ContractReader.tsx'
-import { SourceSection } from '#comps/ContractSource.tsx'
-import { ContractWriter } from '#comps/ContractWriter.tsx'
 import { cx } from '#cva.config.ts'
+
+// Lazy load heavy contract interaction components
+const AbiViewer = React.lazy(() =>
+	import('#comps/ContractAbi.tsx').then((m) => ({ default: m.AbiViewer })),
+)
+const ContractReader = React.lazy(() =>
+	import('#comps/ContractReader.tsx').then((m) => ({
+		default: m.ContractReader,
+	})),
+)
+const SourceSection = React.lazy(() =>
+	import('#comps/ContractSource.tsx').then((m) => ({
+		default: m.SourceSection,
+	})),
+)
+const ContractWriter = React.lazy(() =>
+	import('#comps/ContractWriter.tsx').then((m) => ({
+		default: m.ContractWriter,
+	})),
+)
 import { ellipsis } from '#lib/chars.ts'
 import type { ContractSource } from '#lib/domain/contract-source.ts'
 import { getContractAbi } from '#lib/domain/contracts.ts'
@@ -57,7 +73,17 @@ export function ContractTabContent(props: {
 	return (
 		<div className="flex flex-col h-full [&>*:last-child]:border-b-transparent">
 			{/* Source Section */}
-			{source && <SourceSection {...source} />}
+			{source && (
+				<React.Suspense
+					fallback={
+						<div className="p-4 text-sm text-secondary">
+							Loading source code...
+						</div>
+					}
+				>
+					<SourceSection {...source} />
+				</React.Suspense>
+			)}
 
 			{/* ABI Section */}
 			<CollapsibleSection
@@ -100,7 +126,13 @@ export function ContractTabContent(props: {
 					</>
 				}
 			>
-				<AbiViewer abi={abi} />
+				<React.Suspense
+					fallback={
+						<div className="p-4 text-sm text-secondary">Loading ABI...</div>
+					}
+				>
+					<AbiViewer abi={abi} />
+				</React.Suspense>
 			</CollapsibleSection>
 
 			{/* Bytecode Section */}
@@ -250,7 +282,15 @@ export function InteractTabContent(props: {
 				actions={<ConnectWallet />}
 			>
 				<div className="px-[10px] pb-[10px]">
-					<ContractWriter address={address} abi={abi} />
+					<React.Suspense
+						fallback={
+							<div className="p-4 text-sm text-secondary">
+								Loading contract writer...
+							</div>
+						}
+					>
+						<ContractWriter address={address} abi={abi} />
+					</React.Suspense>
 				</div>
 			</CollapsibleSection>
 
@@ -261,7 +301,15 @@ export function InteractTabContent(props: {
 				onToggle={() => setReadExpanded(!readExpanded)}
 			>
 				<div className="px-[10px] pb-[10px]">
-					<ContractReader address={address} abi={abi} docsUrl={docsUrl} />
+					<React.Suspense
+						fallback={
+							<div className="p-4 text-sm text-secondary">
+								Loading contract reader...
+							</div>
+						}
+					>
+						<ContractReader address={address} abi={abi} docsUrl={docsUrl} />
+					</React.Suspense>
 				</div>
 			</CollapsibleSection>
 		</div>

--- a/apps/explorer/src/routes/_layout/tx/$hash.tsx
+++ b/apps/explorer/src/routes/_layout/tx/$hash.tsx
@@ -24,9 +24,15 @@ import { TxDecodedCalldata } from '#comps/TxDecodedCalldata'
 import { TxDecodedTopics } from '#comps/TxDecodedTopics'
 import { TxEventDescription } from '#comps/TxEventDescription'
 import { TxRawTransaction } from '#comps/TxRawTransaction'
-import { TxStateDiff } from '#comps/TxStateDiff'
-import { TxTraceTree } from '#comps/TxTraceTree'
 import { TxTransactionCard } from '#comps/TxTransactionCard'
+
+// Lazy load heavy trace/state components
+const TxTraceTree = React.lazy(() =>
+	import('#comps/TxTraceTree').then((m) => ({ default: m.TxTraceTree })),
+)
+const TxStateDiff = React.lazy(() =>
+	import('#comps/TxStateDiff').then((m) => ({ default: m.TxStateDiff })),
+)
 import { cx } from '#cva.config.ts'
 import { apostrophe } from '#lib/chars'
 import type { KnownEvent } from '#lib/domain/known-events'
@@ -240,8 +246,16 @@ function RouteComponent() {
 			itemsLabel: 'views',
 			content: (
 				<div className="flex flex-col">
-					<TxTraceTree trace={traceData.trace} />
-					<TxStateDiff prestate={traceData.prestate} />
+					<React.Suspense
+						fallback={
+							<div className="rounded-[10px] bg-card-header p-4 text-sm text-secondary">
+								Loading trace data...
+							</div>
+						}
+					>
+						<TxTraceTree trace={traceData.trace} />
+						<TxStateDiff prestate={traceData.prestate} />
+					</React.Suspense>
 				</div>
 			),
 		})


### PR DESCRIPTION
## Summary
Implements code splitting for large, infrequently-used components to reduce initial bundle size.

## Components Lazy Loaded
This PR adds lazy loading for the following heavy components:
- **TxTraceTree** and **TxStateDiff** - Transaction trace visualization
- **ContractReader** and **ContractWriter** - Contract interaction forms
- **AbiViewer** - ABI JSON viewer
- **SourceSection** - Contract source code viewer

## Solution
- Converted components to `React.lazy()` imports
- Wrapped all usages with `React.Suspense` and loading fallbacks
- Components only load when their respective tabs/sections are accessed

## Impact
- **Reduced initial JavaScript bundle** - Heavy components deferred until needed
- **Faster Time to Interactive (TTI)** - Less JS to parse/execute upfront
- **Better First Contentful Paint (FCP)** - Smaller initial payload
- **On-demand loading** - Components load only when user navigates to their tab

## Test Plan
- [x] Dev server starts without errors
- [ ] Transaction trace tab loads correctly when accessed
- [ ] Contract Read/Write sections work after lazy loading
- [ ] ABI and source code display properly
- [ ] No flash of unstyled content
- [ ] Network tab shows separate chunk files loading on demand

## Related PRs
Part of larger performance improvement initiative alongside:
- #411 - Fix N+1 query pattern
- #412 - Lazy load intro animation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

### Greptile Summary

This PR implements React.lazy() code splitting for heavy components (TxTraceTree, TxStateDiff, ContractReader, ContractWriter, AbiViewer, SourceSection) with Suspense fallbacks.

**Implementation**: The components are correctly converted to lazy imports and wrapped with React.Suspense boundaries showing loading states.

**Critical Issue**: The code splitting is largely ineffective due to how the UI components handle visibility:

1. **Contract sections**: CollapsibleSection uses CSS `hidden` instead of conditional rendering. Since Read/Write sections default to `expanded={true}`, the lazy components load immediately on mount.

2. **Transaction tabs**: In tabs mode (desktop), the Sections component renders all tab content upfront and toggles with CSS `hidden`. Lazy components in inactive tabs still load immediately. Only works properly in stacked mode (mobile) which conditionally renders collapsed content.

**Impact**: Most users on desktop will not see bundle size benefits. The stated performance improvements (reduced initial JS, faster TTI, better FCP) will only partially materialize for mobile users and collapsed sections.

### Confidence Score: 3/5

- Safe to merge but won't achieve stated performance goals
- The code changes are syntactically correct and won't break functionality - all components are properly exported and the lazy loading syntax is valid. However, the implementation doesn't achieve its performance optimization goals due to architectural issues with CSS-based visibility toggling instead of conditional rendering. The code will work but provide minimal benefit.
- Both files need architectural changes to CollapsibleSection and Sections components to enable true conditional rendering for lazy loading to be effective

<details><summary><h3>Important Files Changed</h3></summary>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| apps/explorer/src/comps/Contract.tsx | 3/5 | Added lazy loading for AbiViewer, ContractReader, ContractWriter, and SourceSection with Suspense boundaries. However, code splitting is ineffective for components in expanded sections (Read/Write default to expanded=true) because CollapsibleSection only uses CSS hidden, not conditional rendering. |
| apps/explorer/src/routes/_layout/tx/$hash.tsx | 3/5 | Added lazy loading for TxTraceTree and TxStateDiff with Suspense. Code splitting is ineffective in tabs mode (desktop) because Sections component renders all tab content immediately with CSS hidden. Only works properly in stacked mode (mobile). |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant Browser
    participant App
    participant Sections
    participant Suspense
    participant LazyComponent

    User->>Browser: Navigate to transaction page
    Browser->>App: Load route
    App->>Sections: Render all tabs (tabs mode)
    
    Note over Sections: Renders all tab content<br/>Uses CSS hidden for inactive tabs
    
    Sections->>Suspense: Render trace tab content (hidden)
    Suspense->>LazyComponent: Trigger lazy load
    LazyComponent-->>Browser: Fetch TxTraceTree chunk
    LazyComponent-->>Browser: Fetch TxStateDiff chunk
    
    Sections->>Suspense: Render overview tab (visible)
    
    Note over Browser,LazyComponent: ALL chunks load immediately<br/>despite trace tab being inactive
    
    User->>Sections: Click trace tab
    Sections->>Sections: Toggle CSS visibility
    Note over Sections: Components already loaded<br/>No lazy loading benefit
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->