### PR TITLE
fix(explorer): allow token pages in robots.txt, block ?a= query combos

### DIFF
--- a/apps/explorer/public/robots.txt
+++ b/apps/explorer/public/robots.txt
@@ -1,8 +1,10 @@
 # https://www.robotstxt.org/robotstxt.html
 User-agent: *
 Allow: /$
+Allow: /tokens
+Allow: /token/
+Disallow: /*?a=
 Disallow: /address/
-Disallow: /token/
 Disallow: /block/
 Disallow: /blocks
 Disallow: /tx/


### PR DESCRIPTION
Follow-up to #910.

## Changes
- **Re-enable** `/token/` and `/tokens` for indexing — only 6 tokens exist on the network, so these are valuable, low-volume pages worth having in Google
- **Block** `?a=` query parameter combos (`Disallow: /*?a=`) — these generate thousands of unique URLs per token (one per holder) and were the main source of index bloat