### PR TITLE
fix: stabilize wallet loading button width

### DIFF
--- a/apps/explorer/src/comps/WalletActions.tsx
+++ b/apps/explorer/src/comps/WalletActions.tsx
@@ -73,6 +73,7 @@ export function WalletActions(
 
 	return (
 		<InfoCard
+			className="min-[1240px]:w-full"
 			title={
 				<InfoCard.Title className="w-full justify-between">
 					Wallet actions


### PR DESCRIPTION
## Summary

- Make the wallet actions card fill the sidebar column on desktop.
- Keep the button width stable while labels change between idle and loading states.

## Screenshots

| Before | After |
|--------|-------|
| Not captured locally: pending wallet connection state requires a browser wallet extension. | Not captured locally: pending wallet connection state requires a browser wallet extension. |

## Checks

- `pnpm check`
- `pnpm check:types`
- `pnpm --filter explorer check:types`
- `pnpm exec biome check --write --unsafe apps/explorer/src/comps/WalletActions.tsx`
- `pnpm --filter explorer check:env`
- `pnpm --filter explorer build`
- `pnpm precommit`

## Notes

- `pnpm --filter explorer test --run` still fails before running tests with `Missing "#tanstack-router-entry" specifier in "@tanstack/start-server-core" package`.
