### PR TITLE
feat(explorer): add FeeAMM pools API endpoint

### DIFF
--- a/apps/explorer/src/routeTree.gen.ts
+++ b/apps/explorer/src/routeTree.gen.ts
@@ -15,6 +15,7 @@ import { Route as LayoutIndexRouteImport } from './routes/_layout/index'
 import { Route as ApiTip20RolesRouteImport } from './routes/api/tip20-roles'
 import { Route as ApiSearchRouteImport } from './routes/api/search'
 import { Route as ApiHealthRouteImport } from './routes/api/health'
+import { Route as ApiFeeAmmPoolsRouteImport } from './routes/api/fee-amm/pools'
 import { Route as ApiCodeRouteImport } from './routes/api/code'
 import { Route as LayoutTokensRouteImport } from './routes/_layout/tokens'
 import { Route as LayoutBlocksRouteImport } from './routes/_layout/blocks'
@@ -68,6 +69,11 @@ const ApiSearchRoute = ApiSearchRouteImport.update({
 const ApiHealthRoute = ApiHealthRouteImport.update({
   id: '/api/health',
   path: '/api/health',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiFeeAmmPoolsRoute = ApiFeeAmmPoolsRouteImport.update({
+  id: '/api/fee-amm/pools',
+  path: '/api/fee-amm/pools',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ApiCodeRoute = ApiCodeRouteImport.update({
@@ -209,6 +215,7 @@ export interface FileRoutesByFullPath {
   '/blocks': typeof LayoutBlocksRoute
   '/tokens': typeof LayoutTokensRoute
   '/api/code': typeof ApiCodeRoute
+  '/api/fee-amm/pools': typeof ApiFeeAmmPoolsRoute
   '/api/health': typeof ApiHealthRoute
   '/api/search': typeof ApiSearchRoute
   '/api/tip20-roles': typeof ApiTip20RolesRoute
@@ -240,6 +247,7 @@ export interface FileRoutesByTo {
   '/blocks': typeof LayoutBlocksRoute
   '/tokens': typeof LayoutTokensRoute
   '/api/code': typeof ApiCodeRoute
+  '/api/fee-amm/pools': typeof ApiFeeAmmPoolsRoute
   '/api/health': typeof ApiHealthRoute
   '/api/search': typeof ApiSearchRoute
   '/api/tip20-roles': typeof ApiTip20RolesRoute
@@ -274,6 +282,7 @@ export interface FileRoutesById {
   '/_layout/blocks': typeof LayoutBlocksRoute
   '/_layout/tokens': typeof LayoutTokensRoute
   '/api/code': typeof ApiCodeRoute
+  '/api/fee-amm/pools': typeof ApiFeeAmmPoolsRoute
   '/api/health': typeof ApiHealthRoute
   '/api/search': typeof ApiSearchRoute
   '/api/tip20-roles': typeof ApiTip20RolesRoute
@@ -309,6 +318,7 @@ export interface FileRouteTypes {
     | '/blocks'
     | '/tokens'
     | '/api/code'
+    | '/api/fee-amm/pools'
     | '/api/health'
     | '/api/search'
     | '/api/tip20-roles'
@@ -340,6 +350,7 @@ export interface FileRouteTypes {
     | '/blocks'
     | '/tokens'
     | '/api/code'
+    | '/api/fee-amm/pools'
     | '/api/health'
     | '/api/search'
     | '/api/tip20-roles'
@@ -373,6 +384,7 @@ export interface FileRouteTypes {
     | '/_layout/blocks'
     | '/_layout/tokens'
     | '/api/code'
+    | '/api/fee-amm/pools'
     | '/api/health'
     | '/api/search'
     | '/api/tip20-roles'
@@ -405,6 +417,7 @@ export interface RootRouteChildren {
   LayoutRoute: typeof LayoutRouteWithChildren
   SearchRoute: typeof SearchRoute
   ApiCodeRoute: typeof ApiCodeRoute
+  ApiFeeAmmPoolsRoute: typeof ApiFeeAmmPoolsRoute
   ApiHealthRoute: typeof ApiHealthRoute
   ApiSearchRoute: typeof ApiSearchRoute
   ApiTip20RolesRoute: typeof ApiTip20RolesRoute
@@ -470,6 +483,13 @@ declare module '@tanstack/react-router' {
       path: '/api/code'
       fullPath: '/api/code'
       preLoaderRoute: typeof ApiCodeRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/fee-amm/pools': {
+      id: '/api/fee-amm/pools'
+      path: '/api/fee-amm/pools'
+      fullPath: '/api/fee-amm/pools'
+      preLoaderRoute: typeof ApiFeeAmmPoolsRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/_layout/tokens': {
@@ -684,6 +704,7 @@ const rootRouteChildren: RootRouteChildren = {
   LayoutRoute: LayoutRouteWithChildren,
   SearchRoute: SearchRoute,
   ApiCodeRoute: ApiCodeRoute,
+  ApiFeeAmmPoolsRoute: ApiFeeAmmPoolsRoute,
   ApiHealthRoute: ApiHealthRoute,
   ApiSearchRoute: ApiSearchRoute,
   ApiTip20RolesRoute: ApiTip20RolesRoute,

--- a/apps/explorer/src/routes/api/fee-amm/pools.ts
+++ b/apps/explorer/src/routes/api/fee-amm/pools.ts
@@ -1,0 +1,100 @@
+import { createFileRoute } from '@tanstack/react-router'
+import * as Address from 'ox/Address'
+import { Abis, Addresses } from 'viem/tempo'
+import { getChainId, readContracts } from 'wagmi/actions'
+import { getTokenListAddresses } from '#lib/server/tokens'
+import { getWagmiConfig } from '#wagmi.config'
+
+export type FeeAmmPool = {
+	userToken: string
+	validatorToken: string
+	reserveUserToken: string
+	reserveValidatorToken: string
+}
+
+export type FeeAmmPoolsResponse = {
+	pools: FeeAmmPool[]
+}
+
+const MAX_TOKENS = 32
+
+export const Route = createFileRoute('/api/fee-amm/pools')({
+	server: {
+		handlers: {
+			GET: async () => {
+				try {
+					const config = getWagmiConfig()
+					const chainId = getChainId(config)
+					const addressSet = await getTokenListAddresses(chainId)
+					const tokenAddresses = [...addressSet]
+						.filter((a) => Address.validate(a))
+						.slice(0, MAX_TOKENS) as `0x${string}`[]
+
+					if (tokenAddresses.length === 0) {
+						return Response.json({ pools: [] } satisfies FeeAmmPoolsResponse, {
+							headers: { 'Cache-Control': 'public, max-age=60' },
+						})
+					}
+
+					const pairs: Array<{
+						userToken: `0x${string}`
+						validatorToken: `0x${string}`
+					}> = []
+					for (const a of tokenAddresses) {
+						for (const b of tokenAddresses) {
+							if (a.toLowerCase() !== b.toLowerCase()) {
+								pairs.push({ userToken: a, validatorToken: b })
+							}
+						}
+					}
+
+					const results = await readContracts(config, {
+						contracts: pairs.map((pair) => ({
+							address: Addresses.feeManager,
+							abi: Abis.feeAmm,
+							functionName: 'getPool' as const,
+							args: [pair.userToken, pair.validatorToken] as const,
+						})),
+					})
+
+					const pools: FeeAmmPool[] = []
+					for (let i = 0; i < pairs.length; i++) {
+						const result = results[i]
+						if (result.status !== 'success' || !result.result) continue
+
+						const pool = result.result as {
+							reserveUserToken: bigint
+							reserveValidatorToken: bigint
+						}
+						if (
+							pool.reserveUserToken === 0n &&
+							pool.reserveValidatorToken === 0n
+						) {
+							continue
+						}
+
+						pools.push({
+							userToken: pairs[i].userToken,
+							validatorToken: pairs[i].validatorToken,
+							reserveUserToken: pool.reserveUserToken.toString(),
+							reserveValidatorToken: pool.reserveValidatorToken.toString(),
+						})
+					}
+
+					return Response.json({ pools } satisfies FeeAmmPoolsResponse, {
+						headers: {
+							'Cache-Control':
+								'public, max-age=300, stale-while-revalidate=600',
+						},
+					})
+				} catch (error) {
+					console.error('[fee-amm/pools]', error)
+					return Response.json(
+						{ pools: [], error: 'Internal server error' },
+						{ status: 500 },
+					)
+				}
+			},
+		},
+	},
+})


### PR DESCRIPTION
Adds `GET /api/fee-amm/pools` to the explorer.

Instead of scanning all historical Mint events from TIDX (which times out with 422 on full-chain range queries), this reads pool state directly from the FeeAMM contract at `0xfeeC000000000000000000000000000000000000` via RPC multicall.

**How it works:**
- Fetches the tokenlist (6 tokens today, already cached with 5-min TTL)
- Generates all `n*(n-1)` directional pairs (30 for 6 tokens)
- Calls `getPool(userToken, validatorToken)` for each pair via batched `readContracts`
- Returns only pools with non-zero reserves
- Capped at 32 tokens max to bound the O(n²) expansion

Responses are cached with `Cache-Control: public, max-age=300, stale-while-revalidate=600`.

Prompted by: Alex