### PR TITLE
Fix Foundry example in README and align with actual repo scripts

### DIFF
--- a/apps/contract-verification/README.md
+++ b/apps/contract-verification/README.md
@@ -43,11 +43,10 @@ graph LR
 Pass the API URL to the `--verifier-url` flag and set `--verifier` to `sourcify`:
 
 ```bash
-forge script script/Mail.s.sol --verifier-url https://contracts.tempo.xyz --verifier sourcify
+forge script script/Counter.s.sol:CounterScript --verifier-url https://contracts.tempo.xyz --verifier sourcify --rpc-url <YOUR_TEMPO_RPC_URL>
 ```
 
-See [/apps/contract-verification/scripts/verify-solidity.sh](./scripts/verify-solidity.sh)
-and [/apps/contract-verification/scripts/verify-vyper.sh](./scripts/verify-vyper.sh) for small examples you can run.
+See [`scripts/verify-solidity.sh`](./scripts/verify-solidity.sh) and [`scripts/verify-vyper.sh`](./scripts/verify-vyper.sh) for runnable examples. `verify-solidity.sh` uses `Counter.s.sol:CounterScript` after `forge init`; use a different script path if your project layout differs.
 
 #### Direct API Usage
 


### PR DESCRIPTION
This PR updates the Foundry usage example in README to match the actual repository setup and default Foundry project structure.

### Changes:
- Replaced `script/Mail.s.sol` with `script/Counter.s.sol:CounterScript` to align with `forge init` defaults and existing scripts
- Added `--rpc-url` parameter, which is required for running `forge script` in practice
- Updated references to use local `scripts/verify-solidity.sh` and `scripts/verify-vyper.sh`
- Clarified that the example assumes default Foundry layout and may differ in custom setups

### Reasoning:
The previous example referenced a non-existent script (`Mail.s.sol`) and omitted required parameters. The updated version reflects a working setup used in the repository scripts.