### PR TITLE
feat: add delegate account event

### DIFF
--- a/apps/explorer/src/lib/domain/known-events.ts
+++ b/apps/explorer/src/lib/domain/known-events.ts
@@ -9,6 +9,27 @@ const abi = Object.values(Abis).flat()
 const FEE_MANAGER = Addresses.feeManager
 const STABLECOIN_EXCHANGE = Addresses.stablecoinDex
 
+export type Authorization = {
+	address: Address.Address
+	chainId: number
+	nonce: number
+}
+
+export function parseAuthorizationEvents(
+	authorizationList: readonly Authorization[] | undefined,
+): KnownEvent[] {
+	if (!authorizationList || authorizationList.length === 0) return []
+
+	return authorizationList.map((auth) => ({
+		type: 'delegate account',
+		parts: [
+			{ type: 'action', value: 'Delegate Account' },
+			{ type: 'text', value: 'to' },
+			{ type: 'account', value: auth.address },
+		],
+	}))
+}
+
 type FeeTransferEvent = {
 	amount: bigint
 	token: Address.Address


### PR DESCRIPTION
Type 0x4 transactions that set up account delegation currently show only "Pay Fee" in the Description, making it unclear what the transaction actually does. Parses the authorizationList from EIP-7702 transactions and displays "Delegate Account to [address]" as a known event in the Description section.

before: 
<img width="1140" height="797" alt="image" src="https://github.com/user-attachments/assets/524c6d50-7a6d-4d06-b030-3594ebc8fe5b" />

after:
<img width="1144" height="815" alt="image" src="https://github.com/user-attachments/assets/fc2780ca-6d43-4dab-81db-01258a3ac5cd" />
