### PR TITLE
fix: override basic-ftp to 5.2.2 to resolve CVE

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,11 +37,6 @@
 			"onFail": "download"
 		}
 	},
-	"pnpm": {
-		"overrides": {
-			"basic-ftp": "5.2.2"
-		}
-	},
 	"packageManager": "pnpm@10.33.0",
 	"simple-git-hooks": {
 		"pre-commit": "pnpm prek run --all-files --config='.github/.pre-commit.yml'"

--- a/package.json
+++ b/package.json
@@ -37,6 +37,11 @@
 			"onFail": "download"
 		}
 	},
+	"pnpm": {
+		"overrides": {
+			"basic-ftp": "5.2.2"
+		}
+	},
 	"packageManager": "pnpm@10.33.0",
 	"simple-git-hooks": {
 		"pre-commit": "pnpm prek run --all-files --config='.github/.pre-commit.yml'"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -232,6 +232,9 @@ catalogs:
       specifier: ^4.3.6
       version: 4.3.6
 
+overrides:
+  basic-ftp: 5.2.2
+
 patchedDependencies:
   '@cloudflare/vite-plugin@1.30.3':
     hash: e06eefb6e9635561829ac5e497cea44db1c8cfe738d2336f3f1de75842284333
@@ -3663,10 +3666,9 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  basic-ftp@5.2.0:
-    resolution: {integrity: sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==}
+  basic-ftp@5.2.2:
+    resolution: {integrity: sha512-1tDrzKsdCg70WGvbFss/ulVAxupNauGnOlgpyjKzeQxzyllBLS0CGLV7tjIXTK3ZQA9/FBEm9qyFFN1bciA6pw==}
     engines: {node: '>=10.0.0'}
-    deprecated: Security vulnerability fixed in 5.2.1, please upgrade
 
   bcrypt-pbkdf@1.0.2:
     resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
@@ -8414,7 +8416,7 @@ snapshots:
 
   baseline-browser-mapping@2.10.9: {}
 
-  basic-ftp@5.2.0: {}
+  basic-ftp@5.2.2: {}
 
   bcrypt-pbkdf@1.0.2:
     dependencies:
@@ -9180,7 +9182,7 @@ snapshots:
 
   get-uri@6.0.5:
     dependencies:
-      basic-ftp: 5.2.0
+      basic-ftp: 5.2.2
       data-uri-to-buffer: 6.0.2
       debug: 4.4.3
     transitivePeerDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -80,6 +80,9 @@ catalog:
   wrangler: 4.79.0
   zod: ^4.3.6
 
+overrides:
+  basic-ftp: 5.2.2
+
 patchedDependencies:
   '@cloudflare/vite-plugin@1.30.3': patches/@cloudflare__vite-plugin@1.30.3.patch
 


### PR DESCRIPTION
Override `basic-ftp` from `5.2.0` (deprecated, security vuln) to `5.2.2` via `pnpm.overrides`.

## Dep chain
```
@cloudflare/puppeteer → @puppeteer/browsers → proxy-agent → pac-proxy-agent → get-uri → basic-ftp
```

Resolves https://github.com/tempoxyz/tempo-apps/security/dependabot/68

Co-Authored-By: o-az <23618431+o-az@users.noreply.github.com>

Prompted by: omar