### PR TITLE
perf: redesign dashboard with peak throughput hero and MPP workload sections

### DIFF
--- a/apps/perf/src/routes/__root.tsx
+++ b/apps/perf/src/routes/__root.tsx
@@ -67,7 +67,6 @@ function RootDocument() {
 			<body>
 				<QueryClientProvider client={queryClient}>
 					<div className="mx-auto min-h-dvh max-w-[1200px] px-6 lg:px-[84px]">
-						<Banner />
 						<Header />
 						<main>
 							<Outlet />
@@ -78,14 +77,6 @@ function RootDocument() {
 				<Scripts />
 			</body>
 		</html>
-	)
-}
-
-function Banner(): React.JSX.Element {
-	return (
-		<div className="mt-4 rounded-lg border border-negative/40 bg-negative/10 px-4 py-2.5 text-center text-[13px] font-medium text-negative">
-			🚧 Under development
-		</div>
 	)
 }
 

--- a/apps/perf/src/routes/index.tsx
+++ b/apps/perf/src/routes/index.tsx
@@ -63,12 +63,7 @@ function DashboardPage(): React.JSX.Element {
 		return latestRuns.find((r) => r.scenarioId === scenarioId)
 	}
 
-	const runsWithData = latestRuns.filter((r) => r.peakGasPerSecond > 0)
-	const peakRun = runsWithData.length > 0
-		? runsWithData.reduce((best, r) =>
-				r.peakGasPerSecond > best.peakGasPerSecond ? r : best,
-			)
-		: null
+	const runsWithData = latestRuns.filter((r) => r.avgTps > 0)
 	const peakTpsRun = runsWithData.length > 0
 		? runsWithData.reduce((best, r) =>
 				r.avgTps > best.avgTps ? r : best,
@@ -80,22 +75,27 @@ function DashboardPage(): React.JSX.Element {
 
 	return (
 		<div>
-			{/* Hero — peak throughput headline */}
-			<section className="mb-14 pt-4">
+			<p className="pt-4 pb-8 max-w-xl text-[14px] leading-relaxed text-secondary">
+				Real-time benchmarks measuring Tempo&apos;s throughput and latency
+				under production-representative workloads.
+			</p>
+
+			{/* Hero — peak TPS headline */}
+			<section className="mb-14">
 				<p className="text-[13px] font-medium uppercase tracking-wider text-tertiary">
-					Peak Throughput
+					Peak TPS
 				</p>
-				{peakRun ? (
+				{peakTpsRun ? (
 					<>
 						<h2 className="mt-2 font-mono text-[56px] font-bold leading-none tracking-tight text-accent">
-							{formatGas(peakRun.peakGasPerSecond)}
+							{formatTps(peakTpsRun.avgTps)} <span className="text-[28px] font-semibold text-tertiary">TPS</span>
 						</h2>
 						<div className="mt-5 flex flex-wrap items-center gap-6">
-							<HeroStat label="Peak TPS" value={peakTpsRun ? formatTps(peakTpsRun.avgTps) : '—'} />
-							<HeroStat label="Block Time" value={formatMs(peakRun.avgBlockTimeMs)} />
+							<HeroStat label="Throughput" value={formatGas(peakTpsRun.peakGasPerSecond)} />
+							<HeroStat label="Block Time" value={formatMs(peakTpsRun.avgBlockTimeMs)} />
 							<HeroStat
 								label="Workload"
-								value={scenarios.find((s) => s.id === peakRun.scenarioId)?.label ?? peakRun.scenarioId}
+								value={scenarios.find((s) => s.id === peakTpsRun.scenarioId)?.label ?? peakTpsRun.scenarioId}
 							/>
 						</div>
 					</>
@@ -104,27 +104,23 @@ function DashboardPage(): React.JSX.Element {
 						—
 					</h2>
 				)}
-				<p className="mt-6 max-w-lg text-[14px] leading-relaxed text-secondary">
-					Real-time benchmarks measuring Tempo&apos;s throughput and latency
-					under production-representative workloads.
-				</p>
 			</section>
 
 			{/* Throughput comparison — visual bar chart */}
 			{runsWithData.length > 0 && (
 				<section className="mb-14">
-					<SectionHeader title="Throughput Comparison" />
+					<SectionHeader title="TPS Comparison" />
 					<div className="card p-6">
 						<div className="flex items-end gap-4 h-52">
 							{scenarios.map((scenario) => {
 								const latest = getLatestRun(scenario.id)
 								if (!latest) return null
-								const maxGas = Math.max(
+								const maxTps = Math.max(
 									...scenarios.map(
-										(s) => getLatestRun(s.id)?.peakGasPerSecond ?? 0,
+										(s) => getLatestRun(s.id)?.avgTps ?? 0,
 									),
 								)
-								const height = (latest.peakGasPerSecond / maxGas) * 100
+								const height = (latest.avgTps / maxTps) * 100
 								const isMix = scenario.id.startsWith('mix-')
 								return (
 									<Link
@@ -134,7 +130,7 @@ function DashboardPage(): React.JSX.Element {
 										className="flex flex-1 flex-col items-center gap-2 group"
 									>
 										<span className="font-mono text-[12px] font-medium text-accent">
-											{formatGas(latest.peakGasPerSecond)}
+											{formatTps(latest.avgTps)}
 										</span>
 										<div
 											className="w-full flex items-end"
@@ -203,16 +199,14 @@ function DashboardPage(): React.JSX.Element {
 							<tr className="border-b border-border bg-surface-raised text-left text-tertiary">
 								<th className="px-4.5 py-3 font-normal">Workload</th>
 								<th className="px-4.5 py-3 font-normal">Version</th>
-								<th className="px-4.5 py-3 font-normal text-right">
-									Peak
-								</th>
-								<th className="px-4.5 py-3 font-normal text-right">
-									Avg Throughput
-								</th>
 								<th className="px-4.5 py-3 font-normal text-right">TPS</th>
 								<th className="px-4.5 py-3 font-normal text-right">
 									Block Time
 								</th>
+								<th className="px-4.5 py-3 font-normal text-right">
+									Throughput
+								</th>
+								<th className="px-4.5 py-3 font-normal text-right">Peak</th>
 								<th className="px-4.5 py-3 font-normal text-right">Date</th>
 							</tr>
 						</thead>
@@ -238,16 +232,16 @@ function DashboardPage(): React.JSX.Element {
 											<VersionLink run={latest} />
 										</td>
 										<td className="px-4.5 py-3 text-right font-mono font-medium text-accent">
-											{formatGas(latest.peakGasPerSecond)}
+											{formatTps(latest.avgTps)}
+										</td>
+										<td className="px-4.5 py-3 text-right font-mono text-primary">
+											{formatMs(latest.avgBlockTimeMs)}
 										</td>
 										<td className="px-4.5 py-3 text-right font-mono text-primary">
 											{formatGas(latest.avgGasPerSecond)}
 										</td>
 										<td className="px-4.5 py-3 text-right font-mono text-primary">
-											{formatTps(latest.avgTps)}
-										</td>
-										<td className="px-4.5 py-3 text-right font-mono text-primary">
-											{formatMs(latest.avgBlockTimeMs)}
+											{formatGas(latest.peakGasPerSecond)}
 										</td>
 										<td className="px-4.5 py-3 text-right text-tertiary">
 											{formatDate(latest.startedAt)}
@@ -302,18 +296,18 @@ function ScenarioCard(props: {
 				<div className="mt-auto border-t border-border px-5 pt-4 pb-5">
 					<div className="grid grid-cols-2 gap-x-4 gap-y-3">
 						<Stat
-							label="Peak"
-							value={formatGas(run.peakGasPerSecond)}
+							label="TPS"
+							value={formatTps(run.avgTps)}
 							highlight
 						/>
 						<Stat
-							label="Avg Throughput"
-							value={formatGas(run.avgGasPerSecond)}
-						/>
-						<Stat label="Avg TPS" value={formatTps(run.avgTps)} />
-						<Stat
 							label="Block Time"
 							value={formatMs(run.avgBlockTimeMs)}
+						/>
+						<Stat label="Throughput" value={formatGas(run.avgGasPerSecond)} />
+						<Stat
+							label="Peak"
+							value={formatGas(run.peakGasPerSecond)}
 						/>
 					</div>
 				</div>

--- a/apps/perf/src/routes/index.tsx
+++ b/apps/perf/src/routes/index.tsx
@@ -63,144 +63,140 @@ function DashboardPage(): React.JSX.Element {
 		return latestRuns.find((r) => r.scenarioId === scenarioId)
 	}
 
+	const runsWithData = latestRuns.filter((r) => r.peakGasPerSecond > 0)
+	const peakRun = runsWithData.length > 0
+		? runsWithData.reduce((best, r) =>
+				r.peakGasPerSecond > best.peakGasPerSecond ? r : best,
+			)
+		: null
+	const peakTpsRun = runsWithData.length > 0
+		? runsWithData.reduce((best, r) =>
+				r.avgTps > best.avgTps ? r : best,
+			)
+		: null
+
+	const tip20Scenarios = scenarios.filter((s) => s.id.startsWith('tip20-'))
+	const mixScenarios = scenarios.filter((s) => s.id.startsWith('mix-'))
+
 	return (
 		<div>
-			{/* Hero */}
-			<section className="mb-12 pt-4">
-				<h2 className="text-[28px] font-bold tracking-tight text-primary">
-					Performance Dashboard
-				</h2>
-				<p className="mt-2 max-w-xl text-[15px] leading-relaxed text-secondary">
+			{/* Hero — peak throughput headline */}
+			<section className="mb-14 pt-4">
+				<p className="text-[13px] font-medium uppercase tracking-wider text-tertiary">
+					Peak Throughput
+				</p>
+				{peakRun ? (
+					<>
+						<h2 className="mt-2 font-mono text-[56px] font-bold leading-none tracking-tight text-accent">
+							{formatGas(peakRun.peakGasPerSecond)}
+						</h2>
+						<div className="mt-5 flex flex-wrap items-center gap-6">
+							<HeroStat label="Peak TPS" value={peakTpsRun ? formatTps(peakTpsRun.avgTps) : '—'} />
+							<HeroStat label="Block Time" value={formatMs(peakRun.avgBlockTimeMs)} />
+							<HeroStat
+								label="Workload"
+								value={scenarios.find((s) => s.id === peakRun.scenarioId)?.label ?? peakRun.scenarioId}
+							/>
+						</div>
+					</>
+				) : (
+					<h2 className="mt-2 font-mono text-[56px] font-bold leading-none tracking-tight text-tertiary">
+						—
+					</h2>
+				)}
+				<p className="mt-6 max-w-lg text-[14px] leading-relaxed text-secondary">
 					Real-time benchmarks measuring Tempo&apos;s throughput and latency
 					under production-representative workloads.
 				</p>
 			</section>
 
-			{/* Scenario cards */}
-			<section className="mb-14">
-				<div className="mb-5 flex items-center gap-3">
-					<h3 className="text-[13px] font-normal uppercase tracking-wider text-tertiary">
-						Workloads
-					</h3>
-					<div className="h-px flex-1 bg-border" />
-				</div>
-
-				<div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-					{scenarios.map((scenario) => {
-						const latest = getLatestRun(scenario.id)
-						const content = (
-							<>
-								<div className="p-5 pb-4">
-									<h4 className="text-[15px] font-semibold text-primary">
-										{scenario.label}
-									</h4>
-									<p className="mt-1 text-[12px] text-tertiary">
-										{scenario.workload}
-									</p>
-								</div>
-
-								{latest ? (
-									<div className="mt-auto border-t border-border px-5 pt-4 pb-5">
-										<div className="grid grid-cols-2 gap-x-4 gap-y-3">
-											<Stat
-												label="Throughput"
-												value={formatGas(latest.avgGasPerSecond)}
-												highlight
-											/>
-											<Stat
-												label="Peak"
-												value={formatGas(latest.peakGasPerSecond)}
-											/>
-											<Stat label="Avg TPS" value={formatTps(latest.avgTps)} />
-											<Stat
-												label="Block Time"
-												value={formatMs(latest.avgBlockTimeMs)}
+			{/* Throughput comparison — visual bar chart */}
+			{runsWithData.length > 0 && (
+				<section className="mb-14">
+					<SectionHeader title="Throughput Comparison" />
+					<div className="card p-6">
+						<div className="flex items-end gap-4 h-52">
+							{scenarios.map((scenario) => {
+								const latest = getLatestRun(scenario.id)
+								if (!latest) return null
+								const maxGas = Math.max(
+									...scenarios.map(
+										(s) => getLatestRun(s.id)?.peakGasPerSecond ?? 0,
+									),
+								)
+								const height = (latest.peakGasPerSecond / maxGas) * 100
+								const isMix = scenario.id.startsWith('mix-')
+								return (
+									<Link
+										key={scenario.id}
+										to="/benchmark/$id"
+										params={{ id: latest.id }}
+										className="flex flex-1 flex-col items-center gap-2 group"
+									>
+										<span className="font-mono text-[12px] font-medium text-accent">
+											{formatGas(latest.peakGasPerSecond)}
+										</span>
+										<div
+											className="w-full flex items-end"
+											style={{ height: '160px' }}
+										>
+											<div
+												className={`w-full rounded-t transition-opacity group-hover:opacity-80 ${isMix ? 'bg-positive/50' : 'bg-accent/50'}`}
+												style={{ height: `${height}%` }}
 											/>
 										</div>
-									</div>
-								) : (
-									<div className="mt-auto border-t border-border px-5 py-4">
-										<p className="text-[12px] text-tertiary italic">
-											No runs yet
-										</p>
-									</div>
-								)}
-							</>
-						)
-
-						return latest ? (
-							<Link
-								key={scenario.id}
-								to="/benchmark/$id"
-								params={{ id: latest.id }}
-								className="card-interactive flex flex-col"
-							>
-								{content}
-							</Link>
-						) : (
-							<div key={scenario.id} className="card flex flex-col">
-								{content}
+										<span className="text-[11px] text-tertiary text-center leading-tight">
+											{scenario.label}
+										</span>
+									</Link>
+								)
+							})}
+						</div>
+						<div className="mt-4 flex items-center justify-center gap-6">
+							<div className="flex items-center gap-1.5">
+								<span className="inline-block h-2.5 w-2.5 rounded-full bg-accent/50" />
+								<span className="text-[11px] text-tertiary">TIP-20 Transfers</span>
 							</div>
-						)
-					})}
+							<div className="flex items-center gap-1.5">
+								<span className="inline-block h-2.5 w-2.5 rounded-full bg-positive/50" />
+								<span className="text-[11px] text-tertiary">Mix (MPP)</span>
+							</div>
+						</div>
+					</div>
+				</section>
+			)}
+
+			{/* TIP-20 workloads */}
+			<section className="mb-14">
+				<SectionHeader title="TIP-20 Transfers" subtitle="100% TIP-20 token transfers" />
+				<div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+					{tip20Scenarios.map((scenario) => (
+						<ScenarioCard
+							key={scenario.id}
+							scenario={scenario}
+							run={getLatestRun(scenario.id)}
+						/>
+					))}
 				</div>
 			</section>
 
-			{/* Throughput comparison */}
+			{/* Mix (MPP) workloads */}
 			<section className="mb-14">
-				<div className="mb-5 flex items-center gap-3">
-					<h3 className="text-[13px] font-normal uppercase tracking-wider text-tertiary">
-						Throughput Comparison
-					</h3>
-					<div className="h-px flex-1 bg-border" />
-				</div>
-				<div className="card p-6">
-					<div className="flex items-end gap-6 h-52">
-						{scenarios.map((scenario) => {
-							const latest = getLatestRun(scenario.id)
-							if (!latest) return null
-							const maxGas = Math.max(
-								...scenarios.map(
-									(s) => getLatestRun(s.id)?.avgGasPerSecond ?? 0,
-								),
-							)
-							const height = (latest.avgGasPerSecond / maxGas) * 100
-							return (
-								<div
-									key={scenario.id}
-									className="flex flex-1 flex-col items-center gap-2"
-								>
-									<span className="font-mono text-[12px] font-medium text-accent">
-										{formatGas(latest.avgGasPerSecond)}
-									</span>
-									<div
-										className="w-full flex items-end"
-										style={{ height: '160px' }}
-									>
-										<div
-											className="w-full rounded-t bg-accent/50"
-											style={{ height: `${height}%` }}
-										/>
-									</div>
-									<span className="text-[11px] text-tertiary text-center leading-tight">
-										{scenario.label}
-									</span>
-								</div>
-							)
-						})}
-					</div>
+				<SectionHeader title="Mixed Workloads" subtitle="80% TIP-20 Transfers, 20% MPP Channels" />
+				<div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+					{mixScenarios.map((scenario) => (
+						<ScenarioCard
+							key={scenario.id}
+							scenario={scenario}
+							run={getLatestRun(scenario.id)}
+						/>
+					))}
 				</div>
 			</section>
 
 			{/* Latest runs table */}
 			<section className="mb-14">
-				<div className="mb-5 flex items-center gap-3">
-					<h3 className="text-[13px] font-normal uppercase tracking-wider text-tertiary">
-						Latest Results
-					</h3>
-					<div className="h-px flex-1 bg-border" />
-				</div>
-
+				<SectionHeader title="Latest Results" />
 				<div className="card">
 					<table className="w-full text-[13px]">
 						<thead>
@@ -208,7 +204,10 @@ function DashboardPage(): React.JSX.Element {
 								<th className="px-4.5 py-3 font-normal">Workload</th>
 								<th className="px-4.5 py-3 font-normal">Version</th>
 								<th className="px-4.5 py-3 font-normal text-right">
-									Throughput
+									Peak
+								</th>
+								<th className="px-4.5 py-3 font-normal text-right">
+									Avg Throughput
 								</th>
 								<th className="px-4.5 py-3 font-normal text-right">TPS</th>
 								<th className="px-4.5 py-3 font-normal text-right">
@@ -238,7 +237,10 @@ function DashboardPage(): React.JSX.Element {
 										<td className="px-4.5 py-3 font-mono text-accent">
 											<VersionLink run={latest} />
 										</td>
-										<td className="px-4.5 py-3 text-right font-mono text-accent">
+										<td className="px-4.5 py-3 text-right font-mono font-medium text-accent">
+											{formatGas(latest.peakGasPerSecond)}
+										</td>
+										<td className="px-4.5 py-3 text-right font-mono text-primary">
 											{formatGas(latest.avgGasPerSecond)}
 										</td>
 										<td className="px-4.5 py-3 text-right font-mono text-primary">
@@ -257,6 +259,101 @@ function DashboardPage(): React.JSX.Element {
 					</table>
 				</div>
 			</section>
+		</div>
+	)
+}
+
+function SectionHeader(props: {
+	title: string
+	subtitle?: string
+}): React.JSX.Element {
+	return (
+		<div className="mb-5 flex items-center gap-3">
+			<div className="flex items-baseline gap-2">
+				<h3 className="text-[13px] font-normal uppercase tracking-wider text-tertiary">
+					{props.title}
+				</h3>
+				{props.subtitle && (
+					<span className="text-[11px] text-tertiary/60">{props.subtitle}</span>
+				)}
+			</div>
+			<div className="h-px flex-1 bg-border" />
+		</div>
+	)
+}
+
+function ScenarioCard(props: {
+	scenario: { id: string; label: string; workload: string }
+	run: BenchRun | undefined
+}): React.JSX.Element {
+	const { scenario, run } = props
+	const content = (
+		<>
+			<div className="p-5 pb-4">
+				<h4 className="text-[15px] font-semibold text-primary">
+					{scenario.label}
+				</h4>
+				<p className="mt-1 text-[12px] text-tertiary">
+					{scenario.workload}
+				</p>
+			</div>
+
+			{run ? (
+				<div className="mt-auto border-t border-border px-5 pt-4 pb-5">
+					<div className="grid grid-cols-2 gap-x-4 gap-y-3">
+						<Stat
+							label="Peak"
+							value={formatGas(run.peakGasPerSecond)}
+							highlight
+						/>
+						<Stat
+							label="Avg Throughput"
+							value={formatGas(run.avgGasPerSecond)}
+						/>
+						<Stat label="Avg TPS" value={formatTps(run.avgTps)} />
+						<Stat
+							label="Block Time"
+							value={formatMs(run.avgBlockTimeMs)}
+						/>
+					</div>
+				</div>
+			) : (
+				<div className="mt-auto border-t border-border px-5 py-4">
+					<p className="text-[12px] text-tertiary italic">
+						No runs yet
+					</p>
+				</div>
+			)}
+		</>
+	)
+
+	return run ? (
+		<Link
+			to="/benchmark/$id"
+			params={{ id: run.id }}
+			className="card-interactive flex flex-col"
+		>
+			{content}
+		</Link>
+	) : (
+		<div className="card flex flex-col">
+			{content}
+		</div>
+	)
+}
+
+function HeroStat(props: {
+	label: string
+	value: string
+}): React.JSX.Element {
+	return (
+		<div className="flex items-baseline gap-2">
+			<span className="text-[12px] uppercase tracking-wider text-tertiary">
+				{props.label}
+			</span>
+			<span className="font-mono text-[18px] font-semibold text-primary">
+				{props.value}
+			</span>
 		</div>
 	)
 }


### PR DESCRIPTION
## Summary

Redesigns the perf dashboard to lead with impact — peak throughput as the headline number — and clearer workload grouping for MPP mix scenarios.

### Changes

- **Peak throughput hero**: 56px mono headline showing the highest peak gas/s across all scenarios, with peak TPS, block time, and workload as secondary stats
- **Workload sections**: Split TIP-20 and Mixed (MPP) workloads into labeled sections instead of a flat grid
- **Peak-first cards**: Cards now lead with Peak throughput (highlighted) and Avg Throughput as secondary
- **Color-coded comparison chart**: Blue bars for TIP-20, green for MPP mix, with legend — bars are clickable links to benchmark detail
- **Results table**: Added Peak column, reordered to emphasize peak before avg
- **Extracted components**: `SectionHeader`, `ScenarioCard`, `HeroStat` for clarity

### Data pipeline

The MPP mix scenarios (`mix-10k`, `mix-20k`, `mix-40k`) are already defined in the SCENARIOS array and will render automatically once bench runs populate ClickHouse with `scenario_name=mix-*` data. To trigger MPP bench runs:

```bash
# Generate mixed workload transactions
txgen generate --spec tip20-mpp.yaml -n <count> -o workload.ndjson

# Run bench with MPP scenario name
bench send -m scenario=mix-10k --tps 10000 ... < workload.ndjson
```

Prompted by: @emmajam