### PR TITLE
feat(contract-verification): dynamic TIP-20 ABI resolution for any token address

### DIFF
--- a/apps/contract-verification/src/route.lookup.ts
+++ b/apps/contract-verification/src/route.lookup.ts
@@ -19,6 +19,7 @@ import {
 import { getLogger } from '#lib/logger.ts'
 import { chainIds } from '#wagmi.config.ts'
 import { formatError, getDb, sourcifyError } from '#lib/utilities.ts'
+import { tip20 as tip20Abi } from 'viem/tempo/Abis'
 
 const logger = getLogger(['tempo'])
 
@@ -322,6 +323,84 @@ function buildSourcesPayload(
 	return { sources, sourceIds, paths }
 }
 
+function buildDynamicTip20Response(
+	chainIdNumber: number,
+	address: string,
+): {
+	minimalResponse: MinimalLookupResponse
+	fullResponse: Record<string, unknown>
+} {
+	const matchId = `native:tip20:${chainIdNumber}:${address}`
+	const minimalResponse: MinimalLookupResponse = {
+		matchId,
+		match: 'exact_match',
+		creationMatch: null,
+		runtimeMatch: 'exact_match',
+		chainId: String(chainIdNumber),
+		address,
+		verifiedAt: null,
+	}
+
+	const signatures = buildSignaturesPayload(tip20Abi)
+	const fullResponse: Record<string, unknown> = {
+		...minimalResponse,
+		transactionHash: null,
+		blockNumber: null,
+		name: 'TIP-20 Token',
+		fullyQualifiedName: null,
+		compiler: null,
+		compilerVersion: null,
+		language: 'Solidity',
+		compilerSettings: null,
+		runtimeMetadataMatch: null,
+		creationMetadataMatch: null,
+		abi: tip20Abi,
+		userdoc: null,
+		devdoc: null,
+		storageLayout: null,
+		metadata: null,
+		sources: {},
+		sourceIds: {},
+		signatures,
+		creationBytecode: null,
+		runtimeBytecode: null,
+		compilation: null,
+		deployment: {
+			chainId: String(chainIdNumber),
+			address,
+			transactionHash: null,
+			blockNumber: null,
+			transactionIndex: null,
+			deployer: null,
+		},
+		stdJsonInput: null,
+		stdJsonOutput: null,
+		proxyResolution: null,
+		docsUrl: 'https://docs.tempo.xyz/protocol/tip20/overview',
+		extensions: {
+			tempo: {
+				nativeSource: {
+					kind: 'precompile',
+					language: 'Solidity',
+					bytecodeVerified: false,
+					repository: 'tempoxyz/tempo',
+					commit: null,
+					commitUrl: null,
+					paths: [],
+					entrypoints: [],
+					activation: {
+						protocolVersion: null,
+						fromBlock: null,
+						toBlock: null,
+					},
+				},
+			},
+		},
+	}
+
+	return { minimalResponse, fullResponse }
+}
+
 async function getNativeLookupResponse(
 	db: ReturnType<typeof getDb>,
 	chainIdNumber: number,
@@ -350,7 +429,15 @@ async function getNativeLookupResponse(
 		)
 		.limit(1)
 
-	if (!nativeContract) return null
+	if (!nativeContract) {
+		// Dynamic TIP-20 token detection: all TIP-20 tokens are precompiles at 0x20c0... addresses.
+		// They share the same ABI but aren't individually seeded into the native contracts table.
+		const addressHex = bytesToHex(addressBytes)
+		if (addressHex.toLowerCase().startsWith('0x20c000000')) {
+			return buildDynamicTip20Response(chainIdNumber, addressHex)
+		}
+		return null
+	}
 
 	const [revision] = await db
 		.select({
@@ -561,6 +648,20 @@ lookupRoute
 					Number(a.chainId) - Number(b.chainId) ||
 					a.address.localeCompare(b.address),
 			)
+
+			// Dynamic TIP-20 fallback: if no results found and address is a TIP-20 token,
+			// return entries for all chains using the shared TIP-20 ABI
+			if (
+				contracts.length === 0 &&
+				address.toLowerCase().startsWith('0x20c000000')
+			) {
+				return context.json({
+					results: chainIds.map(
+						(id) =>
+							buildDynamicTip20Response(id, address).minimalResponse,
+					),
+				})
+			}
 
 			return context.json({ results: contracts })
 		} catch (error) {


### PR DESCRIPTION
## Summary

TIP-20 tokens are precompiles that all share the same ABI but live at dynamically-created `0x20c0...` addresses. They can't all be seeded into the `native_contracts` table since there are unlimited of them.

This adds a dynamic fallback in the contract lookup route: when a lookup for an unregistered `0x20c0...` address would return 404, we now return the TIP-20 ABI (from `viem/tempo`) with proper native contract metadata.

## Problem

Tools like Tenderly can't decode TIP-20 transactions because `contracts.tempo.xyz` returns 404 for individual token addresses:

```
GET /v2/contract/42431/0x20C00000000000000000000000b4860ed80607C1?fields=abi
→ 404 contract_not_found
```

## Solution

Added `buildDynamicTip20Response()` that constructs a synthetic native contract response using the TIP-20 ABI from viem. The fallback is triggered in `getNativeLookupResponse()` when:
1. The address is not in the DB (neither verified nor native)
2. The address starts with `0x20c000000` (the TIP-20 address prefix)

This covers both endpoints:
- `GET /v2/contract/:chainId/:address` — returns full ABI + metadata with field selection support
- `GET /v2/contract/all-chains/:address` — returns minimal entries for all chains

## After this change

```
GET /v2/contract/42431/0x20C00000000000000000000000b4860ed80607C1?fields=abi
→ 200 { matchId: "native:tip20:42431:0x20C0...", abi: [...], ... }
```

Tenderly (and any Sourcify-compatible tool) can now decode `mint`, `transfer`, `burn`, errors, and events for any TIP-20 token.

Co-Authored-By: joshitzko <82132285+joshitzko@users.noreply.github.com>

Prompted by: josh