### PR TITLE
feat: RPC auth via URL param

### DIFF
--- a/apps/explorer/src/wagmi.config.ts
+++ b/apps/explorer/src/wagmi.config.ts
@@ -4,6 +4,7 @@ import {
 	createServerOnlyFn,
 } from '@tanstack/react-start'
 import { getRequestHeader } from '@tanstack/react-start/server'
+import { RPC_AUTH_COOKIE } from './index.server'
 import {
 	tempoDevnet,
 	tempoLocalnet,
@@ -113,7 +114,13 @@ const getTempoTransport = createIsomorphicFn()
 			}
 		}
 		if (forwardAuth) {
-			const authHeader = getRequestHeader('authorization')
+			let authHeader = getRequestHeader('authorization')
+			if (!authHeader) {
+				const cookies = getRequestHeader('cookie')
+				const prefix = `${RPC_AUTH_COOKIE}=`
+				const cookie = cookies?.split('; ').find((c) => c.startsWith(prefix))
+				if (cookie) authHeader = `Basic ${cookie.slice(prefix.length)}`
+			}
 			return fallback(
 				getHttpUrls().map((url) =>
 					safeHttp(withKey(url), {


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

### Greptile Summary

This PR adds the ability to authenticate with RPC endpoints by passing credentials via URL parameter, which are then stored in a cookie for subsequent requests.

**Implementation Overview:**
- `handleAuthParam()` intercepts requests with query parameter, base64-encodes credentials (if needed) and stores them in an `rpc_auth` cookie before redirecting
- `getRpcAuthFromCookie()` extracts the cookie value and formats it as a Basic authentication header
- The authentication flow is integrated into both the server entry point (`checkRpcAuth`) and the wagmi transport configuration

**Key Changes:**
1. **index.server.ts**: Adds URL parameter handling and cookie-based credential extraction
2. **wagmi.config.ts**: Extends RPC transport to include headers from cookies when forwarding is enabled

**Issues Found:**
- **Potential runtime error**: `btoa()` will throw an exception if the input string contains non-Latin1 characters (e.g., Unicode)
- **Security considerations**: Credentials passed in URL will be logged in server access logs and browser history, though this is partially mitigated by immediate redirect
- **Missing Secure flag**: Cookie should include `Secure` attribute to prevent transmission over HTTP
- **Code duplication**: Cookie parsing logic is duplicated between the two files

The feature appears to be designed for development/testing convenience when working with authenticated RPC endpoints.

### Confidence Score: 3/5

- This PR is moderately safe to merge but has one critical bug and several security considerations that should be addressed
- Score reflects one logic error (btoa() can throw with Unicode), missing security best practices (Secure cookie flag), and security tradeoffs in the URL-based credential flow. The code duplication is a minor quality issue. These issues should be addressed before production use, though the feature may be intended primarily for development/testing.
- apps/explorer/src/index.server.ts requires the most attention due to the potential btoa() runtime error and security implications of the URL parameter approach

<details><summary><h3>Important Files Changed</h3></summary>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| apps/explorer/src/index.server.ts | 3/5 | Adds RPC authentication via URL parameter with cookie storage. Has potential btoa() error with Unicode chars, missing Secure flag on cookie, and credentials exposure in URL/logs concerns. |
| apps/explorer/src/wagmi.config.ts | 4/5 | Extends transport config to read auth from cookie. Cookie parsing logic is duplicated from index.server.ts - could be refactored into shared utility. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Browser
    participant ServerEntry as index.server.ts
    participant AuthCheck as checkRpcAuth
    participant RpcEndpoint as RPC Server
    participant WagmiConfig as wagmi.config.ts

    Browser->>ServerEntry: Initial request with URL param
    ServerEntry->>ServerEntry: handleAuthParam()
    Note over ServerEntry: Process param<br/>Store in cookie<br/>Clean URL
    ServerEntry->>Browser: Redirect without param
    
    Browser->>ServerEntry: Follow redirect
    ServerEntry->>AuthCheck: Validate request
    AuthCheck->>AuthCheck: Extract cookie value
    AuthCheck->>RpcEndpoint: Verify credentials
    RpcEndpoint-->>AuthCheck: Validation result
    
    alt Validation fails
        AuthCheck-->>Browser: Return 401
    else Validation succeeds
        AuthCheck-->>ServerEntry: Allow request
        ServerEntry->>WagmiConfig: Initialize transport
        WagmiConfig->>WagmiConfig: Read cookie value
        WagmiConfig->>RpcEndpoint: Forward credentials
        RpcEndpoint-->>WagmiConfig: RPC data
        ServerEntry-->>Browser: Render page
    end
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->