### PR TITLE
feat(explorer): label MPP Contract address

### DIFF
--- a/apps/explorer/src/lib/account.ts
+++ b/apps/explorer/src/lib/account.ts
@@ -72,7 +72,7 @@ const taggedAccounts: Record<Address.Address, AccountTag> = {
 	// mpp
 	'0x33b901018174ddabe4841042ab76ba85d4e24f25': {
 		id: 'mpp:contract',
-		label: 'MPP Contract',
+		label: 'MPP Escrow',
 	},
 }
 

--- a/apps/explorer/src/lib/account.ts
+++ b/apps/explorer/src/lib/account.ts
@@ -69,6 +69,11 @@ const taggedAccounts: Record<Address.Address, AccountTag> = {
 		id: 'genesis-token:thetausd',
 		label: 'ThetaUSD',
 	},
+	// mpp
+	'0x33b901018174ddabe4841042ab76ba85d4e24f25': {
+		id: 'mpp:contract',
+		label: 'MPP Contract',
+	},
 }
 
 export function getAccountTag(

--- a/apps/explorer/src/lib/account.ts
+++ b/apps/explorer/src/lib/account.ts
@@ -71,7 +71,7 @@ const taggedAccounts: Record<Address.Address, AccountTag> = {
 	},
 	// mpp
 	'0x33b901018174ddabe4841042ab76ba85d4e24f25': {
-		id: 'mpp:contract',
+		id: 'mpp:escrow',
 		label: 'MPP Escrow',
 	},
 }


### PR DESCRIPTION
Labels `0x33b901018174ddabe4841042ab76ba85d4e24f25` as **MPP Contract** in the block explorer's tagged accounts registry.

Prompted by: Georgios