### PR TITLE
fix: only show testnet migration banner on testnets

### DIFF
--- a/apps/explorer/src/routes/_layout.tsx
+++ b/apps/explorer/src/routes/_layout.tsx
@@ -4,6 +4,7 @@ import { Footer } from '#comps/Footer'
 import { Header } from '#comps/Header'
 import { useIntroSeen } from '#comps/Intro'
 import { Sphere } from '#comps/Sphere'
+import { isTestnet } from '#lib/env'
 import { fetchLatestBlock } from '#lib/server/latest-block.server.ts'
 import TriangleAlert from '~icons/lucide/triangle-alert'
 
@@ -37,27 +38,29 @@ export function Layout(props: Layout.Props) {
 	const isHome = Boolean(matchRoute({ to: '/' }))
 	return (
 		<div className="flex min-h-dvh flex-col print:block print:min-h-0">
-			<div className="bg-base-alt px-[32px] py-[8px] text-sm text-primary text-center">
-				<TriangleAlert className="size-4 inline mr-[4px] relative top-[-1px]" />
-				<span className="">
-					<strong>Testnet migration:</strong> Tempo launched a new testnet
-					(Moderato) on January 8th. The old testnet (Andantino) will be
-					deprecated on{' '}
-					<time dateTime="2026-03-08" title="March 8th, 2026">
-						March 8th
-					</time>
-					.{' '}
-					<a
-						href="https://docs.tempo.xyz/network-upgrades"
-						className="underline press-down-inline"
-						target="_blank"
-						rel="noopener noreferrer"
-					>
-						Read the docs
-					</a>{' '}
-					for more details.
-				</span>
-			</div>
+			{isTestnet() && (
+				<div className="bg-base-alt px-[32px] py-[8px] text-sm text-primary text-center">
+					<TriangleAlert className="size-4 inline mr-[4px] relative top-[-1px]" />
+					<span className="">
+						<strong>Testnet migration:</strong> Tempo launched a new testnet
+						(Moderato) on January 8th. The old testnet (Andantino) will be
+						deprecated on{' '}
+						<time dateTime="2026-03-08" title="March 8th, 2026">
+							March 8th
+						</time>
+						.{' '}
+						<a
+							href="https://docs.tempo.xyz/network-upgrades"
+							className="underline press-down-inline"
+							target="_blank"
+							rel="noopener noreferrer"
+						>
+							Read the docs
+						</a>{' '}
+						for more details.
+					</span>
+				</div>
+			)}
 			<div className={`relative z-2 ${isReceipt ? 'print:hidden' : ''}`}>
 				<Header initialBlockNumber={blockNumber} />
 			</div>


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

### Greptile Summary

This PR adds conditional rendering to the testnet migration banner in the explorer's layout component. Previously, the banner was always displayed regardless of the environment. Now it only appears on testnet environments (both "testnet"/Andantino and "moderato") using the `isTestnet()` helper function.

The change leverages the centralized `isTestnet()` utility that was added in PR #418, which uses `createIsomorphicFn` to ensure consistent behavior across client and server rendering. This prevents hydration mismatches and ensures the banner only shows to users who need to see it.

The implementation is clean and follows existing patterns in the codebase where `isTestnet()` is used for environment-specific features (e.g., disabling block links in Header.tsx, returning empty data in API routes).

### Confidence Score: 5/5

- This PR is safe to merge with no identified risks
- The change is minimal, well-contained, and follows established patterns. It adds a simple conditional check using a properly implemented isomorphic helper function that prevents hydration mismatches. No logic errors, security concerns, or edge cases were identified. The implementation is consistent with how isTestnet() is used throughout the codebase.
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| apps/explorer/src/routes/_layout.tsx | 5/5 | Added conditional rendering to show testnet migration banner only on testnet environments (testnet/moderato) using isTestnet() helper |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant Layout
    participant isTestnet
    participant Env
    
    User->>Layout: Load page
    Layout->>isTestnet: Check if testnet environment
    isTestnet->>Env: Read VITE_TEMPO_ENV
    
    alt Environment is 'testnet' or 'moderato'
        Env-->>isTestnet: Return true
        isTestnet-->>Layout: true
        Layout->>User: Render banner with migration notice
    else Environment is 'devnet', 'presto', or other
        Env-->>isTestnet: Return false
        isTestnet-->>Layout: false
        Layout->>User: Skip banner (no banner rendered)
    end
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->