### PR TITLE
scripts: add Moderato TIP-20 fund + transfer demo

### DIFF
--- a/scripts/tempo-testnet-token-transfer/.env.example
+++ b/scripts/tempo-testnet-token-transfer/.env.example
@@ -1,0 +1,8 @@
+TEMPO_RPC=https://rpc.moderato.tempo.xyz
+PRIVATE_KEY=0xYOUR_PRIVATE_KEY
+
+# pathUSD | AlphaUSD | BetaUSD | ThetaUSD
+TOKEN=AlphaUSD
+
+AMOUNT=1
+# TO_ADDRESS=0x...

--- a/scripts/tempo-testnet-token-transfer/.gitignore
+++ b/scripts/tempo-testnet-token-transfer/.gitignore
@@ -1,0 +1,3 @@
+.env
+node_modules
+package-lock.json

--- a/scripts/tempo-testnet-token-transfer/README.md
+++ b/scripts/tempo-testnet-token-transfer/README.md
@@ -1,0 +1,28 @@
+# Tempo Moderato Testnet: Fund + TIP-20 Token Transfer Demo
+
+This is a self-contained demo for the Tempo Moderato Testnet.
+
+It demonstrates how to:
+1) Fund an address using the Tempo faucet JSON-RPC method (tempo_fundAddress)
+2) Transfer a TIP-20 faucet token (pathUSD / AlphaUSD / BetaUSD / ThetaUSD)
+3) Print the transaction explorer link and before/after balances
+
+## Requirements
+- Node.js >= 18
+
+## How to run this demo
+
+All commands below must be executed from this directory:
+
+scripts/tempo-testnet-token-transfer
+
+## Setup
+cd scripts/tempo-testnet-token-transfer
+cp .env.example .env
+# edit .env and set PRIVATE_KEY (optionally TO_ADDRESS)
+npm install
+
+## Run
+node fund.mjs
+node transfer.mjs
+

--- a/scripts/tempo-testnet-token-transfer/fund.mjs
+++ b/scripts/tempo-testnet-token-transfer/fund.mjs
@@ -1,0 +1,29 @@
+import 'dotenv/config'
+import { createPublicClient, http, defineChain } from 'viem'
+import { privateKeyToAccount } from 'viem/accounts'
+
+const tempoModerato = defineChain({
+  id: 42431,
+  name: 'Tempo Moderato Testnet',
+  network: 'tempo-moderato',
+  nativeCurrency: { name: 'Tempo', symbol: 'TEMPO', decimals: 18 },
+  rpcUrls: { default: { http: [process.env.TEMPO_RPC || 'https://rpc.moderato.tempo.xyz'] } },
+  blockExplorers: { default: { name: 'Tempo Explorer', url: 'https://explore.moderato.tempo.xyz' } },
+})
+
+const pk = process.env.PRIVATE_KEY
+if (!pk) throw new Error('PRIVATE_KEY missing in .env')
+const account = privateKeyToAccount(pk)
+
+const client = createPublicClient({
+  chain: tempoModerato,
+  transport: http(process.env.TEMPO_RPC || 'https://rpc.moderato.tempo.xyz'),
+})
+
+const res = await client.request({
+  method: 'tempo_fundAddress',
+  params: [account.address],
+})
+
+console.log(`Fund requested for ${account.address}`)
+console.log(res)

--- a/scripts/tempo-testnet-token-transfer/package.json
+++ b/scripts/tempo-testnet-token-transfer/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "tempo-testnet-token-transfer",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "fund": "node fund.mjs",
+    "transfer": "node transfer.mjs"
+  },
+  "dependencies": {
+    "dotenv": "^16.4.5",
+    "viem": "^2.45.0"
+  }
+}

