### PR TITLE
fix(explorer): keep contract tab on aggregate failure

### DIFF
--- a/apps/explorer/src/routes/api/address/metadata/$address.ts
+++ b/apps/explorer/src/routes/api/address/metadata/$address.ts
@@ -32,9 +32,10 @@ export const Route = createFileRoute('/api/address/metadata/$address')({
 	server: {
 		handlers: {
 			GET: async ({ params }) => {
+				const { id: chainId } = getTempoChain()
 				const fallback: AddressMetadataResponse = {
 					address: params.address,
-					chainId: 0,
+					chainId,
 					accountType: 'empty',
 				}
 
@@ -45,7 +46,6 @@ export const Route = createFileRoute('/api/address/metadata/$address')({
 					Address.assert(address)
 
 					const client = getBatchedClient()
-					const { id: chainId } = getTempoChain()
 					const isTip20 = isTip20Address(address)
 					const isVirtual = VirtualAddress.validate(address)
 
@@ -96,19 +96,22 @@ export const Route = createFileRoute('/api/address/metadata/$address')({
 					} else {
 						const [bytecode, result] = await Promise.all([
 							bytecodePromise,
-							fetchAddressTxAggregate(address, chainId),
+							fetchAddressTxAggregate(address, chainId).catch((error) => {
+								console.error(error)
+								return undefined
+							}),
 						])
 						response = {
 							address,
 							chainId,
 							accountType: getAccountType(bytecode),
-							txCount: result.count ?? 0,
+							txCount: result?.count,
 							lastActivityTimestamp: parseTimestamp(
-								result.latestTxsBlockTimestamp,
+								result?.latestTxsBlockTimestamp,
 							),
-							createdTimestamp: parseTimestamp(result.oldestTxsBlockTimestamp),
-							createdTxHash: result.oldestTxHash,
-							createdBy: result.oldestTxFrom,
+							createdTimestamp: parseTimestamp(result?.oldestTxsBlockTimestamp),
+							createdTxHash: result?.oldestTxHash,
+							createdBy: result?.oldestTxFrom,
 						}
 					}
 

--- a/apps/explorer/test/address-metadata.node.test.ts
+++ b/apps/explorer/test/address-metadata.node.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+	getCode: vi.fn(),
+	hasIndexSupply: vi.fn(),
+	getBatchedClient: vi.fn(),
+	getTempoChain: vi.fn(),
+	isTip20Address: vi.fn(),
+	validateVirtualAddress: vi.fn(),
+	fetchAddressTxAggregate: vi.fn(),
+}))
+
+vi.mock('@tanstack/react-router', () => ({
+	createFileRoute: () => (config: unknown) => ({
+		options: config,
+	}),
+}))
+
+vi.mock('viem/actions', () => ({
+	getCode: mocks.getCode,
+}))
+
+vi.mock('#lib/env', () => ({
+	hasIndexSupply: mocks.hasIndexSupply,
+}))
+
+vi.mock('#wagmi.config.ts', () => ({
+	getBatchedClient: mocks.getBatchedClient,
+	getTempoChain: mocks.getTempoChain,
+}))
+
+vi.mock('#lib/domain/tip20', () => ({
+	isTip20Address: mocks.isTip20Address,
+}))
+
+vi.mock('ox/tempo', () => ({
+	VirtualAddress: {
+		validate: mocks.validateVirtualAddress,
+	},
+}))
+
+vi.mock('#lib/server/tempo-queries', () => ({
+	fetchAddressTxAggregate: mocks.fetchAddressTxAggregate,
+	fetchTokenHoldersCountRows: vi.fn(),
+	fetchTokenTransferAggregate: vi.fn(),
+	fetchVirtualAddressTransferAggregate: vi.fn(),
+}))
+
+import { Route } from '../src/routes/api/address/metadata/$address'
+
+describe('/api/address/metadata/$address', () => {
+	const address = '0x112fd4042E442C3C12C67AD23587b0afe36eB74E'
+	const handler = Route.options.server.handlers.GET
+
+	beforeEach(() => {
+		vi.clearAllMocks()
+		mocks.getTempoChain.mockReturnValue({ id: 31318 })
+		mocks.getBatchedClient.mockReturnValue({})
+		mocks.hasIndexSupply.mockReturnValue(true)
+		mocks.isTip20Address.mockReturnValue(false)
+		mocks.validateVirtualAddress.mockReturnValue(false)
+	})
+
+	it('uses the active chain id in fallback responses', async () => {
+		mocks.hasIndexSupply.mockReturnValue(false)
+
+		const response = await handler({ params: { address } })
+
+		expect(response.status).toBe(200)
+		await expect(response.json()).resolves.toMatchObject({
+			address,
+			chainId: 31318,
+			accountType: 'empty',
+		})
+	})
+
+	it('keeps contract account type when tx aggregate fetch fails', async () => {
+		mocks.getCode.mockResolvedValue('0x60016000')
+		mocks.fetchAddressTxAggregate.mockRejectedValue(new Error('Status: 400'))
+
+		const response = await handler({ params: { address } })
+
+		expect(response.status).toBe(200)
+		await expect(response.json()).resolves.toMatchObject({
+			address,
+			chainId: 31318,
+			accountType: 'contract',
+		})
+	})
+})


### PR DESCRIPTION
Keeps address metadata usable when aggregate index queries fail, so contract pages still render the Contract tab based on bytecode alone.

This refactors the route so contract detection is derived up front from eth_getCode and is no longer coupled to TIDX-backed metadata. It also fixes the metadata fallback to return the active chain id instead of 0, and adds a regression test covering both cases.

Verification:
- corepack pnpm exec vitest run --config vitest.node.config.ts test/address-metadata.node.test.ts

Notes:
- corepack pnpm check:types in apps/explorer still fails on pre-existing unrelated typing issues in the workspace.
- There is still a separate underlying devnet preview issue where tx-count / aggregate TIDX queries return Status: 400 for chainId 31318; this PR prevents that backend failure from hiding the contract tab, but does not resolve the TIDX-side 400 itself.