### PR TITLE
fix(explorer): show precise total

### DIFF
--- a/apps/explorer/src/comps/Amount.tsx
+++ b/apps/explorer/src/comps/Amount.tsx
@@ -100,6 +100,7 @@ export namespace Amount {
 			prefix,
 			suffix,
 			short,
+			shortMaximumFractionDigits,
 			maxWidth = 24,
 			infinite = true,
 		} = props
@@ -123,7 +124,9 @@ export namespace Amount {
 		const rawFormatted = Value.format(value, decimals)
 		const fullFormatted = PriceFormatter.formatAmount(rawFormatted)
 		const formatted = short
-			? PriceFormatter.formatAmountShort(rawFormatted)
+			? PriceFormatter.formatAmountShort(rawFormatted, {
+					maximumFractionDigits: shortMaximumFractionDigits,
+				})
 			: fullFormatted
 		const isSmall = formatted.startsWith('<')
 
@@ -158,6 +161,7 @@ export namespace Amount {
 			maxWidth?: number
 			prefix?: string
 			short?: boolean
+			shortMaximumFractionDigits?: number
 			suffix?: string
 			value: bigint
 		}

--- a/apps/explorer/src/comps/TxTransactionCard.tsx
+++ b/apps/explorer/src/comps/TxTransactionCard.tsx
@@ -83,7 +83,7 @@ export function TxTransactionCard(props: TxTransactionCard.Props) {
 						<Link
 							to="/address/$address"
 							params={{ address: from }}
-							className="text-[13px] text-accent hover:underline press-down w-full font-mono max-w-[18ch]"
+							className="text-[13px] text-accent hover:underline press-down w-full font-mono max-w-[50ch]"
 							title={from}
 						>
 							<Midcut value={from} prefix="0x" min={4} align="end" />
@@ -97,7 +97,7 @@ export function TxTransactionCard(props: TxTransactionCard.Props) {
 								<Link
 									to="/address/$address"
 									params={{ address: to }}
-									className="text-[13px] text-accent hover:underline press-down w-full font-mono max-w-[18ch]"
+									className="text-[13px] text-accent hover:underline press-down w-full font-mono max-w-[50ch]"
 									title={to}
 								>
 									<Midcut value={to} prefix="0x" min={4} align="end" />

--- a/apps/explorer/src/lib/env.ts
+++ b/apps/explorer/src/lib/env.ts
@@ -91,11 +91,13 @@ export const getTempoEnv = createIsomorphicFn()
 	})
 	.server(() => {
 		// Some modules read the active chain at import time before TanStack Start has
-		// established request AsyncLocalStorage. Fall back to process env there.
+		// established request AsyncLocalStorage. Fall back to Vite env there. In
+		// Cloudflare/Vite dev, `process.env` may not include the command env inside
+		// the worker runtime.
 		const inferred = inferTempoEnvFromHostname(
 			getRequestUrlIfAvailable()?.hostname,
 		)
-		return inferred ?? normalizeTempoEnv(process.env.VITE_TEMPO_ENV)
+		return inferred ?? normalizeTempoEnv(import.meta.env.VITE_TEMPO_ENV)
 	})
 
 export const isTestnet = createIsomorphicFn()

--- a/apps/explorer/src/lib/formatting.ts
+++ b/apps/explorer/src/lib/formatting.ts
@@ -265,11 +265,21 @@ export namespace PriceFormatter {
 		return amountFormatter.format(number)
 	}
 
-	export function formatAmountShort(value: string): string {
+	export function formatAmountShort(
+		value: string,
+		options?: { maximumFractionDigits?: number },
+	): string {
 		const number = Number(value)
 		// Use standard notation for values < 1000 to preserve precision,
 		// compact notation for larger values (1K, 1M, etc.)
-		if (Math.abs(number) < 1000) {
+		if (Math.abs(number) < 1_000) {
+			if (options?.maximumFractionDigits !== undefined) {
+				return new Intl.NumberFormat('en-US', {
+					notation: 'standard',
+					minimumFractionDigits: 0,
+					maximumFractionDigits: options.maximumFractionDigits,
+				}).format(number)
+			}
 			return amountFormatterShortStandard.format(number)
 		}
 		return amountFormatterShortCompact.format(number)

--- a/apps/explorer/src/routes/_layout/block/$id.tsx
+++ b/apps/explorer/src/routes/_layout/block/$id.tsx
@@ -316,7 +316,7 @@ function TransactionsSection(props: TransactionsSectionProps) {
 		{ label: 'From', align: 'end', minWidth: 112, width: '1fr' },
 		{ label: 'Hash', align: 'end', minWidth: 112, width: '1fr' },
 		{ label: 'Fee', align: 'end', minWidth: 64, width: '0.5fr' },
-		{ label: 'Total', align: 'end', minWidth: 72, width: '0.5fr' },
+		{ label: 'Total', align: 'end', minWidth: 96, width: 96 },
 	] satisfies DataGrid.Props['columns']['stacked']
 
 	return (
@@ -457,9 +457,11 @@ function TransactionTotalCell(props: TransactionTotalCellProps) {
 	const hasAmounts = events?.some((event) =>
 		event.parts.some((part) => part.type === 'amount'),
 	)
+	const hasFeeEvent = events?.some((event) => event.type === 'fee') ?? false
+	const fee = hasFeeEvent ? 0n : getEstimatedFee(transaction)
 
 	if (hasAmounts) {
-		const totalValue = calculateKnownEventsTotal(events ?? [])
+		const totalValue = calculateKnownEventsTotal(events ?? []) + fee
 		if (totalValue !== 0n) {
 			return (
 				<Amount.Base
@@ -468,12 +470,13 @@ function TransactionTotalCell(props: TransactionTotalCellProps) {
 					infinite={infiniteLabel}
 					prefix={showUsdPrefix ? '$' : undefined}
 					short
+					shortMaximumFractionDigits={3}
 				/>
 			)
 		}
 	}
 
-	const value = transaction.value ?? 0n
+	const value = (transaction.value ?? 0n) + fee
 	if (value === 0n) return <span className="text-tertiary">—</span>
 	return (
 		<Amount.Base
@@ -482,6 +485,7 @@ function TransactionTotalCell(props: TransactionTotalCellProps) {
 			infinite={infiniteLabel}
 			prefix={showUsdPrefix ? '$' : undefined}
 			short
+			shortMaximumFractionDigits={3}
 		/>
 	)
 }


### PR DESCRIPTION
- Fixed block transaction Total values to include transfer amount + fee.
- Improved small USD total formatting to show values like `$0.003` / `$0.006` instead of `$0` / rounded `$0.01`.
- Made the block page Total column wider/fixed so values don’t get clipped on smaller screens.
- Expanded transaction page From/To address display so more hex is visible on small screens.
- Fixed local block page env detection: server now uses Vite env instead of `process.env`, so mainnet blocks load locally.