### PR TITLE
fix(contract-verification): increase timeout for verify routes to 5 minutes

### DIFF
--- a/apps/contract-verification/src/index.tsx
+++ b/apps/contract-verification/src/index.tsx
@@ -73,7 +73,9 @@ app.use(
 		},
 	}),
 )
-app.use('*', timeout(30_000)) // 30 seconds
+app.use('*', timeout(30_000)) // 30 seconds default
+app.use('/verify/*', timeout(300_000)) // 5 minutes for legacy verify routes
+app.use('/v2/verify/*', timeout(300_000)) // 5 minutes for v2 verify routes
 app.use(prettyJSON())
 app.use(async (context, next) => {
 	if (context.env.NODE_ENV !== 'development') return await next()


### PR DESCRIPTION
## Problem

Large contracts (e.g., Frax OFT with LayerZero dependencies) were timing out during compilation due to the global 30-second timeout.

## Solution

Increase the timeout specifically for verification routes from 30s to 5 minutes:
- `/verify/*` → 5 minutes
- `/v2/verify/*` → 5 minutes
- All other routes remain at 30s

## Context

Reported by Frax team: https://fraxtalk.slack.com/archives/C09FW5ZC3FB/p1767716476889149