### PR TITLE
fix: default snapshots viewer to archive

### DIFF
--- a/apps/tempo-snapshots-viewer/src/index.ts
+++ b/apps/tempo-snapshots-viewer/src/index.ts
@@ -1619,6 +1619,15 @@ async function handleUI(_req: Request, env: Env) {
       background: var(--surface-hover);
     }
 
+    .preset:disabled {
+      cursor: not-allowed;
+      opacity: 0.45;
+    }
+
+    .preset:disabled:hover {
+      background: var(--surface);
+    }
+
     .preset.active {
       background: var(--surface-hover);
       border-color: var(--accent);
@@ -2103,7 +2112,7 @@ async function handleUI(_req: Request, env: Env) {
       <div class="snapshot-status-note" id="snapshotStatusNote"></div>
 
       <div class="presets" id="presets">
-        <button class="preset active" onclick="selectPreset('minimal')" id="preset-minimal">
+        <button class="preset" id="preset-minimal" disabled>
           <div class="preset-header">
             <span class="preset-radio"></span>
             <span class="preset-name">Minimal<span class="preset-modified-tag">(modified)</span></span>
@@ -2112,7 +2121,7 @@ async function handleUI(_req: Request, env: Env) {
           <span class="preset-desc">State and headers with minimal history. Limited historical RPC.</span>
           <span class="preset-ideal">Ideal for validators and constrained environments</span>
         </button>
-        <button class="preset" onclick="selectPreset('full')" id="preset-full">
+        <button class="preset" id="preset-full" disabled>
           <div class="preset-header">
             <span class="preset-radio"></span>
             <span class="preset-name">Full<span class="preset-modified-tag">(modified)</span></span>
@@ -2121,7 +2130,7 @@ async function handleUI(_req: Request, env: Env) {
           <span class="preset-desc">Full transaction history with recent receipts and state history.</span>
           <span class="preset-ideal">Ideal for dApp backends and personal nodes</span>
         </button>
-        <button class="preset" onclick="selectPreset('archive')" id="preset-archive">
+        <button class="preset active" onclick="selectPreset('archive')" id="preset-archive">
           <div class="preset-header">
             <span class="preset-radio"></span>
             <span class="preset-name">Archive<span class="preset-modified-tag">(modified)</span></span>
@@ -2199,9 +2208,9 @@ async function handleUI(_req: Request, env: Env) {
       archive:  { checked: ['state', 'headers', 'txs', 'tx_send', 'receipts', 'acc_cs', 'sto_cs', 'indices'] }
     };
 
-    var checkedComponents = new Set(PRESETS.minimal.checked);
-    var activePreset = 'minimal';
-    var presetBaseComponents = new Set(PRESETS.minimal.checked);
+    var checkedComponents = new Set(PRESETS.archive.checked);
+    var activePreset = 'archive';
+    var presetBaseComponents = new Set(PRESETS.archive.checked);
     var activeSnapshotId = latestModularSnapshotId;
     var activeSnapshotUrl = null;
 


### PR DESCRIPTION
Defaults the Tempo snapshots viewer to the Archive preset and disables the Minimal and Full preset buttons for now.

No banner or command-generation changes are included.

Validation:
- pnpm --filter tempo-snapshots-viewer check

## Screenshots

<img width="1586" height="1346" alt="Screenshot 2026-05-06 at 15 20 33" src="https://github.com/user-attachments/assets/6c5bc18a-93d2-4b01-b486-0b9558d37cb0" />
