### PR TITLE
fix(explorer): normalize non-checksummed addresses instead of 404

### DIFF
--- a/apps/explorer/src/lib/tempo-address.ts
+++ b/apps/explorer/src/lib/tempo-address.ts
@@ -1,3 +1,4 @@
+import * as Address from 'ox/Address'
 import { TempoAddress, VirtualAddress } from 'ox/tempo'
 
 export type VirtualAddressParts = {
@@ -16,5 +17,7 @@ export function normalizeSearchInput(input: string): string {
 	const query = input.trim()
 	if (!query) return ''
 	if (TempoAddress.validate(query)) return TempoAddress.parse(query).address
+	if (Address.validate(query, { strict: false }))
+		return Address.checksum(query)
 	return query
 }


### PR DESCRIPTION
## Problem

Non-checksummed addresses like `0xCCCCCCCC00000000000000000000000000000001` return 404 on the explorer because `ox/Address.validate()` enforces EIP-55 checksum by default. Only the checksummed form `0xCcCCCCcC00000000000000000000000000000001` works.

## Fix

Extend `normalizeSearchInput` to checksum any valid hex address (using `Address.validate(query, { strict: false })` + `Address.checksum()`). The existing `beforeLoad` redirect then fires automatically, sending users to the checksummed URL before the loader's strict validation runs.

This fixes:
- Direct URL navigation with non-checksummed addresses
- Search bar lookups
- Search API endpoint

## Test

Navigate to https://explore.tempo.xyz/address/0xCCCCCCCC00000000000000000000000000000001?tab=contract — should redirect to the checksummed address and display the validator precompile.