### PR TITLE
chore: move snapshots viewer domain to tempo.xyz

### DIFF
--- a/apps/tempo-snapshots-viewer/README.md
+++ b/apps/tempo-snapshots-viewer/README.md
@@ -25,7 +25,7 @@ pnpm --filter tempo-snapshots-viewer dev  # Local development at http://localhos
 ## Deployment
 
 ```bash
-pnpm --filter tempo-snapshots-viewer deploy  # Deploys to snapshots.tempoxyz.dev
+pnpm --filter tempo-snapshots-viewer deploy  # Deploys to snapshots.tempo.xyz and snapshots.tempoxyz.dev
 ```
 
 ## Project Structure

--- a/apps/tempo-snapshots-viewer/src/index.ts
+++ b/apps/tempo-snapshots-viewer/src/index.ts
@@ -658,9 +658,10 @@ async function getSnapshots(env: Env): Promise<Snapshot[]> {
 }
 
 const CACHE_VERSION = 'v18'
-const CACHE_KEY_FULL = `https://snapshots.tempoxyz.dev/cache/${CACHE_VERSION}/full`
-const CACHE_KEY_API = `https://snapshots.tempoxyz.dev/cache/${CACHE_VERSION}/api`
-const CACHE_KEY_UI_HTML = `https://snapshots.tempoxyz.dev/cache/${CACHE_VERSION}/ui-html`
+const VIEWER_ORIGIN = 'https://snapshots.tempo.xyz'
+const CACHE_KEY_FULL = `${VIEWER_ORIGIN}/cache/${CACHE_VERSION}/full`
+const CACHE_KEY_API = `${VIEWER_ORIGIN}/cache/${CACHE_VERSION}/api`
+const CACHE_KEY_UI_HTML = `${VIEWER_ORIGIN}/cache/${CACHE_VERSION}/ui-html`
 const CACHE_TTL = 3600 // 1 hour — snapshots change at most once per day
 let snapshotRefreshPromise: Promise<Snapshot[]> | undefined
 
@@ -885,7 +886,7 @@ async function handleUI(_req: Request, env: Env) {
   <meta property="og:title" content="Snapshots - Tempo">
   <meta property="og:description" content="Download Tempo snapshots with network-aware profiles and generated tempo download commands.">
   <meta property="og:type" content="website">
-  <meta property="og:url" content="https://snapshots.tempoxyz.dev">
+  <meta property="og:url" content="${VIEWER_ORIGIN}">
   <meta name="twitter:card" content="summary">
   <meta name="twitter:title" content="Snapshots - Tempo">
   <meta name="twitter:description" content="Download Tempo snapshots with network-aware profiles and generated tempo download commands.">

--- a/apps/tempo-snapshots-viewer/wrangler.json
+++ b/apps/tempo-snapshots-viewer/wrangler.json
@@ -30,6 +30,10 @@
 		{
 			"pattern": "snapshots.tempoxyz.dev",
 			"custom_domain": true
+		},
+		{
+			"pattern": "snapshots.tempo.xyz",
+			"custom_domain": true
 		}
 	],
 	"triggers": {


### PR DESCRIPTION
## Summary

- add `snapshots.tempo.xyz` as an additional custom domain for the Tempo snapshots viewer
- use `https://snapshots.tempo.xyz` as the viewer canonical/cache origin
- update the deployment note to mention both viewer domains

## Validation

- `pnpm check`
- `pnpm --filter tempo-snapshots-viewer check`
- `pnpm check:types`
- `pnpm precommit`

## Screenshots

Not applicable; this changes routing, canonical metadata, and cache keys only.