### PR TITLE
feat: fix missing blocks on block page

### DIFF
--- a/apps/explorer/src/comps/ContractSource.tsx
+++ b/apps/explorer/src/comps/ContractSource.tsx
@@ -10,12 +10,10 @@ import SolidityIcon from '~icons/vscode-icons/file-type-solidity'
 import VyperIcon from '~icons/vscode-icons/file-type-vyper'
 
 function getCompilerVersionUrl(compiler: string, version: string) {
-	const isVyper = compiler.toLowerCase() === "vyper"
-	const repo = isVyper ? "vyperlang/vyper" : "argotorg/solidity"
+	const isVyper = compiler.toLowerCase() === 'vyper'
+	const repo = isVyper ? 'vyperlang/vyper' : 'argotorg/solidity'
 
-	const tag = isVyper
-		? version.trim()
-		: version.trim().split("+commit.", 1)[0]
+	const tag = isVyper ? version.trim() : version.trim().split('+commit.', 1)[0]
 
 	return `https://github.com/${repo}/releases/tag/v${tag}`
 }


### PR DESCRIPTION
Fixes blocks page skipping blocks during live updates

When blocks arrive faster than the polling interval or if a poll is missed, the /blocks page would skip intermediate blocks (e.g., showing block 359 → 361, missing 360).

Root cause: useWatchBlockNumber triggers with the latest block number, but the original code only fetched that single block via useBlock. Any blocks between the previous highest and the new latest were never fetched.

Fix: When a new block number arrives, calculate the gap from the current highest displayed block and fetch all missing blocks in parallel. Uses queryClient.fetchQuery with caching to avoid duplicate requests.

Before:
<img width="1303" height="546" alt="image" src="https://github.com/user-attachments/assets/95aefb94-31d9-42c1-9731-811523ca8f21" />


After: 
<img width="1330" height="495" alt="image" src="https://github.com/user-attachments/assets/137933ee-de86-4e91-b790-2b8df67e4f2f" />
