### PR TITLE
chore: remove legacy snapshots viewer domain

### DIFF
--- a/apps/tempo-snapshots-viewer/README.md
+++ b/apps/tempo-snapshots-viewer/README.md
@@ -25,7 +25,7 @@ pnpm --filter tempo-snapshots-viewer dev  # Local development at http://localhos
 ## Deployment
 
 ```bash
-pnpm --filter tempo-snapshots-viewer deploy  # Deploys to snapshots.tempo.xyz and snapshots.tempoxyz.dev
+pnpm --filter tempo-snapshots-viewer deploy  # Deploys to snapshots.tempo.xyz
 ```
 
 ## Project Structure

--- a/apps/tempo-snapshots-viewer/wrangler.json
+++ b/apps/tempo-snapshots-viewer/wrangler.json
@@ -28,10 +28,6 @@
 	},
 	"routes": [
 		{
-			"pattern": "snapshots.tempoxyz.dev",
-			"custom_domain": true
-		},
-		{
 			"pattern": "snapshots.tempo.xyz",
 			"custom_domain": true
 		}


### PR DESCRIPTION
## Summary

- remove `snapshots.tempoxyz.dev` from the Tempo snapshots viewer Worker routes
- keep `snapshots.tempo.xyz` as the only viewer custom domain
- update the deployment note to reference only the new viewer domain

## Notes

The R2 public snapshot download URL remains unchanged at `tempo-node-snapshots.tempoxyz.dev`.

## Validation

- `pnpm check`
- `pnpm --filter tempo-snapshots-viewer check`
- `pnpm check:types`
- `pnpm precommit`

## Screenshots

Not applicable; this only changes Worker routing and documentation.