### PR TITLE
fix: pass holders, currency, and created to token social card

### DIFF
--- a/apps/explorer/src/routes/_layout/address/$address.tsx
+++ b/apps/explorer/src/routes/_layout/address/$address.tsx
@@ -397,6 +397,13 @@ export const Route = createFileRoute('/_layout/address/$address')({
 			const supply = formatSupply(totalSupply)
 			const chainId = getTempoChain().id
 
+			let created: string | undefined
+			if (loaderData?.ogMeta?.createdTimestamp) {
+				created = DateFormatter.formatTimestampForOg(
+					BigInt(loaderData.ogMeta.createdTimestamp),
+				).date
+			}
+
 			description = buildTokenDescription({
 				name: tokenMeta.name ?? '—',
 				symbol: tokenMeta.symbol,
@@ -409,6 +416,9 @@ export const Route = createFileRoute('/_layout/address/$address')({
 				name: tokenMeta.name,
 				symbol: tokenMeta.symbol,
 				supply,
+				currency: tokenMeta.currency ?? undefined,
+				holders: loaderData?.ogMeta?.holdersCount ?? undefined,
+				created,
 			})
 		} else {
 			const txCount = loaderData?.ogMeta?.txCount ?? 0
@@ -698,6 +708,7 @@ async function fetchAddressMetadata(address: Address.Address) {
 	return response.json() as Promise<{
 		accountType: AccountType
 		txCount: number | null
+		holdersCount?: number | null
 		lastActivityTimestamp: number | null
 		createdTimestamp: number | null
 	}>

--- a/apps/explorer/src/routes/api/address/metadata/$address.ts
+++ b/apps/explorer/src/routes/api/address/metadata/$address.ts
@@ -7,6 +7,7 @@ import { isTip20Address } from '#lib/domain/tip20'
 import { hasIndexSupply } from '#lib/env'
 import {
 	fetchAddressTxAggregate,
+	fetchTokenHoldersCountRows,
 	fetchTokenTransferAggregate,
 	fetchVirtualAddressTransferAggregate,
 } from '#lib/server/tempo-queries'
@@ -19,6 +20,7 @@ export type AddressMetadataResponse = {
 	chainId: number
 	accountType: AccountType
 	txCount?: number
+	holdersCount?: number
 	lastActivityTimestamp?: number
 	createdTimestamp?: number
 	createdTxHash?: string
@@ -73,17 +75,23 @@ export const Route = createFileRoute('/api/address/metadata/$address')({
 							createdTimestamp: parseTimestamp(result.oldestTimestamp),
 						}
 					} else if (isTip20) {
-						const [bytecode, result] = await Promise.all([
+						const [bytecode, result, holdersRows] = await Promise.all([
 							bytecodePromise,
 							fetchTokenTransferAggregate(address, chainId).catch(() => ({
 								oldestTimestamp: undefined,
 								latestTimestamp: undefined,
 							})),
+							fetchTokenHoldersCountRows(
+								[address],
+								chainId,
+								10_000,
+							).catch(() => []),
 						])
 						response = {
 							address,
 							chainId,
 							accountType: getAccountType(bytecode),
+							holdersCount: holdersRows[0]?.count ?? 0,
 							lastActivityTimestamp: parseTimestamp(result.latestTimestamp),
 							createdTimestamp: parseTimestamp(result.oldestTimestamp),
 						}


### PR DESCRIPTION
## Problem

The social card (OG image) for token addresses like [`0x20c0...0000`](https://explore.tempo.xyz/address/0x20c0000000000000000000000000000000000000) was missing three fields:

- **Holders**: showed `0` (dash fallback)
- **Currency**: showed `—` (dash fallback)
- **Created**: showed `—` (dash fallback)

The root cause: `buildTokenOgImageUrl` in the `head()` function was only called with `address`, `chainId`, `name`, `symbol`, and `supply` — even though it accepts `currency`, `holders`, and `created` as optional params. The OG worker at `og.tempo.xyz` defaults these to `—` when absent.

## Fix

1. **`currency`** — already available on `tokenMetadata.currency` from `Actions.token.getMetadata` in the loader; now passed through to `buildTokenOgImageUrl`.

2. **`created`** — already available on `ogMeta.createdTimestamp` from the address metadata API; now formatted via `DateFormatter.formatTimestampForOg` and passed through.

3. **`holders`** — added `holdersCount` to the address metadata API response for TIP-20 addresses by calling `fetchTokenHoldersCountRows` (runs in parallel with existing fetches); passed through to `buildTokenOgImageUrl`.

## Files changed

- `apps/explorer/src/routes/api/address/metadata/$address.ts` — add `holdersCount` field for TIP-20 addresses
- `apps/explorer/src/routes/_layout/address/$address.tsx` — pass `currency`, `holders`, `created` to `buildTokenOgImageUrl` in `head()`