### PR TITLE
Fix README import: use tempo.ts/server for Key Manager

### DIFF
--- a/apps/key-manager/README.md
+++ b/apps/key-manager/README.md
@@ -1,6 +1,6 @@
 # Key Manager
 
-WebAuthn key management service using `Handler.keyManager` from `tempo.ts`.
+WebAuthn key management service using `Handler.keyManager` from `tempo.ts/server`.
 
 ## Endpoints
 


### PR DESCRIPTION
Updated the README to use the correct import path tempo.ts/server instead of tempo.ts.

This aligns the documentation with the actual API usage in the codebase and prevents incorrect imports when integrating the Key Manager in a server/Worker environment.