### PR TITLE
fix(explorer): handle null contractAddress in transaction receipts

### DIFF
--- a/apps/explorer/src/comps/TxEventDescription.tsx
+++ b/apps/explorer/src/comps/TxEventDescription.tsx
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query'
 import { Link } from '@tanstack/react-router'
+import * as OxAddress from 'ox/Address'
 import type { Address as AddressType } from 'ox'
 import * as Hex from 'ox/Hex'
 import * as Value from 'ox/Value'
@@ -101,7 +102,9 @@ export namespace TxEventDescription {
 	export function Part(props: Part.Props) {
 		const { part, seenAs } = props
 		switch (part.type) {
-			case 'account':
+			case 'account': {
+				if (!OxAddress.validate(part.value))
+					return <span className="text-tertiary">{String(part.value)}</span>
 				return (
 					<Address
 						address={part.value}
@@ -109,6 +112,7 @@ export namespace TxEventDescription {
 						self={seenAs ? isAddressEqual(part.value, seenAs) : false}
 					/>
 				)
+			}
 			case 'action':
 				return (
 					<span className="inline-flex items-center h-[24px] px-[5px] bg-base-alt text-base-content capitalize">

--- a/apps/explorer/src/lib/domain/known-events.ts
+++ b/apps/explorer/src/lib/domain/known-events.ts
@@ -1073,12 +1073,12 @@ export function parseKnownEvents(
 
 	// Detect contract creation (transaction.to is null for deployments)
 	const transaction = options?.transaction
-	if (transaction && transaction.to === null) {
+	if (transaction && transaction.to === null && receipt.contractAddress) {
 		knownEvents.push({
 			type: 'contract creation',
 			parts: [
 				{ type: 'action', value: 'Deploy Contract' },
-				{ type: 'account', value: receipt.contractAddress as Address.Address },
+				{ type: 'account', value: receipt.contractAddress },
 			],
 		})
 	}


### PR DESCRIPTION
Fixes crash on address pages when viewing transactions with `to: null` but no `contractAddress` in the receipt.

## Problem
Certain Tempo transaction types (e.g., type `0x76`) have `to: null` but `contractAddress: null` in the receipt. The code assumed `contractAddress` was always set when `to` was null, passing `null` to viem's address validation which threw:

```
Address "null" is invalid.
- Address must be a hex value of 20 bytes (40 hex characters).
- Address must match its checksum counterpart.
```

## Fix
- Check `receipt.contractAddress` is truthy before creating "Deploy Contract" events
- Add defensive validation in `TxEventDescription.Part` for invalid addresses

## Screenshots

| Before | After |
|--------|-------|
| ![before](https://i.ibb.co/N2DcykBz/before.png) | ![after](https://i.ibb.co/wr8LtzQW/after.png) |

**Repro URL:** https://explore.moderato.tempo.xyz/address/0xa726a1CD723409074DF9108A2187cfA19899aCF8?live=false