### PR TITLE
fix(explorer): block search engines from indexing dynamic explorer pages

### DIFF
--- a/apps/explorer/public/robots.txt
+++ b/apps/explorer/public/robots.txt
@@ -1,3 +1,10 @@
 # https://www.robotstxt.org/robotstxt.html
 User-agent: *
-Disallow:
+Allow: /$
+Disallow: /address/
+Disallow: /token/
+Disallow: /block/
+Disallow: /blocks
+Disallow: /tx/
+Disallow: /receipt/
+Disallow: /demo/


### PR DESCRIPTION
## Problem
The explorer's `robots.txt` currently allows all crawling (`Disallow:` with no paths). This causes tens of thousands of `/address/`, `/token/`, `/block/`, and `/tx/` pages to be indexed by Google, likely triggering spam detection and hurting SEO for tempo.xyz.

## Fix
Update `robots.txt` to block all dynamic explorer routes while keeping the homepage indexable:
- `/address/`
- `/token/`
- `/block/` and `/blocks`
- `/tx/`
- `/receipt/`
- `/demo/`

## Post-merge
After deploying, use [Google Search Console Removals](https://search.google.com/search-console/removals) to request de-indexing of the already-crawled URLs, since `robots.txt` only prevents **future** crawling.