### PR TITLE
fix: make TEMPO_RPC_KEY optional in server RPC URLs

### DIFF
--- a/apps/explorer/src/wagmi.config.ts
+++ b/apps/explorer/src/wagmi.config.ts
@@ -56,9 +56,11 @@ const getRpcProxyUrl = createIsomorphicFn()
 	})
 	.server(() => {
 		const chain = getTempoChain()
+		const key = process.env.TEMPO_RPC_KEY
+		const keyParam = key ? `?key=${key}` : ''
 		return {
-			http: `https://${RPC_PROXY_HOSTNAME}/rpc/${chain.id}?key=${process.env.TEMPO_RPC_KEY}`,
-			webSocket: `wss://${RPC_PROXY_HOSTNAME}/rpc/${chain.id}?key=${process.env.TEMPO_RPC_KEY}`,
+			http: `https://${RPC_PROXY_HOSTNAME}/rpc/${chain.id}${keyParam}`,
+			webSocket: `wss://${RPC_PROXY_HOSTNAME}/rpc/${chain.id}${keyParam}`,
 		}
 	})
 
@@ -69,12 +71,13 @@ const getFallbackUrls = createIsomorphicFn()
 	})
 	.server(() => {
 		const chain = getTempoChain()
+		const key = process.env.TEMPO_RPC_KEY
 		return {
-			webSocket: chain.rpcUrls.default.webSocket.map(
-				(url) => `${url}/${process.env.TEMPO_RPC_KEY}`,
+			webSocket: chain.rpcUrls.default.webSocket.map((url) =>
+				key ? `${url}/${key}` : url,
 			),
-			http: chain.rpcUrls.default.http.map(
-				(url) => `${url}/${process.env.TEMPO_RPC_KEY}`,
+			http: chain.rpcUrls.default.http.map((url) =>
+				key ? `${url}/${key}` : url,
 			),
 		}
 	})


### PR DESCRIPTION
<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>


Made the RPC authentication key environment variable optional in server-side RPC URL construction. The key is now only appended to proxy and fallback URLs when it's defined in the environment.

- Updated `getRpcProxyUrl` to conditionally append key as query parameter
- Updated `getFallbackUrls` to conditionally append key as path segment
- Both changes maintain backward compatibility when key is present


</details>
<details><summary><h3>Confidence Score: 5/5</h3></summary>


- This PR is safe to merge with minimal risk
- The changes are straightforward and well-implemented. The conditional logic properly handles both cases (key present and absent), maintains backward compatibility, and follows consistent patterns across both modified functions.
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/explorer/src/wagmi.config.ts | Made `TEMPO_RPC_KEY` optional by conditionally appending it to RPC URLs only when defined |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Server
    participant getRpcProxyUrl
    participant getFallbackUrls
    participant RPC_Proxy
    
    Server->>getRpcProxyUrl: Call .server()
    getRpcProxyUrl->>getRpcProxyUrl: Check for auth key
    alt Key exists
        getRpcProxyUrl->>RPC_Proxy: URLs with key parameter
    else Key undefined
        getRpcProxyUrl->>RPC_Proxy: URLs without key
    end
    
    Server->>getFallbackUrls: Call .server()
    getFallbackUrls->>getFallbackUrls: Check for auth key
    alt Key exists
        getFallbackUrls->>RPC_Proxy: Append key to each URL
    else Key undefined
        getFallbackUrls->>RPC_Proxy: Return URLs unchanged
    end
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->