### PR TITLE
fix: avoid double-counting forwarded transaction totals

### DIFF
--- a/apps/explorer/src/comps/TxTransactionRow.tsx
+++ b/apps/explorer/src/comps/TxTransactionRow.tsx
@@ -10,6 +10,10 @@ import { useTokenListMembership } from '#comps/TokenListMembership'
 import { FormattedTimestamp, type TimeFormat } from '#comps/TimeFormat'
 import { TxEventDescription } from '#comps/TxEventDescription'
 import type { KnownEvent } from '#lib/domain/known-events'
+import {
+	calculateKnownEventsTotal,
+	NORMALIZED_KNOWN_EVENT_TOTAL_DECIMALS,
+} from '#lib/domain/known-event-totals'
 import { PriceFormatter } from '#lib/formatting'
 import { getFeeTokenForChain } from '#lib/tokenlist'
 import { getTempoChain } from '#wagmi.config.ts'
@@ -166,20 +170,8 @@ export function TransactionTotal(props: { transaction: Transaction }) {
 			/>
 		)
 
-	// For each event, take the max amount (avoids double-counting swap legs),
-	// then sum across events.
-	const normalizedDecimals = 18
-	const totalValue = events.reduce((sum, event) => {
-		let maxAmount = 0n
-		for (const part of event.parts) {
-			if (part.type !== 'amount') continue
-			const decimals = part.value.decimals ?? 6
-			const scale = 10n ** BigInt(normalizedDecimals - decimals)
-			const normalized = part.value.value * scale
-			if (normalized > maxAmount) maxAmount = normalized
-		}
-		return sum + maxAmount
-	}, 0n)
+	const normalizedDecimals = NORMALIZED_KNOWN_EVENT_TOTAL_DECIMALS
+	const totalValue = calculateKnownEventsTotal(events)
 
 	if (totalValue === 0n) {
 		const value = transaction.value ? Hex.toBigInt(transaction.value) : 0n

--- a/apps/explorer/src/lib/domain/known-event-totals.ts
+++ b/apps/explorer/src/lib/domain/known-event-totals.ts
@@ -1,0 +1,79 @@
+import type { KnownEvent } from '#lib/domain/known-events'
+
+export const NORMALIZED_KNOWN_EVENT_TOTAL_DECIMALS = 18
+
+type AmountValue = KnownEvent['parts'][number] & { type: 'amount' }
+
+type Flow = {
+	inflow: bigint
+	outflow: bigint
+}
+
+function toBigInt(value: bigint | string | number): bigint {
+	return typeof value === 'bigint' ? value : BigInt(value)
+}
+
+function normalizeAmount(part: AmountValue): bigint {
+	const decimals = part.value.decimals ?? 6
+	const value = toBigInt(part.value.value as bigint | string | number)
+	const decimalDelta = NORMALIZED_KNOWN_EVENT_TOTAL_DECIMALS - decimals
+
+	if (decimalDelta === 0) return value
+	if (decimalDelta > 0) return value * 10n ** BigInt(decimalDelta)
+	return value / 10n ** BigInt(-decimalDelta)
+}
+
+export function calculateKnownEventsTotal(
+	events: readonly KnownEvent[],
+): bigint {
+	let fallbackTotal = 0n
+	const flowsByToken = new Map<string, Map<string, Flow>>()
+
+	for (const event of events) {
+		const amounts = event.parts.filter(
+			(part): part is AmountValue => part.type === 'amount',
+		)
+		if (amounts.length === 0) continue
+
+		const from = event.meta?.from?.toLowerCase()
+		const to = event.meta?.to?.toLowerCase()
+
+		if (!from || !to) {
+			fallbackTotal += amounts.reduce((max, part) => {
+				const amount = normalizeAmount(part)
+				return amount > max ? amount : max
+			}, 0n)
+			continue
+		}
+
+		for (const part of amounts) {
+			const token = part.value.token.toLowerCase()
+			const amount = normalizeAmount(part)
+			let flows = flowsByToken.get(token)
+			if (!flows) {
+				flows = new Map()
+				flowsByToken.set(token, flows)
+			}
+
+			const fromFlow = flows.get(from) ?? { inflow: 0n, outflow: 0n }
+			fromFlow.outflow += amount
+			flows.set(from, fromFlow)
+
+			const toFlow = flows.get(to) ?? { inflow: 0n, outflow: 0n }
+			toFlow.inflow += amount
+			flows.set(to, toFlow)
+		}
+	}
+
+	let netOutflowTotal = 0n
+	for (const flows of flowsByToken.values()) {
+		let maxNetOutflow = 0n
+		for (const flow of flows.values()) {
+			const netOutflow = flow.outflow - flow.inflow
+			if (netOutflow > maxNetOutflow) maxNetOutflow = netOutflow
+		}
+		netOutflowTotal += maxNetOutflow
+	}
+
+	return netOutflowTotal + fallbackTotal
+}

--- a/apps/explorer/src/routes/_layout/address/$address.tsx
+++ b/apps/explorer/src/routes/_layout/address/$address.tsx
@@ -46,6 +46,10 @@ import {
 } from '#comps/TxTransactionRow'
 import { TxEventDescription } from '#comps/TxEventDescription'
 import type { KnownEvent } from '#lib/domain/known-events'
+import {
+	calculateKnownEventsTotal,
+	NORMALIZED_KNOWN_EVENT_TOTAL_DECIMALS,
+} from '#lib/domain/known-event-totals'
 import { TransactionFilters } from '#comps/TransactionFilters'
 import { cx } from '#lib/css'
 import {
@@ -1789,24 +1793,8 @@ function TransactionTotalCell(props: { transaction: EnrichedTransaction }) {
 			/>
 		)
 
-	// For each event, take the max amount (avoids double-counting swap legs),
-	// then sum across events.
-	const normalizedDecimals = 18
-	const totalValue = events.reduce((sum, event) => {
-		let maxAmount = 0n
-		for (const part of event.parts) {
-			if (part.type !== 'amount') continue
-			const decimals = part.value.decimals ?? 6
-			const scale = 10n ** BigInt(normalizedDecimals - decimals)
-			const value =
-				typeof part.value.value === 'bigint'
-					? part.value.value
-					: BigInt(part.value.value)
-			const normalized = value * scale
-			if (normalized > maxAmount) maxAmount = normalized
-		}
-		return sum + maxAmount
-	}, 0n)
+	const normalizedDecimals = NORMALIZED_KNOWN_EVENT_TOTAL_DECIMALS
+	const totalValue = calculateKnownEventsTotal(events)
 
 	if (totalValue === 0n) {
 		const value = transaction.value

--- a/apps/explorer/test/known-event-totals.node.test.ts
+++ b/apps/explorer/test/known-event-totals.node.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import type { KnownEvent } from '../src/lib/domain/known-events'
+import { calculateKnownEventsTotal } from '../src/lib/domain/known-event-totals'
+
+const senderAddress = `0x${'a'.repeat(40)}` as const
+const forwardedAddress = `0x${'b'.repeat(40)}` as const
+const recipientAddress = `0x${'c'.repeat(40)}` as const
+const tokenAddress = `0x${'d'.repeat(40)}` as const
+
+function sendEvent(params: {
+	from: `0x${string}`
+	to: `0x${string}`
+	amount: bigint
+}): KnownEvent {
+	return {
+		type: 'send',
+		parts: [
+			{ type: 'action', value: 'Send' },
+			{
+				type: 'amount',
+				value: {
+					token: tokenAddress,
+					value: params.amount,
+					decimals: 6,
+					symbol: 'PathUSD',
+				},
+			},
+			{ type: 'text', value: 'to' },
+			{ type: 'account', value: params.to },
+		],
+		meta: { from: params.from, to: params.to },
+	}
+}
+
+describe('calculateKnownEventsTotal', () => {
+	it('uses max net outflow to avoid double-counting forwarded transfers', () => {
+		const amount = 100_000_000n
+		const events = [
+			sendEvent({ from: senderAddress, to: forwardedAddress, amount }),
+			sendEvent({ from: forwardedAddress, to: recipientAddress, amount }),
+		]
+
+		expect(calculateKnownEventsTotal(events)).toBe(100n * 10n ** 18n)
+	})
+})


### PR DESCRIPTION
## Summary
- calculate transaction row totals from max net outflow instead of summing forwarded transfer legs
- share the total calculation across address and transaction rows
- add a regression test for forwarded transfers
