### PR TITLE
chore: remove explorer Index Supply guards

### DIFF
--- a/apps/explorer/package.json
+++ b/apps/explorer/package.json
@@ -53,7 +53,6 @@
 		"animejs": "catalog:",
 		"cva": "catalog:",
 		"hono": "catalog:",
-		"idxs": "catalog:",
 		"midcut": "catalog:",
 		"ox": "catalog:",
 		"react": "catalog:",

--- a/apps/explorer/src/lib/env.ts
+++ b/apps/explorer/src/lib/env.ts
@@ -103,17 +103,3 @@ export const getTempoEnv = createIsomorphicFn()
 export const isTestnet = createIsomorphicFn()
 	.client(() => getTempoEnv() === 'testnet')
 	.server(() => getTempoEnv() === 'testnet')
-
-export const hasIndexSupply = createIsomorphicFn()
-	.client(
-		() =>
-			getTempoEnv() === 'testnet' ||
-			getTempoEnv() === 'mainnet' ||
-			getTempoEnv() === 'devnet',
-	)
-	.server(
-		() =>
-			getTempoEnv() === 'testnet' ||
-			getTempoEnv() === 'mainnet' ||
-			getTempoEnv() === 'devnet',
-	)

--- a/apps/explorer/src/lib/server/fee-amm.ts
+++ b/apps/explorer/src/lib/server/fee-amm.ts
@@ -5,7 +5,6 @@ import { Abis, Addresses } from 'viem/tempo'
 import type { Config } from 'wagmi'
 import { getChainId, readContracts } from 'wagmi/actions'
 import { Actions } from 'wagmi/tempo'
