### PR TITLE
feat(explorer): streamed payment demo via ?voucher URL param

### DIFF
--- a/apps/explorer/src/routes/_layout/address/$address.tsx
+++ b/apps/explorer/src/routes/_layout/address/$address.tsx
@@ -44,6 +44,8 @@ import {
 	TransactionDescription,
 	TransactionTimestamp,
 } from '#comps/TxTransactionRow'
+import { TxEventDescription } from '#comps/TxEventDescription'
+import type { KnownEvent } from '#lib/domain/known-events'
 import { TransactionFilters } from '#comps/TransactionFilters'
 import { cx } from '#lib/css'
 import {
@@ -166,6 +168,13 @@ export const Route = createFileRoute('/_layout/address/$address')({
 		status: z.optional(z.enum(['success', 'reverted'])),
 		dir: z.optional(z.enum(['sent', 'received'])),
 		period: z.optional(z.enum(['24h', '7d'])),
+		voucher: z.optional(
+			z.object({
+				final_voucher: z.optional(z.string()),
+				packet_size: z.optional(z.coerce.number()),
+				number: z.optional(z.coerce.number()),
+			}),
+		),
 	}),
 	search: {
 		middlewares: [stripSearchParams(defaultSearchValues)],
@@ -867,6 +876,7 @@ function SectionsWrapper(props: {
 		onPeriodChange,
 	} = props
 	const { timeFormat, cycleTimeFormat, formatLabel } = useTimeFormat()
+	const { voucher } = Route.useSearch()
 
 	const after = React.useMemo(() => {
 		if (period === '24h') return Math.floor(Date.now() / 1000) - 86400
@@ -1296,40 +1306,53 @@ function SectionsWrapper(props: {
 								tabs: transactionsColumns,
 							}}
 							items={() =>
-								transactions.map((transaction) => ({
-									cells: [
-										<TransactionTimeCell
-											key="time"
-											timestamp={transaction.timestamp}
-											hash={transaction.hash}
-											format={timeFormat}
-										/>,
-										<TransactionDescCell
-											key="desc"
-											transaction={transaction}
-											accountAddress={address}
-										/>,
-										<Midcut
-											key="hash"
-											value={transaction.hash}
-											prefix="0x"
-											align="end"
-										/>,
-										<TransactionFeeCell
-											key="fee"
-											gasUsed={transaction.gasUsed}
-											effectiveGasPrice={transaction.effectiveGasPrice}
-										/>,
-										<TransactionTotalCell
-											key="total"
-											transaction={transaction}
-										/>,
-									],
-									link: {
-										href: `/receipt/${transaction.hash}`,
-										title: `View receipt ${transaction.hash}`,
-									},
-								}))
+								transactions.map((transaction) => {
+									const isVoucherMatch =
+										voucher?.final_voucher &&
+										transaction.hash.toLowerCase() ===
+											voucher.final_voucher.toLowerCase()
+									return {
+										cells: [
+											<TransactionTimeCell
+												key="time"
+												timestamp={transaction.timestamp}
+												hash={transaction.hash}
+												format={timeFormat}
+											/>,
+											<TransactionDescCell
+												key="desc"
+												transaction={transaction}
+												accountAddress={address}
+											/>,
+											<Midcut
+												key="hash"
+												value={transaction.hash}
+												prefix="0x"
+												align="end"
+											/>,
+											<TransactionFeeCell
+												key="fee"
+												gasUsed={transaction.gasUsed}
+												effectiveGasPrice={transaction.effectiveGasPrice}
+											/>,
+											<TransactionTotalCell
+												key="total"
+												transaction={transaction}
+											/>,
+										],
+										link: {
+											href: `/receipt/${transaction.hash}`,
+											title: `View receipt ${transaction.hash}`,
+										},
+										expanded: isVoucherMatch ? (
+											<StreamedPaymentReceipt
+												transaction={transaction}
+												packetSize={voucher.packet_size ?? 0}
+												packetCount={voucher.number ?? 0}
+											/>
+										) : undefined,
+									}
+								})
 							}
 							totalItems={totalTrxCount ?? transactions.length}
 							pages={
@@ -2013,6 +2036,88 @@ function FilterIndicator(props: {
 			>
 				<XIcon className="size-3.5 translate-y-px" />
 			</Link>
+		</div>
+	)
+}
+
+function StreamedPaymentReceipt(props: {
+	transaction: EnrichedTransaction
+	packetSize: number
+	packetCount: number
+}) {
+	const { transaction, packetSize, packetCount } = props
+
+	// Extract payee from the settlement/close channel event
+	const payee = transaction.knownEvents.find(
+		(e) => e.type === 'settle channel' || e.type === 'close channel',
+	)?.meta?.to
+
+	const packetMicros = BigInt(Math.round(packetSize * 1_000_000))
+	const voucherEvent: KnownEvent = {
+		type: 'send',
+		parts: [
+			{ type: 'action', value: 'Pay' },
+			...(TEMPO_FEE_TOKEN
+				? ([
+						{
+							type: 'amount',
+							value: { value: packetMicros, decimals: 6, token: TEMPO_FEE_TOKEN },
+						},
+					] as KnownEvent['parts'])
+				: []),
+			...(payee
+				? ([
+						{ type: 'text', value: 'to' },
+						{ type: 'account', value: payee },
+					] as KnownEvent['parts'])
+				: []),
+		],
+	}
+
+	const digits = String(packetCount).length
+
+	return (
+		<div className="pb-4 font-mono text-[13px]">
+			{/* On-chain settlement — visually part of the main row */}
+			<div className="bg-base-alt -mx-[16px] px-[16px] py-[10px] border-b-2 border-base-border flex items-center">
+				<span className="text-tertiary tabular-nums text-right shrink-0 mr-[10px]"
+					style={{ minWidth: `${digits}ch` }}
+				>
+					↓
+				</span>
+				<span className="text-[11px] text-accent shrink-0 w-[64px] italic">on-chain</span>
+				{transaction.knownEvents.filter(e => e.type === 'settle channel' || e.type === 'close channel').map((e, i) => (
+					<TxEventDescription key={i} event={e} />
+				))}
+			</div>
+
+			{/* Off-chain section header */}
+			<div className="flex items-center gap-[8px] pt-[12px] pb-[6px] text-[11px] text-tertiary uppercase tracking-wider">
+				<span>off-chain vouchers</span>
+				<span className="flex-1 border-t border-dashed border-distinct" />
+				<span>{packetCount.toLocaleString()}</span>
+			</div>
+
+			{/* Off-chain voucher rows */}
+			{Array.from({ length: packetCount }, (_, i) => (
+				<div
+					key={i}
+					className="flex items-center py-[9px] border-b border-dashed border-distinct"
+				>
+					<span className="text-tertiary tabular-nums text-right shrink-0 mr-[10px]"
+						style={{ minWidth: `${digits}ch` }}
+					>
+						{i + 1}
+					</span>
+					<span className="text-[11px] text-tertiary shrink-0 w-[64px]">off-chain</span>
+					<div className="flex items-center gap-[10px] ml-auto">
+						<TxEventDescription.Part part={{ type: 'action', value: 'Pay' }} />
+						{voucherEvent.parts.filter(p => p.type === 'amount').map((p, j) => (
+							<TxEventDescription.Part key={j} part={p} />
+						))}
+					</div>
+				</div>
+			))}
 		</div>
 	)
 }

--- a/apps/explorer/src/routes/_layout/receipt/$hash.tsx
+++ b/apps/explorer/src/routes/_layout/receipt/$hash.tsx
@@ -16,7 +16,11 @@ import { NotFound } from '#comps/NotFound'
 import { Receipt } from '#comps/Receipt'
 import { useTokenListMembership } from '#comps/TokenListMembership'
 import { apostrophe } from '#lib/chars'
-import { decodeKnownCall, parseKnownEvents } from '#lib/domain/known-events'
+import {
+	decodeKnownCall,
+	parseKnownEvents,
+	type KnownEvent,
+} from '#lib/domain/known-events'
 import { getFeeBreakdown, LineItems } from '#lib/domain/receipt'
 import * as Tip20 from '#lib/domain/tip20'
 import { DateFormatter, PriceFormatter } from '#lib/formatting'
@@ -132,6 +136,15 @@ export const Route = createFileRoute('/_layout/receipt/$hash')({
 			data={data as NotFound.NotFoundData}
 		/>
 	),
+	validateSearch: z.object({
+		voucher: z.optional(
+			z.object({
+				final_voucher: z.optional(z.string()),
+				packet_size: z.optional(z.coerce.number()),
+				number: z.optional(z.coerce.number()),
+			}),
+		),
+	}).parse,
 	headers: () => ({
 		...(import.meta.env.PROD
 			? {
@@ -342,12 +355,27 @@ export const Route = createFileRoute('/_layout/receipt/$hash')({
 	},
 })
 
+function parseVoucherParam(
+	raw:
+		| { final_voucher?: string; packet_size?: number; number?: number }
+		| undefined,
+): { packetSize: number; packetCount: number } | null {
+	if (!raw) return null
+	const packetSize = Number(raw.packet_size)
+	const packetCount = Number(raw.number)
+	if (!Number.isFinite(packetSize) || !Number.isFinite(packetCount)) return null
+	return { packetSize, packetCount }
+}
+
 function Component() {
 	const { hash } = Route.useParams()
+	const { voucher: voucherRaw } = Route.useSearch()
 	const navigate = useNavigate()
 	const loaderData = Route.useLoaderData() as Awaited<
 		ReturnType<typeof fetchReceiptData>
 	>
+
+	const voucherData = parseVoucherParam(voucherRaw)
 
 	const { data } = useQuery({
 		...receiptDetailQueryOptions({ hash }),
@@ -358,8 +386,9 @@ function Component() {
 		t: () => navigate({ to: '/tx/$hash', params: { hash } }),
 	})
 
-	const { block, feeBreakdown, knownEvents, lineItems, receipt } = data
 	const { areTokensListed, isTokenListed } = useTokenListMembership()
+
+	const { block, feeBreakdown, knownEvents, lineItems, receipt } = data
 
 	const feePrice = lineItems.feeTotals?.[0]?.price
 	const previousFee = feePrice
@@ -389,8 +418,28 @@ function Component() {
 		? PriceFormatter.format(fee)
 		: PriceFormatter.formatAmountShort(feeRaw)
 
+	// Inject a streaming payment event when voucher params are present
+	const displayEvents: KnownEvent[] = voucherData
+		? [
+				buildStreamedPaymentEvent(
+					voucherData.packetSize,
+					voucherData.packetCount,
+				),
+				...knownEvents,
+			]
+		: knownEvents
+
+	// When a voucher is present, show the streaming total as the receipt total
+	const streamingTotal = voucherData
+		? voucherData.packetSize * voucherData.packetCount
+		: undefined
+
 	const total =
-		previousTotal !== undefined ? previousTotal - previousFee + fee : fee
+		streamingTotal !== undefined
+			? streamingTotal
+			: previousTotal !== undefined
+				? previousTotal - previousFee + fee
+				: fee
 	const totalTokenAddresses = lineItems.totals
 		.map((item) => item.price?.token)
 		.filter((token): token is `0x${string}` => Boolean(token))
@@ -398,7 +447,12 @@ function Component() {
 		totalTokenAddresses.length > 0
 			? areTokensListed(TEMPO_CHAIN_ID, totalTokenAddresses)
 			: showUsdFeePrefix
-	const totalDisplayValue = previousTotal !== undefined ? previousTotal : total
+	const totalDisplayValue =
+		streamingTotal !== undefined
+			? streamingTotal
+			: previousTotal !== undefined
+				? previousTotal
+				: total
 	const totalDisplay = showUsdTotalPrefix
 		? PriceFormatter.format(totalDisplayValue)
 		: PriceFormatter.formatAmountShort(String(totalDisplayValue))
@@ -407,7 +461,7 @@ function Component() {
 		<div className="font-mono text-[13px] flex flex-col items-center justify-center gap-8 pt-16 pb-8 grow print:pt-8 print:pb-0 print:grow-0">
 			<Receipt
 				blockNumber={receipt.blockNumber}
-				events={knownEvents}
+				events={displayEvents}
 				fee={fee}
 				feeBreakdown={feeBreakdown}
 				feeDisplay={feeDisplay}
@@ -420,6 +474,47 @@ function Component() {
 			/>
 		</div>
 	)
+}
+
+/**
+ * Builds a synthetic KnownEvent representing a streamed (off-chain) payment session.
+ * The final voucher proves all prior off-chain packets were authorized.
+ */
+function buildStreamedPaymentEvent(
+	packetSize: number,
+	packetCount: number,
+): KnownEvent {
+	const totalMicros = BigInt(Math.round(packetSize * packetCount * 1_000_000))
+
+	const parts: KnownEvent['parts'] = [
+		{ type: 'action', value: 'Streamed Payment' },
+	]
+
+	// Include total amount using pathUSD (6 decimals) if the fee token is available
+	if (TEMPO_FEE_TOKEN) {
+		parts.push({
+			type: 'amount',
+			value: {
+				value: totalMicros,
+				decimals: 6,
+				token: TEMPO_FEE_TOKEN,
+				symbol: 'pathUSD',
+			},
+		})
+	}
+
+	return {
+		type: 'streamed payment',
+		parts,
+		note: [
+			[
+				'Packets',
+				{ type: 'number', value: [BigInt(packetCount), 0] as [bigint, number] },
+			],
+			['Per packet', { type: 'text', value: `$${packetSize}` }],
+			['Settlement', { type: 'text', value: 'final voucher proven on-chain' }],
+		],
+	}
 }
 
 namespace TextRenderer {


### PR DESCRIPTION
Adds support for visualizing off-chain MPP voucher streams on the block explorer. The final settlement tx hash anchors the whole session.

- /receipt/$hash?voucher={"final_voucher":"0x...","packet_size":0.01,"number":1000} injects a synthetic "Streamed Payment" event into the receipt view

- /address/$address?voucher={...} expands the matching settlement tx row inline with a full voucher breakdown: on-chain settle event at top, labeled divider, then each off-chain Pay voucher as a numbered row


Committed-By-Agent: claude