### PR TITLE
fix(explorer): populate address OG metadata via TIDX

### DIFF
--- a/apps/explorer/src/lib/server/tempo-queries.ts
+++ b/apps/explorer/src/lib/server/tempo-queries.ts
@@ -1496,6 +1496,7 @@ export async function fetchAddressOgMeta(
 	txCount: number
 	createdTimestamp: number | undefined
 	lastActivityTimestamp: number | undefined
+	accountType: 'contract' | 'account' | undefined
 }> {
 	const aggregate = await fetchAddressTxAggregate(address, chainId)
 	let txCount = aggregate.count ?? 0
@@ -1524,5 +1525,12 @@ export async function fetchAddressOgMeta(
 		}
 	}
 
-	return { txCount, createdTimestamp, lastActivityTimestamp }
+	// Derive accountType from TIDX data when bytecode check is unavailable
+	const accountType = creation
+		? ('contract' as const)
+		: txCount > 0
+			? ('account' as const)
+			: undefined
+
+	return { txCount, createdTimestamp, lastActivityTimestamp, accountType }
 }

--- a/apps/explorer/src/lib/server/tempo-queries.ts
+++ b/apps/explorer/src/lib/server/tempo-queries.ts
@@ -1484,3 +1484,45 @@ export async function fetchAddressTransferActivity(
 }
 
 export type { SortDirection }
+
+/**
+ * Fetches OG metadata for an address: tx count (including contract creation)
+ * and the contract creation timestamp from the receipts table.
+ */
+export async function fetchAddressOgMeta(
+	address: Address.Address,
+	chainId: number,
+): Promise<{
+	txCount: number
+	createdTimestamp: number | undefined
+	lastActivityTimestamp: number | undefined
+}> {
+	const aggregate = await fetchAddressTxAggregate(address, chainId)
+	let txCount = aggregate.count ?? 0
+	const lastActivityTimestamp = parseTimestamp(
+		aggregate.latestTxsBlockTimestamp,
+	)
+	let createdTimestamp = parseTimestamp(aggregate.oldestTxsBlockTimestamp)
+
+	// Check receipts for contract creation (deployments have to=null,
+	// so they won't appear in the from/to aggregate)
+	type CreationRow = {
+		block_timestamp: string | number | bigint | null
+	}
+	const creation = (await QB(chainId)
+		.selectFrom('receipts')
+		.select(['block_timestamp'])
+		.where('contract_address', '=', address)
+		.limit(1)
+		.executeTakeFirst()) as CreationRow | undefined
+
+	if (creation) {
+		txCount += 1
+		const ts = parseTimestamp(creation.block_timestamp)
+		if (ts && (!createdTimestamp || ts < createdTimestamp)) {
+			createdTimestamp = ts
+		}
+	}
+
+	return { txCount, createdTimestamp, lastActivityTimestamp }
+}

--- a/apps/explorer/src/routes/_layout/address/$address.tsx
+++ b/apps/explorer/src/routes/_layout/address/$address.tsx
@@ -73,6 +73,7 @@ import {
 	historyQueryOptions,
 } from '#lib/queries/account'
 import { transfersQueryOptions, holdersQueryOptions } from '#lib/queries/tokens'
+import { fetchAddressOgMeta } from '#lib/server/tempo-queries'
 import { getApiUrl } from '#lib/env.ts'
 import { getFeeTokenForChain } from '#lib/tokenlist'
 import { getTempoChain, getWagmiConfig } from '#wagmi.config.ts'
