### PR TITLE
fix(explorer): return 0n instead of undefined from fetchLatestBlock

### DIFF
--- a/apps/explorer/src/lib/server/latest-block.server.ts
+++ b/apps/explorer/src/lib/server/latest-block.server.ts
@@ -12,7 +12,7 @@ const QB = IDX.QueryBuilder.from(IS)
 
 export const fetchLatestBlock = createServerFn({ method: 'GET' }).handler(
 	async () => {
-		if (!hasIndexSupply()) return
+		if (!hasIndexSupply()) return 0n
 		try {
 			const config = getWagmiConfig()
 			const chainId = getChainId(config)
@@ -27,7 +27,7 @@ export const fetchLatestBlock = createServerFn({ method: 'GET' }).handler(
 			return BigInt(result.num)
 		} catch (error) {
 			console.error('Failed to fetch latest block:', error)
-			return undefined
+			return 0n
 		}
 	},
 )


### PR DESCRIPTION
## Problem

`fetchLatestBlock` returns `undefined` when:
- `hasIndexSupply()` is false (no INDEXER_API_KEY configured)
- The query fails

This causes `useSuspenseQuery` in Layout.tsx to throw:
```
Query data cannot be undefined. Please make sure to return a value other than undefined from your query function.
```

## Solution

Return `0n` as a fallback instead of `undefined`. This allows local development without IndexSupply configured.