--- a/scripts/tempo-testnet-token-transfer/transfer.mjs
+++ b/scripts/tempo-testnet-token-transfer/transfer.mjs
@@ -1,0 +1,109 @@
+import 'dotenv/config'
+import {
+  createPublicClient,
+  createWalletClient,
+  http,
+  defineChain,
+  parseUnits,
+  formatUnits,
+} from 'viem'
+import { privateKeyToAccount, generatePrivateKey } from 'viem/accounts'
+
+const tempoModerato = defineChain({
+  id: 42431,
+  name: 'Tempo Moderato Testnet',
+  network: 'tempo-moderato',
+  nativeCurrency: { name: 'Tempo', symbol: 'TEMPO', decimals: 18 },
+  rpcUrls: { default: { http: [process.env.TEMPO_RPC || 'https://rpc.moderato.tempo.xyz'] } },
+  blockExplorers: { default: { name: 'Tempo Explorer', url: 'https://explore.moderato.tempo.xyz' } },
+})
+
+const TOKENS = {
+  pathUSD:  '0x20c0000000000000000000000000000000000000',
+  AlphaUSD: '0x20c0000000000000000000000000000000000001',
+  BetaUSD:  '0x20c0000000000000000000000000000000000002',
+  ThetaUSD: '0x20c0000000000000000000000000000000000003',
+}
+
+const TIP20_ABI = [
+  {
+    type: 'function',
+    name: 'balanceOf',
+    stateMutability: 'view',
+    inputs: [{ name: 'a', type: 'address' }],
+    outputs: [{ name: 'b', type: 'uint256' }],
+  },
+  {
+    type: 'function',
+    name: 'transfer',
+    stateMutability: 'nonpayable',
+    inputs: [
+      { name: 'to', type: 'address' },
+      { name: 'amount', type: 'uint256' },
+    ],
+    outputs: [{ name: 'ok', type: 'bool' }],
+  },
+]
+
+const pk = process.env.PRIVATE_KEY
+if (!pk) throw new Error('PRIVATE_KEY missing in .env')
+
+const tokenKey = process.env.TOKEN || 'AlphaUSD'
+const amountHuman = process.env.AMOUNT || '1'
+const rpc = process.env.TEMPO_RPC || 'https://rpc.moderato.tempo.xyz'
+
+const account = privateKeyToAccount(pk)
+const to = process.env.TO_ADDRESS || privateKeyToAccount(generatePrivateKey()).address
+
+const token = TOKENS[tokenKey]
+if (!token) throw new Error(`Unknown TOKEN=${tokenKey}`)
+
+const publicClient = createPublicClient({ chain: tempoModerato, transport: http(rpc) })
+const walletClient = createWalletClient({ chain: tempoModerato, transport: http(rpc), account })
+
+const DECIMALS = 6
+
+async function balance(addr) {
+  const raw = await publicClient.readContract({
+    address: token,
+    abi: TIP20_ABI,
+    functionName: 'balanceOf',
+    args: [addr],
+  })
+  return { raw, formatted: formatUnits(raw, DECIMALS) }
+}
+
+async function main() {
+  const beforeFrom = await balance(account.address)
+  const beforeTo = await balance(to)
+
+  const amount = parseUnits(amountHuman, DECIMALS)
+
+  const hash = await walletClient.writeContract({
+    address: token,
+    abi: TIP20_ABI,
+    functionName: 'transfer',
+    args: [to, amount],
+  })
+
+  console.log(`From:   ${account.address}`)
+  console.log(`To:     ${to}`)
+  console.log(`Token:  ${tokenKey} @ ${token}`)
+  console.log(`Amount: ${amountHuman}`)
+  console.log(`Tx:     ${hash}`)
+  console.log(`Explorer: ${tempoModerato.blockExplorers.default.url}/tx/${hash}`)
+
+  await publicClient.waitForTransactionReceipt({ hash })
+
+  const afterFrom = await balance(account.address)
+  const afterTo = await balance(to)
+
+  console.log(`\nBalances (${tokenKey})`)
+  console.log(`From: ${beforeFrom.formatted} -> ${afterFrom.formatted}`)
+  console.log(`To:   ${beforeTo.formatted} -> ${afterTo.formatted}`)
+}
+
+main().catch((e) => {
+  console.error(e)
+  process.exit(1)
+})


### PR DESCRIPTION
Adds a self-contained Moderato testnet demo script that:
- funds an address via tempo_fundAddress
- transfers a TIP-20 faucet token (pathUSD/AlphaUSD/BetaUSD/ThetaUSD)
- prints explorer URL and before/after balances

Example tx:
0x8cabb229fe5991ec63cbc47716d218b98a093105610ee98af98404479b4cdc88
