### PR TITLE
fix(explorer): make tx hash in contract writer a clickable link to receipt

### DIFF
--- a/apps/explorer/src/comps/ContractWriter.tsx
+++ b/apps/explorer/src/comps/ContractWriter.tsx
@@ -1,5 +1,5 @@
 import { useQueryClient } from '@tanstack/react-query'
-
+import { Link } from '@tanstack/react-router'
 import type { Address } from 'ox'
 import { getSignature } from 'ox/AbiItem'
 import * as React from 'react'
@@ -307,7 +307,14 @@ function WriteContractFunction(props: {
 					{writeContract.isSuccess && writeContract.data && (
 						<div className="p-2.5 rounded-md bg-green-500/10 border border-green-500/20">
 							<p className="text-[12px] text-green-400 font-mono break-all">
-								tx: {writeContract.data}
+								tx:{' '}
+								<Link
+									to="/receipt/$hash"
+									params={{ hash: writeContract.data }}
+									className="underline hover:text-green-300"
+								>
+									{writeContract.data}
+								</Link>
 							</p>
 						</div>
 					)}


### PR DESCRIPTION
The transaction hash shown in the green success banner after a write call in the Interact tab was plain text. This wraps it in a `<Link>` to `/receipt/$hash` so it's clickable.