### PR TITLE
feat(contract-verification): use Cloudflare Queues for verification jobs

### DIFF
--- a/apps/contract-verification/database/drizzle/0002_add_ephemeral_input.sql
+++ b/apps/contract-verification/database/drizzle/0002_add_ephemeral_input.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `verification_jobs_ephemeral` ADD COLUMN `input` text;

--- a/apps/contract-verification/database/drizzle/meta/_journal.json
+++ b/apps/contract-verification/database/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1775671878724,
       "tag": "0001_lyrical_raider",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "6",
+      "when": 1744581546000,
+      "tag": "0002_add_ephemeral_input",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/contract-verification/database/schema.ts
+++ b/apps/contract-verification/database/schema.ts
@@ -506,5 +506,7 @@ export const verificationJobsEphemeralTable = p.sqliteTable(
 		onchainRuntimeCode: s.blob('onchain_runtime_code'),
 		/** Creation transaction hash */
 		creationTransactionHash: s.blob('creation_transaction_hash'),
+		/** Verification input (JSON) — stored temporarily for queue-based processing */
+		input: s.text('input'),
 	}),
 )

--- a/apps/contract-verification/src/index.tsx
+++ b/apps/contract-verification/src/index.tsx
@@ -11,14 +11,27 @@ import { rateLimiter } from 'hono-rate-limiter'
 import { getContainer } from '@cloudflare/containers'
 import { contextStorage } from 'hono/context-storage'
 
+import { eq } from 'drizzle-orm'
+
 import { docsRoute } from '#route.docs.tsx'
-import { verifyRoute } from '#route.verify.ts'
+import {
+	verifyRoute,
+	runVerificationJob,
+	type VerificationInput,
+	type VerificationQueueMessage,
+} from '#route.verify.ts'
+import { verificationJobsEphemeralTable } from '#database/schema.ts'
 import { sourcifyChains } from '#wagmi.config.ts'
 import { VerificationContainer } from '#container.ts'
 import { legacyVerifyRoute } from '#route.verify-legacy.ts'
 import { configureLogger, getLogger, withContext } from '#lib/logger.ts'
 import { lookupAllChainContractsRoute, lookupRoute } from '#route.lookup.ts'
-import { handleError, originMatches, sourcifyError } from '#lib/utilities.ts'
+import {
+	getDb,
+	handleError,
+	originMatches,
+	sourcifyError,
+} from '#lib/utilities.ts'
 
 import OpenApiSpec from '#openapi.json' with { type: 'json' }
 import packageJSON from '#package.json' with { type: 'json' }
@@ -149,4 +162,37 @@ app
 
 showRoutes(app)
 
-export default app satisfies ExportedHandler<Cloudflare.Env>
+export default {
+	fetch: app.fetch,
+	async queue(batch, env) {
+		await configureLogger(env.NODE_ENV)
+		const db = getDb(env.CONTRACTS_DB)
+
+		for (const msg of batch.messages) {
+			const { jobId, chainId, address } = msg.body as VerificationQueueMessage
+
+			const rows = await db
+				.select({ input: verificationJobsEphemeralTable.input })
+				.from(verificationJobsEphemeralTable)
+				.where(eq(verificationJobsEphemeralTable.id, jobId))
+				.limit(1)
+
+			const input = rows.at(0)?.input
+			if (!input) {
+				logger.warn('queue_job_missing_input', { jobId })
+				msg.ack()
+				continue
+			}
+
+			const body = JSON.parse(input) as VerificationInput
+			await runVerificationJob(env, jobId, chainId, address, body)
+
+			// Clean up ephemeral input
+			await db
+				.delete(verificationJobsEphemeralTable)
+				.where(eq(verificationJobsEphemeralTable.id, jobId))
+
+			msg.ack()
+		}
+	},
+} satisfies ExportedHandler<Cloudflare.Env>

