### PR TITLE
fix(explorer): point main explorer domains to mainnet (presto)

### DIFF
--- a/apps/explorer/wrangler.jsonc
+++ b/apps/explorer/wrangler.jsonc
@@ -46,27 +46,12 @@
 				{
 					"custom_domain": true,
 					"zone_name": "tempo.xyz",
-					"pattern": "explore.tempo.xyz"
-				},
-				{
-					"custom_domain": true,
-					"zone_name": "tempo.xyz",
-					"pattern": "explorer.tempo.xyz"
-				},
-				{
-					"custom_domain": true,
-					"zone_name": "tempo.xyz",
 					"pattern": "explore.42431.tempo.xyz"
 				},
 				{
 					"custom_domain": true,
 					"zone_name": "tempo.xyz",
 					"pattern": "explore.moderato.tempo.xyz"
-				},
-				{
-					"custom_domain": true,
-					"zone_name": "tempo.xyz",
-					"pattern": "explore.testnet.tempo.xyz"
 				}
 			],
 			"vars": {
@@ -119,6 +104,16 @@
 				{
 					"custom_domain": true,
 					"zone_name": "tempo.xyz",
+					"pattern": "explore.tempo.xyz"
+				},
+				{
+					"custom_domain": true,
+					"zone_name": "tempo.xyz",
+					"pattern": "explorer.tempo.xyz"
+				},
+				{
+					"custom_domain": true,
+					"zone_name": "tempo.xyz",
 					"pattern": "explore.4217.tempo.xyz"
 				},
 				{
@@ -130,6 +125,11 @@
 					"custom_domain": true,
 					"zone_name": "tempo.xyz",
 					"pattern": "explore.mainnet.tempo.xyz"
+				},
+				{
+					"custom_domain": true,
+					"zone_name": "tempo.xyz",
+					"pattern": "explore.testnet.tempo.xyz"
 				}
 			],
 			"vars": {


### PR DESCRIPTION
## Summary

The homepage of the explorer on `explore.mainnet.tempo.xyz` was showing transactions from the moderato testnet instead of mainnet because the main explorer domains were incorrectly routed to the `moderato` Cloudflare environment.

## Changes

Moves the following domains from the `moderato` environment to `presto` (mainnet):
- `explore.tempo.xyz`
- `explorer.tempo.xyz`
- `explore.testnet.tempo.xyz`

The `moderato` environment now only serves:
- `explore.42431.tempo.xyz`
- `explore.moderato.tempo.xyz`

This ensures the main explorer serves mainnet transactions with the correct `VITE_TEMPO_ENV=presto` environment variable, which selects the correct spotlight data (account, contract, and transaction hashes) for mainnet.