### PR TITLE
fix(explorer): update MPP session event labels

### DIFF
--- a/apps/explorer/src/comps/Receipt.tsx
+++ b/apps/explorer/src/comps/Receipt.tsx
@@ -140,17 +140,21 @@ export function Receipt(props: Receipt.Props) {
 									(part) => part.type === 'amount',
 								)
 								const firstAmountPart = amountParts[0]
-								const amountTokenAddresses = amountParts.flatMap((part) =>
-									part.type === 'amount' ? [part.value.token] : [],
-								)
+								const displayTotalAmount = event.totalAmount
+								const amountTokenAddresses = displayTotalAmount
+									? [displayTotalAmount.token]
+									: amountParts.flatMap((part) =>
+											part.type === 'amount' ? [part.value.token] : [],
+										)
 								const showUsdPrefix =
 									amountTokenAddresses.length > 0
 										? areTokensListed(TEMPO_CHAIN_ID, amountTokenAddresses)
 										: TEMPO_FEE_TOKEN
 											? isTokenListed(TEMPO_CHAIN_ID, TEMPO_FEE_TOKEN)
 											: true
-								const totalAmountBigInt =
-									event.type === 'swap' && amountParts.length > 0
+								const totalAmountBigInt = displayTotalAmount
+									? displayTotalAmount.value
+									: event.type === 'swap' && amountParts.length > 0
 										? firstAmountPart?.type === 'amount'
 											? firstAmountPart.value.value
 											: 0n
@@ -159,8 +163,9 @@ export function Receipt(props: Receipt.Props) {
 													return sum + part.value.value
 												return sum
 											}, 0n)
-								const decimals =
-									firstAmountPart?.type === 'amount'
+								const decimals = displayTotalAmount
+									? (displayTotalAmount.decimals ?? 6)
+									: firstAmountPart?.type === 'amount'
 										? (firstAmountPart.value.decimals ?? 6)
 										: 6
 

--- a/apps/explorer/src/lib/domain/known-event-totals.ts
+++ b/apps/explorer/src/lib/domain/known-event-totals.ts
@@ -2,7 +2,8 @@ import type { KnownEvent } from '#lib/domain/known-events'
 
 export const NORMALIZED_KNOWN_EVENT_TOTAL_DECIMALS = 18
 
