### PR TITLE
feat(explorer): differentiate 'Receive Mint' from 'Mint' in tx view

### DIFF
--- a/apps/explorer/src/lib/domain/known-events.ts
+++ b/apps/explorer/src/lib/domain/known-events.ts
@@ -99,11 +99,23 @@ function createDetectors(
 				const mintKey = `mint:${address}:${amount}:${to}`
 				const memo = mintBurnMemos?.get(mintKey)
 
+				// Differentiate between minting and receiving a mint:
+				// - "Receive Mint" when viewer is the recipient but not the minter
+				// - "Mint" when viewer is the minter or no viewer context
+				const isRecipientNotMinter =
+					viewer &&
+					transactionSender &&
+					Address.isEqual(viewer, to) &&
+					!Address.isEqual(viewer, transactionSender)
+
 				return {
 					type: 'mint',
 					note: memo,
 					parts: [
-						{ type: 'action', value: 'Mint' },
+						{
+							type: 'action',
+							value: isRecipientNotMinter ? 'Receive Mint' : 'Mint',
+						},
 						{
 							type: 'amount',
 							value: createAmount(amount, address),


### PR DESCRIPTION
## Summary

When viewing an account's transaction history, this change differentiates between:
- **Mint** - when the viewer is the minter (transaction sender)
- **Receive Mint** - when the viewer is the recipient but not the minter

## Problem

Mints looked the same regardless of whether the address was the minter or a mint recipient. This was confusing when users received minted tokens from another address.

Example: https://explore.tempo.xyz/account/0xAe781Ee740852A839b4D9735808383fbF92846dE shows 'Mint' even when the user just received tokens.

## Solution

Added logic in `known-events.ts` to check if the viewer is the recipient but not the transaction sender. In this case, the action label shows 'Receive Mint' instead of 'Mint'.

Fixes [WEB-51](https://linear.app/tempoxyz/issue/WEB-51)