### PR TITLE
perf(explorer): add manual chunks for better caching

### DIFF
--- a/apps/explorer/scripts/chunk-config.test.ts
+++ b/apps/explorer/scripts/chunk-config.test.ts
@@ -36,49 +36,81 @@ describe('extractPackageName', () => {
 })
 
 describe('getVendorChunk', () => {
-	it('returns undefined for non-vendor modules', () => {
-		expect(getVendorChunk('/src/App.tsx')).toBeUndefined()
-		expect(getVendorChunk('./components/Button.tsx')).toBeUndefined()
+	describe('server builds (isClientBuild = false)', () => {
+		it('returns undefined for all modules to avoid browser code in server', () => {
+			expect(getVendorChunk('/src/App.tsx', false)).toBeUndefined()
+			expect(
+				getVendorChunk('/node_modules/react/index.js', false),
+			).toBeUndefined()
+			expect(
+				getVendorChunk(
+					'/node_modules/@tanstack/react-query/dist/index.js',
+					false,
+				),
+			).toBeUndefined()
+		})
 	})
 
-	it('returns undefined for unlisted vendor packages', () => {
-		expect(getVendorChunk('/node_modules/lodash/index.js')).toBeUndefined()
-		expect(getVendorChunk('/node_modules/zod/index.js')).toBeUndefined()
-	})
+	describe('client builds (isClientBuild = true)', () => {
+		it('returns undefined for non-vendor modules', () => {
+			expect(getVendorChunk('/src/App.tsx', true)).toBeUndefined()
+			expect(getVendorChunk('./components/Button.tsx', true)).toBeUndefined()
+		})
 
-	it('matches react packages', () => {
-		expect(getVendorChunk('/node_modules/react/index.js')).toBe('vendor-react')
-		expect(getVendorChunk('/node_modules/react-dom/client.js')).toBe(
-			'vendor-react',
-		)
-		expect(getVendorChunk('/node_modules/scheduler/index.js')).toBe(
-			'vendor-react',
-		)
-	})
+		it('returns undefined for unlisted vendor packages', () => {
+			expect(
+				getVendorChunk('/node_modules/lodash/index.js', true),
+			).toBeUndefined()
+			expect(getVendorChunk('/node_modules/zod/index.js', true)).toBeUndefined()
+		})
 
-	it('matches tanstack packages by prefix', () => {
-		expect(
-			getVendorChunk('/node_modules/@tanstack/react-query/dist/index.js'),
-		).toBe('vendor-tanstack')
-		expect(
-			getVendorChunk('/node_modules/@tanstack/react-router/dist/index.js'),
-		).toBe('vendor-tanstack')
-		expect(
-			getVendorChunk('/node_modules/@tanstack/query-core/dist/index.js'),
-		).toBe('vendor-tanstack')
-	})
+		it('matches react packages', () => {
+			expect(getVendorChunk('/node_modules/react/index.js', true)).toBe(
+				'vendor-react',
+			)
+			expect(getVendorChunk('/node_modules/react-dom/client.js', true)).toBe(
+				'vendor-react',
+			)
+			expect(getVendorChunk('/node_modules/scheduler/index.js', true)).toBe(
+				'vendor-react',
+			)
+		})
 
-	it('matches web3 packages', () => {
-		expect(getVendorChunk('/node_modules/viem/dist/index.js')).toBe(
-			'vendor-web3',
-		)
-		expect(getVendorChunk('/node_modules/wagmi/dist/index.js')).toBe(
-			'vendor-web3',
-		)
-		expect(getVendorChunk('/node_modules/ox/dist/index.js')).toBe('vendor-web3')
-		expect(getVendorChunk('/node_modules/abitype/dist/index.js')).toBe(
-			'vendor-web3',
-		)
+		it('matches tanstack packages by prefix', () => {
+			expect(
+				getVendorChunk(
+					'/node_modules/@tanstack/react-query/dist/index.js',
+					true,
+				),
+			).toBe('vendor-tanstack')
+			expect(
+				getVendorChunk(
+					'/node_modules/@tanstack/react-router/dist/index.js',
+					true,
+				),
+			).toBe('vendor-tanstack')
+			expect(
+				getVendorChunk(
+					'/node_modules/@tanstack/query-core/dist/index.js',
+					true,
+				),
+			).toBe('vendor-tanstack')
+		})
+
+		it('matches web3 packages', () => {
+			expect(getVendorChunk('/node_modules/viem/dist/index.js', true)).toBe(
+				'vendor-web3',
+			)
+			expect(getVendorChunk('/node_modules/wagmi/dist/index.js', true)).toBe(
+				'vendor-web3',
+			)
+			expect(getVendorChunk('/node_modules/ox/dist/index.js', true)).toBe(
+				'vendor-web3',
+			)
+			expect(getVendorChunk('/node_modules/abitype/dist/index.js', true)).toBe(
+				'vendor-web3',
+			)
+		})
 	})
 })
 

--- a/apps/explorer/scripts/chunk-config.ts
+++ b/apps/explorer/scripts/chunk-config.ts
@@ -1,6 +1,9 @@
 /**
  * Vendor chunk configuration for Vite/Rolldown builds.
  * Separates vendor dependencies into cacheable chunks.
+ *
+ * IMPORTANT: Only applies to client builds to avoid bundling browser-specific
+ * code (like `window` references) into the server bundle.
  */
 
 // Key = chunk name suffix, value = exact packages or prefix to match
@@ -23,8 +26,18 @@ export function extractPackageName(id: string): string | undefined {
 /**
  * Determine which vendor chunk a module belongs to based on its path.
  * Returns the chunk name (e.g., 'vendor-react') or undefined if not a vendor chunk.
+ *
+ * @param id - Module path
+ * @param isClientBuild - Whether this is a client build (not SSR/server)
  */
-export function getVendorChunk(id: string): string | undefined {
+export function getVendorChunk(
+	id: string,
+	isClientBuild: boolean = false,
+): string | undefined {
+	// Only apply manual chunks to client builds to avoid bundling
+	// browser-specific code into the server bundle
+	if (!isClientBuild) return undefined
+
 	const pkg = extractPackageName(id)
 	if (!pkg) return undefined
 

--- a/apps/explorer/src/routes/__root.tsx
+++ b/apps/explorer/src/routes/__root.tsx
@@ -276,9 +276,9 @@ function RootDocument({ children }: { children: React.ReactNode }) {
 					<QueryClientProvider client={queryClient}>
 						<BreadcrumbsProvider>
 							<AddressHighlightProvider>
-                <IntroSeenProvider>
-                  <ThemeProvider>{children}</ThemeProvider>
-                </IntroSeenProvider>
+								<IntroSeenProvider>
+									<ThemeProvider>{children}</ThemeProvider>
+								</IntroSeenProvider>
 							</AddressHighlightProvider>
 						</BreadcrumbsProvider>
 						{import.meta.env.DEV && (

--- a/apps/explorer/vite.config.ts
+++ b/apps/explorer/vite.config.ts
@@ -94,7 +94,21 @@ export default defineConfig((config) => {
 								? { dropConsole: true, dropDebugger: true }
 								: undefined,
 					},
-					manualChunks: getVendorChunk,
+					manualChunks: (id, { getModuleInfo }) => {
+						// Only apply vendor chunking to client builds to avoid bundling
+						// browser-specific code (window, document, etc.) into the server bundle
+						const moduleInfo = getModuleInfo(id)
+						const isClientBuild =
+							id.includes('index.client') ||
+							id.includes('/client/') ||
+							moduleInfo?.importers.some(
+								(importer) =>
+									importer.includes('index.client') ||
+									importer.includes('/client/'),
+							)
+
+						return getVendorChunk(id, isClientBuild)
+					},
 				},
 			},
 		},


### PR DESCRIPTION
## Summary

Split vendor dependencies into separate chunks for better browser caching using a robust automatic approach.

## Changes

Added `manualChunks` function to `vite.config.ts` that automatically extracts package names from `node_modules` paths and groups them:

```typescript
manualChunks(id) {
  if (!id.includes('node_modules')) return
  // Extract package name from path
  const parts = id.split('node_modules/').pop()?.split('/') ?? []
  const pkg = parts[0]?.startsWith('@')
    ? `${parts[0]}/${parts[1]}`
    : parts[0]
  // Group by category for better caching
  if (['react', 'react-dom', 'scheduler'].includes(pkg ?? ''))
    return 'vendor-react'
  if (pkg?.startsWith('@tanstack/')) return 'vendor-tanstack'
  if (['viem', 'wagmi', 'ox', 'abitype'].includes(pkg ?? ''))
    return 'vendor-web3'
}
```

## New Vendor Chunks

| Chunk | Contents | Size |
|-------|----------|------|
| `vendor-react` | react, react-dom, scheduler | 686 KB |
| `vendor-tanstack` | @tanstack/* (router, query, devtools) | 1.0 MB |
| `vendor-web3` | viem, wagmi, ox, abitype | 1.1 MB |

## Why This Matters

- **Better caching**: Vendor chunks rarely change between deployments, so browsers will cache them long-term
- **Smaller entry point**: App code changes no longer invalidate vendor caches
- **Robust approach**: Automatically extracts package names instead of hardcoding paths

## Testing

```bash
cd apps/explorer
pnpm bundle:analyze:json
npx tsx scripts/bundle-diff.ts --skip-build
```