### PR TITLE
chore: remove snapshots preview trigger workaround

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -112,16 +112,6 @@ jobs:
         run: pnpm build
         working-directory: apps/${{ matrix.app }}
 
-      - name: Apply Preview Triggers
-        if: steps.changes.outputs.relevant == 'true' && matrix.app == 'tempo-snapshots-viewer'
-        uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          workingDirectory: apps/${{ matrix.app }}
-          environment: ${{ env.CLOUDFLARE_ENV }}
-          command: triggers deploy
-
       - name: Upload Worker Version
         if: steps.changes.outputs.relevant == 'true'
         id: deploy


### PR DESCRIPTION
## Summary

- Remove the temporary `triggers deploy` step for `tempo-snapshots-viewer` previews
- Keep the normal `versions upload` preview deployment path intact

## Validation

- Parsed `.github/workflows/pull-request.yml` with Ruby YAML loader
- `pnpm check`
- `pnpm check:types`
- `pnpm precommit`

No app tests were run because this change only touches the pull request workflow.