### PR TITLE
fix: initial 500 red error in txs page

### DIFF
--- a/apps/explorer/src/lib/queries/account.ts
+++ b/apps/explorer/src/lib/queries/account.ts
@@ -1,12 +1,13 @@
 import { queryOptions } from '@tanstack/react-query'
 import type { Address } from 'ox'
 import type { RpcTransaction } from 'viem'
-import type * as z from 'zod/mini'
+import * as z from 'zod/mini'
 
 import { isTip20Address } from '#lib/domain/tip20'
 import { getApiUrl } from '#lib/env.ts'
 import type { RequestParametersSchema as AccountRequestParametersSchema } from '#routes/api/address/$address.ts'
 import type { HistoryResponse } from '#routes/api/address/history/$address.ts'
+export type { HistoryResponse }
 
 type AccountRequestParameters = Omit<
 	z.infer<typeof AccountRequestParametersSchema>,
@@ -22,7 +23,19 @@ type TransactionsApiResponse = {
 	error: null | string
 }
 
-export type { HistoryResponse }
+const HistoryResponseSchema = z.object({
+	transactions: z.array(z.any()),
+	total: z.number(),
+	offset: z.number(),
+	limit: z.number(),
+	hasMore: z.boolean(),
+	countCapped: z.boolean(),
+	error: z.union([z.string(), z.null()]),
+})
+
+const HistoryErrorResponseSchema = z.object({
+	error: z.string(),
+})
 
 export function transactionsQueryOptions(
 	params: {
@@ -125,8 +138,23 @@ export function historyQueryOptions(params: {
 				searchParams,
 			)
 			const response = await fetch(url, { signal })
-			const data = await response.json()
-			return data as HistoryResponse
+			const json = await response.json()
+
+			const parsed = z.safeParse(HistoryResponseSchema, json)
+			if (parsed.success) return parsed.data
+
+			const parsedError = z.safeParse(HistoryErrorResponseSchema, json)
+			if (parsedError.success) throw new Error(parsedError.data.error)
+
+			return {
+				transactions: [],
+				total: 0,
+				offset: params.offset,
+				limit: params.limit,
+				hasMore: false,
+				countCapped: false,
+				error: `Failed to load transaction history: ${z.prettifyError(parsed.error)}`,
+			}
 		},
 		staleTime: 10_000,
 		refetchInterval: false,

--- a/apps/explorer/src/lib/server/tempo-queries.ts
+++ b/apps/explorer/src/lib/server/tempo-queries.ts
@@ -5,6 +5,7 @@ import { Tidx } from 'tidx.ts'
 import { decodeAbiParameters, zeroAddress } from 'viem'
 import * as ABIS from '#lib/abis'
 import { tempoQueryBuilder } from '#lib/server/tempo-queries-provider'
+import { parseTimestamp } from '#lib/timestamp'
 
 const QB = tempoQueryBuilder
 
@@ -1348,13 +1349,8 @@ export async function fetchAddressTxAggregate(
 			.executeTakeFirst()) as AddressTxBoundaryRow | undefined
 
 	const toComparableTimestamp = (value: unknown): number => {
-		if (typeof value === 'number') return value
 		if (typeof value === 'bigint') return Number(value)
-		if (typeof value === 'string') {
-			const parsed = Number(value)
-			if (Number.isFinite(parsed)) return parsed
-		}
-		return Number.NaN
+		return parseTimestamp(value) ?? Number.NaN
 	}
 
 	const pickBoundary = (

--- a/apps/explorer/src/lib/server/tempo-queries.ts
+++ b/apps/explorer/src/lib/server/tempo-queries.ts
@@ -1314,32 +1314,108 @@ export async function fetchAddressTxAggregate(
 	oldestTxHash?: string
 	oldestTxFrom?: string
 }> {
-	const qb = QB(chainId)
-	const result = await qb
-		.selectFrom('txs')
-		.where((wb) => wb.or([wb('from', '=', address), wb('to', '=', address)]))
-		.select((sb) => [
-			sb.fn.count('hash').as('count'),
-			sb.fn.max('block_timestamp').as('latestTxsBlockTimestamp'),
-			sb.fn.min('block_timestamp').as('oldestTxsBlockTimestamp'),
-		])
-		.executeTakeFirst()
+	type AddressTxBoundaryRow = {
+		hash: Hex.Hex
+		from: string
+		block_timestamp: string | number | bigint | null
+	}
 
-	// Fetch the hash of the oldest transaction separately
-	const oldest = await qb
-		.selectFrom('txs')
-		.where((wb) => wb.or([wb('from', '=', address), wb('to', '=', address)]))
-		.select((eb) => [eb.ref('hash').as('hash'), eb.ref('from').as('sender')])
-		.orderBy('block_timestamp', 'asc')
-		.limit(1)
-		.executeTakeFirst()
+	type AddressTxCountRow = {
+		count: string | number | bigint
+	}
+
+	const countByField = async (field: 'from' | 'to'): Promise<number> => {
+		const result = (await QB(chainId)
+			.selectFrom('txs')
+			.select((eb) => eb.fn.count('hash').as('count'))
+			.where(field, '=', address)
+			.executeTakeFirst()) as AddressTxCountRow | undefined
+
+		return Number(result?.count ?? 0)
+	}
+
+	const fetchBoundaryByField = async (
+		field: 'from' | 'to',
+		sortDirection: SortDirection,
+	): Promise<AddressTxBoundaryRow | undefined> =>
+		(await QB(chainId)
+			.selectFrom('txs')
+			.select(['hash', 'from', 'block_timestamp'])
+			.where(field, '=', address)
+			.orderBy('block_timestamp', sortDirection)
+			.orderBy('hash', sortDirection)
+			.limit(1)
+			.executeTakeFirst()) as AddressTxBoundaryRow | undefined
+
+	const toComparableTimestamp = (value: unknown): number => {
+		if (typeof value === 'number') return value
+		if (typeof value === 'bigint') return Number(value)
+		if (typeof value === 'string') {
+			const parsed = Number(value)
+			if (Number.isFinite(parsed)) return parsed
+		}
+		return Number.NaN
+	}
+
+	const pickBoundary = (
+		sortDirection: SortDirection,
+		rows: Array<AddressTxBoundaryRow | undefined>,
+	): AddressTxBoundaryRow | undefined => {
+		const presentRows = rows.filter((row) => row !== undefined)
+		if (presentRows.length === 0) return undefined
+
+		presentRows.sort((left, right) => {
+			const leftTimestamp = toComparableTimestamp(left.block_timestamp)
+			const rightTimestamp = toComparableTimestamp(right.block_timestamp)
+			const timestampDiff =
+				sortDirection === 'asc'
+					? leftTimestamp - rightTimestamp
+					: rightTimestamp - leftTimestamp
+			if (timestampDiff !== 0) return timestampDiff
+
+			return sortDirection === 'asc'
+				? left.hash.localeCompare(right.hash)
+				: right.hash.localeCompare(left.hash)
+		})
+
+		return presentRows[0]
+	}
+
+	const [
+		sentCount,
+		receivedCount,
+		selfCount,
+		latestSent,
+		latestReceived,
+		oldestSent,
+		oldestReceived,
+	] = await Promise.all([
+		countByField('from'),
+		countByField('to'),
+		QB(chainId)
+			.selectFrom('txs')
+			.select((eb) => eb.fn.count('hash').as('count'))
+			.where('from', '=', address)
+			.where('to', '=', address)
+			.executeTakeFirst()
+			.then((result) =>
+				Number((result as AddressTxCountRow | undefined)?.count ?? 0),
+			),
+		fetchBoundaryByField('from', 'desc'),
+		fetchBoundaryByField('to', 'desc'),
+		fetchBoundaryByField('from', 'asc'),
+		fetchBoundaryByField('to', 'asc'),
+	])
+
+	const latest = pickBoundary('desc', [latestSent, latestReceived])
+	const oldest = pickBoundary('asc', [oldestSent, oldestReceived])
 
 	return {
-		count: result?.count ? Number(result.count) : undefined,
-		latestTxsBlockTimestamp: result?.latestTxsBlockTimestamp,
-		oldestTxsBlockTimestamp: result?.oldestTxsBlockTimestamp,
+		count: sentCount + receivedCount - selfCount,
+		latestTxsBlockTimestamp: latest?.block_timestamp,
+		oldestTxsBlockTimestamp: oldest?.block_timestamp,
 		oldestTxHash: oldest?.hash as string | undefined,
-		oldestTxFrom: oldest?.sender as string | undefined,
+		oldestTxFrom: oldest?.from as string | undefined,
 	}
 }
 

--- a/apps/explorer/src/routes/_layout/address/$address.tsx
+++ b/apps/explorer/src/routes/_layout/address/$address.tsx
@@ -325,30 +325,30 @@ export const Route = createFileRoute('/_layout/address/$address')({
 			else if (period === '7d')
 				after = Math.floor(Date.now() / 1000) - 7 * 86400
 
+			const transactionsQuery = historyQueryOptions({
+				address,
+				page,
+				limit,
+				offset,
+				sources: historySources,
+				status,
+				include:
+					dir === 'sent' ? 'sent' : dir === 'received' ? 'received' : 'all',
+				after,
+			})
+
 			// Only block on transactions if transactions tab is active.
 			// Select history sources from address type so SSR and client stay aligned.
 			const transactionsPromise = isTransactionsTab
 				? timeout(
 						context.queryClient
-							.ensureQueryData(
-								historyQueryOptions({
-									address,
-									page,
-									limit,
-									offset,
-									sources: historySources,
-									status,
-									include:
-										dir === 'sent'
-											? 'sent'
-											: dir === 'received'
-												? 'received'
-												: 'all',
-									after,
-								}),
-							)
+							.ensureQueryData(transactionsQuery)
 							.catch((error) => {
 								console.error('Fetch transactions error:', error)
+								context.queryClient.removeQueries({
+									queryKey: transactionsQuery.queryKey,
+									exact: true,
+								})
 								return undefined
 							}),
 						QUERY_TIMEOUT_MS,

--- a/apps/explorer/src/routes/api/address/metadata/$address.ts
+++ b/apps/explorer/src/routes/api/address/metadata/$address.ts
@@ -1,7 +1,6 @@
 import { createFileRoute } from '@tanstack/react-router'
 import * as Address from 'ox/Address'
 import { getCode } from 'viem/actions'
-import { getChainId } from 'wagmi/actions'
 import { getAccountType, type AccountType } from '#lib/account'
 import { isTip20Address } from '#lib/domain/tip20'
 import { hasIndexSupply } from '#lib/env'
@@ -11,7 +10,7 @@ import {
 } from '#lib/server/tempo-queries'
 import { parseTimestamp } from '#lib/timestamp'
 import { zAddress } from '#lib/zod'
-import { getWagmiConfig } from '#wagmi.config'
+import { getBatchedClient, getTempoChain } from '#wagmi.config.ts'
 
 export type AddressMetadataResponse = {
 	address: string
@@ -41,10 +40,8 @@ export const Route = createFileRoute('/api/address/metadata/$address')({
 					const address = zAddress().parse(params.address)
 					Address.assert(address)
 
-					const config = getWagmiConfig()
-					const client = config.getClient()
-					const chainId = getChainId(config)
-
+					const client = getBatchedClient()
+					const { id: chainId } = getTempoChain()
 					const isTip20 = isTip20Address(address)
 
 					const bytecodePromise = getCode(client, { address }).catch(


### PR DESCRIPTION
ex:
https://explore.testnet.tempo.xyz/address/0xe887e26615a6fa40edb06761ce6a1e0b19476f63

initial flashing red error cause:

The address page was hydrating a failed SSR account-history query into the client cache. When the history endpoint briefly returned a non-JSON edge error page, the client blindly called response.json(), producing the red flash with a misleading JSON parse error before a later retry recovered.

fix:

Validate history responses with `zod` and clear failed best-effort SSR history queries from the loader cache so transient SSR failures don’t hydrate into a visible red error state. Also fix the address metadata route by replacing the failing aggregate query with smaller indexed queries and using the explorer’s active chain client, so metadata no longer falls into the broken 422 -> 500 path.