### PR TITLE
fix: auth cookie SameSite=Lax

### DIFF
--- a/apps/explorer/src/index.server.ts
+++ b/apps/explorer/src/index.server.ts
@@ -30,7 +30,7 @@ function handleAuthParam(request: Request): Response | null {
 		status: 302,
 		headers: {
 			Location: url.toString(),
-			'Set-Cookie': `${RPC_AUTH_COOKIE}=${auth.includes(':') ? btoa(auth) : auth}; Path=/; HttpOnly; SameSite=Strict; Max-Age=31536000`,
+			'Set-Cookie': `${RPC_AUTH_COOKIE}=${auth.includes(':') ? btoa(auth) : auth}; Path=/; HttpOnly; SameSite=Lax; Max-Age=31536000`,
 		},
 	})
 }


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

### Greptile Summary

This PR changes the authentication cookie's `SameSite` attribute from `Strict` to `Lax`. 

**What changed:** The `rpc_auth` cookie (which stores Basic auth credentials for RPC forwarding) now uses `SameSite=Lax` instead of `SameSite=Strict`.

**Why this matters:** `SameSite=Strict` prevents the cookie from being sent on any cross-site requests, including top-level navigations (e.g., clicking a link from another site). `SameSite=Lax` relaxes this to allow the cookie on "safe" top-level navigations (GET requests from links), making the auth experience more user-friendly when users navigate to the explorer from external sites while still providing CSRF protection against POST/PUT/DELETE cross-site requests.

**Trade-off:** This slightly reduces CSRF protection in exchange for better UX, but `SameSite=Lax` is the recommended default for most authentication cookies and still provides meaningful security.

### Confidence Score: 4/5

- Safe to merge - intentional security policy change with reasonable trade-off
- This is a deliberate change to relax cookie policy from Strict to Lax, which is a standard and recommended approach for authentication cookies. The change improves UX (users stay authenticated when navigating from external links) while maintaining CSRF protection for non-safe methods. The only minor concern is the missing Secure flag, but the app is deployed over HTTPS-only infrastructure.
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| apps/explorer/src/index.server.ts | 4/5 | Changed auth cookie from SameSite=Strict to SameSite=Lax to allow cookie on top-level cross-site navigations. Missing Secure flag but deployed over HTTPS. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant Browser
    participant Explorer
    participant RPC

    Note over User,RPC: Authentication Flow with SameSite=Lax Cookie

    User->>Browser: Navigate with auth parameter
    Browser->>Explorer: GET with auth in query
    Explorer->>Explorer: Extract and encode parameter
    Explorer->>Browser: 302 Redirect with Set-Cookie (SameSite=Lax)
    Note over Browser: Cookie stored with SameSite=Lax
    Browser->>Explorer: GET redirected URL (with cookie)
    
    Note over User,RPC: Subsequent Authenticated Request
    
    Browser->>Explorer: Request page/data (with rpc_auth cookie)
    Explorer->>Explorer: Extract credentials from cookie
    Explorer->>RPC: POST RPC call (with authorization)
    alt Valid Credentials
        RPC-->>Explorer: 200 OK
        Explorer-->>Browser: Serve page
    else Invalid Credentials
        RPC-->>Explorer: 401 Unauthorized
        Explorer-->>Browser: 401 Response
    end
    
    Note over User,RPC: Cross-Site Navigation (SameSite=Lax allows this)
    
    User->>Browser: Click link from external site
    Browser->>Explorer: GET request (cookie sent due to Lax)
    Explorer->>RPC: Validate using cookie
    RPC-->>Explorer: 200 OK
    Explorer-->>Browser: Serve page (user stays authenticated)
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->