-type AmountValue = KnownEvent['parts'][number] & { type: 'amount' }
+type Amount = NonNullable<KnownEvent['totalAmount']>
+type AmountPart = KnownEvent['parts'][number] & { type: 'amount' }
 
 type Flow = {
 	inflow: bigint
@@ -13,9 +14,9 @@ function toBigInt(value: bigint | string | number): bigint {
 	return typeof value === 'bigint' ? value : BigInt(value)
 }
 
-function normalizeAmount(part: AmountValue): bigint {
-	const decimals = part.value.decimals ?? 6
-	const value = toBigInt(part.value.value as bigint | string | number)
+function normalizeAmount(amountValue: Amount): bigint {
+	const decimals = amountValue.decimals ?? 6
+	const value = toBigInt(amountValue.value as bigint | string | number)
 	const decimalDelta = NORMALIZED_KNOWN_EVENT_TOTAL_DECIMALS - decimals
 
 	if (decimalDelta === 0) return value
@@ -30,25 +31,27 @@ export function calculateKnownEventsTotal(
 	const flowsByToken = new Map<string, Map<string, Flow>>()
 
 	for (const event of events) {
-		const amounts = event.parts.filter(
-			(part): part is AmountValue => part.type === 'amount',
-		)
+		const amounts = event.totalAmount
+			? [event.totalAmount]
+			: event.parts
+					.filter((part): part is AmountPart => part.type === 'amount')
+					.map((part) => part.value)
 		if (amounts.length === 0) continue
 
 		const from = event.meta?.from?.toLowerCase()
 		const to = event.meta?.to?.toLowerCase()
 
 		if (!from || !to) {
-			fallbackTotal += amounts.reduce((max, part) => {
-				const amount = normalizeAmount(part)
+			fallbackTotal += amounts.reduce((max, amountValue) => {
+				const amount = normalizeAmount(amountValue)
 				return amount > max ? amount : max
 			}, 0n)
 			continue
 		}
 
-		for (const part of amounts) {
-			const token = part.value.token.toLowerCase()
-			const amount = normalizeAmount(part)
+		for (const amountValue of amounts) {
+			const token = amountValue.token.toLowerCase()
+			const amount = normalizeAmount(amountValue)
 			let flows = flowsByToken.get(token)
 			if (!flows) {
 				flows = new Map()

--- a/apps/explorer/src/lib/domain/known-events.ts
+++ b/apps/explorer/src/lib/domain/known-events.ts
@@ -23,6 +23,20 @@ export const streamChannelAbi = [
 	},
 	{
 		type: 'event',
+		name: 'ChannelOpened',
+		inputs: [
+			{ indexed: true, name: 'channelId', type: 'bytes32' },
+			{ indexed: true, name: 'payer', type: 'address' },
+			{ indexed: true, name: 'payee', type: 'address' },
+			{ indexed: false, name: 'token', type: 'address' },
+			{ indexed: false, name: 'authorizedSigner', type: 'address' },
+			{ indexed: false, name: 'salt', type: 'bytes32' },
+			{ indexed: false, name: 'deposit', type: 'uint256' },
+		],
+		anonymous: false,
+	},
+	{
+		type: 'event',
 		name: 'Settled',
 		inputs: [
 			{ indexed: true, name: 'channelId', type: 'bytes32' },
@@ -223,6 +237,16 @@ const abi = [
 const FEE_MANAGER = Addresses.feeManager
 const STABLECOIN_EXCHANGE = Addresses.stablecoinDex
 export const STREAM_CHANNEL = '0x9d136eEa063eDE5418A6BC7bEafF009bBb6CFa70'
+export const STREAM_CHANNELS = [
+	STREAM_CHANNEL,
+	'0xe1c4d3dce17bc111181ddf716f75bae49e61a336',
+] as const
+
+export function isStreamChannelAddress(address: Address.Address): boolean {
+	return STREAM_CHANNELS.some((streamChannel) =>
+		Address.isEqual(address, streamChannel),
+	)
+}
 const KNOWN_ZONES: ReadonlyMap<Address.Address, { name: string }> = new Map([
 	[
 		Address.from('0x7069DeC4E64Fd07334A0933eDe836C17259c9B23'),
@@ -1085,7 +1109,7 @@ function createDetectors(
 		streamChannel(event: ParsedEvent) {
 			const { eventName, args, address } = event
 
-			if (!Address.isEqual(address, STREAM_CHANNEL)) return null
+			if (!isStreamChannelAddress(address)) return null
 
 			if (eventName === 'ChannelOpened') {
 				const { payer, payee, deposit, token } = args as {
@@ -1098,7 +1122,7 @@ function createDetectors(
 				return {
 					type: 'open channel',
 					parts: [
-						{ type: 'action', value: 'Open Channel' },
+						{ type: 'action', value: 'MPP Session Opened' },
 						{ type: 'amount', value: createAmount(deposit, token) },
 						{ type: 'text', value: 'to' },
 						{ type: 'account', value: payee },
@@ -1199,32 +1223,31 @@ function createDetectors(
 					refundedToPayer: bigint
 				}
 				const token = getStreamChannelToken?.(payer, payee)
+				const paidAmount = token
+					? createAmount(settledToPayee, token)
+					: undefined
 
 				return {
 					type: 'close channel',
 					parts: [
-						{ type: 'action', value: 'Close Channel' },
+						{ type: 'action', value: 'MPP Session Closed' },
+						{ type: 'text', value: 'Paid' },
+						paidAmount
+							? {
+									type: 'amount',
+									value: paidAmount,
+								}
+							: { type: 'number', value: settledToPayee },
+						{ type: 'text', value: 'Refunded' },
 						token
 							? {
 									type: 'amount',
-									value: createAmount(settledToPayee, token),
+									value: createAmount(refundedToPayer, token),
 								}
-							: { type: 'number', value: settledToPayee },
-						{ type: 'text', value: 'to' },
-						{ type: 'account', value: payee },
-					],
-					note: [
-						[
-							'Refund',
-							token
-								? {
-										type: 'amount',
-										value: createAmount(refundedToPayer, token),
-									}
-								: { type: 'number', value: refundedToPayer },
-						],
+							: { type: 'number', value: refundedToPayer },
 					],
 					meta: { from: payer, to: payee },
+					totalAmount: paidAmount,
 				}
 			}
 
@@ -1359,6 +1382,7 @@ export interface KnownEvent {
 		from?: Address.Address
 		to?: Address.Address
 	}
+	totalAmount?: Amount
 	failed?: boolean
 }
 
@@ -1913,7 +1937,7 @@ export function parseKnownEvents(
 
 	const streamChannelIndices = new Set<number>()
 	const hasStreamChannelEvents = dedupedEvents.some((event) =>
-		Address.isEqual(event.address, STREAM_CHANNEL),
+		isStreamChannelAddress(event.address),
 	)
 
 	if (hasStreamChannelEvents) {
@@ -1923,7 +1947,7 @@ export function parseKnownEvents(
 			payee: Address.Address
 		}> = []
 		for (const event of dedupedEvents) {
-			if (!Address.isEqual(event.address, STREAM_CHANNEL)) continue
+			if (!isStreamChannelAddress(event.address)) continue
 			const args = event.args as {
 				payer?: Address.Address
 				payee?: Address.Address
@@ -1936,16 +1960,18 @@ export function parseKnownEvents(
 		for (const [index, event] of dedupedEvents.entries()) {
 			if (!isTransferEvent(event)) continue
 
-			const involvesStreamChannel =
-				Address.isEqual(event.args.from, STREAM_CHANNEL) ||
-				Address.isEqual(event.args.to, STREAM_CHANNEL)
+			const streamChannel = STREAM_CHANNELS.find(
+				(streamChannel) =>
+					Address.isEqual(event.args.from, streamChannel) ||
+					Address.isEqual(event.args.to, streamChannel),
+			)
 
-			if (!involvesStreamChannel) continue
+			if (!streamChannel) continue
 
 			streamChannelIndices.add(index)
 
 			// Associate this transfer's token with the matching payer/payee pair
-			const otherParty = Address.isEqual(event.args.from, STREAM_CHANNEL)
+			const otherParty = Address.isEqual(event.args.from, streamChannel)
 				? event.args.to
 				: event.args.from
 			for (const pair of streamChannelPairs) {

--- a/apps/explorer/src/lib/queries/tx.ts
+++ b/apps/explorer/src/lib/queries/tx.ts
@@ -7,8 +7,9 @@ import {
 	decodeKnownCall,
 	parseAuthorizationEvents,
 	parseKnownEvent,
+	isStreamChannelAddress,
 	parseKnownEvents,
-	STREAM_CHANNEL,
+	STREAM_CHANNELS,
 } from '#lib/domain/known-events'
 import { getFeeBreakdown } from '#lib/domain/receipt'
 import * as Tip20 from '#lib/domain/tip20'
@@ -71,8 +72,8 @@ async function fetchTxData(params: { hash: Hex.Hex }) {
 	const streamChannelIndices = new Set<number>()
 	let streamChannelToken: `0x${string}` | undefined
 
-	const hasStreamChannelEvents = receipt.logs.some(
-		(log) => log.address.toLowerCase() === STREAM_CHANNEL.toLowerCase(),
+	const hasStreamChannelEvents = receipt.logs.some((log) =>
+		isStreamChannelAddress(log.address),
 	)
 
 	if (hasStreamChannelEvents) {
@@ -89,9 +90,12 @@ async function fetchTxData(params: { hash: Hex.Hex }) {
 
 			const from = `0x${fromTopic.slice(-40)}`.toLowerCase()
 			const to = `0x${toTopic.slice(-40)}`.toLowerCase()
-			const streamChannel = STREAM_CHANNEL.toLowerCase()
+			const streamChannel = STREAM_CHANNELS.find((streamChannel) => {
+				const lower = streamChannel.toLowerCase()
+				return from === lower || to === lower
+			})
 
-			if (from !== streamChannel && to !== streamChannel) continue
+			if (!streamChannel) continue
 
 			streamChannelIndices.add(index)
 			if (!streamChannelToken) streamChannelToken = log.address

--- a/apps/explorer/src/routes/_layout/receipt/$hash.tsx
+++ b/apps/explorer/src/routes/_layout/receipt/$hash.tsx
@@ -21,6 +21,7 @@ import {
 	parseKnownEvents,
 	type KnownEvent,
 } from '#lib/domain/known-events'
+import { calculateKnownEventsTotal } from '#lib/domain/known-event-totals'
 import { getFeeBreakdown, LineItems } from '#lib/domain/receipt'
 import * as Tip20 from '#lib/domain/tip20'
 import { DateFormatter, PriceFormatter } from '#lib/formatting'
@@ -434,12 +435,18 @@ function Component() {
 		? voucherData.packetSize * voucherData.packetCount
 		: undefined
 
+	const eventsTotal = calculateKnownEventsTotal(displayEvents)
+	const eventsTotalDisplayValue =
+		eventsTotal > 0n ? Number(Value.format(eventsTotal, 18)) : undefined
+
 	const total =
 		streamingTotal !== undefined
 			? streamingTotal
-			: previousTotal !== undefined
-				? previousTotal - previousFee + fee
-				: fee
+			: eventsTotalDisplayValue !== undefined
+				? eventsTotalDisplayValue
+				: previousTotal !== undefined
+					? previousTotal - previousFee + fee
+					: fee
 	const totalTokenAddresses = lineItems.totals
 		.map((item) => item.price?.token)
 		.filter((token): token is `0x${string}` => Boolean(token))
@@ -450,9 +457,11 @@ function Component() {
 	const totalDisplayValue =
 		streamingTotal !== undefined
 			? streamingTotal
-			: previousTotal !== undefined
-				? previousTotal
-				: total
+			: eventsTotalDisplayValue !== undefined
+				? eventsTotalDisplayValue
+				: previousTotal !== undefined
+					? previousTotal
+					: total
 	const totalDisplay = showUsdTotalPrefix
 		? PriceFormatter.format(totalDisplayValue)
 		: PriceFormatter.formatAmountShort(String(totalDisplayValue))


### PR DESCRIPTION
## Summary
- Rename stream channel open events to `MPP Session Opened`
- Render stream channel close events as `MPP Session Closed Paid X refunded Y`

## Checks
- `pnpm check:types`
- `pnpm check`