### PR TITLE
fix(explorer): exclude approvals from receipt total

### DIFF
--- a/apps/explorer/src/lib/domain/known-event-totals.ts
+++ b/apps/explorer/src/lib/domain/known-event-totals.ts
@@ -31,6 +31,11 @@ export function calculateKnownEventsTotal(
 	const flowsByToken = new Map<string, Map<string, Flow>>()
 
 	for (const event of events) {
+		// Approvals grant spending permission rather than moving value, and
+		// frequently use type(uint256).max ("infinite approval"), which would
+		// otherwise dominate the total.
+		if (event.type === 'approval') continue
+
 		const amounts = event.totalAmount
 			? [event.totalAmount]
 			: event.parts

--- a/apps/explorer/test/known-event-totals.node.test.ts
+++ b/apps/explorer/test/known-event-totals.node.test.ts
@@ -42,4 +42,31 @@ describe('calculateKnownEventsTotal', () => {
 
 		expect(calculateKnownEventsTotal(events)).toBe(100n * 10n ** 18n)
 	})
+
+	it('ignores approval events (which often use type(uint256).max)', () => {
+		const amount = 100_000_000n
+		const maxUint256 = 2n ** 256n - 1n
+		const approval: KnownEvent = {
+			type: 'approval',
+			parts: [
+				{ type: 'action', value: 'Approve' },
+				{
+					type: 'amount',
+					value: {
+						token: tokenAddress,
+						value: maxUint256,
+						decimals: 6,
+						symbol: 'PathUSD',
+					},
+				},
+				{ type: 'account', value: recipientAddress },
+			],
+		}
+		const events = [
+			approval,
+			sendEvent({ from: senderAddress, to: recipientAddress, amount }),
+		]
+
+		expect(calculateKnownEventsTotal(events)).toBe(100n * 10n ** 18n)
+	})
 })


### PR DESCRIPTION
## Summary

The receipt 'Total' was overflowing on any transaction containing an ERC20 `Approval` log with `type(uint256).max` (infinite approval). Approvals don't move value — they only grant spending permission — but because they have no `meta.from`/`meta.to` they fell into the `fallbackTotal` branch in `calculateKnownEventsTotal` and dominated the sum.

Example: `/receipt/0x71be547f735029940dbbd3daa9eef2379df047c68f13e4d7c0323a70adc310a5` was showing `$115,792,089,237,316,200,000,000,...` (≈ 2²⁵⁶−1).

## Fix

Skip events with `type === 'approval'` in [`calculateKnownEventsTotal`](apps/explorer/src/lib/domain/known-event-totals.ts).

## Test

Added a regression test that mixes an infinite-approval event with a normal send and asserts the total reflects only the send.