### PR TITLE
feat(explorer): add validator name tags

### DIFF
--- a/apps/explorer/src/comps/BlockCard.tsx
+++ b/apps/explorer/src/comps/BlockCard.tsx
@@ -4,6 +4,7 @@ import * as React from 'react'
 import { useWatchBlockNumber } from 'wagmi'
 import { InfoCard } from '#comps/InfoCard'
 import { Midcut } from '#comps/Midcut'
+import { ValidatorTag } from '#comps/ValidatorTag'
 import { cx } from '#lib/css'
 import { DateFormatter } from '#lib/formatting'
 import { useCopy, useIsMounted } from '#lib/hooks'
@@ -154,14 +155,7 @@ export function BlockCard(props: BlockCard.Props) {
 				>
 					<BlockCard.InfoRow label="Miner">
 						{miner ? (
-							<Link
-								to="/address/$address"
-								params={{ address: miner }}
-								className="text-accent hover:underline press-down min-w-0 flex-1 flex justify-end font-mono"
-								title={miner}
-							>
-								<Midcut value={miner} prefix="0x" align="end" min={4} />
-							</Link>
+							<ValidatorTag address={miner} />
 						) : (
 							<span className="text-tertiary">—</span>
 						)}

--- a/apps/explorer/src/comps/ValidatorTag.tsx
+++ b/apps/explorer/src/comps/ValidatorTag.tsx
@@ -1,0 +1,37 @@
+import { Link } from '@tanstack/react-router'
+import type { Address } from 'ox'
+import { Midcut } from '#comps/Midcut'
+import { getValidatorLabel } from '#lib/validators'
+
+export function ValidatorTag(props: ValidatorTag.Props) {
+	const { address, showAddress = true, align = 'end' } = props
+	const name = getValidatorLabel(address)
+
+	return (
+		<Link
+			to="/address/$address"
+			params={{ address }}
+			className="text-accent hover:underline press-down min-w-0 flex-1 flex items-center gap-2 justify-end"
+			title={address}
+		>
+			{name && (
+				<span className="text-[11px] px-[6px] py-[2px] rounded bg-base-alt/65 text-tertiary whitespace-nowrap">
+					{name}
+				</span>
+			)}
+			{showAddress && (
+				<span className="font-mono">
+					<Midcut value={address} prefix="0x" align={align} min={4} />
+				</span>
+			)}
+		</Link>
+	)
+}
+
+export namespace ValidatorTag {
+	export interface Props {
+		address: Address.Address
+		showAddress?: boolean
+		align?: 'start' | 'end'
+	}
+}

--- a/apps/explorer/src/lib/validators.ts
+++ b/apps/explorer/src/lib/validators.ts
@@ -1,0 +1,25 @@
+import type { Address } from 'ox'
+
+/**
+ * Validator address to display name mapping.
+ * These are well-known validators on the Tempo network.
+ */
+export const VALIDATOR_LABELS: Record<Lowercase<Address.Address>, string> = {
+	'0x9899cd5b8190bfd9bbaee463f7bde4c7e687fdac': 'Tempo 1',
+	'0xa1dd6fc0791b186654e246a8966b1a44854a4e27': 'Tempo 2',
+	'0xde19771801afc496e1c4bb584bb5875322f68a4a': 'Tempo 3',
+	'0xcf12263139789466d91b9fde920053bda20e7af5': 'Tempo 4',
+	'0x0000000000000000000000000000000000000010': 'Stripe (inactive)',
+	'0x0000000000000000000000000000000000000011': 'Stripe',
+	'0x0000000000000000000000000000000000000012': 'Paradigm',
+}
+
+/**
+ * Returns the display label for a validator address if known.
+ */
+export function getValidatorLabel(
+	address: Address.Address | undefined,
+): string | undefined {
+	if (!address) return undefined
+	return VALIDATOR_LABELS[address.toLowerCase() as Lowercase<Address.Address>]
+}

--- a/apps/explorer/src/routes/_layout/validators.tsx
+++ b/apps/explorer/src/routes/_layout/validators.tsx
@@ -7,8 +7,19 @@ import { Sections } from '#comps/Sections'
 import { useMediaQuery } from '#lib/hooks'
 import { withLoaderTiming } from '#lib/profiling'
 import { validatorsQueryOptions } from '#lib/queries'
+import { getValidatorLabel } from '#lib/validators'
 import Check from '~icons/lucide/check'
 import X from '~icons/lucide/x'
+
+function ValidatorName({ address }: { address: `0x${string}` }) {
+	const name = getValidatorLabel(address)
+	if (!name) return <span className="text-tertiary">—</span>
+	return (
+		<span className="text-[11px] px-[6px] py-[2px] rounded bg-base-alt/65 text-primary whitespace-nowrap">
+			{name}
+		</span>
+	)
+}
 
 export const Route = createFileRoute('/_layout/validators')({
 	component: ValidatorsPage,
@@ -37,6 +48,7 @@ function ValidatorsPage() {
 
 	const columns: DataGrid.Column[] = [
 		{ label: 'Index', align: 'start', minWidth: 60 },
+		{ label: 'Name', align: 'start', minWidth: 100 },
 		{ label: 'Address', align: 'start', minWidth: 120 },
 		{ label: 'Status', align: 'start', minWidth: 80 },
 		{ label: 'Public Key', align: 'start', minWidth: 120 },
@@ -44,7 +56,7 @@ function ValidatorsPage() {
 
 	const stackedColumns: DataGrid.Column[] = [
 		{ label: 'Index', align: 'start', minWidth: 50 },
-		{ label: 'Address', align: 'start', minWidth: 100 },
+		{ label: 'Name', align: 'start', minWidth: 80 },
 		{ label: 'Status', align: 'start', minWidth: 60 },
 	]
 
@@ -70,6 +82,10 @@ function ValidatorsPage() {
 											>
 												#{String(validator.index)}
 											</span>,
+											<ValidatorName
+												key="name"
+												address={validator.validatorAddress}
+											/>,
 											<Address
 												key="address"
 												address={validator.validatorAddress}


### PR DESCRIPTION
Adds display names for known validators (Tempo 1-4, Stripe, Paradigm) in the explorer.

## Changes
- Add `validators.ts` with address→name mapping (case-insensitive lookup)
- Add `ValidatorTag` shared component showing name badge + address
- Update BlockCard miner row to show validator names
- Add Name column to validators page table

## Preview
- Block details: shows "Tempo 1" badge next to miner address
- Validators page: dedicated Name column with styled badges

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>


Added display names for known validators (Tempo 1-4, Stripe, Paradigm) that appear as styled badges throughout the explorer. The implementation introduces a centralized mapping in `validators.ts` with case-insensitive lookup, a reusable `ValidatorTag` component, and updates to both the block details page and validators table to show these names.

- Created `validators.ts` with address-to-name mappings and lookup function
- Added `ValidatorTag` component for consistent validator display with name badges
- Updated BlockCard miner row to use ValidatorTag instead of raw address
- Added Name column to validators page table with styled badges


</details>
<details><summary><h3>Confidence Score: 5/5</h3></summary>


- This PR is safe to merge with no concerns
- Clean implementation with proper TypeScript types, reusable components, and consistent styling that follows existing patterns in the codebase
- No files require special attention
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/explorer/src/lib/validators.ts | Added validator address-to-name mapping with case-insensitive lookup, includes Tempo 1-4, Stripe, and Paradigm validators |
| apps/explorer/src/comps/ValidatorTag.tsx | Created reusable component that displays validator name badge with clickable address link |
| apps/explorer/src/comps/BlockCard.tsx | Replaced inline miner address display with ValidatorTag component to show validator names |
| apps/explorer/src/routes/_layout/validators.tsx | Added Name column with ValidatorName component to validators table, showing badges for known validators |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User
    participant BlockCard/ValidatorsPage
    participant ValidatorTag/ValidatorName
    participant validators.ts
    
    User->>BlockCard/ValidatorsPage: View block or validators page
    BlockCard/ValidatorsPage->>ValidatorTag/ValidatorName: Pass validator address
    ValidatorTag/ValidatorName->>validators.ts: getValidatorLabel(address)
    validators.ts->>validators.ts: Convert to lowercase
    validators.ts->>validators.ts: Lookup in VALIDATOR_LABELS
    validators.ts-->>ValidatorTag/ValidatorName: Return name or undefined
    
    alt Known validator
        ValidatorTag/ValidatorName->>User: Display badge with name + address
    else Unknown validator
        ValidatorTag/ValidatorName->>User: Display only address (or "—")
    end
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->