### PR TITLE
fix: ensure bundle size baseline updates on every main push

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -3,9 +3,9 @@ name: Bundle Size
 on:
   push:
     branches: [main]
-    paths:
-      - "apps/explorer/**"
-      - "pnpm-lock.yaml"
+    # No path filter on main - we need to generate baseline on every push
+    # so PRs always compare against the latest main, even if main has
+    # commits that don't touch explorer (e.g., workflow changes, other apps)
   pull_request:
     types: [opened, reopened, synchronize]
     paths:


### PR DESCRIPTION
## Summary

Fixes two issues preventing PRs from comparing against the latest bundle size baseline:

1. **Path filter issue**: Bundle Size workflow was skipping main branch commits that didn't touch `apps/explorer/**`
2. **Immutable cache issue**: GitHub Actions caches cannot be overwritten once created

## Problem 1: Path Filters Causing Skipped Runs

The workflow had path filters that caused it to skip commits like:
- Workflow file changes (`.github/workflows/`)
- Other app changes outside explorer
- CI/docs-only changes

**Example**: The most recent main commit only changed `.github/workflows/bundle-size.yml`, so the Bundle Size workflow didn't run, meaning no baseline was generated.

This caused PRs to compare against outdated baselines that were missing recent commits.

## Problem 2: Immutable Cache

GitHub Actions caches are **immutable** - once saved, they cannot be overwritten. The workflow saved `bundle-stats-explorer-main-latest` once, and all subsequent saves silently failed.

## Solutions

### 1. Remove path filter for main branch
```yaml
on:
  push:
    branches: [main]
    # No path filter - generate baseline on EVERY push
  pull_request:
    paths:
      - "apps/explorer/**"  # Keep filter for PRs
```

### 2. Delete old cache before saving new one
```yaml
- name: Delete old latest cache (main branch)
  run: gh cache delete bundle-stats-explorer-main-latest
```

Also added `actions: write` permission required for cache deletion.

## Result

After merge, **every** main branch push will:
1. Run the Bundle Size workflow (no path filter)
2. Build and save bundle stats with SHA key
3. Delete the old `latest` cache key
4. Save with new `latest` cache key

PRs will correctly diff against the true latest main branch build.