### PR TITLE
feat(explorer): add Interact tab to token page

### DIFF
--- a/apps/explorer/src/comps/Breadcrumbs.tsx
+++ b/apps/explorer/src/comps/Breadcrumbs.tsx
@@ -18,7 +18,10 @@ function truncateHash(hash: string, prefixLen = 6, suffixLen = 4): string {
 	return `${hash.slice(0, prefixLen)}…${hash.slice(-suffixLen)}`
 }
 
-function getLabelForPath(pathname: string): { label: string; type: Crumb['type'] } {
+function getLabelForPath(pathname: string): {
+	label: string
+	type: Crumb['type']
+} {
 	if (pathname === '/') {
 		return { label: 'Home', type: 'home' }
 	}
@@ -30,7 +33,10 @@ function getLabelForPath(pathname: string): { label: string; type: Crumb['type']
 
 	const receiptMatch = pathname.match(/^\/receipt\/(0x[a-fA-F0-9]+)$/)
 	if (receiptMatch) {
-		return { label: `Receipt ${truncateHash(receiptMatch[1])}`, type: 'receipt' }
+		return {
+			label: `Receipt ${truncateHash(receiptMatch[1])}`,
+			type: 'receipt',
+		}
 	}
 
 	const addressMatch = pathname.match(/^\/address\/(0x[a-fA-F0-9]+)$/)
@@ -64,7 +70,9 @@ interface BreadcrumbsContextValue {
 	clearCrumbs: () => void
 }
 
-const BreadcrumbsContext = React.createContext<BreadcrumbsContextValue | null>(null)
+const BreadcrumbsContext = React.createContext<BreadcrumbsContextValue | null>(
+	null,
+)
 
 export function BreadcrumbsProvider(props: { children: React.ReactNode }) {
 	const { children } = props
@@ -98,7 +106,10 @@ export function BreadcrumbsProvider(props: { children: React.ReactNode }) {
 		setCrumbs([])
 	}, [])
 
-	const value = React.useMemo(() => ({ crumbs, clearCrumbs }), [crumbs, clearCrumbs])
+	const value = React.useMemo(
+		() => ({ crumbs, clearCrumbs }),
+		[crumbs, clearCrumbs],
+	)
 
 	return (
 		<BreadcrumbsContext.Provider value={value}>
@@ -149,7 +160,10 @@ export function Breadcrumbs(props: Breadcrumbs.Props) {
 					<React.Fragment key={crumb.path}>
 						<ChevronRight className="size-3 text-tertiary shrink-0" />
 						{isLast ? (
-							<span className="text-primary font-medium truncate max-w-[120px]" title={crumb.path}>
+							<span
+								className="text-primary font-medium truncate max-w-[120px]"
+								title={crumb.path}
+							>
 								{crumb.label}
 							</span>
 						) : (

--- a/apps/explorer/src/routes/_layout/token/$address.tsx
+++ b/apps/explorer/src/routes/_layout/token/$address.tsx
@@ -19,7 +19,7 @@ import * as z from 'zod/mini'
 import { AddressCell } from '#comps/AddressCell'
 import { Breadcrumbs } from '#comps/Breadcrumbs'
 import { AmountCell, BalanceCell } from '#comps/AmountCell'
-import { ContractTabContent } from '#comps/Contract.tsx'
+import { ContractTabContent, InteractTabContent } from '#comps/Contract.tsx'
 import { DataGrid } from '#comps/DataGrid'
 import { InfoCard } from '#comps/InfoCard'
 import { Midcut } from '#comps/Midcut'
@@ -52,7 +52,7 @@ const defaultSearchValues = {
 	tab: 'transfers',
 } as const
 
-const tabOrder = ['transfers', 'holders', 'contract'] as const
+const tabOrder = ['transfers', 'holders', 'contract', 'interact'] as const
 
 const chainId = getChainId(getWagmiConfig())
 
@@ -80,7 +80,12 @@ export const Route = createFileRoute('/_layout/token/$address')({
 			z.pipe(
 				z.string(),
 				z.transform((val) => {
-					if (val === 'transfers' || val === 'holders' || val === 'contract')
+					if (
+						val === 'transfers' ||
+						val === 'holders' ||
+						val === 'contract' ||
+						val === 'interact'
+					)
 						return val
 					return 'transfers'
 				}),
@@ -270,7 +275,8 @@ function RouteComponent() {
 		[navigate, limit, a],
 	)
 
-	const activeSection = tab === 'holders' ? 1 : tab === 'contract' ? 2 : 0
+	const activeSection =
+		tab === 'holders' ? 1 : tab === 'contract' ? 2 : tab === 'interact' ? 3 : 0
 
 	return (
 		<div
@@ -669,6 +675,12 @@ function SectionsWrapper(props: {
 					itemsLabel: 'functions',
 					content: <ContractSection address={address} />,
 				},
+				{
+					title: 'Interact',
+					totalItems: 0,
+					itemsLabel: 'functions',
+					content: <InteractSection address={address} />,
+				},
 			]}
 			activeSection={activeSection}
 			onSectionChange={onSectionChange}
@@ -710,6 +722,19 @@ function ContractSection(props: { address: Address.Address }) {
 
 	return (
 		<ContractTabContent
+			address={address}
+			abi={contractInfo?.abi}
+			docsUrl={contractInfo?.docsUrl}
+		/>
+	)
+}
+
+function InteractSection(props: { address: Address.Address }) {
+	const { address } = props
+	const contractInfo = getContractInfo(address)
+
+	return (
+		<InteractTabContent
 			address={address}
 			abi={contractInfo?.abi}
 			docsUrl={contractInfo?.docsUrl}


### PR DESCRIPTION
The token page only had a Contract tab showing ABI/Source/Bytecode, but was missing the Interact tab that enables Read/Write contract interactions. This adds the Interact tab for TIP-20 tokens and any other tokens with ABIs.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>


Added the missing Interact tab to the token page, enabling users to read and write to token contracts directly from the explorer. The implementation mirrors the existing address page pattern, properly handling tab routing, validation, and section navigation. The changes also include code formatting improvements to the Breadcrumbs component.


</details>
<details><summary><h3>Confidence Score: 5/5</h3></summary>


- This PR is safe to merge with minimal risk
- The changes follow established patterns from the address page implementation, all new tab logic is properly validated in the search params transform, and the activeSection calculation correctly maps to the new tab index. The Breadcrumbs changes are purely formatting with no functional impact.
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/explorer/src/comps/Breadcrumbs.tsx | Code formatting improvements with no functional changes |
| apps/explorer/src/routes/_layout/token/$address.tsx | Added Interact tab with proper routing, validation, and section handling |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant TokenPage as Token Page
    participant Router as Router/Navigation
    participant InteractSection as InteractSection Component
    participant Contract as Contract.tsx
    participant ContractInfo as getContractInfo()

    User->>TokenPage: Navigate to /token/{address}?tab=interact
    TokenPage->>Router: Validate 'interact' tab in search params
    Router->>TokenPage: Return validated tab='interact'
    TokenPage->>TokenPage: Calculate activeSection (3 for 'interact')
    TokenPage->>InteractSection: Render InteractSection(address)
    InteractSection->>ContractInfo: getContractInfo(address)
    ContractInfo-->>InteractSection: Return contractInfo with ABI
    InteractSection->>Contract: Render InteractTabContent(address, abi, docsUrl)
    Contract->>Contract: Initialize Read/Write sections (expanded=true)
    Contract-->>InteractSection: Display ContractReader and ContractWriter
    InteractSection-->>User: Show Interact tab with Read/Write functions
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->