--- a/apps/contract-verification/src/route.verify.ts
+++ b/apps/contract-verification/src/route.verify.ts
@@ -26,6 +26,7 @@ import {
 	contractDeploymentsTable,
 	compiledContractsSourcesTable,
 	compiledContractsSignaturesTable,
+	verificationJobsEphemeralTable,
 } from '#database/schema.ts'
 import {
 	AuxdataStyle,
@@ -300,16 +301,18 @@ verifyRoute
 				return context.json({ verificationId: firstJob.id }, 202)
 			}
 
-			// Run verification in background
-			context.executionCtx.waitUntil(
-				runVerificationJob(
-					context.env,
-					jobId,
-					chainId,
-					address,
-					parsedBody.data as VerificationInput,
-				),
-			)
+			// Store input in ephemeral table for queue-based processing
+			await db.insert(verificationJobsEphemeralTable).values({
+				id: jobId,
+				input: JSON.stringify(parsedBody.data),
+			})
+
+			// Enqueue verification job
+			await context.env.VERIFICATION_QUEUE.send({
+				jobId,
+				chainId,
+				address,
+			} satisfies VerificationQueueMessage)
 
 			return context.json({ verificationId: jobId }, 202)
 		} catch (error) {
@@ -1232,4 +1235,15 @@ async function runVerificationJob(
 	}
 }
 
-export { runVerificationJob, verifyRoute }
+type VerificationQueueMessage = {
+	jobId: string
+	chainId: number
+	address: string
+}
+
+export {
+	runVerificationJob,
+	verifyRoute,
+	type VerificationInput,
+	type VerificationQueueMessage,
+}

--- a/apps/contract-verification/test/setup.ts
+++ b/apps/contract-verification/test/setup.ts
@@ -6,6 +6,7 @@ import { beforeEach } from 'vitest'
 import * as DB from '#database/schema.ts'
 
 const tables = [
+	DB.verificationJobsEphemeralTable,
 	DB.verificationJobsTable,
 	DB.verifiedContractsTable,
 	DB.compiledContractsSignaturesTable,

--- a/apps/contract-verification/wrangler.json
+++ b/apps/contract-verification/wrangler.json
@@ -21,6 +21,22 @@
 			}
 		}
 	],
+	"queues": {
+		"producers": [
+			{
+				"binding": "VERIFICATION_QUEUE",
+				"queue": "contract-verification-jobs"
+			}
+		],
+		"consumers": [
+			{
+				"queue": "contract-verification-jobs",
+				"max_batch_size": 1,
+				"max_retries": 2,
+				"dead_letter_queue": "contract-verification-dlq"
+			}
+		]
+	},
 	"d1_databases": [
 		{
 			"binding": "CONTRACTS_DB",


### PR DESCRIPTION
## Summary

Replace `waitUntil` with Cloudflare Queues for running verification jobs. This increases the execution time limit from **30 seconds to 15 minutes** per job, adds automatic retries (max 2), and a dead-letter queue for failed jobs.

The verification input is stored in the `verification_jobs_ephemeral` table (D1) to avoid the 128KB queue message size limit. The queue consumer reads the input, runs the job, and cleans up the ephemeral row.

## Changes

- **`wrangler.json`** — added queue producer/consumer config
- **`route.verify.ts`** — replaced `waitUntil(runVerificationJob(...))` with ephemeral DB insert + queue send
- **`index.tsx`** — added `queue` handler export
- **`database/schema.ts`** — added `input` column to `verification_jobs_ephemeral`
- **`database/drizzle/0002_add_ephemeral_input.sql`** — migration
- **`test/setup.ts`** — fixed teardown order for FK constraint

## Before deploying

Run these commands **once** to create the queues and apply the migration:

```bash
# Create the queues
npx wrangler queues create contract-verification-jobs
npx wrangler queues create contract-verification-dlq

# Apply the D1 migration
pnpm --filter contracts db:prepare:remote
```