### PR TITLE
fix: remove test tokens from mainnet tokenlist

### DIFF
--- a/apps/tokenlist/data/4217/tokenlist.json
+++ b/apps/tokenlist/data/4217/tokenlist.json
@@ -19,39 +19,6 @@
 			"extensions": {
 				"chain": "tempo"
 			}
-		},
-		{
-			"name": "AlphaUSD",
-			"symbol": "alphaUSD",
-			"decimals": 6,
-			"chainId": 4217,
-			"address": "0x20c0000000000000000000000000000000000001",
-			"logoURI": "https://esm.sh/gh/tempoxyz/tempo-apps/apps/tokenlist/data/4217/icons/0x20c0000000000000000000000000000000000001.svg",
-			"extensions": {
-				"chain": "tempo"
-			}
-		},
-		{
-			"name": "BetaUSD",
-			"symbol": "betaUSD",
-			"decimals": 6,
-			"chainId": 4217,
-			"address": "0x20c0000000000000000000000000000000000002",
-			"logoURI": "https://esm.sh/gh/tempoxyz/tempo-apps/apps/tokenlist/data/4217/icons/0x20c0000000000000000000000000000000000002.svg",
-			"extensions": {
-				"chain": "tempo"
-			}
-		},
-		{
-			"name": "ThetaUSD",
-			"symbol": "thetaUSD",
-			"decimals": 6,
-			"chainId": 4217,
-			"address": "0x20c0000000000000000000000000000000000003",
-			"logoURI": "https://esm.sh/gh/tempoxyz/tempo-apps/apps/tokenlist/data/4217/icons/0x20c0000000000000000000000000000000000003.svg",
-			"extensions": {
-				"chain": "tempo"
-			}
 		}
 	]
 }


### PR DESCRIPTION
## Summary

Removes AlphaUSD, BetaUSD, and ThetaUSD from the mainnet (4217) tokenlist.

## Problem

The mainnet tokenlist was likely copied from the testnet tokenlist and still contained test tokens (alphaUSD, betaUSD, thetaUSD) that shouldn't be exposed on mainnet.

## Changes

- Removed AlphaUSD, BetaUSD, and ThetaUSD from `apps/tokenlist/data/4217/tokenlist.json`
- Mainnet tokenlist now only contains PathUSD