### PR TITLE
fix(explorer): show implementation functions on proxy contract Interact tab

### DIFF
--- a/apps/explorer/src/comps/Contract.tsx
+++ b/apps/explorer/src/comps/Contract.tsx
@@ -252,7 +252,7 @@ export function InteractTabContent(props: {
 				// If it's a proxy, load both implementation and proxy ABIs
 				if (proxy.isProxy && proxy.implementationAddress) {
 					const [loadedImplAbi, loadedProxyAbi] = await Promise.all([
-						!props.abi ? autoloadAbi(proxy.implementationAddress) : null,
+						autoloadAbi(proxy.implementationAddress),
 						autoloadAbi(address, { followProxies: false }),
 					])
 					if (loadedImplAbi) setImplAbi(loadedImplAbi)
@@ -266,10 +266,13 @@ export function InteractTabContent(props: {
 		}
 
 		void loadProxyInfo()
-	}, [publicClient, address, props.abi])
+	}, [publicClient, address])
 
-	// Use implementation ABI if available, otherwise fall back to provided or registry ABI
-	const abi = props.abi ?? implAbi ?? getContractAbi(address)
+	// For proxies, prefer implementation ABI so users see callable functions
+	const abi =
+		(implAbi && implAbi.length > 0 ? implAbi : null) ??
+		props.abi ??
+		getContractAbi(address)
 
 	if (isLoadingProxy) {
 		return (


### PR DESCRIPTION
## Problem

Proxy contract [`0x8354d80e`](https://explore.tempo.xyz/address/0x8354d80eea9978faa04c3b36771c1e8b9c3e9058?tab=interact) on mainnet shows **"No write/read functions available"** on the Interact tab, despite both proxy and implementation being verified.

## Root Cause

Two independent bugs:

1. **`contracts.ts`**: `autoloadAbi` only uses Sourcify as an ABI source. Sourcify doesn't support chain 4217 (returns HTTP 400), which causes whatsabi's `MultiABILoader` to throw (it only swallows 404s), so `autoloadAbi` returns `null`.

2. **`Contract.tsx`**: When the proxy contract is verified, the route provides the proxy's own ABI (`constructor + fallback`, no functions) as `props.abi`. This both (a) skips loading the implementation ABI (`!props.abi` guard) and (b) takes precedence over `implAbi` in the nullish coalescing chain.

## Fix

- Add `TempoABILoader` to whatsabi's `MultiABILoader` chain, querying `contracts.tempo.xyz` before Sourcify
- Always load implementation ABI when a proxy is detected (remove `!props.abi` guard)
- Prefer non-empty `implAbi` over `props.abi`

## Screenshots

| Before | After |
|--------|-------|
| ![before](https://files.catbox.moe/zuz7e0.png) | ![after](https://files.catbox.moe/yw434u.png) |

Proxy detected but "No functions available" → Implementation functions (`burn`, `grantRole`, `initialize`, `mint`, `mintBridgeEcosystem`, etc.) now visible via the proxy address.

## Files Changed

- `apps/explorer/src/lib/domain/contracts.ts` — `TempoABILoader` class (+28 lines)
- `apps/explorer/src/comps/Contract.tsx` — ABI loading and precedence fix (+5/-4 lines)