### PR TITLE
fix: use indexed explorer creation timestamps

### DIFF
--- a/apps/explorer/src/lib/server/address-metadata.ts
+++ b/apps/explorer/src/lib/server/address-metadata.ts
@@ -1,0 +1,72 @@
+import type { ContractCreationReceiptRow } from '#lib/server/tempo-queries'
+import { parseTimestamp } from '#lib/timestamp'
+
+type AddressTxAggregate = {
+	count?: number
+	latestTxsBlockTimestamp?: unknown
+	oldestTxsBlockTimestamp?: unknown
+	oldestTxHash?: string
+	oldestTxFrom?: string
+}
+
+type TokenCreatedTimestampRow = {
+	block_timestamp: unknown
+}
+
+export function pickTokenCreatedTimestamp(
+	createdRows: TokenCreatedTimestampRow[],
+): number | undefined {
+	return createdRows
+		.map((row) => parseTimestamp(row.block_timestamp))
+		.filter((value): value is number => value != null)
+		.sort((left, right) => left - right)[0]
+}
+
+export function pickTip20CreatedTimestamp(params: {
+	createdRows: TokenCreatedTimestampRow[]
+	firstTransferTimestamp: unknown
+	contractCreationTimestamp?: unknown
+}): number | undefined {
+	const tokenCreatedTimestamp = pickTokenCreatedTimestamp(params.createdRows)
+	const firstTransferTimestamp = parseTimestamp(params.firstTransferTimestamp)
+	const contractCreationTimestamp = parseTimestamp(
+		params.contractCreationTimestamp,
+	)
+
+	if (tokenCreatedTimestamp != null) return tokenCreatedTimestamp
+
+	return contractCreationTimestamp != null &&
+		(firstTransferTimestamp == null ||
+			contractCreationTimestamp < firstTransferTimestamp)
+		? contractCreationTimestamp
+		: firstTransferTimestamp
+}
+
+export function buildAddressTxMetadata(
+	aggregate: AddressTxAggregate,
+	creation: ContractCreationReceiptRow | undefined,
+): {
+	txCount: number
+	lastActivityTimestamp?: number
+	createdTimestamp?: number
+	createdTxHash?: string
+	createdBy?: string
+} {
+	const oldestTimestamp = parseTimestamp(aggregate.oldestTxsBlockTimestamp)
+	const creationTimestamp = parseTimestamp(creation?.block_timestamp)
+	const useCreation =
+		creationTimestamp != null &&
+		(oldestTimestamp == null || creationTimestamp <= oldestTimestamp)
+
+	return {
+		txCount: (aggregate.count ?? 0) + (creation ? 1 : 0),
+		lastActivityTimestamp: parseTimestamp(aggregate.latestTxsBlockTimestamp),
+		createdTimestamp:
+			useCreation && creationTimestamp != null
+				? creationTimestamp
+				: oldestTimestamp,
+		createdTxHash:
+			useCreation && creation ? creation.tx_hash : aggregate.oldestTxHash,
+		createdBy: useCreation && creation ? creation.from : aggregate.oldestTxFrom,
+	}
+}

