### PR TITLE
only generate sourcemaps during analyze commands

### DIFF
--- a/apps/explorer/vite.config.ts
+++ b/apps/explorer/vite.config.ts
@@ -84,7 +84,7 @@ export default defineConfig((config) => {
 		},
 		build: {
 			minify: 'oxc',
-			sourcemap: true, // Required for Sonda
+			sourcemap: process.env.ANALYZE === 'true', // Required for Sonda
 			rollupOptions: {
 				output: {
 					minify: {


### PR DESCRIPTION
## Context

Ensures that sourcemaps are only generated under the ANALYZE env

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>


This PR optimizes the build configuration by conditionally generating sourcemaps only when the `ANALYZE` environment variable is set to `'true'`. Previously, sourcemaps were always generated, which increases bundle size and build time. This change aligns with the analysis-focused plugins (Sonda and visualizer) that are also conditionally enabled, reducing unnecessary overhead in production builds while maintaining debugging information when needed for bundle analysis.


</details>
<details><summary><h3>Confidence Score: 5/5</h3></summary>


- This PR is safe to merge with no concerns. It's a straightforward optimization that aligns with existing conditional logic in the build configuration.
- The change is minimal, focused, and correct. It replaces a hardcoded `true` value with a conditional check on `process.env.ANALYZE === 'true'`, matching the pattern already used for other analysis tools (Sonda on line 68 and visualizer on line 69-75). The comment is preserved and remains accurate. There are no introduced bugs, security issues, or logic errors.
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/explorer/vite.config.ts | Sourcemap generation now conditionally enabled only when `ANALYZE=true`. Changes line 87 to gate sourcemap generation, improving build performance for non-analysis builds while preserving required sourcemaps for bundle analysis tools like Sonda. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant Vite as Vite Build Config
    participant Env as Environment
    participant Build as Build Process
    participant Sonda as Analysis Tools

    Dev->>Env: Set ANALYZE=true
    Env->>Vite: Load environment variables
    Vite->>Vite: Check ANALYZE condition
    Vite->>Build: Enable sourcemap generation
    Build->>Sonda: Provide sourcemaps for analysis
    Sonda->>Dev: Bundle analysis output

    Note over Dev,Sonda: Default (ANALYZE not set)
    Dev->>Env: Run normal build
    Env->>Vite: Load environment variables
    Vite->>Vite: Check ANALYZE condition (false)
    Vite->>Build: Skip sourcemap generation
    Build->>Build: Faster build, smaller output
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->