### PR TITLE
publishes bundle report to pages on builds

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
-      contents: read
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -117,3 +117,19 @@ jobs:
           issue-number: ${{ github.event.pull_request.number }}
           body-path: apps/explorer/bundle-report.md
           edit-mode: replace
+
+      - name: Upload Sonda report artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: sonda-bundle-report-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('main-{0}', github.sha) }}
+          path: apps/explorer/.sonda/
+          retention-days: 90
+
+      - name: Deploy to GitHub Pages (main only)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./apps/explorer/.sonda
+          destination_dir: explorer-bundle-stats
+          keep_files: false


### PR DESCRIPTION
## Context

Pushes sonda bundle reports to github pages when the build finishes 

also saves artifacts so that we can track over time (with TTL)

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>


Adds GitHub Pages deployment for Sonda bundle reports when builds complete on main branch. Also uploads bundle reports as artifacts with 90-day retention for both PRs and main branch builds, enabling historical tracking of bundle size changes.

- Changed `contents` permission from `read` to `write` to enable GitHub Pages deployment
- Added artifact upload step for `.sonda/` directory with dynamic naming (`pr-{number}` or `main-{sha}`)
- Added GitHub Pages deployment step using `peaceiris/actions-gh-pages@v4` to publish reports to `explorer-bundle-stats/` directory (main branch only)
- Used `keep_files: false` to overwrite previous reports rather than accumulate them


</details>
<details><summary><h3>Confidence Score: 5/5</h3></summary>


- This PR is safe to merge with minimal risk
- The changes are well-scoped additions to an existing workflow. The permission change from `contents: read` to `contents: write` is necessary for the GitHub Pages deployment action. The artifact upload and Pages deployment steps are properly guarded with conditionals and use established GitHub Actions. The `.sonda/` directory is already gitignored, and the 90-day retention prevents indefinite artifact accumulation.
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/bundle-size.yml | Added artifact upload for bundle reports and GitHub Pages deployment to publish Sonda reports on main branch builds |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant GHA as GitHub Actions
    participant Build as Bundle Build
    participant Cache as Actions Cache
    participant Artifacts as Artifacts Storage
    participant GHP as GitHub Pages (gh-pages branch)
    
    alt Pull Request
        GHA->>Cache: Restore baseline stats from main
        GHA->>Build: Build with bundle analysis
        Build->>Build: Generate .sonda/ report
        GHA->>Build: Generate comparison report
        GHA->>GHA: Post/update PR comment
        GHA->>Artifacts: Upload .sonda/ (pr-{number})
    else Main Branch Push
        GHA->>Build: Build with bundle analysis
        Build->>Build: Generate .sonda/ report
        GHA->>Build: Parse bundle stats
        GHA->>Cache: Save stats (sha + latest)
        GHA->>Artifacts: Upload .sonda/ (main-{sha})
        GHA->>GHP: Deploy to explorer-bundle-stats/
    end
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->