### PR TITLE
fix(explorer): update testnet migration banner link

### DIFF
--- a/apps/explorer/src/comps/Layout.tsx
+++ b/apps/explorer/src/comps/Layout.tsx
@@ -33,7 +33,7 @@ export function Layout(props: Layout.Props) {
 						</time>
 						.{' '}
 						<a
-							href="https://docs.tempo.xyz/network-upgrades"
+							href="https://docs.tempo.xyz/#testnet-migration"
 							className="underline press-down-inline"
 							target="_blank"
 							rel="noopener noreferrer"


### PR DESCRIPTION
Updates the testnet migration banner link from `/network-upgrades` to `/#testnet-migration`.