### PR TITLE
feat(explorer): add filter to hide inactive validators by default

### DIFF
--- a/apps/explorer/src/routes/_layout/validators.tsx
+++ b/apps/explorer/src/routes/_layout/validators.tsx
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query'
 import { createFileRoute } from '@tanstack/react-router'
+import * as React from 'react'
 import { Address } from '#comps/Address'
 import { DataGrid } from '#comps/DataGrid'
 import { Midcut } from '#comps/Midcut'
@@ -29,11 +30,19 @@ function ValidatorsPage() {
 		initialData: loaderData,
 	})
 
+	const [hideInactive, setHideInactive] = React.useState(true)
+	const hideInactiveId = React.useId()
+
 	const isMobile = useMediaQuery('(max-width: 799px)')
 	const mode = isMobile ? 'stacked' : 'tabs'
 
 	const activeCount = validators?.filter((v) => v.active).length ?? 0
 	const totalCount = validators?.length ?? 0
+
+	const filteredValidators = React.useMemo(() => {
+		if (!validators) return []
+		return hideInactive ? validators.filter((v) => v.active) : validators
+	}, [validators, hideInactive])
 
 	const columns: DataGrid.Column[] = [
 		{ label: 'Index', align: 'start', minWidth: 60 },
@@ -50,6 +59,21 @@ function ValidatorsPage() {
 
 	return (
 		<div className="flex flex-col gap-6 px-4 pt-20 pb-16 max-w-[1200px] mx-auto w-full">
+			<div className="flex items-center justify-end gap-2">
+				<input
+					id={hideInactiveId}
+					type="checkbox"
+					checked={hideInactive}
+					onChange={(e) => setHideInactive(e.target.checked)}
+					className="w-4 h-4 rounded border-base-border"
+				/>
+				<label
+					htmlFor={hideInactiveId}
+					className="text-sm text-secondary cursor-pointer select-none"
+				>
+					Hide inactive validators
+				</label>
+			</div>
 			<Sections
 				mode={mode}
 				sections={[
@@ -62,7 +86,7 @@ function ValidatorsPage() {
 							<DataGrid
 								columns={{ stacked: stackedColumns, tabs: columns }}
 								items={() =>
-									(validators ?? []).map((validator) => ({
+									filteredValidators.map((validator) => ({
 										cells: [
 											<span
 												key="index"
@@ -104,11 +128,11 @@ function ValidatorsPage() {
 										},
 									}))
 								}
-								totalItems={totalCount}
+								totalItems={filteredValidators.length}
 								page={1}
 								loading={isPending}
 								itemsLabel="validators"
-								itemsPerPage={totalCount || 10}
+								itemsPerPage={filteredValidators.length || 10}
 								emptyState="No validators found."
 								pagination={false}
 							/>


### PR DESCRIPTION
Adds a 'Hide inactive validators' checkbox to the validators page that is enabled by default. Users can uncheck it to see all validators including inactive ones.

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>


Added a checkbox to hide inactive validators by default on the validators page, improving the default user experience by focusing on active validators while still allowing users to view all validators when needed.

- Introduced `hideInactive` state (defaults to `true`) with React hooks
- Implemented memoized filtering logic using `useMemo` for performance
- Added accessible checkbox UI with proper `id` and `htmlFor` attributes
- Updated DataGrid to consistently use filtered validators for display and pagination


</details>
<details><summary><h3>Confidence Score: 5/5</h3></summary>


- This PR is safe to merge with minimal risk
- The implementation is clean, well-structured, and follows React best practices. The filtering logic is correct with proper memoization, accessibility is handled appropriately, and all relevant display/pagination properties are updated consistently. No security concerns or logical errors detected.
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/explorer/src/routes/_layout/validators.tsx | Added checkbox filter to hide inactive validators (enabled by default) with proper memoization and accessibility |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant ValidatorsPage
    participant React
    participant QueryClient
    
    User->>ValidatorsPage: Navigate to /validators
    ValidatorsPage->>QueryClient: ensureQueryData(validatorsQueryOptions())
    QueryClient-->>ValidatorsPage: Return validators data
    
    ValidatorsPage->>React: useState(true) - hideInactive
    ValidatorsPage->>React: useId() - generate hideInactiveId
    ValidatorsPage->>React: useMemo() - filter validators
    React-->>ValidatorsPage: filteredValidators (active only)
    
    ValidatorsPage->>User: Render page with checkbox (checked)
    ValidatorsPage->>User: Display filtered validators (active only)
    
    User->>ValidatorsPage: Uncheck "Hide inactive validators"
    ValidatorsPage->>React: setHideInactive(false)
    React->>ValidatorsPage: Trigger re-render
    ValidatorsPage->>React: useMemo() - recompute filter
    React-->>ValidatorsPage: filteredValidators (all validators)
    ValidatorsPage->>User: Display all validators
    
    User->>ValidatorsPage: Check "Hide inactive validators"
    ValidatorsPage->>React: setHideInactive(true)
    React->>ValidatorsPage: Trigger re-render
    ValidatorsPage->>React: useMemo() - recompute filter
    React-->>ValidatorsPage: filteredValidators (active only)
    ValidatorsPage->>User: Display active validators only
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->