### PR TITLE
explorer: add nonce manager precompile

### DIFF
--- a/apps/explorer/src/lib/account.ts
+++ b/apps/explorer/src/lib/account.ts
@@ -47,6 +47,10 @@ const taggedAccounts: Record<Address.Address, AccountTag> = {
 		id: 'system:validator-config',
 		label: 'Validator Config',
 	},
+	'0x4e4f4e4345000000000000000000000000000000': {
+		id: 'system:nonce-manager',
+		label: 'Nonce Manager',
+	},
 	// genesis tip20 tokens
 	'0x20c0000000000000000000000000000000000000': {
 		id: 'genesis-token:pathusd',

--- a/apps/explorer/src/lib/domain/contracts.ts
+++ b/apps/explorer/src/lib/domain/contracts.ts
@@ -284,6 +284,17 @@ export const systemContractRegistry = new Map<Address.Address, ContractInfo>(<
 			address: '0xcccccccc00000000000000000000000000000000',
 		},
 	],
+	[
+		Addresses.nonceManager,
+		{
+			name: 'Nonce Manager',
+			code: '0xef',
+			description: 'Manage account nonces',
+			abi: [],
+			category: 'system',
+			address: Addresses.nonceManager,
+		},
+	],
 ])
 
 /**


### PR DESCRIPTION
Same as https://github.com/tempoxyz/tempo-apps/pull/447 but for the nonce manager precompile

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>


Adds Nonce Manager precompile support to the explorer, following the same pattern as other system contracts like the TIP-403 Registry and Fee Manager. The implementation registers the nonce manager at address `0x4e4f4e4345000000000000000000000000000000` (which encodes "NONCE" in the first 5 bytes) in both the account tagging system and the system contract registry.


</details>
<details><summary><h3>Confidence Score: 5/5</h3></summary>


- Safe to merge - straightforward addition following established patterns
- This PR makes minimal, consistent changes that mirror the existing codebase structure. It adds registry entries for a new system precompile without modifying any logic or affecting existing functionality.
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/explorer/src/lib/account.ts | Added nonce manager address tag for UI display - follows existing pattern |
| apps/explorer/src/lib/domain/contracts.ts | Registered nonce manager in system contract registry with empty ABI - consistent with pattern |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant Explorer
    participant AccountModule
    participant ContractRegistry
    participant NonceManager as Nonce Manager<br/>(0x4e4f4e43...)

    User->>Explorer: View address 0x4e4f4e43...
    Explorer->>AccountModule: getAccountTag(address)
    AccountModule-->>Explorer: {id: 'system:nonce-manager', label: 'Nonce Manager'}
    Explorer->>ContractRegistry: getContractInfo(address)
    ContractRegistry-->>Explorer: {name: 'Nonce Manager', category: 'system', ...}
    Explorer->>NonceManager: Interact with contract
    NonceManager-->>Explorer: Manage account nonces
    Explorer-->>User: Display tagged account with contract info
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->