### PR TITLE
fix(explorer): restore batch submitted note fields on receipt

### DIFF
--- a/apps/explorer/src/comps/Receipt.tsx
+++ b/apps/explorer/src/comps/Receipt.tsx
@@ -207,11 +207,14 @@ export function Receipt(props: Receipt.Props) {
 																			className="flex gap-2 min-w-0"
 																		>
 																			<div className="text-tertiary shrink-0">
-																				{label}:
+																				{label}
+																				{!(part.type === 'text' && part.value === '') && ':'}
 																			</div>
-																			<div className="min-w-0 overflow-hidden text-ellipsis whitespace-nowrap">
-																				<TxEventDescription.Part part={part} />
-																			</div>
+																			{!(part.type === 'text' && part.value === '') && (
+																				<div className="min-w-0 overflow-hidden text-ellipsis whitespace-nowrap">
+																					<TxEventDescription.Part part={part} />
+																				</div>
+																			)}
 																		</div>
 																	)
 																})}

--- a/apps/explorer/src/lib/domain/known-events.ts
+++ b/apps/explorer/src/lib/domain/known-events.ts
@@ -433,10 +433,7 @@ function createDetectors(
 				const zoneName = getZoneName(address)
 				return {
 					type: 'zone batch submitted',
-					parts: [
-						{ type: 'action', value: `Submit ${zoneName} Batch` },
-						{ type: 'text', value: `#${args.withdrawalBatchIndex}` },
-					],
+					parts: [{ type: 'action', value: `Submit ${zoneName} Batch` }],
 					note: [
 						['Processed Deposits', { type: 'text', value: '' }],
 						['Next Block', { type: 'text', value: '' }],

--- a/apps/explorer/src/lib/domain/known-events.ts
+++ b/apps/explorer/src/lib/domain/known-events.ts
@@ -433,7 +433,15 @@ function createDetectors(
 				const zoneName = getZoneName(address)
 				return {
 					type: 'zone batch submitted',
-					parts: [{ type: 'action', value: `Submit ${zoneName} Batch` }],
+					parts: [
+						{ type: 'action', value: `Submit ${zoneName} Batch` },
+						{ type: 'text', value: `#${args.withdrawalBatchIndex}` },
+					],
+					note: [
+						['Processed Deposits', { type: 'text', value: '' }],
+						['Next Block', { type: 'text', value: '' }],
+						['Withdrawal Queue', { type: 'text', value: '' }],
+					],
 				}
 			}
 


### PR DESCRIPTION
Restores the three note lines (Processed Deposits, Next Block, Withdrawal Queue) and the batch index number (`#N`) on the `BatchSubmitted` receipt event.

These were previously visible on the receipt page but got lost. The hex hash values are **not** re-added since they are opaque state commitment hashes (not addresses or tx hashes that could be linked).

## Screenshots

| Before (current prod) | After (old preview, reference) |
|--------|-------|
| Missing note lines | Shows Processed Deposits, Next Block, Withdrawal Queue + batch `#7412` |

Prompted by: omar

Co-Authored-By: o-az <23618431+o-az@users.noreply.github.com>