### PR TITLE
fix(explorer): add block_timestamp to /api/address endpoint

### DIFF
--- a/apps/explorer/src/lib/server/tempo-queries.test.ts
+++ b/apps/explorer/src/lib/server/tempo-queries.test.ts
@@ -498,6 +498,7 @@ describe('tempo-queries', () => {
 				{
 					hash: '0xabc' as Hex.Hex,
 					block_num: 1n,
+					block_timestamp: '1700000000',
 					from: '0x1111',
 					to: '0x2222',
 					value: 5n,
@@ -515,6 +516,7 @@ describe('tempo-queries', () => {
 				{
 					hash: '0xabc',
 					block_num: 1n,
+					block_timestamp: '1700000000',
 					from: '0x1111',
 					to: '0x2222',
 					value: 5n,

--- a/apps/explorer/src/lib/server/tempo-queries.ts
+++ b/apps/explorer/src/lib/server/tempo-queries.ts
@@ -423,6 +423,7 @@ export async function fetchAddressTransferEmittedCountRows(params: {
 export type TxDataRow = {
 	hash: Hex.Hex
 	block_num: bigint
+	block_timestamp: string | number | null
 	from: string
 	to: string | null
 	value: bigint
@@ -443,6 +444,7 @@ export async function fetchTxDataByHashes(
 		.select([
 			'hash',
 			'block_num',
+			'block_timestamp',
 			'from',
 			'to',
 			'value',

--- a/apps/explorer/src/routes/api/address/$address.ts
+++ b/apps/explorer/src/routes/api/address/$address.ts
@@ -267,7 +267,7 @@ export const Route = createFileRoute('/api/address/$address')({
 						: paginatedHashes
 
 					// Fetch full tx data only for the final set of hashes
-					let transactions: RpcTransaction[] = []
+					let transactions: (RpcTransaction & { timestamp?: string })[] = []
 					if (finalHashes.length > 0) {
 						const txDataResult = await fetchTxDataByHashes(
 							chainId,
@@ -301,7 +301,10 @@ export const Route = createFileRoute('/api/address/$address')({
 									v: '0x0',
 									r: '0x0',
 									s: '0x0',
-								} as RpcTransaction
+									timestamp: row.block_timestamp
+										? String(row.block_timestamp)
+										: undefined,
+								} as RpcTransaction & { timestamp?: string }
 							})
 					}
 


### PR DESCRIPTION
## Summary

Adds the `block_timestamp` field to transaction data returned by the `/api/address` endpoint.

## Problem

The app's activity heatmap relies on this timestamp field to display transaction times correctly. Without it, the IndexSupply API returns Unix timestamps in seconds as strings, but since the endpoint wasn't including `block_timestamp` in the select query, all transactions appeared in the most recent bucket (timestamp defaulted to undefined).

## Changes

- Add `block_timestamp` to the select fields in the txs query
- Include `timestamp` field in the response object (Unix seconds as string)
- Update TypeScript types to include the optional timestamp field

## Testing

Type checks pass. The app will be able to parse these timestamps using `Number(txInfo.timestamp) * 1000` to convert from Unix seconds to JavaScript milliseconds.