### PR TITLE
fix(contract-verification): replace waitUntil with Durable Object alarm for verification jobs

### DIFF
--- a/apps/contract-verification/src/index.tsx
+++ b/apps/contract-verification/src/index.tsx
@@ -15,6 +15,7 @@ import { docsRoute } from '#route.docs.tsx'
 import { verifyRoute } from '#route.verify.ts'
 import { sourcifyChains } from '#wagmi.config.ts'
 import { VerificationContainer } from '#container.ts'
+import { VerificationJobRunner } from '#job-runner.ts'
 import { legacyVerifyRoute } from '#route.verify-legacy.ts'
 import { configureLogger, getLogger, withContext } from '#lib/logger.ts'
 import { lookupAllChainContractsRoute, lookupRoute } from '#route.lookup.ts'
@@ -25,7 +26,7 @@ import packageJSON from '#package.json' with { type: 'json' }
 
 const logger = getLogger(['tempo'])
 
-export { VerificationContainer }
+export { VerificationContainer, VerificationJobRunner }
 
 const WHITELISTED_ORIGINS = [
 	'http://localhost',

--- a/apps/contract-verification/src/job-runner.ts
+++ b/apps/contract-verification/src/job-runner.ts
@@ -1,0 +1,68 @@
+import { DurableObject } from 'cloudflare:workers'
+
+import { getLogger } from '#lib/logger.ts'
+import { formatError } from '#lib/utilities.ts'
+import { runVerificationJob } from '#route.verify.ts'
+
+const logger = getLogger(['tempo', 'job-runner'])
+
+type StoredJob = {
+	jobId: string
+	chainId: number
+	address: string
+	body: {
+		stdJsonInput: {
+			language: string
+			sources: Record<string, { content: string }>
+			settings: object
+		}
+		compilerVersion: string
+		contractIdentifier: string
+		creationTransactionHash?: string
+	}
+}
+
+export class VerificationJobRunner extends DurableObject<Cloudflare.Env> {
+	async enqueue(job: StoredJob): Promise<void> {
+		logger.info('job_enqueued', {
+			jobId: job.jobId,
+			chainId: job.chainId,
+			address: job.address,
+		})
+
+		await this.ctx.storage.put('job', job)
+		await this.ctx.storage.setAlarm(Date.now())
+	}
+
+	override async alarm(): Promise<void> {
+		const job = await this.ctx.storage.get<StoredJob>('job')
+		if (!job) {
+			logger.warn('alarm_job_missing')
+			return
+		}
+
+		logger.info('job_started', {
+			jobId: job.jobId,
+			chainId: job.chainId,
+			address: job.address,
+		})
+
+		try {
+			await runVerificationJob(
+				this.env,
+				job.jobId,
+				job.chainId,
+				job.address,
+				job.body,
+			)
+			logger.info('job_finished', { jobId: job.jobId })
+		} catch (error) {
+			logger.error('job_alarm_error', {
+				jobId: job.jobId,
+				error: formatError(error),
+			})
+		}
+
+		await this.ctx.storage.delete('job')
+	}
+}

--- a/apps/contract-verification/src/route.verify.ts
+++ b/apps/contract-verification/src/route.verify.ts
@@ -41,8 +41,8 @@ import { getLogger } from '#lib/logger.ts'
 const logger = getLogger(['tempo'])
 import wranglerJSON from '#wrangler.json' with { type: 'json' }
 
-/** Jobs older than this are considered stale and can be retried (5 minutes). */
-const JOB_TTL_MS = 5 * 60 * 1_000
+/** Jobs older than this are considered stale and can be retried (15 minutes). */
+const JOB_TTL_MS = 15 * 60 * 1_000
 /** Number of container instances to load-balance across. */
 const CONTAINER_INSTANCE_COUNT =
 	wranglerJSON.containers.at(0)?.max_instances ?? 10
@@ -300,16 +300,33 @@ verifyRoute
 				return context.json({ verificationId: firstJob.id }, 202)
 			}
 
