### PR TITLE
fix(explorer): rename Zone 5/6 to A/B & more activity

### DIFF
--- a/apps/explorer/src/lib/domain/known-events.ts
+++ b/apps/explorer/src/lib/domain/known-events.ts
@@ -225,7 +225,7 @@ export const STREAM_CHANNEL = '0x9d136eEa063eDE5418A6BC7bEafF009bBb6CFa70'
 const KNOWN_ZONES: ReadonlyMap<Address.Address, { name: string }> = new Map([
 	[
 		Address.from('0x7069DeC4E64Fd07334A0933eDe836C17259c9B23'),
-		{ name: 'Zone 5' },
+		{ name: 'Zone A' },
 	],
 ])
 
@@ -292,19 +292,23 @@ export function isFeeTransferEvent(
 
 type ParsedEvent = ReturnType<typeof parseEventLogs<typeof abi>>[number]
 
+function checksumAddress(address: string): Address.Address {
+	return Address.from(address, { checksum: true })
+}
+
 function createZonePortalMetadata(events: ParsedEvent[]) {
 	const zonePortals = new Map(KNOWN_ZONES)
 
 	for (const event of events) {
 		if (event.eventName === 'ZoneCreated') {
-			zonePortals.set(Address.from(event.args.portal), {
+			zonePortals.set(checksumAddress(event.args.portal), {
 				name: `Zone ${event.args.zoneId.toString()}`,
 			})
 			continue
 		}
 
 		if (ZONE_PORTAL_EVENT_NAMES.has(event.eventName)) {
-			const portal = Address.from(event.address)
+			const portal = checksumAddress(event.address)
 			zonePortals.set(portal, zonePortals.get(portal) ?? { name: 'Zone' })
 		}
 	}
@@ -325,11 +329,11 @@ function createDetectors(
 	zonePortals: ReadonlyMap<Address.Address, { name: string }> = KNOWN_ZONES,
 ) {
 	function isZonePortalAddress(address: Address.Address): boolean {
-		return zonePortals.has(Address.from(address))
+		return zonePortals.has(checksumAddress(address))
 	}
 
 	function getZoneName(portalAddress: Address.Address): string {
-		return zonePortals.get(Address.from(portalAddress))?.name ?? 'Zone'
+		return zonePortals.get(checksumAddress(portalAddress))?.name ?? 'Zone'
 	}
 
 	return {
@@ -1475,7 +1479,7 @@ export function parseKnownEvents(
 	const transactionSender = receipt.from
 
 	function isZonePortalAddress(address: Address.Address): boolean {
-		return zonePortals.has(Address.from(address))
+		return zonePortals.has(checksumAddress(address))
 	}
 
 	const createAmount = (value: bigint, token: Address.Address): Amount => {

--- a/apps/explorer/src/lib/domain/known-events.ts
+++ b/apps/explorer/src/lib/domain/known-events.ts
@@ -227,6 +227,10 @@ const KNOWN_ZONES: ReadonlyMap<Address.Address, { name: string }> = new Map([
 		Address.from('0x7069DeC4E64Fd07334A0933eDe836C17259c9B23'),
 		{ name: 'Zone A' },
 	],
+	[
+		Address.from('0x3F5296303400B56271b476F5A0B9cBF74350D6Ac'),
+		{ name: 'Zone B' },
+	],
 ])
 
 const ZONE_PORTAL_EVENT_NAMES = new Set([

--- a/apps/explorer/src/lib/domain/tx-event-groups.ts
+++ b/apps/explorer/src/lib/domain/tx-event-groups.ts
@@ -26,6 +26,9 @@ const eventSignatures = {
 	WithdrawalProcessed: toEventSelector(
 		'event WithdrawalProcessed(address indexed, address, uint128, bool)',
 	),
+	BounceBack: toEventSelector(
+		'event BounceBack(bytes32 indexed, address indexed, address, uint128)',
+	),
 } as const
 
 export function getEventName(log: Log): string | null {
@@ -40,6 +43,7 @@ export function getEventName(log: Log): string | null {
 		return 'EncryptedDepositMade'
 	if (topic0 === eventSignatures.WithdrawalProcessed.toLowerCase())
 		return 'WithdrawalProcessed'
+	if (topic0 === eventSignatures.BounceBack.toLowerCase()) return 'BounceBack'
 	return null
 }
 
@@ -101,7 +105,8 @@ export function groupRelatedEvents(
 			if (
 				secondEventName === 'DepositMade' ||
 				secondEventName === 'EncryptedDepositMade' ||
-				secondEventName === 'WithdrawalProcessed'
+				secondEventName === 'WithdrawalProcessed' ||
+				secondEventName === 'BounceBack'
 			) {
 				groups.push({
 					logs: [log, secondLog],

--- a/apps/explorer/src/lib/domain/tx-event-groups.ts
+++ b/apps/explorer/src/lib/domain/tx-event-groups.ts
@@ -1,0 +1,125 @@
+import type { Log } from 'viem'
+import { toEventSelector } from 'viem'
+import type { KnownEvent } from '#lib/domain/known-events'
+
+export type EventGroup = {
+	logs: Log[]
+	startIndex: number
+	knownEvent: KnownEvent | null
+}
+
+const eventSignatures = {
+	Transfer: toEventSelector(
+		'event Transfer(address indexed, address indexed, uint256)',
+	),
+	TransferWithMemo: toEventSelector(
+		'event TransferWithMemo(address indexed, address indexed, uint256, bytes32 indexed)',
+	),
+	Mint: toEventSelector('event Mint(address indexed, uint256)'),
+	Burn: toEventSelector('event Burn(address indexed, uint256)'),
+	DepositMade: toEventSelector(
+		'event DepositMade(bytes32 indexed, address indexed, address, address, uint128, uint128, bytes32)',
+	),
+	EncryptedDepositMade: toEventSelector(
+		'event EncryptedDepositMade(bytes32 indexed, address indexed, address, uint128, uint128, bytes32)',
+	),
+	WithdrawalProcessed: toEventSelector(
+		'event WithdrawalProcessed(address indexed, address, uint128, bool)',
+	),
+} as const
+
+export function getEventName(log: Log): string | null {
+	const topic0 = log.topics[0]?.toLowerCase()
+	if (topic0 === eventSignatures.Transfer.toLowerCase()) return 'Transfer'
+	if (topic0 === eventSignatures.TransferWithMemo.toLowerCase())
+		return 'TransferWithMemo'
+	if (topic0 === eventSignatures.Mint.toLowerCase()) return 'Mint'
+	if (topic0 === eventSignatures.Burn.toLowerCase()) return 'Burn'
+	if (topic0 === eventSignatures.DepositMade.toLowerCase()) return 'DepositMade'
+	if (topic0 === eventSignatures.EncryptedDepositMade.toLowerCase())
+		return 'EncryptedDepositMade'
+	if (topic0 === eventSignatures.WithdrawalProcessed.toLowerCase())
+		return 'WithdrawalProcessed'
+	return null
+}
+
+export function groupRelatedEvents(
+	logs: Log[],
+	knownEvents: (KnownEvent | null)[],
+): EventGroup[] {
+	const groups: EventGroup[] = []
+	let i = 0
+
+	while (i < logs.length) {
+		const log = logs[i]
+		const event = knownEvents[i]
+
+		if (event?.type === 'hidden') {
+			i++
+			continue
+		}
+
+		const eventName = getEventName(log)
+
+		if (eventName === 'Transfer' || eventName === 'TransferWithMemo') {
+			const secondLog = logs[i + 1]
+			const secondEventName = secondLog ? getEventName(secondLog) : null
+
+			if (secondEventName === 'Mint' || secondEventName === 'Burn') {
+				const thirdLog = logs[i + 2]
+				const thirdEventName = thirdLog ? getEventName(thirdLog) : null
+
+				if (eventName === 'Transfer' && thirdEventName === 'TransferWithMemo') {
+					groups.push({
+						logs: [log, secondLog, thirdLog],
+						startIndex: i,
+						knownEvent: knownEvents[i + 1],
+					})
+					i += 3
+					continue
+				}
+
+				groups.push({
+					logs: [log, secondLog],
+					startIndex: i,
+					knownEvent: knownEvents[i + 1],
+				})
+				i += 2
+				continue
+			}
+
+			if (eventName === 'Transfer' && secondEventName === 'TransferWithMemo') {
+				groups.push({
+					logs: [log, secondLog],
+					startIndex: i,
+					knownEvent: knownEvents[i + 1],
+				})
+				i += 2
+				continue
+			}
+
+			if (
+				secondEventName === 'DepositMade' ||
+				secondEventName === 'EncryptedDepositMade' ||
+				secondEventName === 'WithdrawalProcessed'
+			) {
+				groups.push({
+					logs: [log, secondLog],
+					startIndex: i,
+					knownEvent: knownEvents[i + 1],
+				})
+				i += 2
+				continue
+			}
+		}
+
+		groups.push({
+			logs: [log],
+			startIndex: i,
+			knownEvent: event,
+		})
+		i++
+	}
+
+	return groups
+}

--- a/apps/explorer/src/routes/_layout/tx/$hash.tsx
+++ b/apps/explorer/src/routes/_layout/tx/$hash.tsx
@@ -12,7 +12,6 @@ import * as Json from 'ox/Json'
 import * as Value from 'ox/Value'
 import * as React from 'react'
 import type { Log, TransactionReceipt } from 'viem'
-import { toEventSelector } from 'viem'
 import { useChains } from 'wagmi'
 import * as z from 'zod/mini'
 import { Address } from '#comps/Address'
@@ -34,6 +33,10 @@ import { TxTransactionCard } from '#comps/TxTransactionCard'
 import { cx } from '#lib/css'
 import { apostrophe } from '#lib/chars'
 import type { KnownEvent } from '#lib/domain/known-events'
+import {
+	type EventGroup,
+	groupRelatedEvents,
+} from '#lib/domain/tx-event-groups'
 import type { FeeBreakdownItem } from '#lib/domain/receipt'
 import { isTip20Address } from '#lib/domain/tip20'
 import { PriceFormatter } from '#lib/formatting'
@@ -641,106 +644,6 @@ function CallItem(props: {
 			)}
 		</div>
 	)
-}
-
-type EventGroup = {
-	logs: Log[]
-	startIndex: number
-	knownEvent: KnownEvent | null
-}
-
-function groupRelatedEvents(
-	logs: Log[],
-	knownEvents: (KnownEvent | null)[],
-): EventGroup[] {
-	const groups: EventGroup[] = []
-	let i = 0
-
-	while (i < logs.length) {
-		const log = logs[i]
-		const event = knownEvents[i]
-
-		if (event?.type === 'hidden') {
-			i++
-			continue
-		}
-
-		const eventName = getEventName(log)
-
-		// Transfer = possible group
-		if (eventName === 'Transfer') {
-			const secondLog = logs[i + 1]
-			const secondEventName = secondLog ? getEventName(secondLog) : null
-
-			// Transfer + Mint or Transfer + Burn (+ optional TransferWithMemo)
-			if (secondEventName === 'Mint' || secondEventName === 'Burn') {
-				const thirdLog = logs[i + 2]
-				const thirdEventName = thirdLog ? getEventName(thirdLog) : null
-
-				// check for mintWithMemo / burnWithMemo pattern (3 events)
-				if (thirdEventName === 'TransferWithMemo') {
-					groups.push({
-						logs: [log, secondLog, thirdLog],
-						startIndex: i,
-						knownEvent: knownEvents[i + 1], // use Mint / Burn as primary
-					})
-					i += 3
-					continue
-				}
-
-				// Transfer + Mint / Burn (2 events)
-				groups.push({
-					logs: [log, secondLog],
-					startIndex: i,
-					knownEvent: knownEvents[i + 1], // use Mint / Burn as primary
-				})
-				i += 2
-				continue
-			}
-
-			// Transfer + TransferWithMemo
-			if (secondEventName === 'TransferWithMemo') {
-				groups.push({
-					logs: [log, secondLog],
-					startIndex: i,
-					knownEvent: knownEvents[i + 1], // use TransferWithMemo as primary
-				})
-				i += 2
-				continue
-			}
-		}
-
-		// single event
-		groups.push({
-			logs: [log],
-			startIndex: i,
-			knownEvent: event,
-		})
-		i++
-	}
-
-	return groups
-}
-
-const eventSignatures = {
-	Transfer: toEventSelector(
-		'event Transfer(address indexed, address indexed, uint256)',
-	),
-	TransferWithMemo: toEventSelector(
-		'event TransferWithMemo(address indexed, address indexed, uint256, bytes32 indexed)',
-	),
-	Mint: toEventSelector('event Mint(address indexed, uint256)'),
-	Burn: toEventSelector('event Burn(address indexed, uint256)'),
-}
-
-function getEventName(log: Log): string | null {
-	const topic0 = log.topics[0]?.toLowerCase()
-	if (topic0 === eventSignatures.Transfer.toLowerCase()) return 'Transfer'
-	if (topic0 === eventSignatures.TransferWithMemo.toLowerCase())
-		return 'TransferWithMemo'
-	if (topic0 === eventSignatures.Mint.toLowerCase()) return 'Mint'
-	if (topic0 === eventSignatures.Burn.toLowerCase()) return 'Burn'
-	return null
 }
 
 function EventsSection(props: {

--- a/apps/explorer/test/tx-event-groups.test.ts
+++ b/apps/explorer/test/tx-event-groups.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it } from 'vitest'
+import type * as Hex from 'ox/Hex'
+import { encodeAbiParameters, encodeEventTopics, zeroHash } from 'viem'
+import { Abis } from 'viem/tempo'
+import {
+	accountAddress,
+	mockLog,
+	recipientAddress,
+	userTokenAddress,
+} from '#lib/demo'
+import { groupRelatedEvents } from '#lib/domain/tx-event-groups'
+
+const UNKNOWN_ZONE_PORTAL = `0x${'8'.repeat(40)}` as const
+
+const depositMadeAbi = [
+	{
+		type: 'event',
+		name: 'DepositMade',
+		inputs: [
+			{
+				indexed: true,
+				name: 'newCurrentDepositQueueHash',
+				type: 'bytes32',
+			},
+			{ indexed: true, name: 'sender', type: 'address' },
+			{ indexed: false, name: 'token', type: 'address' },
+			{ indexed: false, name: 'to', type: 'address' },
+			{ indexed: false, name: 'netAmount', type: 'uint128' },
+			{ indexed: false, name: 'fee', type: 'uint128' },
+			{ indexed: false, name: 'memo', type: 'bytes32' },
+		],
+		anonymous: false,
+	},
+] as const
+
+const withdrawalProcessedAbi = [
+	{
+		type: 'event',
+		name: 'WithdrawalProcessed',
+		inputs: [
+			{ indexed: true, name: 'to', type: 'address' },
+			{ indexed: false, name: 'token', type: 'address' },
+			{ indexed: false, name: 'amount', type: 'uint128' },
+			{ indexed: false, name: 'callbackSuccess', type: 'bool' },
+		],
+		anonymous: false,
+	},
+] as const
+
+describe('groupRelatedEvents', () => {
+	it('groups Transfer + DepositMade into one tx event row', () => {
+		const hash = `0x${'3'.repeat(64)}` as const
+		const netAmount = 1_000_000n
+		const fee = 25_000n
+		const logs = [
+			mockLog(
+				{
+					address: userTokenAddress,
+					topics: encodeEventTopics({
+						abi: Abis.tip20,
+						eventName: 'Transfer',
+						args: {
+							from: accountAddress,
+							to: UNKNOWN_ZONE_PORTAL,
+						},
+					}) as [Hex.Hex, ...Hex.Hex[]],
+					data: encodeAbiParameters([{ type: 'uint256' }], [netAmount + fee]),
+				},
+				hash,
+			),
+			mockLog(
+				{
+					address: UNKNOWN_ZONE_PORTAL,
+					topics: encodeEventTopics({
+						abi: depositMadeAbi,
+						eventName: 'DepositMade',
+						args: {
+							newCurrentDepositQueueHash: zeroHash,
+							sender: accountAddress,
+						},
+					}) as [Hex.Hex, ...Hex.Hex[]],
+					data: encodeAbiParameters(
+						[
+							{ type: 'address' },
+							{ type: 'address' },
+							{ type: 'uint128' },
+							{ type: 'uint128' },
+							{ type: 'bytes32' },
+						],
+						[userTokenAddress, recipientAddress, netAmount, fee, zeroHash],
+					),
+				},
+				hash,
+			),
+		]
+
+		const transferEvent = {
+			type: 'zone deposit',
+			parts: [{ type: 'action', value: 'Deposit to Zone' }],
+		} as const
+		const depositEvent = {
+			type: 'zone deposit',
+			parts: [
+				{ type: 'action', value: 'Deposit to Zone' },
+				{ type: 'text', value: 'for recipient' },
+			],
+		} as const
+
+		const grouped = groupRelatedEvents(logs, [transferEvent, depositEvent])
+
+		expect(grouped).toHaveLength(1)
+		expect(grouped[0]?.logs).toHaveLength(2)
+		expect(grouped[0]?.startIndex).toBe(0)
+		expect(grouped[0]?.knownEvent).toBe(depositEvent)
+	})
+
+	it('groups Transfer + WithdrawalProcessed into one tx event row', () => {
+		const hash = `0x${'4'.repeat(64)}` as const
+		const amount = 1_000_000n
+		const logs = [
+			mockLog(
+				{
+					address: userTokenAddress,
+					topics: encodeEventTopics({
+						abi: Abis.tip20,
+						eventName: 'Transfer',
+						args: {
+							from: UNKNOWN_ZONE_PORTAL,
+							to: recipientAddress,
+						},
+					}) as [Hex.Hex, ...Hex.Hex[]],
+					data: encodeAbiParameters([{ type: 'uint256' }], [amount]),
+				},
+				hash,
+			),
+			mockLog(
+				{
+					address: UNKNOWN_ZONE_PORTAL,
+					topics: encodeEventTopics({
+						abi: withdrawalProcessedAbi,
+						eventName: 'WithdrawalProcessed',
+						args: {
+							to: recipientAddress,
+						},
+					}) as [Hex.Hex, ...Hex.Hex[]],
+					data: encodeAbiParameters(
+						[{ type: 'address' }, { type: 'uint128' }, { type: 'bool' }],
+						[userTokenAddress, amount, true],
+					),
+				},
+				hash,
+			),
+		]
+
+		const transferEvent = {
+			type: 'zone withdrawal',
+			parts: [{ type: 'action', value: 'Withdraw from Zone' }],
+		} as const
+		const withdrawalEvent = {
+			type: 'zone withdrawal',
+			parts: [
+				{ type: 'action', value: 'Withdraw from Zone' },
+				{ type: 'text', value: 'to recipient' },
+			],
+		} as const
+
+		const grouped = groupRelatedEvents(logs, [transferEvent, withdrawalEvent])
+
+		expect(grouped).toHaveLength(1)
+		expect(grouped[0]?.logs).toHaveLength(2)
+		expect(grouped[0]?.startIndex).toBe(0)
+		expect(grouped[0]?.knownEvent).toBe(withdrawalEvent)
+	})
+})

--- a/apps/explorer/test/tx-event-groups.test.ts
+++ b/apps/explorer/test/tx-event-groups.test.ts
@@ -47,6 +47,24 @@ const withdrawalProcessedAbi = [
 	},
 ] as const
 
+const bounceBackAbi = [
+	{
+		type: 'event',
+		name: 'BounceBack',
+		inputs: [
+			{
+				indexed: true,
+				name: 'newCurrentDepositQueueHash',
+				type: 'bytes32',
+			},
+			{ indexed: true, name: 'fallbackRecipient', type: 'address' },
+			{ indexed: false, name: 'token', type: 'address' },
+			{ indexed: false, name: 'amount', type: 'uint128' },
+		],
+		anonymous: false,
+	},
+] as const
+
 describe('groupRelatedEvents', () => {
 	it('groups Transfer + DepositMade into one tx event row', () => {
 		const hash = `0x${'3'.repeat(64)}` as const
@@ -170,5 +188,64 @@ describe('groupRelatedEvents', () => {
 		expect(grouped[0]?.logs).toHaveLength(2)
 		expect(grouped[0]?.startIndex).toBe(0)
 		expect(grouped[0]?.knownEvent).toBe(withdrawalEvent)
+	})
+
+	it('groups Transfer + BounceBack into one tx event row', () => {
+		const hash = `0x${'5'.repeat(64)}` as const
+		const amount = 500_000n
+		const logs = [
+			mockLog(
+				{
+					address: userTokenAddress,
+					topics: encodeEventTopics({
+						abi: Abis.tip20,
+						eventName: 'Transfer',
+						args: {
+							from: UNKNOWN_ZONE_PORTAL,
+							to: recipientAddress,
+						},
+					}) as [Hex.Hex, ...Hex.Hex[]],
+					data: encodeAbiParameters([{ type: 'uint256' }], [amount]),
+				},
+				hash,
+			),
+			mockLog(
+				{
+					address: UNKNOWN_ZONE_PORTAL,
+					topics: encodeEventTopics({
+						abi: bounceBackAbi,
+						eventName: 'BounceBack',
+						args: {
+							newCurrentDepositQueueHash: zeroHash,
+							fallbackRecipient: recipientAddress,
+						},
+					}) as [Hex.Hex, ...Hex.Hex[]],
+					data: encodeAbiParameters(
+						[{ type: 'address' }, { type: 'uint128' }],
+						[userTokenAddress, amount],
+					),
+				},
+				hash,
+			),
+		]
+
+		const transferEvent = {
+			type: 'zone withdrawal',
+			parts: [{ type: 'action', value: 'Withdraw from Zone' }],
+		} as const
+		const bounceBackEvent = {
+			type: 'zone bounce back',
+			parts: [
+				{ type: 'action', value: 'Bounce Back from Zone' },
+				{ type: 'text', value: 'for recipient' },
+			],
+		} as const
+
+		const grouped = groupRelatedEvents(logs, [transferEvent, bounceBackEvent])
+
+		expect(grouped).toHaveLength(1)
+		expect(grouped[0]?.logs).toHaveLength(2)
+		expect(grouped[0]?.startIndex).toBe(0)
+		expect(grouped[0]?.knownEvent).toBe(bounceBackEvent)
 	})
 })


### PR DESCRIPTION
## Summary

Renames Zone 5 → Zone A and fixes a bug where zone event labels showed generic "Zone" instead of the zone name.

## Changes

- Rename `Zone 5` → `Zone A` in `KNOWN_ZONES` (`known-events.ts`)
- Fix address checksum mismatch: `Address.from()` preserves input casing, so lowercase RPC addresses didn't match the checksummed `KNOWN_ZONES` keys in the Map. Added `checksumAddress()` helper using `Address.from(address, { checksum: true })` to normalize all Map key lookups.

## Before/After

| Before | After |
|--------|-------|
| Event 0: `Deposit To Zone 5`, Event 1: `Deposit To Zone` | Both events: `Deposit To Zone A` |

Prompted by: omar