### PR TITLE
fix(explorer): show full precision for asset balances

### DIFF
--- a/apps/explorer/src/lib/formatting.ts
+++ b/apps/explorer/src/lib/formatting.ts
@@ -261,6 +261,11 @@ export namespace PriceFormatter {
 		return amountFormatter.format(number)
 	}
 
+	export function formatAmountFull(value: string): string {
+		const number = Number(value)
+		return amountFormatter.format(number)
+	}
+
 	export function formatAmountShort(value: string): string {
 		const number = Number(value)
 		if (number > 0 && number < 0.01) return '<0.01'

--- a/apps/explorer/src/routes/_layout/address/$address.tsx
+++ b/apps/explorer/src/routes/_layout/address/$address.tsx
@@ -1085,7 +1085,7 @@ function AssetAmount(props: { asset: AssetData }) {
 	if (asset.metadata?.decimals === undefined || asset.balance === undefined)
 		return <span className="text-tertiary">…</span>
 	const formatted = formatUnits(asset.balance, asset.metadata.decimals)
-	return <span>{PriceFormatter.formatAmountShort(formatted)}</span>
+	return <span>{PriceFormatter.formatAmountFull(formatted)}</span>
 }
 
 function AssetValue(props: { asset: AssetData }) {


### PR DESCRIPTION
## Summary

Previously, asset balances were formatted with `formatAmountShort` which rounds to 2 decimal places and shows `<0.01` for small values. This made it impossible to see the actual balance (e.g., 1.997726 pathUSD displayed as "2").

Now uses `formatAmountFull` which preserves full precision up to 18 decimals.

## Screenshots

| Before | After |
|--------|-------|
| ![before](https://files.catbox.moe/uyh9pe.png) | ![after](https://files.catbox.moe/zf0i7w.png) |

The actual balance on-chain is `1997726` (with 6 decimals) = `1.997726 pathUSD`

## Changes

- Added `formatAmountFull()` in `formatting.ts` - same as `formatAmount` but without the `<0.01` threshold
- Updated `AssetAmount` component to use `formatAmountFull` instead of `formatAmountShort`