### PR TITLE
explorer: remove Solidity reference code links from TIP-20 pages

### DIFF
--- a/apps/explorer/src/comps/Contract.tsx
+++ b/apps/explorer/src/comps/Contract.tsx
@@ -89,14 +89,6 @@ export function ContractTabContent(props: {
 						Spec
 					</a>
 					<a
-						href="https://github.com/tempoxyz/tempo/blob/main/tips/ref-impls/src/TIP20.sol"
-						target="_blank"
-						rel="noopener noreferrer"
-						className="text-accent hover:underline whitespace-nowrap"
-					>
-						Solidity
-					</a>
-					<a
 						href="https://github.com/tempoxyz/tempo/tree/main/crates/precompiles/src/tip20"
 						target="_blank"
 						rel="noopener noreferrer"

--- a/apps/explorer/src/comps/Tip20ContractInfo.tsx
+++ b/apps/explorer/src/comps/Tip20ContractInfo.tsx
@@ -104,14 +104,6 @@ export function Tip20TokenTabContent(
 					Spec
 				</a>
 				<a
-					href="https://github.com/tempoxyz/tempo/blob/main/tips/ref-impls/src/TIP20.sol"
-					target="_blank"
-					rel="noopener noreferrer"
-					className="text-accent hover:underline whitespace-nowrap"
-				>
-					Solidity
-				</a>
-				<a
 					href="https://github.com/tempoxyz/tempo/tree/main/crates/precompiles/src/tip20"
 					target="_blank"
 					rel="noopener noreferrer"


### PR DESCRIPTION
Removes the Solidity reference implementation link from TIP-20 token pages on the explorer. Keeps Rust and Spec links.

**Files changed:**
- `apps/explorer/src/comps/Contract.tsx` — contract tab banner
- `apps/explorer/src/comps/Tip20ContractInfo.tsx` — TIP-20 token tab banner