--- a/apps/explorer/src/lib/server/contract-creation.ts
+++ b/apps/explorer/src/lib/server/contract-creation.ts
@@ -1,0 +1,201 @@
+import * as Address from 'ox/Address'
+import type * as Hex from 'ox/Hex'
+import { getTransactionReceipt } from 'viem/actions'
+import { getChainId, getPublicClient } from 'wagmi/actions'
+import { getWagmiConfig } from '#wagmi.config'
+
+export type ContractCreationData = {
+	blockNumber: bigint
+	timestamp: bigint
+	hash: Hex.Hex | null
+	from: Address.Address | null
+	to: Address.Address | null
+	value: bigint | null
+	status: 'success' | 'reverted' | null
+	gasUsed: bigint | null
+	effectiveGasPrice: bigint | null
+}
+
+type CreationTxData = {
+	hash: Hex.Hex
+	from: Address.Address
+	to: Address.Address | null
+	value: bigint
+	status: 'success' | 'reverted'
+	gasUsed: bigint
+	effectiveGasPrice: bigint | null
+}
+
+const MAX_CREATION_CACHE_SIZE = 1000
+const creationCache = new Map<string, ContractCreationData>()
+
+export function serializeContractCreation(creation: ContractCreationData) {
+	return {
+		blockNumber: creation.blockNumber.toString(),
+		timestamp: creation.timestamp.toString(),
+		hash: creation.hash,
+		from: creation.from,
+		to: creation.to,
+		value: creation.value?.toString() ?? null,
+		status: creation.status,
+		gasUsed: creation.gasUsed?.toString() ?? null,
+		effectiveGasPrice: creation.effectiveGasPrice?.toString() ?? null,
+	}
+}
+
+export async function fetchContractCreationData(
+	address: Address.Address,
+): Promise<ContractCreationData | null> {
+	const config = getWagmiConfig()
+	const chainId = getChainId(config)
+	const cacheKey = `${chainId}:${address.toLowerCase()}`
+
+	const cached = creationCache.get(cacheKey)
+	if (cached) return cached
+
+	const client = getPublicClient(config, { chainId })
+	if (!client) throw new Error('No client available')
+
+	const bytecode = await client.getCode({ address })
+	if (!bytecode || bytecode === '0x') return null
+
+	const latestBlock = await client.getBlockNumber()
+	const creationBlock = await binarySearchCreationBlock(
+		client,
+		address,
+		1n,
+		latestBlock,
+	)
+
+	if (creationBlock === null) return null
+
+	const block = await client.getBlock({
+		blockNumber: creationBlock,
+		includeTransactions: true,
+	})
+	const creationTx = await findCreationTxInBlock(
+		client,
+		address,
+		block.transactions,
+	)
+
+	const creation = {
+		blockNumber: creationBlock,
+		timestamp: block.timestamp,
+		hash: creationTx?.hash ?? null,
+		from: creationTx?.from ?? null,
+		to: creationTx?.to ?? null,
+		value: creationTx?.value ?? null,
+		status: creationTx?.status ?? null,
+		gasUsed: creationTx?.gasUsed ?? null,
+		effectiveGasPrice: creationTx?.effectiveGasPrice ?? null,
+	} satisfies ContractCreationData
+
+	if (creationCache.size >= MAX_CREATION_CACHE_SIZE) {
+		const firstKey = creationCache.keys().next().value
+		if (firstKey) creationCache.delete(firstKey)
+	}
+	creationCache.set(cacheKey, creation)
+
+	return creation
+}
+
+async function findCreationTxInBlock(
+	client: NonNullable<ReturnType<typeof getPublicClient>>,
+	address: Address.Address,
+	transactions: readonly {
+		hash: Hex.Hex
+		to: Address.Address | null
+		from: Address.Address
+		value: bigint
+	}[],
+): Promise<CreationTxData | null> {
+	// Filter to contract creation txs (to === null) to avoid N+1 receipt fetches
+	const candidates = transactions.filter((tx) => tx.to === null)
+	if (candidates.length === 0) return null
+
+	const receipts = await Promise.all(
+		candidates.map(async (tx) => {
+			try {
+				const receipt = await getTransactionReceipt(client, {
+					hash: tx.hash,
+				})
+				return { receipt, tx }
+			} catch {
+				return null
+			}
+		}),
+	)
+
+	for (const result of receipts) {
+		if (!result?.receipt.contractAddress) continue
+		if (!Address.isEqual(result.receipt.contractAddress, address)) continue
+
+		return {
+			hash: result.receipt.transactionHash,
+			from: result.receipt.from,
+			to: result.receipt.to,
+			value: result.tx.value,
+			status: result.receipt.status,
+			gasUsed: result.receipt.gasUsed,
+			effectiveGasPrice: result.receipt.effectiveGasPrice ?? null,
+		}
+	}
+
+	return null
+}
+
+async function binarySearchCreationBlock(
+	client: NonNullable<ReturnType<typeof getPublicClient>>,
+	address: Address.Address,
+	low: bigint,
+	high: bigint,
+): Promise<bigint | null> {
+	const MAX_BATCH_SIZE = 10
+
+	while (high - low > BigInt(MAX_BATCH_SIZE)) {
+		const mid = (low + high) / 2n
+
+		try {
+			const code = await client.getCode({
+				address,
+				blockNumber: mid,
+			})
+
+			if (code && code !== '0x') {
+				high = mid
+			} else {
+				low = mid + 1n
+			}
+		} catch {
+			low = mid + 1n
+		}
+	}
+
+	const blocksToCheck = []
+	for (let b = low; b <= high; b++) {
+		blocksToCheck.push(b)
+	}
+
+	const results = await Promise.all(
+		blocksToCheck.map(async (blockNum) => {
+			try {
+				const code = await client.getCode({
+					address,
+					blockNumber: blockNum,
+				})
+				return { blockNum, hasCode: Boolean(code && code !== '0x') }
+			} catch {
+				return { blockNum, hasCode: false }
+			}
+		}),
+	)
+
+	for (const result of results) {
+		if (result.hasCode) {
+			return result.blockNum
+		}
+	}
+
+	return null
+}

