### PR TITLE
feat: warm snapshot caches on cron

### DIFF
--- a/apps/tempo-snapshots-viewer/src/index.ts
+++ b/apps/tempo-snapshots-viewer/src/index.ts
@@ -315,7 +315,19 @@ app.get('/:chainId/:snapshotName', (context) =>
 )
 app.get('/', (context) => handleUI(context.req.raw, context.env))
 
-export default app
+export default {
+	fetch: app.fetch,
+	scheduled(_controller: ScheduledController, env: Env, ctx: ExecutionContext) {
+		ctx.waitUntil(refreshSnapshotCaches(env))
+	},
+}
+
+async function refreshSnapshotCaches(env: Env): Promise<void> {
+	const snapshots = await getSnapshots(env)
+	const cache = caches.default
+	await populateSnapshotCaches(cache, snapshots)
+	await cache.delete(new Request(CACHE_KEY_UI_HTML, { method: 'GET' }))
+}
 
 async function serveLatest(
 	{ chainId = DEFAULT_CHAIN_ID }: { chainId?: string },

--- a/apps/tempo-snapshots-viewer/wrangler.json
+++ b/apps/tempo-snapshots-viewer/wrangler.json
@@ -31,5 +31,8 @@
 			"pattern": "snapshots.tempoxyz.dev",
 			"custom_domain": true
 		}
-	]
+	],
+	"triggers": {
+		"crons": ["*/15 * * * *"]
+	}
 }


### PR DESCRIPTION
## Summary

- add a scheduled Worker handler for tempo-snapshots-viewer
- refresh snapshot JSON caches every 15 minutes
- invalidate cached UI HTML after each scheduled refresh so the next page render uses fresh data

## Validation

- `pnpm --filter tempo-snapshots-viewer check`
- `pnpm check:types`
- `pnpm precommit`
- `pnpm test` fails in existing explorer setup: missing `#tanstack-router-entry` specifier in `@tanstack/start-server-core`

Ports tempoxyz/tempo-snapshots-viewer#14 into the monorepo app.