### PR TITLE
fix: label virtual address forwarded transfers

### DIFF
--- a/apps/explorer/src/lib/domain/known-events.ts
+++ b/apps/explorer/src/lib/domain/known-events.ts
@@ -1,4 +1,5 @@
 import * as Address from 'ox/Address'
+import { VirtualAddress } from 'ox/tempo'
 import type * as Hex from 'ox/Hex'
 import type { AbiEvent, Log, TransactionReceipt } from 'viem'
 import { decodeFunctionData, parseEventLogs, zeroAddress } from 'viem'
@@ -567,7 +568,10 @@ function createDetectors(
 					type: 'send',
 					note: 'memo' in args ? decodeMemoForDisplay(args.memo) : undefined,
 					parts: [
-						{ type: 'action', value: 'Send' },
+						{
+							type: 'action',
+							value: VirtualAddress.validate(args.from) ? 'Forwarded' : 'Send',
+						},
 						{
 							type: 'amount',
 							value: createAmount(args.amount, address),

--- a/apps/explorer/test/known-events.test.ts
+++ b/apps/explorer/test/known-events.test.ts
@@ -83,6 +83,56 @@ describe('parseKnownEvents', () => {
 		expect(knownEvents[0]?.type).toBe('approval')
 	})
 
+	it('labels virtual address outgoing transfers as forwarded', () => {
+		const hash = `0x${'5'.repeat(64)}` as const
+		const virtualAddress = '0xb385A519FDFDFDfdfdFDfdFdFDFD000000000001' as const
+		const amount = 100_000_000n
+		const logs = [
+			mockLog(
+				{
+					address: userTokenAddress,
+					topics: encodeEventTopics({
+						abi: Abis.tip20,
+						eventName: 'Transfer',
+						args: {
+							from: accountAddress,
+							to: virtualAddress,
+						},
+					}) as [Hex.Hex, ...Hex.Hex[]],
+					data: encodeAbiParameters([{ type: 'uint256' }], [amount]),
+				},
+				hash,
+			),
+			mockLog(
+				{
+					address: userTokenAddress,
+					topics: encodeEventTopics({
+						abi: Abis.tip20,
+						eventName: 'Transfer',
+						args: {
+							from: virtualAddress,
+							to: recipientAddress,
+						},
+					}) as [Hex.Hex, ...Hex.Hex[]],
+					data: encodeAbiParameters([{ type: 'uint256' }], [amount]),
+				},
+				hash,
+			),
+		]
+
+		const receipt = mockReceipt(logs, accountAddress, hash)
+		const knownEvents = parseKnownEvents(receipt, { getTokenMetadata })
+
+		expect(knownEvents[0]?.parts[0]).toEqual({
+			type: 'action',
+			value: 'Send',
+		})
+		expect(knownEvents[1]?.parts[0]).toEqual({
+			type: 'action',
+			value: 'Forwarded',
+		})
+	})
+
 	it('deduplicates bounce-back transfers against BounceBack events', () => {
 		const hash = `0x${'2'.repeat(64)}` as const
 		const amount = 1_000_000n


### PR DESCRIPTION
## Summary
- label TIP20 transfers sent from a virtual address as `Forwarded` instead of `Send`
- add a regression test for virtual address transfer legs

## Validation
- pnpm check:types
- pnpm vitest run test/known-events.test.ts -t "virtual address"
- pnpm check:biome