### PR TITLE
feat(explorer): show full hex values in receipt text format

### DIFF
--- a/apps/explorer/src/routes/_layout/receipt/$hash.tsx
+++ b/apps/explorer/src/routes/_layout/receipt/$hash.tsx
@@ -372,7 +372,7 @@ function Component() {
 }
 
 namespace TextRenderer {
-	const width = 50
+	const width = 76
 	const indent = '  '
 
 	export function render(data: Awaited<ReturnType<typeof fetchReceiptData>>) {


### PR DESCRIPTION
Removes the ellipsis truncation from hex values in the receipt text format, showing full addresses and hashes. Increases receipt width from 50 to 76 characters to accommodate.

**Example receipt:**
```
                                TEMPO RECEIPT

Tx Hash: 0x3945596e1234567890abcdef1234567890abcdef1234567890abcdef1e7eab87
Date: 01/17/2026, 08:49 AM
Block: 1404613
Sender: 0x85ba3C1234567890abcdef1234567890abcd1F8ef7

----------------------------------------------------------------------------

SEND ALPHAUSD TO 0X0AA31234567890ABCDEF1234567890ABCD8581            $1.26

FEE (ALPHAUSD)                                                      <$0.01
  Paid by: 0x85ba3C1234567890abcdef1234567890abcd1F8ef7

FEE                                                                 <$0.01
TOTAL                                                                $1.26
```