### PR TITLE
explorer: add ValidatorConfig precompile

### DIFF
--- a/apps/explorer/src/lib/account.ts
+++ b/apps/explorer/src/lib/account.ts
@@ -43,6 +43,10 @@ const taggedAccounts: Record<Address.Address, AccountTag> = {
 		id: 'system:default-account',
 		label: 'Default Account',
 	},
+	'0xcccccccc00000000000000000000000000000000': {
+		id: 'system:validator-config',
+		label: 'Validator Config',
+	},
 	// genesis tip20 tokens
 	'0x20c0000000000000000000000000000000000000': {
 		id: 'genesis-token:pathusd',

--- a/apps/explorer/src/lib/domain/contracts.ts
+++ b/apps/explorer/src/lib/domain/contracts.ts
@@ -273,6 +273,17 @@ export const systemContractRegistry = new Map<Address.Address, ContractInfo>(<
 			address: Addresses.tip403Registry,
 		},
 	],
+	[
+		'0xcccccccc00000000000000000000000000000000',
+		{
+			name: 'Validator Config',
+			code: '0xef',
+			description: 'Manage validator set and configuration',
+			abi: Abis.validatorConfig,
+			category: 'system',
+			address: '0xcccccccc00000000000000000000000000000000',
+		},
+	],
 ])
 
 /**


### PR DESCRIPTION
Add ValidatorConfig (0xCCCCCCCC...) to systemContractRegistry and taggedAccounts so it appears in the explorer with proper labeling and ABI support.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>


This PR adds ValidatorConfig (address `0xcccccccc00000000000000000000000000000000`) to the explorer's system contract registry and tagged accounts. The changes enable proper display and labeling of the validator configuration contract in the explorer UI with ABI support.

- Added `ValidatorConfig` entry to `taggedAccounts` in `account.ts` with consistent id and label naming
- Registered `ValidatorConfig` in `systemContractRegistry` in `contracts.ts` with metadata, ABI reference, and proper categorization
- ABI imported from external `viem/tempo` package and integrated following existing patterns
- Changes are minimal, focused, and follow established conventions in the codebase


</details>
<details><summary><h3>Confidence Score: 5/5</h3></summary>


- This PR is safe to merge - it adds a straightforward registry entry for the ValidatorConfig system contract with no breaking changes or complex logic.
- Score reflects several positive factors: (1) minimal, focused changes affecting only two files; (2) follows existing code patterns and conventions consistently; (3) addresses the stated objective clearly (adding ValidatorConfig to registries); (4) no syntax errors or logical issues; (5) properly reuses existing infrastructure (Abis.validatorConfig from viem/tempo); (6) changes are additive with no modifications to existing code that could introduce regressions.
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/explorer/src/lib/account.ts | Added ValidatorConfig tagged account entry with id `system:validator-config` and label `Validator Config` at address `0xcccccccc00000000000000000000000000000000`. Correctly placed within system contracts section. No issues detected. |
| apps/explorer/src/lib/domain/contracts.ts | Added ValidatorConfig system contract registry entry with proper metadata (name, description, ABI reference, category). Uses `Abis.validatorConfig` which is imported from `viem/tempo`. Follows existing contract entry patterns consistently. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User as Explorer User
    participant UI as Explorer UI
    participant account as account.ts<br/>(Tagged Accounts)
    participant contracts as contracts.ts<br/>(Contract Registry)
    participant viem as viem/tempo<br/>(ABI)
    
    User->>UI: View ValidatorConfig Contract
    UI->>account: getAccountTag(0xcccccccc...)
    account-->>UI: Returns tag:<br/>system:validator-config
    UI->>contracts: getContractInfo(0xcccccccc...)
    contracts->>contracts: Look up in systemContractRegistry
    contracts->>viem: Import Abis.validatorConfig
    viem-->>contracts: Return ABI
    contracts-->>UI: Return ContractInfo with ABI
    UI-->>User: Display ValidatorConfig with<br/>proper label & ABI
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->