### PR TITLE
chore: bump idxs to 0.0.6

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -127,8 +127,8 @@ catalogs:
       specifier: ^0.5.3
       version: 0.5.3
     idxs:
-      specifier: ^0.0.5
-      version: 0.0.5
+      specifier: ^0.0.6
+      version: 0.0.6
     jsonc-parser:
       specifier: ^3.3.1
       version: 3.3.1
@@ -341,7 +341,7 @@ importers:
         version: 4.11.4
       idxs:
         specifier: 'catalog:'
-        version: 0.0.5(typescript@5.9.3)
+        version: 0.0.6(typescript@5.9.3)
       ox:
         specifier: 'catalog:'
         version: 0.11.3(typescript@5.9.3)(zod@4.3.5)
@@ -462,7 +462,7 @@ importers:
         version: 4.11.4
       idxs:
         specifier: 'catalog:'
-        version: 0.0.5(typescript@5.9.3)
+        version: 0.0.6(typescript@5.9.3)
       kysely:
         specifier: 'catalog:'
         version: 0.28.9
@@ -4308,8 +4308,8 @@ packages:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
 
-  idxs@0.0.5:
-    resolution: {integrity: sha512-PI+gllRtlove7942sQUA2y0OM9qgifvGQlPQbXozwY43sRoiGC9Fq7btNB+9WJzw+3tcutneuQeBi5pwTx13GA==}
+  idxs@0.0.6:
+    resolution: {integrity: sha512-CjrtIJQNhABCsa8YFyxLxkVbn5DexSgMxqd31I32PnagUl4cewlm3IZZwo7ARabq3bRlkYXXRFk9b7BZboM0vA==}
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
@@ -9901,7 +9901,7 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
-  idxs@0.0.5(typescript@5.9.3):
+  idxs@0.0.6(typescript@5.9.3):
     dependencies:
       abitype: 1.2.3(typescript@5.9.3)(zod@4.3.5)
       kysely: 0.28.9

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -44,7 +44,7 @@ catalog:
   globals: ^17.0.0
   hono: ^4.11.4
   hono-rate-limiter: ^0.5.3
-  idxs: ^0.0.5
+  idxs: ^0.0.6
   jsonc-parser: ^3.3.1
   kysely: ^0.28.9
   ox: ^0.11.3


### PR DESCRIPTION
Fixes explorer activity not showing due to 'bytea = bit' PostgreSQL type mismatch when querying with hex strings in WHERE IN clauses.

See: https://github.com/wevm/idxs/pull/10

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>


This PR bumps the `idxs` dependency from 0.0.5 to 0.0.6 to fix a PostgreSQL type mismatch issue where hex strings in WHERE IN clauses were being incorrectly compared against bytea/bit columns, preventing explorer activity from displaying correctly. The change is a simple, targeted dependency upgrade that resolves the root cause identified in the upstream idxs library.


</details>
<details><summary><h3>Confidence Score: 5/5</h3></summary>


- This PR is safe to merge. It's a straightforward dependency bump with a clear bugfix in the upstream library.
- Score of 5 reflects that this is a minimal, low-risk change consisting solely of a patch version bump to a dependency. The upstream fix addresses a specific PostgreSQL type handling issue, and the change is automatically managed through the lock file. No code changes or configuration modifications are present.
- No files require special attention.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| pnpm-workspace.yaml | Updated `idxs` dependency from 0.0.5 to 0.0.6 in the catalog to fix PostgreSQL bytea/bit type mismatch issue affecting explorer activity queries. |
| pnpm-lock.yaml | Lock file updated to reflect idxs 0.0.6 dependency and its resolved integrity hash. All consumers of idxs (explorer and server packages) updated to the new version. |

</details>


</details>


<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Explorer as Explorer App
    participant IDXS as IDXS Library<br/>(0.0.6)
    participant DB as PostgreSQL<br/>Database
    
    Explorer->>IDXS: Query activity with hex strings
    Note over IDXS: Fixed bytea type<br/>handling in WHERE IN
    IDXS->>DB: Execute corrected query
    DB-->>IDXS: Return activity data
    IDXS-->>Explorer: Activity results displayed
    Note over Explorer: Explorer activity<br/>now shows correctly
```
</details>


<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->