### PR TITLE
ci: use DEPOT_ENABLED variable to toggle depot runners

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -22,7 +22,7 @@ env:
 jobs:
   bundle-size:
     name: Bundle Size
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.DEPOT_ENABLED == 'true' && 'depot-ubuntu-latest' || 'ubuntu-latest' }}
     permissions:
       actions: write
       pull-requests: write

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
 
   deploy:
     name: Deploy (${{ matrix.app }}${{ matrix.env && format('-{0}', matrix.env) || '' }})
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.DEPOT_ENABLED == 'true' && 'depot-ubuntu-latest' || 'ubuntu-latest' }}
     timeout-minutes: 60
     strategy:
       matrix:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -25,7 +25,7 @@ env:
 jobs:
   pages-directory-listing:
     name: "Directory Listing Index"
-    runs-on: ["ubuntu-latest"]
+    runs-on: ${{ vars.DEPOT_ENABLED == 'true' && 'depot-ubuntu-latest' || 'ubuntu-latest' }}
     steps:
       - name: "Checkout"
         uses: actions/checkout@v6
@@ -55,7 +55,7 @@ jobs:
     environment:
       name: "tokenlist-github-pages"
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ["ubuntu-latest"]
+    runs-on: ${{ vars.DEPOT_ENABLED == 'true' && 'depot-ubuntu-latest' || 'ubuntu-latest' }}
     steps:
       - name: "Deploy Pages"
         id: deployment

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -20,7 +20,7 @@ jobs:
 
   deploy-preview:
     name: Deploy Preview (${{ matrix.app }}${{ matrix.env && format('-{0}', matrix.env) || '' }})
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.DEPOT_ENABLED == 'true' && 'depot-ubuntu-latest' || 'ubuntu-latest' }}
     permissions:
       issues: write
       contents: read
@@ -133,7 +133,7 @@ jobs:
 
   comment-deployments:
     name: Post Deployment Table
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.DEPOT_ENABLED == 'true' && 'depot-ubuntu-latest' || 'ubuntu-latest' }}
     needs: deploy-preview
     if: always()
     permissions:

--- a/.github/workflows/test-fee-payer.yml
+++ b/.github/workflows/test-fee-payer.yml
@@ -22,7 +22,7 @@ env:
 jobs:
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.DEPOT_ENABLED == 'true' && 'depot-ubuntu-latest' || 'ubuntu-latest' }}
 
     steps:
       - name: Clone repository

--- a/.github/workflows/test-verification.yml
+++ b/.github/workflows/test-verification.yml
@@ -19,7 +19,7 @@ env:
 
 jobs:
   tempo-check:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.DEPOT_ENABLED == 'true' && 'depot-ubuntu-latest' || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -9,7 +9,7 @@ env:
 jobs:
   checks:
     name: Checks
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.DEPOT_ENABLED == 'true' && 'depot-ubuntu-latest' || 'ubuntu-latest' }}
 
     steps:
       - name: Clone repository


### PR DESCRIPTION
Set vars.DEPOT_ENABLED to 'true' in repo settings to use depot-ubuntu-latest runners instead of ubuntu-latest.

Amp-Thread-ID: https://ampcode.com/threads/T-019c2005-6c91-707a-88f0-9937d482e8d4
Co-authored-by: Amp <amp@ampcode.com>