-import { hasIndexSupply } from '#lib/env'
 import { getWagmiConfig } from '#wagmi.config'
 
 export type FeeAmmPoolRow = {
@@ -89,8 +88,6 @@ async function fetchTokenMetadata(
 
 export const fetchFeeAmmPools = createServerFn({ method: 'POST' }).handler(
 	async (): Promise<FeeAmmPool[]> => {
-		if (!hasIndexSupply()) return []
-
 		try {
 			const config = getWagmiConfig()
 			const chainId = getChainId(config)

--- a/apps/explorer/src/lib/server/latest-block.ts
+++ b/apps/explorer/src/lib/server/latest-block.ts
@@ -1,12 +1,10 @@
 import { createServerFn } from '@tanstack/react-start'
 import { getChainId } from 'wagmi/actions'
-import { hasIndexSupply } from '#lib/env'
 import { fetchLatestBlockNumber } from '#lib/server/tempo-queries'
 import { getWagmiConfig } from '#wagmi.config'
 
 export const fetchLatestBlock = createServerFn({ method: 'GET' }).handler(
 	async () => {
-		if (!hasIndexSupply()) return 0n
 		try {
 			const config = getWagmiConfig()
 			const chainId = getChainId(config)

--- a/apps/explorer/src/routes/api/address/$address.ts
+++ b/apps/explorer/src/routes/api/address/$address.ts
@@ -5,7 +5,7 @@ import type { RpcTransaction } from 'viem'
 import { getBlockNumber, getCode, getTransactionReceipt } from 'viem/actions'
 import { getChainId } from 'wagmi/actions'
 import * as z from 'zod/mini'
-import { getRequestURL, hasIndexSupply } from '#lib/env'
+import { getRequestURL } from '#lib/env'
 import {
 	fetchAddressDirectTxHashes,
 	fetchAddressTransferEmittedHashes,
@@ -62,7 +62,7 @@ async function findCreationBlock(
  * Strategy:
  * 1. Check if address has code (is a contract)
  * 2. Binary search to find the exact creation block using historical eth_getCode
- * 3. Query IndexSupply for creation txs at that specific block
+ * 3. Query indexed data for creation txs at that specific block
  */
 async function findContractCreationTx(
 	address: Address.Address,
@@ -82,7 +82,7 @@ async function findContractCreationTx(
 	const creationBlock = await findCreationBlock(client, address, latestBlock)
 	if (!creationBlock) return null
 
-	// Query IndexSupply for contract creation txs at the creation block
+	// Query indexed data for contract creation txs at the creation block
 	const creationTxs = await fetchContractCreationTxCandidates(
 		chainId,
 		creationBlock,
@@ -126,16 +126,6 @@ export const Route = createFileRoute('/api/address/$address')({
 	server: {
 		handlers: {
 			GET: async ({ params }) => {
-				if (!hasIndexSupply())
-					return Response.json({
-						limit: 0,
-						total: 0,
-						offset: 0,
-						hasMore: false,
-						transactions: [],
-						error: null,
-					})
-
 				try {
 					const url = getRequestURL()
 					const address = zAddress().parse(params.address)

--- a/apps/explorer/src/routes/api/address/balances/$address.ts
+++ b/apps/explorer/src/routes/api/address/balances/$address.ts
@@ -1,6 +1,6 @@
 import { createFileRoute } from '@tanstack/react-router'
 import { getChainId } from 'wagmi/actions'
-import { getRequestURL, hasIndexSupply } from '#lib/env'
+import { getRequestURL } from '#lib/env'
 import type { BalancesResponse } from '#lib/address-balances'
 import {
 	MAX_TOKENS,
@@ -16,9 +16,6 @@ export const Route = createFileRoute('/api/address/balances/$address')({
 	server: {
 		handlers: {
 			GET: async ({ params }) => {
-				if (!hasIndexSupply())
-					return Response.json({ balances: [] } satisfies BalancesResponse)
-
 				try {
 					const url = getRequestURL()
 					const isCsvExport = url.searchParams.get('format') === 'csv'

--- a/apps/explorer/src/routes/api/address/history/$address.ts
+++ b/apps/explorer/src/routes/api/address/history/$address.ts
@@ -2,7 +2,7 @@ import { createFileRoute } from '@tanstack/react-router'
 import * as Address from 'ox/Address'
 import { getChainId } from 'wagmi/actions'
 import * as z from 'zod/mini'
-import { getRequestURL, hasIndexSupply } from '#lib/env'
+import { getRequestURL } from '#lib/env'
 import {
 	MAX_LIMIT,
 	RequestParametersSchema,
@@ -28,17 +28,6 @@ export const Route = createFileRoute('/api/address/history/$address')({
 	server: {
 		handlers: {
 			GET: async ({ params }) => {
-				if (!hasIndexSupply())
-					return Response.json({
-						limit: 0,
-						total: 0,
-						offset: 0,
-						hasMore: false,
-						countCapped: false,
-						transactions: [],
-						error: null,
-					} satisfies HistoryResponse)
-
 				try {
 					const url = getRequestURL()
 					const address = zAddress().parse(params.address)

--- a/apps/explorer/src/routes/api/address/metadata/$address.ts
+++ b/apps/explorer/src/routes/api/address/metadata/$address.ts
@@ -4,7 +4,6 @@ import { VirtualAddress } from 'ox/tempo'
 import { getCode } from 'viem/actions'
 import { getAccountType, type AccountType } from '#lib/account'
 import { isTip20Address } from '#lib/domain/tip20'
-import { hasIndexSupply } from '#lib/env'
 import {
 	fetchAddressTxAggregate,
 	fetchTokenHoldersCountRows,
@@ -37,8 +36,6 @@ export const Route = createFileRoute('/api/address/metadata/$address')({
 					chainId: 0,
 					accountType: 'empty',
 				}
-
-				if (!hasIndexSupply()) return Response.json(fallback)
 
 				try {
 					const address = zAddress().parse(params.address)

--- a/apps/explorer/src/routes/api/address/total-value/$address.ts
+++ b/apps/explorer/src/routes/api/address/total-value/$address.ts
@@ -3,7 +3,6 @@ import * as Address from 'ox/Address'
 import { formatUnits } from 'viem'
 import { Abis } from 'viem/tempo'
 import { getChainId, readContracts } from 'wagmi/actions'
-import { hasIndexSupply } from '#lib/env'
 import { getTokenListAddresses } from '#lib/server/tokens'
 import { fetchAddressTransfersForValue } from '#lib/server/tempo-queries'
 import { zAddress } from '#lib/zod'
@@ -13,8 +12,6 @@ export const Route = createFileRoute('/api/address/total-value/$address')({
 	server: {
 		handlers: {
 			GET: async ({ params }) => {
-				if (!hasIndexSupply()) return Response.json({ totalValue: 0 })
-
 				try {
 					const address = zAddress().parse(params.address)
 					const chainId = getChainId(getWagmiConfig())

--- a/apps/explorer/src/routes/api/address/txs-count/$address.ts
+++ b/apps/explorer/src/routes/api/address/txs-count/$address.ts
@@ -3,7 +3,6 @@ import * as Address from 'ox/Address'
 import { getBlockNumber, getCode } from 'viem/actions'
 import { getChainId } from 'wagmi/actions'
 import * as z from 'zod/mini'
-import { hasIndexSupply } from '#lib/env'
 import { fetchAddressTxCounts } from '#lib/server/tempo-queries'
 import { zAddress } from '#lib/zod'
 import { getWagmiConfig } from '#wagmi.config'
@@ -71,8 +70,6 @@ export const Route = createFileRoute('/api/address/txs-count/$address')({
 	server: {
 		handlers: {
 			GET: async ({ params }) => {
-				if (!hasIndexSupply()) return Response.json({ data: 0, error: null })
-
 				try {
 					const address = zAddress().parse(params.address)
 					Address.assert(address)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -455,9 +455,6 @@ importers:
       hono:
         specifier: 'catalog:'
         version: 4.12.14
-      idxs:
-        specifier: 'catalog:'
-        version: 0.0.6(typescript@6.0.2)
       midcut:
         specifier: 'catalog:'
         version: 0.2.0(react@19.2.5)


### PR DESCRIPTION
Explorer already uses TIDX-backed helpers for these paths.

Remove stale availability checks and the unused idxs dependency.

Update contract creation comments to refer to indexed data.