@@ -368,16 +369,24 @@ export const Route = createFileRoute('/_layout/address/$address')({
 						)
 					: Promise.resolve(undefined)
 
+			// Fetch OG metadata (txCount + timestamps) via direct TIDX query
+			const ogMetaPromise = timeout(
+				fetchAddressOgMeta(address, TEMPO_CHAIN_ID).catch(() => undefined),
+				QUERY_TIMEOUT_MS,
+			)
+
 			const [
 				contractBytecode,
 				transactionsData,
 				balancesResult,
 				tokenMetadata,
+				ogMeta,
 			] = await Promise.all([
 				contractBytecodePromise,
 				transactionsPromise,
 				balancesPromise,
 				tokenMetadataPromise,
+				ogMetaPromise,
 			])
 
 			const accountType = getAccountType(contractBytecode)
@@ -405,6 +414,7 @@ export const Route = createFileRoute('/_layout/address/$address')({
 				contractSource,
 				transactionsData,
 				balancesData,
+				ogMeta,
 			}
 		}),
 	head: async ({ params, loaderData }) => {
@@ -455,7 +465,7 @@ export const Route = createFileRoute('/_layout/address/$address')({
 				supply,
 			})
 		} else {
-			const txCount = loaderData?.transactionsData?.total ?? 0
+			const txCount = loaderData?.ogMeta?.txCount ?? 0
 			let lastActive: string | undefined
 			let created: string | undefined
 			let holdings = '—'
@@ -476,18 +486,15 @@ export const Route = createFileRoute('/_layout/address/$address')({
 				}
 			}
 
-			const transactions = loaderData?.transactionsData?.transactions
-			const recentTx = transactions?.at(0)
-			if (recentTx?.timestamp) {
+			if (loaderData?.ogMeta?.lastActivityTimestamp) {
 				lastActive = DateFormatter.formatTimestampForOg(
-					BigInt(recentTx.timestamp),
+					BigInt(loaderData.ogMeta.lastActivityTimestamp),
 				).date
 			}
 
-			const oldestTx = transactions?.at(-1)
-			if (oldestTx?.timestamp) {
+			if (loaderData?.ogMeta?.createdTimestamp) {
 				created = DateFormatter.formatTimestampForOg(
-					BigInt(oldestTx.timestamp),
+					BigInt(loaderData.ogMeta.createdTimestamp),
 				).date
 			}
 

--- a/apps/explorer/src/routes/_layout/address/$address.tsx
+++ b/apps/explorer/src/routes/_layout/address/$address.tsx
@@ -418,7 +418,11 @@ export const Route = createFileRoute('/_layout/address/$address')({
 			}
 		}),
 	head: async ({ params, loaderData }) => {
-		const accountType = loaderData?.accountType ?? 'empty'
+		// Use ogMeta.accountType as fallback when bytecode check timed out
+		const accountType =
+			loaderData?.accountType !== 'empty'
+				? (loaderData?.accountType ?? 'empty')
+				: (loaderData?.ogMeta?.accountType ?? 'empty')
 		const isToken = loaderData?.isToken ?? false
 		const tokenMeta = loaderData?.tokenMetadata
 

--- a/apps/explorer/src/routes/_layout/address/$address.tsx
+++ b/apps/explorer/src/routes/_layout/address/$address.tsx
@@ -418,11 +418,12 @@ export const Route = createFileRoute('/_layout/address/$address')({
 			}
 		}),
 	head: async ({ params, loaderData }) => {
-		// Use ogMeta.accountType as fallback when bytecode check timed out
-		const accountType =
-			loaderData?.accountType !== 'empty'
-				? (loaderData?.accountType ?? 'empty')
-				: (loaderData?.ogMeta?.accountType ?? 'empty')
+		// Fallback to ogMeta.accountType only for contracts (receipts-proven)
+		// since 'empty' is the correct type for regular EOAs
+		let accountType = loaderData?.accountType ?? 'empty'
+		if (accountType === 'empty' && loaderData?.ogMeta?.accountType === 'contract') {
+			accountType = 'contract'
+		}
 		const isToken = loaderData?.isToken ?? false
 		const tokenMeta = loaderData?.tokenMetadata
 

--- a/apps/explorer/src/routes/_layout/address/$address.tsx
+++ b/apps/explorer/src/routes/_layout/address/$address.tsx
@@ -455,8 +455,9 @@ export const Route = createFileRoute('/_layout/address/$address')({
 				supply,
 			})
 		} else {
-			const txCount = 0
+			const txCount = loaderData?.transactionsData?.total ?? 0
 			let lastActive: string | undefined
+			let created: string | undefined
 			let holdings = '—'
 
 			if (loaderData?.balancesData?.balances) {
@@ -475,10 +476,18 @@ export const Route = createFileRoute('/_layout/address/$address')({
 				}
 			}
 
-			const recentTx = loaderData?.transactionsData?.transactions?.at(0)
+			const transactions = loaderData?.transactionsData?.transactions
+			const recentTx = transactions?.at(0)
 			if (recentTx?.timestamp) {
 				lastActive = DateFormatter.formatTimestampForOg(
 					BigInt(recentTx.timestamp),
+				).date
+			}
+
+			const oldestTx = transactions?.at(-1)
+			if (oldestTx?.timestamp) {
+				created = DateFormatter.formatTimestampForOg(
+					BigInt(oldestTx.timestamp),
 				).date
 			}
 
@@ -493,6 +502,7 @@ export const Route = createFileRoute('/_layout/address/$address')({
 				txCount,
 				accountType,
 				lastActive,
+				created,
 				contractName: loaderData?.contractInfo?.name,
 			})
 		}


### PR DESCRIPTION
Address OG images were missing txCount, created, and lastActive data. The previous approach derived these from paginated transaction history (`transactionsData.total`), which returned empty for contracts (deployment txs have `to=null`) and was tab-dependent.

Now queries TIDX directly via `fetchAddressOgMeta` in `tempo-queries.ts`:
- `txs` table for aggregate counts + timestamps (`fetchAddressTxAggregate`)
- `receipts` table for contract creation timestamp and +1 tx count
- Derives `accountType` from TIDX as fallback when `getContractBytecode` times out during SSR

Prompted by: omar