### PR TITLE
fix(explorer): empty history in contract history page

### DIFF
--- a/apps/explorer/src/routes/api/address/txs-count/$address.ts
+++ b/apps/explorer/src/routes/api/address/txs-count/$address.ts
@@ -1,6 +1,7 @@
 import { createFileRoute } from '@tanstack/react-router'
 import * as IDX from 'idxs'
 import * as Address from 'ox/Address'
+import { getBlockNumber, getCode } from 'viem/actions'
 import { getChainId } from 'wagmi/actions'
 import * as z from 'zod/mini'
 import { hasIndexSupply } from '#lib/env'
@@ -18,6 +19,59 @@ const chainId = getChainId(getWagmiConfig())
 const RequestSchema = z.object({
 	chainId: z.prefault(z.coerce.number(), chainId),
 })
+
+/**
+ * Binary search to find the block where a contract was created.
+ */
+async function findCreationBlock(
+	client: ReturnType<ReturnType<typeof getWagmiConfig>['getClient']>,
+	address: Address.Address,
+	latestBlock: bigint,
+): Promise<bigint | null> {
+	let low = 0n
+	let high = latestBlock
+	let result: bigint | null = null
+
+	while (low <= high) {
+		const mid = (low + high) / 2n
+		try {
+			const code = await getCode(client, { address, blockNumber: mid })
+			if (code && code !== '0x') {
+				result = mid
+				high = mid - 1n
+			} else {
+				low = mid + 1n
+			}
+		} catch {
+			low = mid + 1n
+		}
+	}
+
+	return result
+}
+
+/**
+ * Checks if address is a contract (has creation tx that should be counted).
+ * Uses binary search for efficient detection.
+ */
+async function hasContractCreation(
+	address: Address.Address,
+	_chainId: number,
+): Promise<boolean> {
+	const config = getWagmiConfig()
+	const client = config.getClient()
+
+	// Check if this address has code (is a contract)
+	const code = await getCode(client, { address })
+	if (!code || code === '0x') return false
+
+	// If it has code, there must be a creation tx
+	// Use binary search to confirm and find the block
+	const latestBlock = await getBlockNumber(client)
+	const creationBlock = await findCreationBlock(client, address, latestBlock)
+
+	return creationBlock !== null
+}
 
 export const Route = createFileRoute('/api/address/txs-count/$address')({
 	server: {
@@ -38,24 +92,29 @@ export const Route = createFileRoute('/api/address/txs-count/$address')({
 
 					const { chainId } = parseResult.data
 
-					const [txSentResult, txReceivedResult] = await Promise.all([
-						QB.selectFrom('txs')
-							.select((eb) => eb.fn.count('hash').as('cnt'))
-							.where('from', '=', address)
-							.where('chain', '=', chainId)
-							.executeTakeFirst(),
-						QB.selectFrom('txs')
-							.select((eb) => eb.fn.count('hash').as('cnt'))
-							.where('to', '=', address)
-							.where('chain', '=', chainId)
-							.executeTakeFirst(),
-					])
+					const [txSentResult, txReceivedResult, hasCreation] =
+						await Promise.all([
+							QB.selectFrom('txs')
+								.select((eb) => eb.fn.count('hash').as('cnt'))
+								.where('from', '=', address)
+								.where('chain', '=', chainId)
+								.executeTakeFirst(),
+							QB.selectFrom('txs')
+								.select((eb) => eb.fn.count('hash').as('cnt'))
+								.where('to', '=', address)
+								.where('chain', '=', chainId)
+								.executeTakeFirst(),
+							// Check if this is a contract with a creation tx
+							hasContractCreation(address, chainId),
+						])
 
 					const txSent = txSentResult?.cnt ?? 0
 					const txReceived = txReceivedResult?.cnt ?? 0
+					// Add 1 if contract has a creation tx
+					const creationCount = hasCreation ? 1 : 0
 
 					return Response.json({
-						data: Number(txSent) + Number(txReceived),
+						data: Number(txSent) + Number(txReceived) + creationCount,
 						error: null,
 					})
 				} catch (error) {


### PR DESCRIPTION
Fix empty transaction history for contract addresses

Problem

Contract addresses were showing an empty transaction history table in the explorer because the contract creation transaction was not being included in the results.

Solution

Added logic to find and include contract creation transactions for contract addresses using a two-step approach:

Binary search with `eth_getCode`: Efficiently finds the exact block where a contract was created by querying historical code state
Receipt verification: Queries IndexSupply for `to=0x0` transactions at the creation block and verifies `receipt.contractAddress` matches

Also added a `transferEmittedQuery` to capture transactions where the contract emits Transfer events (helps with token contracts that mint on creation).

Changes

`apps/explorer/src/routes/api/address/$address.ts`: Added `findCreationBlock` and findContractCreationTx helpers, integrated creation tx into the transaction list
`apps/explorer/src/routes/api/address/txs-count/$address.ts`: Added `hasContractCreation` check to include creation tx in the count

Notes

Works for direct EOA deployments (`to=0x0`)
Factory-deployed contracts are partially supported via transfer event queries
Binary search is efficient (~20 RPC calls for chains with millions of blocks)