### PR TITLE
fix(explorer): contract lookup schema

### DIFF
--- a/apps/explorer/src/comps/ContractSource.tsx
+++ b/apps/explorer/src/comps/ContractSource.tsx
@@ -48,7 +48,7 @@ export function SourceSection(props: ContractSource) {
 	const optimizerText = getOptimizerText(compilation)
 	const compilerVersionUrl = getCompilerVersionUrl(
 		compilation.compiler,
-		compilation.version,
+		compilation.compilerVersion,
 	)
 
 	return (
@@ -73,7 +73,7 @@ export function SourceSection(props: ContractSource) {
 							className="font-medium text-primary/80"
 							href={compilerVersionUrl}
 						>
-							{compilation.version} ({compilation.compiler})
+							{compilation.compilerVersion} ({compilation.compiler})
 						</a>
 					),
 				},

--- a/apps/explorer/src/lib/domain/contract-source.ts
+++ b/apps/explorer/src/lib/domain/contract-source.ts
@@ -32,11 +32,11 @@ const SoliditySettingsSchema = z.object({
 })
 
 export const ContractVerificationLookupSchema = z.object({
-	matchId: z.number(),
+	matchId: z.coerce.number(),
 	match: z.string(),
 	creationMatch: z.string(),
 	runtimeMatch: z.string(),
-	chainId: z.number(),
+	chainId: z.coerce.number(),
 	address: z.string(),
 	verifiedAt: z.string(),
 	stdJsonInput: z.object({
@@ -53,7 +53,7 @@ export const ContractVerificationLookupSchema = z.object({
 	abi: z.array(z.any()),
 	compilation: z.object({
 		compiler: z.string(),
-		version: z.string(),
+		compilerVersion: z.string(),
 		language: z.string(),
 		name: z.string(),
 		fullyQualifiedName: z.string(),

--- a/apps/explorer/src/routes/_layout/receipt/$hash.tsx
+++ b/apps/explorer/src/routes/_layout/receipt/$hash.tsx
@@ -18,7 +18,7 @@ import { apostrophe } from '#lib/chars'
 import { decodeKnownCall, parseKnownEvents } from '#lib/domain/known-events'
 import { getFeeBreakdown, LineItems } from '#lib/domain/receipt'
 import * as Tip20 from '#lib/domain/tip20'
-import { DateFormatter, HexFormatter, PriceFormatter } from '#lib/formatting'
+import { DateFormatter, PriceFormatter } from '#lib/formatting'
 import { useKeyboardShortcut } from '#lib/hooks'
 import {
 	buildTxDescription,
@@ -421,8 +421,7 @@ namespace TextRenderer {
 					format: 'short',
 				})
 				lines.push(leftRight(label.toUpperCase(), amount))
-				if (item.payer)
-					lines.push(`${indent}Paid by: ${item.payer}`)
+				if (item.payer) lines.push(`${indent}Paid by: ${item.payer}`)
 			}
 
 			lines.push('')

--- a/apps/og/src/index.tsx
+++ b/apps/og/src/index.tsx
@@ -170,9 +170,7 @@ app.get(
 		const [fonts, images, tokenIcon] = await Promise.all([
 			loadFonts(),
 			loadImages(context.env),
-			tokenParams.chainId
-				? fetchTokenIcon(address, tokenParams.chainId)
-				: null,
+			tokenParams.chainId ? fetchTokenIcon(address, tokenParams.chainId) : null,
 		])
 
 		const imageResponse = new ImageResponse(

--- a/apps/tokenlist/env.d.ts
+++ b/apps/tokenlist/env.d.ts
@@ -30,5 +30,4 @@ interface ImportMeta {
 	readonly env: ImportMetaEnv
 }
 
-
 declare const __BUILD_VERSION__: string

--- a/apps/tokenlist/src/docs.tsx
+++ b/apps/tokenlist/src/docs.tsx
@@ -4,9 +4,7 @@ import { html, raw } from 'hono/html'
 const scalarConfig = {
 	slug: 'tokenlist',
 	hideModels: true,
-	sources: [
-		{ url: '/schema/openapi.json', default: true },
-	],
+	sources: [{ url: '/schema/openapi.json', default: true }],
 	hideClientButton: true,
 	url: '/schema/openapi.json',
 	showDeveloperTools: 'never',

--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
 	},
 	"packageManager": "pnpm@10.28.0",
 	"pnpm": {
-		"onlyBuiltDependencies": ["@ast-grep/cli"]
+		"onlyBuiltDependencies": [
+			"@ast-grep/cli"
+		]
 	}
 }


### PR DESCRIPTION
Fixed. The issue was that the upstream API returns:

`matchId` and chainId as strings (not numbers)
`compilerVersion` instead of version in the compilation object

Changes made:

`contract-source.ts`: Used `z.coerce.number()` for `matchId` and `chainId`, renamed `version` to `compilerVersion`
`ContractSource.tsx`: Updated usages from `compilation.version` to `compilation.compilerVersion`