### PR TITLE
fix(contract-verification): match sourcify schema

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -22,4 +22,3 @@ jobs:
 
       - name: Check code and types
         run: pnpm gen:types && pnpm check
-

--- a/apps/contract-verification/container/compiler.ts
+++ b/apps/contract-verification/container/compiler.ts
@@ -69,7 +69,7 @@ export async function getVyperPath(requestedVersion: string) {
 	await NodeFS.mkdir(VYPER_CACHE_DIR, { recursive: true })
 
 	// Sanitize the version string
-	// Vyper versions can be: 0.3.10, 0.4.0, 0.4.1, v0.3.10, 0.3.10+commit.XXXXXXX
+	// Vyper versions can be: 0.3.10, v0.3.10, 0.3.10+commit.XXXXXXX
 	const cleaned = requestedVersion.replace(/^v/, '')
 	const match = cleaned.match(/^(\d+\.\d+\.\d+)(?:\+commit\.[0-9a-f]+)?$/)
 	if (!match) throw new Error(`Unsupported Vyper version: ${requestedVersion}`)

--- a/apps/contract-verification/src/chains.ts
+++ b/apps/contract-verification/src/chains.ts
@@ -8,7 +8,10 @@ const tempoPresto = {
 	id: 4217,
 	name: 'Tempo Mainnet',
 	blockExplorers: {
-		default: { name: 'Tempo Explorer', url: 'https://explore.mainnet.tempo.xyz' },
+		default: {
+			name: 'Tempo Explorer',
+			url: 'https://explore.mainnet.tempo.xyz',
+		},
 	},
 	rpcUrls: {
 		default: {

--- a/apps/contract-verification/src/container.ts
+++ b/apps/contract-verification/src/container.ts
@@ -6,24 +6,22 @@ export class VerificationContainer extends Container<Cloudflare.Env> {
 	enableInternet = true
 
 	override async onStart(): Promise<void> {
-		console.log('onStart hook called')
-
 		const response = await this.containerFetch('http://localhost:8080/health')
 		if (!response.ok) throw new Error('Container health check failed')
 
 		const data = await response.text()
-		console.log('onStart hook called with data:', data)
+		console.info('onStart hook called with data:', data)
 	}
 
 	override onStop(stopParams: StopParams): void {
-		if (stopParams.exitCode === 0) console.log('Container stopped gracefully')
-		else console.log('Container stopped with exit code:', stopParams.exitCode)
+		if (stopParams.exitCode === 0) console.info('Container stopped gracefully')
+		else console.warn('Container stopped with exit code:', stopParams.exitCode)
 
-		console.log('Container stop reason:', stopParams.reason)
+		console.info('Container stop reason:', stopParams.reason)
 	}
 
 	override onError(error: unknown): unknown {
-		console.log('onError hook called with error:', error)
+		console.error('onError hook called with error:', error)
 		throw error
 	}
 }

--- a/apps/contract-verification/src/route.lookup.ts
+++ b/apps/contract-verification/src/route.lookup.ts
@@ -77,11 +77,11 @@ lookupRoute.get('/all-chains/:address', async (context) => {
 					: runtimeMatchStatus || creationMatchStatus
 
 			return {
-				matchId: row.matchId,
+				matchId: String(row.matchId),
 				match: matchStatus,
 				creationMatch: creationMatchStatus,
 				runtimeMatch: runtimeMatchStatus,
-				chainId: row.chainId,
+				chainId: String(row.chainId),
 				address: Hex.fromBytes(new Uint8Array(row.address as ArrayBuffer)),
 				verifiedAt: row.verifiedAt,
 			}
@@ -218,11 +218,11 @@ lookupRoute.get('/:chainId/:address', async (context) => {
 
 		// Minimal response (default)
 		const minimalResponse = {
-			matchId: row.matchId,
+			matchId: String(row.matchId),
 			match: matchStatus,
 			creationMatch: creationMatchStatus,
 			runtimeMatch: runtimeMatchStatus,
-			chainId: row.chainId,
+			chainId: String(row.chainId),
 			address: formattedAddress,
 			verifiedAt: row.verifiedAt,
 		}
@@ -423,7 +423,7 @@ lookupRoute.get('/:chainId/:address', async (context) => {
 			name: row.contractName,
 			fullyQualifiedName: row.fullyQualifiedName,
 			compiler: row.compiler,
-			version: row.version,
+			compilerVersion: row.version,
 			language: row.language,
 			compilerSettings: JSON.parse(row.compilerSettings),
 			runtimeMetadataMatch: row.runtimeMetadataMatch ? 'exact_match' : 'match',
@@ -458,7 +458,7 @@ lookupRoute.get('/:chainId/:address', async (context) => {
 				: null,
 			compilation: {
 				compiler: row.compiler,
-				version: row.version,
+				compilerVersion: row.version,
 				language: row.language,
 				name: row.contractName,
 				fullyQualifiedName: row.fullyQualifiedName,
@@ -579,11 +579,11 @@ lookupAllChainContractsRoute.get('/:chainId', async (context) => {
 					: 'match'
 
 			return {
-				matchId: row.matchId,
+				matchId: String(row.matchId),
 				match: matchStatus,
 				creationMatch: creationMatchStatus,
 				runtimeMatch: runtimeMatchStatus,
-				chainId: row.chainId,
+				chainId: String(row.chainId),
 				address: Hex.fromBytes(new Uint8Array(row.address as ArrayBuffer)),
 				verifiedAt: row.verifiedAt,
 			}

--- a/apps/explorer/src/comps/AddressHighlight.tsx
+++ b/apps/explorer/src/comps/AddressHighlight.tsx
@@ -10,9 +10,7 @@ interface AddressHighlightContextValue {
 const AddressHighlightContext =
 	React.createContext<AddressHighlightContextValue | null>(null)
 
-export function AddressHighlightProvider(props: {
-	children: React.ReactNode
-}) {
+export function AddressHighlightProvider(props: { children: React.ReactNode }) {
 	const [highlightedAddress, setHighlightedAddress] =
 		React.useState<Address.Address | null>(null)
 


### PR DESCRIPTION
Sourcify's API uses:

`chainId: string`
`matchId: string`
`compilerVersion: string` (different field name)

Our API response before:

`chainId: number`
`matchId: number`
`version: string`

Our API response after:

`chainId: string`
`matchId: string`
`compilerVersion: string`