### PR TITLE
fix: prevent mobile transaction grid overlap

### DIFF
--- a/apps/explorer/src/comps/DataGrid.tsx
+++ b/apps/explorer/src/comps/DataGrid.tsx
@@ -77,7 +77,7 @@ export function DataGrid(props: DataGrid.Props) {
 
 	return (
 		<div className="flex flex-col min-h-0">
-			<div className="relative w-full">
+			<div className="relative w-full overflow-x-auto">
 				<div
 					className={cx(
 						'w-full text-[13px] rounded-t-[2px] grid',

--- a/apps/explorer/src/routes/_layout/address/$address.tsx
+++ b/apps/explorer/src/routes/_layout/address/$address.tsx
@@ -1215,12 +1215,13 @@ function SectionsWrapper(props: {
 				/>
 			),
 			align: 'start',
+			minWidth: 86,
 			width: '0.5fr',
 		},
-		{ label: 'Description', align: 'start', width: '2fr' },
-		{ label: 'Hash', align: 'end', width: '1fr' },
-		{ label: 'Fee', align: 'end', width: '0.5fr' },
-		{ label: 'Total', align: 'end', width: '0.5fr' },
+		{ label: 'Description', align: 'start', minWidth: 260, width: '2fr' },
+		{ label: 'Hash', align: 'end', minWidth: 112, width: '1fr' },
+		{ label: 'Fee', align: 'end', minWidth: 64, width: '0.5fr' },
+		{ label: 'Total', align: 'end', minWidth: 72, width: '0.5fr' },
 	]
 
 	const transfersColumns: DataGrid.Column[] = [
@@ -1293,7 +1294,7 @@ function SectionsWrapper(props: {
 					totalItems: totalTrxCount ?? transactions.length,
 					itemsLabel: 'transactions',
 					contextual: (
-						<div className="flex flex-col gap-[10px] min-[800px]:flex-row min-[800px]:items-center min-[800px]:justify-end">
+						<div className="flex items-center justify-start gap-[8px] min-[800px]:justify-end">
 							<TransactionFilters
 								status={status}
 								period={period}

--- a/apps/explorer/src/routes/_layout/address/$address.tsx
+++ b/apps/explorer/src/routes/_layout/address/$address.tsx
@@ -1294,7 +1294,7 @@ function SectionsWrapper(props: {
 					totalItems: totalTrxCount ?? transactions.length,
 					itemsLabel: 'transactions',
 					contextual: (
-						<div className="flex items-center justify-start gap-[8px] min-[800px]:justify-end">
+						<div className="flex items-center justify-end gap-[8px]">
 							<TransactionFilters
 								status={status}
 								period={period}


### PR DESCRIPTION
## Summary
- make data grids horizontally scroll when their columns exceed the viewport
- add minimum widths to address transaction columns so cells do not overlap on small screens
- keep the transaction filter and CSV export controls side-by-side on mobile

## Validation
- pnpm check:types
- pnpm check:biome


before
<img width="523" height="622" alt="image" src="https://github.com/user-attachments/assets/b62137df-2f69-4b72-976b-c1f1b1bd773b" />

after
<img width="492" height="508" alt="CleanShot 2026-04-27 at 22 52 40" src="https://github.com/user-attachments/assets/e669cd3f-fbb2-4e72-b41f-709190bdc383" />
