### PR TITLE
feat(explorer): add Contract Creation event to known events

### DIFF
--- a/apps/explorer/src/lib/domain/known-events.ts
+++ b/apps/explorer/src/lib/domain/known-events.ts
@@ -1071,6 +1071,18 @@ export function parseKnownEvents(
 
 	const knownEvents: KnownEvent[] = []
 
+	// Detect contract creation (transaction.to is null for deployments)
+	const transaction = options?.transaction
+	if (transaction && transaction.to === null) {
+		knownEvents.push({
+			type: 'contract creation',
+			parts: [
+				{ type: 'action', value: 'Deploy Contract' },
+				{ type: 'account', value: receipt.contractAddress as Address.Address },
+			],
+		})
+	}
+
 	if (feeManagerCall && feeManagerCall.functionName === 'mint') {
 		const validatorToken = feeManagerCall.args[1]
 		const amountValidatorToken = feeManagerCall.args[2]


### PR DESCRIPTION
## Summary
When a transaction is a contract creation (`transaction.to` is null), add a 'contract creation' `KnownEvent` with 'Deploy Contract' action and the deployed contract address.

This makes contract creation transactions show properly in:
- Transaction page description
- Address caller history

## Example URLs

### Production (before):
- [Transaction](https://explore.tempo.xyz/tx/0x67139a552b0d3fffc30c0fa7d0c20d42144138c8fe07fc5691f09c1cce632e15) - shows "Pay Fee"
- [Caller history](https://explore.tempo.xyz/address/0x0000f90827f1c53a10cb7a02335b175320002935?live=false) - shows "Pay Fee"

### Preview (after):
- [Transaction](https://e7f47130-explorer-moderato.porto.workers.dev/tx/0x67139a552b0d3fffc30c0fa7d0c20d42144138c8fe07fc5691f09c1cce632e15) - shows "Deploy Contract 0x000...935"
- [Caller history](https://e7f47130-explorer-moderato.porto.workers.dev/address/0x0000f90827f1c53a10cb7a02335b175320002935?live=false) - shows "Deploy Contract 0x000...935 (self)"

## Screenshots

### Transaction Page
| Before | After |
|--------|-------|
| ![tx-before](https://ampcode.com/attachments/df6cbb026b21401abc6b98f3409d52d1b7f661408fabd78cc94d3ff4e0788303.png) | ![tx-after](https://ampcode.com/attachments/df6cbb026b21401abc6b98f3409d52d1b7f661408fabd78cc94d3ff4e0788303.png) |

### Address Caller History
| Before | After |
|--------|-------|
| ![address-before](https://ampcode.com/attachments/03693e8aec1199543f6c6f95cd643b6419d559d2e968227528a544b6c7280ace.png) | ![address-after](https://ampcode.com/attachments/c72f4597bbab136e7b42c6dd0fe7c56fe40f0d1796bb20dddb6323b57d637c3f.png) |

## Changes
- `apps/explorer/src/lib/domain/known-events.ts`: Detect contract creation in `parseKnownEvents` when `transaction.to === null` and add a `contract creation` event

cc @gorrie