-			// Run verification in background
-			context.executionCtx.waitUntil(
-				runVerificationJob(
-					context.env,
+			// Dispatch verification to a per-job Durable Object for durable background execution
+			const doId = context.env.VERIFICATION_JOB_RUNNER.idFromName(jobId)
+			const runner = context.env.VERIFICATION_JOB_RUNNER.get(doId)
+			try {
+				await runner.enqueue({
 					jobId,
 					chainId,
 					address,
-					parsedBody.data as VerificationInput,
-				),
-			)
+					body: parsedBody.data as VerificationInput,
+				})
+			} catch (enqueueError) {
+				logger.error('job_enqueue_failed', {
+					error: formatError(enqueueError),
+					jobId,
+					chainId,
+					address,
+				})
+				await db
+					.delete(verificationJobsTable)
+					.where(eq(verificationJobsTable.id, jobId))
+				return sourcifyError(
+					context,
+					500,
+					'internal_error',
+					'Failed to enqueue verification job',
+				)
+			}
 
 			return context.json({ verificationId: jobId }, 202)
 		} catch (error) {
@@ -1201,12 +1218,15 @@ async function runVerificationJob(
 
 		const verifiedContractId = verificationResult.at(0)?.id ?? null
 
-		// Mark job as completed
+		// Mark job as completed (clear any stale timeout/error fields)
 		await db
 			.update(verificationJobsTable)
 			.set({
 				completedAt: new Date().toISOString(),
 				verifiedContractId,
+				errorCode: null,
+				errorId: null,
+				errorData: null,
 				compilationTime: Date.now() - startTime,
 			})
 			.where(eq(verificationJobsTable.id, jobId))

--- a/apps/contract-verification/wrangler.json
+++ b/apps/contract-verification/wrangler.json
@@ -43,6 +43,10 @@
 			{
 				"name": "VERIFICATION_CONTAINER",
 				"class_name": "VerificationContainer"
+			},
+			{
+				"name": "VERIFICATION_JOB_RUNNER",
+				"class_name": "VerificationJobRunner"
 			}
 		]
 	},
@@ -50,6 +54,10 @@
 		{
 			"tag": "v1",
 			"new_sqlite_classes": ["VerificationContainer"]
+		},
+		{
+			"tag": "v2",
+			"new_sqlite_classes": ["VerificationJobRunner"]
 		}
 	],
 	"observability": {


### PR DESCRIPTION
## Summary

Contract verification jobs dispatched via `waitUntil` die after the 202 response is sent, causing synthetic timeouts on large contracts (e.g. 73 sources, `viaIR`, optimizer enabled). Both [90db8073-4679-4f45-8fc6-0d6aee7becc9](https://contracts.tempo.xyz/v2/verify/90db8073-4679-4f45-8fc6-0d6aee7becc9) and [f8676df1-ac66-4b00-9e6a-05ae5f95ab85](https://contracts.tempo.xyz/v2/verify/f8676df1-ac66-4b00-9e6a-05ae5f95ab85) hit this.

## Motivation

`waitUntil` only gets a short grace period after the HTTP response is sent. The contract verification API returns 202 immediately, so the client disconnects almost immediately and `waitUntil` gets killed. Large contracts with slow compilation (viaIR + many sources + cold compiler download) exceed this window.

## Changes

- `apps/contract-verification/src/job-runner.ts`: New `VerificationJobRunner` Durable Object. One DO per job, SQLite-backed storage, alarm-driven execution. Stores payload durably before returning, then processes via `alarm()`.
- `apps/contract-verification/src/route.verify.ts`: Replace `waitUntil(runVerificationJob(...))` with DO dispatch. Clean up DB row on enqueue failure. Clear stale error fields (`errorCode`/`errorId`/`errorData`) on successful completion. Bump `JOB_TTL_MS` from 5 min → 15 min.
- `apps/contract-verification/src/index.tsx`: Export `VerificationJobRunner`.
- `apps/contract-verification/wrangler.json`: Add `VERIFICATION_JOB_RUNNER` DO binding + v2 migration (`new_sqlite_classes`).

## Testing

- Type check passes: `tsc --noEmit` — zero errors
- Biome lint/format passes: zero warnings

Prompted by: Liam