### PR TITLE
fix(explorer): unwrap zero-address root from callTracer trace

### DIFF
--- a/apps/explorer/src/lib/queries/trace.ts
+++ b/apps/explorer/src/lib/queries/trace.ts
@@ -1,5 +1,6 @@
 import { queryOptions } from '@tanstack/react-query'
 import type { Address, Hex } from 'ox'
+import { zeroAddress } from 'viem'
 import { getWagmiConfig } from '#wagmi.config.ts'
 
 export interface CallTrace {
@@ -55,7 +56,14 @@ export async function fetchTraceData(hash: Hex.Hex): Promise<TraceData> {
 			} as Parameters<typeof client.request>[0]) as Promise<PrestateDiff>
 		).catch(() => null),
 	])
-	return { trace, prestate }
+	// Tempo's callTracer wraps the real execution in a system-level CALL to the
+	// zero address. Unwrap it so the trace tree starts at the actual transaction.
+	const unwrapped =
+		trace?.to === zeroAddress && trace.calls?.length === 1
+			? trace.calls[0]
+			: trace
+
+	return { trace: unwrapped ?? null, prestate }
 }
 
 export function traceQueryOptions(params: { hash: string }) {


### PR DESCRIPTION
Tempo's `callTracer` wraps the real execution in a system-level CALL to `0x0000000000000000000000000000000000000000`. This makes the trace tree show a confusing `0x000...000.call()` as the root instead of the actual contract call.

When the root trace targets the zero address and has exactly one child, unwrap it so the trace tree starts at the actual transaction.

Prompted by: Georgios