--- a/apps/explorer/src/lib/server/tempo-queries.ts
+++ b/apps/explorer/src/lib/server/tempo-queries.ts
@@ -1511,6 +1511,25 @@ export async function fetchAddressTxAggregate(
 	}
 }
 
+export type ContractCreationReceiptRow = {
+	tx_hash: Hex.Hex
+	from: string
+	block_timestamp: string | number | bigint | null
+}
+
+export async function fetchContractCreationReceipt(
+	address: Address.Address,
+	chainId: number,
+): Promise<ContractCreationReceiptRow | undefined> {
+	return (await QB(chainId)
+		.selectFrom('receipts')
+		.select(['tx_hash', 'from', 'block_timestamp'])
+		.where('contract_address', '=', address)
+		.orderBy('block_num', 'asc')
+		.limit(1)
+		.executeTakeFirst()) as ContractCreationReceiptRow | undefined
+}
+
 export async function fetchAddressTxCounts(
 	address: Address.Address,
 	chainId: number,
@@ -1603,15 +1622,7 @@ export async function fetchAddressOgMeta(
 
 	// Check receipts for contract creation (deployments have to=null,
 	// so they won't appear in the from/to aggregate)
-	type CreationRow = {
-		block_timestamp: string | number | bigint | null
-	}
-	const creation = (await QB(chainId)
-		.selectFrom('receipts')
-		.select(['block_timestamp'])
-		.where('contract_address', '=', address)
-		.limit(1)
-		.executeTakeFirst()) as CreationRow | undefined
+	const creation = await fetchContractCreationReceipt(address, chainId)
 
 	if (creation) {
 		txCount += 1

--- a/apps/explorer/src/lib/timestamp.ts
+++ b/apps/explorer/src/lib/timestamp.ts
@@ -1,5 +1,8 @@
 export function parseTimestamp(value: unknown): number | undefined {
 	if (typeof value === 'number' && Number.isFinite(value)) return value
+	// Unix seconds fit comfortably within Number.MAX_SAFE_INTEGER (~285,000 years
+	// from epoch), so the bigint -> number cast is safe for timestamp inputs.
+	if (typeof value === 'bigint') return Number(value)
 	if (typeof value !== 'string') return undefined
 
 	const parsedNumber = Number(value)

--- a/apps/explorer/src/routes/_layout/address/$address.tsx
+++ b/apps/explorer/src/routes/_layout/address/$address.tsx
@@ -793,24 +793,34 @@ function AccountCardWithTimestamps(props: {
 
 	const resolvedAccountType = addressMetadata?.accountType ?? initialAccountType
 	const isContract = resolvedAccountType === 'contract'
-	const missingCreated = !addressMetadata?.createdTimestamp
+	const missingCreated = addressMetadata?.createdTimestamp == null
+	const isTip20 = Tip20.isTip20Address(address)
 
-	// For contracts without a createdTimestamp from metadata (0-tx contracts),
-	// fall back to binary-search contract creation lookup
+	// Fall back to binary-search contract creation lookup when metadata has no
+	// timestamp, and cross-check TIP-20 tokens whose first transfer can be later
+	// than their creation block.
 	const { data: contractCreation } = useQuery({
 		queryKey: ['contract-creation', address],
 		queryFn: () => fetchContractCreation(address),
-		enabled: isContract && missingCreated,
+		enabled: isContract && (missingCreated || isTip20),
 		staleTime: 60_000,
 	})
 
-	const createdTimestamp = addressMetadata?.createdTimestamp
-		? BigInt(addressMetadata.createdTimestamp)
-		: contractCreation?.creation?.timestamp
+	const metadataCreatedTimestamp =
+		addressMetadata?.createdTimestamp != null
+			? BigInt(addressMetadata.createdTimestamp)
+			: undefined
+	const contractCreatedTimestamp =
+		contractCreation?.creation?.timestamp != null
 			? BigInt(contractCreation.creation.timestamp)
 			: undefined
+	const createdTimestamp =
+		metadataCreatedTimestamp != null && contractCreatedTimestamp != null
+			? metadataCreatedTimestamp <= contractCreatedTimestamp
+				? metadataCreatedTimestamp
+				: contractCreatedTimestamp
+			: (metadataCreatedTimestamp ?? contractCreatedTimestamp)
 
-	const isTip20 = Tip20.isTip20Address(address)
 	const virtualAddressParts = getVirtualAddressParts(address)
 	const { isTokenListed } = useTokenListMembership()
 	const totalValue = React.useMemo(

--- a/apps/explorer/src/routes/api/address/metadata/$address.ts
+++ b/apps/explorer/src/routes/api/address/metadata/$address.ts
@@ -4,12 +4,20 @@ import { VirtualAddress } from 'ox/tempo'
 import { getCode } from 'viem/actions'
 import { getAccountType, type AccountType } from '#lib/account'
 import { isTip20Address } from '#lib/domain/tip20'
+import { fetchContractCreationData } from '#lib/server/contract-creation'
 import {
 	fetchAddressTxAggregate,
+	fetchContractCreationReceipt,
+	fetchTokenCreatedMetadata,
 	fetchTokenHoldersCountRows,
 	fetchTokenTransferAggregate,
 	fetchVirtualAddressTransferAggregate,
 } from '#lib/server/tempo-queries'
+import {
+	buildAddressTxMetadata,
+	pickTip20CreatedTimestamp,
+	pickTokenCreatedTimestamp,
+} from '#lib/server/address-metadata'
 import { parseTimestamp } from '#lib/timestamp'
 import { zAddress } from '#lib/zod'
 import { getBatchedClient, getTempoChain } from '#wagmi.config.ts'
@@ -72,40 +80,51 @@ export const Route = createFileRoute('/api/address/metadata/$address')({
 							createdTimestamp: parseTimestamp(result.oldestTimestamp),
 						}
 					} else if (isTip20) {
-						const [bytecode, result, holdersRows] = await Promise.all([
-							bytecodePromise,
-							fetchTokenTransferAggregate(address, chainId).catch(() => ({
-								oldestTimestamp: undefined,
-								latestTimestamp: undefined,
-							})),
-							fetchTokenHoldersCountRows([address], chainId, 10_000).catch(
-								() => [],
-							),
-						])
+						const [bytecode, result, holdersRows, createdRows] =
+							await Promise.all([
+								bytecodePromise,
+								fetchTokenTransferAggregate(address, chainId).catch(() => ({
+									oldestTimestamp: undefined,
+									latestTimestamp: undefined,
+								})),
+								fetchTokenHoldersCountRows([address], chainId, 10_000).catch(
+									() => [],
+								),
+								fetchTokenCreatedMetadata(chainId, [address]).catch(() => []),
+							])
+						const tokenCreatedTimestamp = pickTokenCreatedTimestamp(createdRows)
+						const contractCreation =
+							tokenCreatedTimestamp == null
+								? await fetchContractCreationData(address).catch(() => null)
+								: null
+
 						response = {
 							address,
 							chainId,
 							accountType: getAccountType(bytecode),
 							holdersCount: holdersRows[0]?.count ?? 0,
 							lastActivityTimestamp: parseTimestamp(result.latestTimestamp),
-							createdTimestamp: parseTimestamp(result.oldestTimestamp),
+							createdTimestamp: pickTip20CreatedTimestamp({
+								createdRows,
+								firstTransferTimestamp: result.oldestTimestamp,
+								contractCreationTimestamp: contractCreation?.timestamp,
+							}),
 						}
 					} else {
-						const [bytecode, result] = await Promise.all([
+						const [bytecode, result, creation] = await Promise.all([
 							bytecodePromise,
 							fetchAddressTxAggregate(address, chainId),
+							fetchContractCreationReceipt(address, chainId).catch(
+								() => undefined,
+							),
 						])
+						const metadata = buildAddressTxMetadata(result, creation)
+
 						response = {
 							address,
 							chainId,
 							accountType: getAccountType(bytecode),
-							txCount: result.count ?? 0,
-							lastActivityTimestamp: parseTimestamp(
-								result.latestTxsBlockTimestamp,
-							),
-							createdTimestamp: parseTimestamp(result.oldestTxsBlockTimestamp),
-							createdTxHash: result.oldestTxHash,
-							createdBy: result.oldestTxFrom,
+							...metadata,
 						}
 					}
 

--- a/apps/explorer/src/routes/api/contract/creation/$address.ts
+++ b/apps/explorer/src/routes/api/contract/creation/$address.ts
@@ -1,49 +1,10 @@
 import { createFileRoute } from '@tanstack/react-router'
 import * as Address from 'ox/Address'
-import type * as Hex from 'ox/Hex'
-import { getTransactionReceipt } from 'viem/actions'
-import { getChainId, getPublicClient } from 'wagmi/actions'
+import {
+	fetchContractCreationData,
+	serializeContractCreation,
+} from '#lib/server/contract-creation'
 import { zAddress } from '#lib/zod'
-import { getWagmiConfig } from '#wagmi.config'
-
-type CreationData = {
-	blockNumber: bigint
-	timestamp: bigint
-	hash: Hex.Hex | null
-	from: Address.Address | null
-	to: Address.Address | null
-	value: bigint | null
-	status: 'success' | 'reverted' | null
-	gasUsed: bigint | null
-	effectiveGasPrice: bigint | null
-}
-
-type CreationTxData = {
-	hash: Hex.Hex
-	from: Address.Address
-	to: Address.Address | null
-	value: bigint
-	status: 'success' | 'reverted'
-	gasUsed: bigint
-	effectiveGasPrice: bigint | null
-}
-
-const MAX_CREATION_CACHE_SIZE = 1000
-const creationCache = new Map<string, CreationData>()
-
-function serializeCreation(creation: CreationData) {
-	return {
-		blockNumber: creation.blockNumber.toString(),
-		timestamp: creation.timestamp.toString(),
-		hash: creation.hash,
-		from: creation.from,
-		to: creation.to,
-		value: creation.value?.toString() ?? null,
-		status: creation.status,
-		gasUsed: creation.gasUsed?.toString() ?? null,
-		effectiveGasPrice: creation.effectiveGasPrice?.toString() ?? null,
-	}
-}
 
 export const Route = createFileRoute('/api/contract/creation/$address')({
 	server: {
@@ -53,74 +14,10 @@ export const Route = createFileRoute('/api/contract/creation/$address')({
 					const address = zAddress().parse(params.address)
 					Address.assert(address)
 
-					const config = getWagmiConfig()
-					const chainId = getChainId(config)
-					const cacheKey = `${chainId}:${address.toLowerCase()}`
-
-					const cached = creationCache.get(cacheKey)
-					if (cached) {
-						return Response.json({
-							creation: serializeCreation(cached),
-							error: null,
-						})
-					}
-
-					const client = getPublicClient(config, { chainId })
-
-					if (!client) {
-						return Response.json(
-							{ creation: null, error: 'No client available' },
-							{ status: 500 },
-						)
-					}
-
-					const bytecode = await client.getCode({ address })
-					if (!bytecode || bytecode === '0x') {
-						return Response.json({ creation: null, error: null })
-					}
-
-					const latestBlock = await client.getBlockNumber()
-					const creationBlock = await binarySearchCreationBlock(
-						client,
-						address,
-						1n,
-						latestBlock,
-					)
-
-					if (creationBlock === null) {
-						return Response.json({ creation: null, error: null })
-					}
-
-					const block = await client.getBlock({
-						blockNumber: creationBlock,
-						includeTransactions: true,
-					})
-					const creationTx = await findCreationTxInBlock(
-						client,
-						address,
-						block.transactions,
-					)
-
-					const creation = {
-						blockNumber: creationBlock,
-						timestamp: block.timestamp,
-						hash: creationTx?.hash ?? null,
-						from: creationTx?.from ?? null,
-						to: creationTx?.to ?? null,
-						value: creationTx?.value ?? null,
-						status: creationTx?.status ?? null,
-						gasUsed: creationTx?.gasUsed ?? null,
-						effectiveGasPrice: creationTx?.effectiveGasPrice ?? null,
-					} satisfies CreationData
-
-					if (creationCache.size >= MAX_CREATION_CACHE_SIZE) {
-						const firstKey = creationCache.keys().next().value
-						if (firstKey) creationCache.delete(firstKey)
-					}
-					creationCache.set(cacheKey, creation)
+					const creation = await fetchContractCreationData(address)
 
 					return Response.json({
-						creation: serializeCreation(creation),
+						creation: creation ? serializeContractCreation(creation) : null,
 						error: null,
 					})
 				} catch (error) {
@@ -135,103 +32,3 @@ export const Route = createFileRoute('/api/contract/creation/$address')({
 		},
 	},
 })
-
-async function findCreationTxInBlock(
-	client: NonNullable<ReturnType<typeof getPublicClient>>,
-	address: Address.Address,
-	transactions: readonly {
-		hash: Hex.Hex
-		to: Address.Address | null
-		from: Address.Address
-		value: bigint
-	}[],
-): Promise<CreationTxData | null> {
-	// Filter to contract creation txs (to === null) to avoid N+1 receipt fetches
-	const candidates = transactions.filter((tx) => tx.to === null)
-	if (candidates.length === 0) return null
-
-	const receipts = await Promise.all(
-		candidates.map(async (tx) => {
-			try {
-				const receipt = await getTransactionReceipt(client, {
-					hash: tx.hash,
-				})
-				return { receipt, tx }
-			} catch {
-				return null
-			}
-		}),
-	)
-
-	for (const result of receipts) {
-		if (!result?.receipt.contractAddress) continue
-		if (!Address.isEqual(result.receipt.contractAddress, address)) continue
-
-		return {
-			hash: result.receipt.transactionHash,
-			from: result.receipt.from,
-			to: result.receipt.to,
-			value: result.tx.value,
-			status: result.receipt.status,
-			gasUsed: result.receipt.gasUsed,
-			effectiveGasPrice: result.receipt.effectiveGasPrice ?? null,
-		}
-	}
-
-	return null
-}
-
-async function binarySearchCreationBlock(
-	client: NonNullable<ReturnType<typeof getPublicClient>>,
-	address: Address.Address,
-	low: bigint,
-	high: bigint,
-): Promise<bigint | null> {
-	const MAX_BATCH_SIZE = 10
-
-	while (high - low > BigInt(MAX_BATCH_SIZE)) {
-		const mid = (low + high) / 2n
-
-		try {
-			const code = await client.getCode({
-				address,
-				blockNumber: mid,
-			})
-
-			if (code && code !== '0x') {
-				high = mid
-			} else {
-				low = mid + 1n
-			}
-		} catch {
-			low = mid + 1n
-		}
-	}
-
-	const blocksToCheck = []
-	for (let b = low; b <= high; b++) {
-		blocksToCheck.push(b)
-	}
-
-	const results = await Promise.all(
-		blocksToCheck.map(async (blockNum) => {
-			try {
-				const code = await client.getCode({
-					address,
-					blockNumber: blockNum,
-				})
-				return { blockNum, hasCode: Boolean(code && code !== '0x') }
-			} catch {
-				return { blockNum, hasCode: false }
-			}
-		}),
-	)
-
-	for (const result of results) {
-		if (result.hasCode) {
-			return result.blockNum
-		}
-	}
-
-	return null
-}

--- a/apps/explorer/test/tempo-queries.test.ts
+++ b/apps/explorer/test/tempo-queries.test.ts
@@ -142,6 +142,7 @@ import {
 	fetchAddressTxAggregate,
 	fetchAddressTxCounts,
 	fetchBasicTxDataByHashes,
+	fetchContractCreationReceipt,
 	fetchContractCreationTxCandidates,
 	fetchLatestBlockNumber,
 	fetchTokenCreatedCount,
@@ -791,6 +792,7 @@ describe('tempo-queries', () => {
 				{
 					topic1,
 					data,
+					block_timestamp: '123',
 				},
 			],
 		])
@@ -801,6 +803,7 @@ describe('tempo-queries', () => {
 				name: 'Token',
 				symbol: 'TOK',
 				currency: 'USD',
+				block_timestamp: '123',
 			},
 		])
 	})
@@ -1564,6 +1567,32 @@ describe('tempo-queries', () => {
 			oldestTxHash: '0xoldest',
 			oldestTxFrom: '0xCreator',
 		})
+	})
+
+	it('fetchContractCreationReceipt returns the creation receipt row', async () => {
+		mockQueryBuilder.setResponses([
+			{
+				tx_hash: '0xcreated',
+				from: '0xCreator',
+				block_timestamp: '123',
+			},
+		])
+
+		await expect(
+			fetchContractCreationReceipt('0x1111' as Address.Address, 1),
+		).resolves.toEqual({
+			tx_hash: '0xcreated',
+			from: '0xCreator',
+			block_timestamp: '123',
+		})
+	})
+
+	it('fetchContractCreationReceipt returns undefined when missing', async () => {
+		mockQueryBuilder.setResponses([undefined])
+
+		await expect(
+			fetchContractCreationReceipt('0x1111' as Address.Address, 1),
+		).resolves.toBeUndefined()
 	})
 
 	it('fetchAddressTxCounts returns sent and received counts', async () => {


### PR DESCRIPTION
## Summary
- Prefer bounded TokenCreated metadata for TIP-20 created timestamps.
- Use indexed contract creation receipts for non-TIP20 address metadata.
- Let the contract creation fallback cross-check TIP-20 pages and render the earliest timestamp.

## Tests
- pnpm --filter explorer check:types
- pnpm --filter explorer check:env
- scoped Biome check on touched explorer files

## Notes
- Exact Cloudflare-pool command pnpm --filter explorer test -- run test/tempo-queries.test.ts still fails before tests with missing #tanstack-router-entry in @tanstack/start-server-core.
- Root pnpm check/check:types still fail in apps/contract-verification due missing generated Env bindings.

Closes #858