### PR TITLE
fix(explorer): make breadcrumbs load instantly during navigation

### DIFF
--- a/apps/explorer/src/comps/Layout.tsx
+++ b/apps/explorer/src/comps/Layout.tsx
@@ -1,5 +1,6 @@
 import { useSuspenseQuery } from '@tanstack/react-query'
 import { useMatchRoute } from '@tanstack/react-router'
+import { BreadcrumbsPortal } from '#comps/Breadcrumbs'
 import { Footer } from '#comps/Footer'
 import { Header } from '#comps/Header'
 import { useIntroSeen } from '#comps/Intro'
@@ -48,6 +49,7 @@ export function Layout(props: Layout.Props) {
 				<Header initialBlockNumber={blockNumber} />
 			</div>
 			<main className="flex flex-1 size-full flex-col items-center relative z-1 print:block print:flex-none">
+				<BreadcrumbsPortal />
 				{children}
 			</main>
 			<div className="w-full mt-6 relative z-1 print:hidden">

--- a/apps/explorer/src/routes/_layout/address/$address.tsx
+++ b/apps/explorer/src/routes/_layout/address/$address.tsx
@@ -19,7 +19,7 @@ import { useBlock, useChainId, usePublicClient } from 'wagmi'
 import { type GetBlockReturnType, getBlock, getChainId } from 'wagmi/actions'
 import * as z from 'zod/mini'
 import { AccountCard } from '#comps/AccountCard'
-import { Breadcrumbs } from '#comps/Breadcrumbs'
+import { BreadcrumbsSlot } from '#comps/Breadcrumbs'
 import { ContractTabContent, InteractTabContent } from '#comps/Contract'
 import { DataGrid } from '#comps/DataGrid'
 import { Midcut } from '#comps/Midcut'
@@ -596,7 +596,7 @@ function RouteComponent() {
 				'grid w-full pt-20 pb-16 px-4 gap-3.5 min-w-0 grid-cols-[auto_1fr] min-[1240px]:max-w-7xl',
 			)}
 		>
-			<Breadcrumbs className="col-span-full" />
+			<BreadcrumbsSlot className="col-span-full" />
 			<AccountCardWithTimestamps
 				address={address}
 				assetsData={assetsData}

--- a/apps/explorer/src/routes/_layout/block/$id.tsx
+++ b/apps/explorer/src/routes/_layout/block/$id.tsx
@@ -16,7 +16,7 @@ import { useChains } from 'wagmi'
 import * as z from 'zod/mini'
 import { Address as AddressLink } from '#comps/Address'
 import { BlockCard } from '#comps/BlockCard'
-import { Breadcrumbs } from '#comps/Breadcrumbs'
+import { BreadcrumbsSlot } from '#comps/Breadcrumbs'
 import { DataGrid } from '#comps/DataGrid'
 import { Midcut } from '#comps/Midcut'
 import { NotFound } from '#comps/NotFound'
@@ -141,7 +141,7 @@ function RouteComponent() {
 				'grid w-full pt-20 pb-16 px-4 gap-[14px] min-w-0 grid-cols-[auto_1fr] min-[1240px]:max-w-[1280px]',
 			)}
 		>
-			<Breadcrumbs className="col-span-full" />
+			<BreadcrumbsSlot className="col-span-full" />
 			<div className="self-start max-[800px]:self-stretch">
 				<BlockCard block={block} />
 			</div>

--- a/apps/explorer/src/routes/_layout/block/countdown.$targetBlock.tsx
+++ b/apps/explorer/src/routes/_layout/block/countdown.$targetBlock.tsx
@@ -7,7 +7,7 @@ import {
 } from '@tanstack/react-router'
 import * as React from 'react'
 import { useWatchBlockNumber } from 'wagmi'
-import { Breadcrumbs } from '#comps/Breadcrumbs'
+import { BreadcrumbsSlot } from '#comps/Breadcrumbs'
 import { InfoCard } from '#comps/InfoCard'
 import { NotFound } from '#comps/NotFound'
 import { cx } from '#lib/css'
@@ -96,8 +96,7 @@ function RouteComponent() {
 				'pt-20 pb-16 px-4',
 			)}
 		>
-			<Breadcrumbs className="w-full max-w-[600px]" />
-
+			<BreadcrumbsSlot className="w-full max-w-[600px]" />
 			<CountdownCard
 				targetBlockNumber={targetBlockNumber}
 				currentBlockNumber={currentBlockNumber}

--- a/apps/explorer/src/routes/_layout/token/$address.tsx
+++ b/apps/explorer/src/routes/_layout/token/$address.tsx
@@ -17,7 +17,7 @@ import { getChainId, getPublicClient } from 'wagmi/actions'
 import { Actions, Hooks } from 'wagmi/tempo'
 import * as z from 'zod/mini'
 import { AddressCell } from '#comps/AddressCell'
-import { Breadcrumbs } from '#comps/Breadcrumbs'
+import { BreadcrumbsSlot } from '#comps/Breadcrumbs'
 import { AmountCell, BalanceCell } from '#comps/AmountCell'
 import { ContractTabContent, InteractTabContent } from '#comps/Contract.tsx'
 import { DataGrid } from '#comps/DataGrid'
@@ -285,7 +285,7 @@ function RouteComponent() {
 				'grid w-full pt-20 pb-16 px-4 gap-3.5 min-w-0 grid-cols-[auto_1fr] min-[1240px]:max-w-270',
 			)}
 		>
-			<Breadcrumbs className="col-span-full" />
+			<BreadcrumbsSlot className="col-span-full" />
 			<TokenCard
 				address={address}
 				className="self-start"

--- a/apps/explorer/src/routes/_layout/tx/$hash.tsx
+++ b/apps/explorer/src/routes/_layout/tx/$hash.tsx
@@ -16,7 +16,7 @@ import { toEventSelector } from 'viem'
 import { useChains } from 'wagmi'
 import * as z from 'zod/mini'
 import { Address } from '#comps/Address'
-import { Breadcrumbs } from '#comps/Breadcrumbs'
+import { BreadcrumbsSlot } from '#comps/Breadcrumbs'
 import { DataGrid } from '#comps/DataGrid'
 import { InfoRow } from '#comps/InfoRow'
 import { Midcut } from '#comps/Midcut'
@@ -274,7 +274,7 @@ function RouteComponent() {
 				'grid w-full pt-20 pb-16 px-4 gap-[14px] min-w-0 grid-cols-[auto_1fr] min-[1240px]:max-w-[1080px]',
 			)}
 		>
-			<Breadcrumbs className="col-span-full" />
+			<BreadcrumbsSlot className="col-span-full" />
 			<TxTransactionCard
 				hash={receipt.transactionHash}
 				status={receipt.status}


### PR DESCRIPTION
- Move breadcrumbs from page components to Layout using slot+portal pattern
- BreadcrumbsSlot renders in each page's grid for correct positioning
- BreadcrumbsPortal in Layout keeps state across navigations
- Update crumbs on resolvedLocation for correctness, show pending crumb instantly
- Add loading fallback in slot to prevent content jump on initial load
- Clear button now keeps current page, only clears history

Amp-Thread-ID: https://ampcode.com/threads/T-019c1169-1a84-70d7-995c-14fc9ee77bc4
Co-authored-by: Amp <amp@ampcode.com>
