### PR TITLE
fix: rebalance swap shows correct tokens in and out

### DIFF
--- a/apps/explorer/src/lib/domain/known-events.ts
+++ b/apps/explorer/src/lib/domain/known-events.ts
@@ -606,12 +606,12 @@ function createDetectors(
 						{ type: 'action', value: 'Rebalance Swap' },
 						{
 							type: 'amount',
-							value: createAmount(args.amountIn, args.userToken),
+							value: createAmount(args.amountIn, args.validatorToken),
 						},
 						{ type: 'text', value: 'for' },
 						{
 							type: 'amount',
-							value: createAmount(args.amountOut, args.validatorToken),
+							value: createAmount(args.amountOut, args.userToken),
 						},
 					],
 				}


### PR DESCRIPTION
Fixes the token assignment in RebalanceSwap event display. The `amountIn` was incorrectly paired with `userToken` when it should be paired with `validatorToken`, and vice versa for `amountOut`.

Before: 
<img width="833" height="679" alt="image" src="https://github.com/user-attachments/assets/4e6e98ae-8fce-45e9-9c58-02b0b6510d7a" />

After:
<img width="850" height="670" alt="image" src="https://github.com/user-attachments/assets/635be5f0-4f94-416b-ad95-ba22492fdaca" />
