### PR TITLE
fix: update key manager WebAuthn routes

### DIFF
--- a/apps/key-manager/README.md
+++ b/apps/key-manager/README.md
@@ -1,14 +1,15 @@
 # Key Manager
 
-WebAuthn key management service using `Handler.keyManager` from `tempo.ts`.
+WebAuthn key management service using `Handler.webAuthn` from `accounts/server`.
 
 ## Endpoints
 
 | Endpoint | Method | Purpose |
 |----------|--------|---------|
-| `/challenge` | GET | Generate a new WebAuthn challenge |
-| `/:id` | GET | Retrieve the public key for a credential |
-| `/:id` | POST | Register a new credential with its public key |
+| `/register/options` | POST | Generate credential creation options |
+| `/register` | POST | Verify registration and store a credential |
+| `/login/options` | POST | Generate credential request options |
+| `/login` | POST | Verify authentication |
 
 ## Development
 

--- a/apps/key-manager/package.json
+++ b/apps/key-manager/package.json
@@ -11,7 +11,7 @@
 		"gen:types": "wrangler types --env-interface='CloudflareBindings'"
 	},
 	"dependencies": {
-		"tempo.ts": "catalog:"
+		"accounts": "catalog:"
 	},
 	"devDependencies": {
 		"@cloudflare/workers-types": "catalog:",

--- a/apps/key-manager/src/index.ts
+++ b/apps/key-manager/src/index.ts
@@ -1,6 +1,12 @@
 import { env } from 'cloudflare:workers'
-import { Handler, Kv } from 'tempo.ts/server'
+import { Handler, Kv } from 'accounts/server'
 
-export default Handler.keyManager({
+const allowedOrigins = env.ALLOWED_ORIGINS.split(',')
+	.map((origin) => origin.trim())
+	.filter(Boolean)
+
+export default Handler.webAuthn({
 	kv: Kv.cloudflare(env.KEY_STORE),
+	origin: allowedOrigins.length === 1 ? allowedOrigins[0] : allowedOrigins,
+	rpId: env.RP_ID,
 })

--- a/apps/key-manager/wrangler.json
+++ b/apps/key-manager/wrangler.json
@@ -7,6 +7,10 @@
 	"workers_dev": true,
 	"preview_urls": true,
 	"keep_vars": true,
+	"vars": {
+		"ALLOWED_ORIGINS": "https://tempo.xyz,https://www.tempo.xyz,https://docs.tempo.xyz,https://explorer.tempo.xyz,https://explorer.testnet.tempo.xyz",
+		"RP_ID": "tempo.xyz"
+	},
 	"observability": {
 		"enabled": true,
 		"logs": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -677,9 +677,9 @@ importers:
 
   apps/key-manager:
     dependencies:
-      tempo.ts:
+      accounts:
         specifier: 'catalog:'
-        version: 0.14.2(typescript@6.0.2)(viem@2.48.4(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6))(zod@4.3.6)
+        version: 0.8.5(@types/react@19.2.14)(@wagmi/core@3.4.8)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.48.4(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6))(wagmi@3.6.9)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: 'catalog:'


### PR DESCRIPTION
Switch keys.tempo.xyz to the accounts WebAuthn handler so it serves
the HTTP ceremony routes used by wagmi/tempo.

Keep the worker origin and RP ID explicit in Wrangler config.

Closes tempoxyz/tempo-apps#870

Closes tempoxyz/tempo-apps#887
