### PR TITLE
feat: add blank starter app

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@ This is a **TypeScript monorepo** for applications on the Tempo blockchain appli
 | `apps/tokenlist` | Token registry API |
 | `apps/contract-verification` | Smart contract verification |
 | `apps/og` | OpenGraph image generation |
+| `apps/blank` | Blank starter app |
 
 ## Commands
 

--- a/apps/blank/.env.example
+++ b/apps/blank/.env.example
@@ -1,0 +1,1 @@
+NODE_ENV="development"

--- a/apps/blank/package.json
+++ b/apps/blank/package.json
@@ -1,0 +1,22 @@
+{
+	"name": "blank",
+	"type": "module",
+	"scripts": {
+		"build": "echo 'No build step needed for Cloudflare Worker'",
+		"dev": "wrangler dev",
+		"deploy": "wrangler deploy",
+		"check": "pnpm check:biome && pnpm check:types",
+		"check:biome": "biome check --write --unsafe",
+		"check:types": "tsgo --project tsconfig.json --noEmit",
+		"gen:types": "test -f .env || cp .env.example .env; CLOUDFLARE_ENV= wrangler types"
+	},
+	"dependencies": {
+		"hono": "catalog:"
+	},
+	"devDependencies": {
+		"@biomejs/biome": "catalog:",
+		"@cloudflare/workers-types": "catalog:",
+		"@types/node": "catalog:",
+		"wrangler": "catalog:"
+	}
+}

--- a/apps/blank/src/index.ts
+++ b/apps/blank/src/index.ts
@@ -1,0 +1,8 @@
+import { Hono } from 'hono'
+
+const app = new Hono<{ Bindings: Cloudflare.Env }>()
+
+app.get('/', (c) => c.text('OK'))
+app.get('/health', (c) => c.text('OK'))
+
+export default app

--- a/apps/blank/tsconfig.json
+++ b/apps/blank/tsconfig.json
@@ -1,0 +1,38 @@
+{
+	"schema": "https://json.schemastore.org/tsconfig.json",
+	"compilerOptions": {
+		"strict": true,
+		"noEmit": true,
+		"allowJs": true,
+		"checkJs": true,
+		"lib": ["DOM", "ESNext"],
+		"target": "ESNext",
+		"module": "ESNext",
+		"skipLibCheck": true,
+		"alwaysStrict": true,
+		"esModuleInterop": true,
+		"isolatedModules": true,
+		"strictNullChecks": true,
+		"resolveJsonModule": true,
+		"verbatimModuleSyntax": true,
+		"moduleResolution": "Bundler",
+		"useDefineForClassFields": true,
+		"allowArbitraryExtensions": true,
+		"noUncheckedIndexedAccess": true,
+		"resolvePackageJsonImports": true,
+		"resolvePackageJsonExports": true,
+		"useUnknownInCatchVariables": true,
+		"allowImportingTsExtensions": true,
+		"noFallthroughCasesInSwitch": true,
+		"allowSyntheticDefaultImports": true,
+		"forceConsistentCasingInFileNames": true,
+		"paths": {
+			"*": ["./*"],
+			"#*": ["./src/*"]
+		},
+		"types": ["@cloudflare/workers-types", "node"]
+	},
+	"include": ["src/**/*"],
+	"files": ["worker-configuration.d.ts"],
+	"exclude": ["_", "dist", "node_modules"]
+}

--- a/apps/blank/wrangler.jsonc
+++ b/apps/blank/wrangler.jsonc
@@ -1,0 +1,11 @@
+{
+	"$schema": "./node_modules/wrangler/config-schema.json",
+	"name": "blank",
+	"main": "src/index.ts",
+	"compatibility_date": "2025-12-17",
+	"compatibility_flags": ["nodejs_compat"],
+	"observability": {
+		"enabled": true,
+		"head_sampling_rate": 1
+	}
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -234,6 +234,25 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
 
+  apps/blank:
+    dependencies:
+      hono:
+        specifier: 'catalog:'
+        version: 4.11.7
+    devDependencies:
+      '@biomejs/biome':
+        specifier: 'catalog:'
+        version: 2.3.13
+      '@cloudflare/workers-types':
+        specifier: 'catalog:'
+        version: 4.20260128.0
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.1.0
+      wrangler:
+        specifier: 'catalog:'
+        version: 4.61.0(@cloudflare/workers-types@4.20260128.0)
+
   apps/contract-verification:
     dependencies:
       '@cloudflare/containers':


### PR DESCRIPTION
## Summary
Adds a minimal blank Cloudflare Worker app as a starter template.

## Changes
- New `apps/blank` directory with Hono-based worker
- Basic health check endpoints (`/` and `/health`)
- Standard package.json scripts, tsconfig, wrangler config
- Updated AGENTS.md apps table

## Testing
- `pnpm check` passes in `apps/blank`

---
Thread: https://tempoxyz.slack.com/archives/C0A87C21805/p1769720495310829