### PR TITLE
feat: use KeyManager.http('https://keystore.tempo.xyz')

### DIFF
--- a/apps/fee-payer/playground/src/wagmi.config.ts
+++ b/apps/fee-payer/playground/src/wagmi.config.ts
@@ -14,7 +14,7 @@ export const config = createConfig({
 	},
 	connectors: [
 		webAuthn({
-			keyManager: KeyManager.localStorage(),
+			keyManager: KeyManager.http('https://keystore.tempo.xyz'),
 		}),
 	],
 	chains: [tempoTestnet.extend({ feeToken: alphaUsd })],


### PR DESCRIPTION
Update fee-payer playground to use `KeyManager.http('https://keystore.tempo.xyz')` instead of `KeyManager.localStorage()`.