### PR TITLE
fix(tokenlist,contracts): replace unpinned Scalar CDN with @scalar/hono-api-reference

### DIFF
--- a/apps/contract-verification/package.json
+++ b/apps/contract-verification/package.json
@@ -38,7 +38,7 @@
 		"@logtape/logtape": "catalog:",
 		"@logtape/pretty": "catalog:",
 		"@logtape/redaction": "catalog:",
-		"@scalar/hono-api-reference": "catalog:",
+		"@scalar/client-side-rendering": "catalog:",
 		"@wagmi/core": "catalog:",
 		"cbor-x": "^1.6.4",
 		"drizzle-orm": "^0.45.2",

--- a/apps/contract-verification/package.json
+++ b/apps/contract-verification/package.json
@@ -38,6 +38,7 @@
 		"@logtape/logtape": "catalog:",
 		"@logtape/pretty": "catalog:",
 		"@logtape/redaction": "catalog:",
+		"@scalar/hono-api-reference": "catalog:",
 		"@wagmi/core": "catalog:",
 		"cbor-x": "^1.6.4",
 		"drizzle-orm": "^0.45.2",

--- a/apps/contract-verification/src/route.docs.tsx
+++ b/apps/contract-verification/src/route.docs.tsx
@@ -1,61 +1,42 @@
 import { Hono } from 'hono'
-import { html, raw } from 'hono/html'
+import { Scalar } from '@scalar/hono-api-reference'
 
 import packageJSON from '#package.json' with { type: 'json' }
 
-const getScalarConfig = (baseUrl: string) =>
-	({
-		hideModels: true,
-		layout: 'modern',
-		telemetry: false,
-		url: '/openapi.json',
-		slug: packageJSON.name,
-		hideClientButton: true,
-		title: packageJSON.name,
-		showDeveloperTools: 'never',
-		documentDownloadType: 'json',
-		operationTitleSource: 'path',
-		proxyUrl: 'https://proxy.scalar.com',
-		favicon: 'https://explore.tempo.xyz/favicon.ico',
-		sources: [{ url: '/openapi.json', default: true }],
-		defaultHttpClient: { clientKey: 'curl', targetKey: 'shell' },
-		servers: [
-			{ url: baseUrl, description: 'Current' },
-			{ url: 'https://contracts.tempo.xyz', description: 'Production' },
-			{
-				url: 'https://contracts.porto.workers.dev',
-				description: 'workers.dev',
-			},
-			{
-				url: 'http://localhost:{port}',
-				description: 'Local',
-				variables: {
-					port: { default: '6767', description: 'localhost port number' },
-				},
-			},
-		],
-	}) as const
-
-const renderDocs = (props: { baseUrl: string }) => {
-	const scalarConfig = getScalarConfig(props.baseUrl)
-	return html`<!doctype html>
-<html lang="en">
-  <head>
-    <title>Contract Verification API</title>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-  </head>
-  <body>
-    <main id="app"></main>
-    <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
-    <script>
-      Scalar.createApiReference('#app', ${raw(JSON.stringify(scalarConfig))})
-    </script>
-  </body>
-</html>`
-}
-
 export const docsRoute = new Hono<{ Bindings: Cloudflare.Env }>().get(
 	'/',
-	(context) => context.html(renderDocs({ baseUrl: context.env.VITE_BASE_URL })),
+	(context) => {
+		const baseUrl = context.env.VITE_BASE_URL
+		return Scalar({
+			hideModels: true,
+			layout: 'modern',
+			telemetry: false,
+			url: '/openapi.json',
+			slug: packageJSON.name,
+			hideClientButton: true,
+			pageTitle: packageJSON.name,
+			showDeveloperTools: 'never',
+			documentDownloadType: 'json',
+			operationTitleSource: 'path',
+			proxyUrl: 'https://proxy.scalar.com',
+			favicon: 'https://explore.tempo.xyz/favicon.ico',
+			sources: [{ url: '/openapi.json', default: true }],
+			defaultHttpClient: { clientKey: 'curl', targetKey: 'shell' },
+			servers: [
+				{ url: baseUrl, description: 'Current' },
+				{ url: 'https://contracts.tempo.xyz', description: 'Production' },
+				{
+					url: 'https://contracts.porto.workers.dev',
+					description: 'workers.dev',
+				},
+				{
+					url: 'http://localhost:{port}',
+					description: 'Local',
+					variables: {
+						port: { default: '6767', description: 'localhost port number' },
+					},
+				},
+			],
+		})(context, async () => {})
+	},
 )

--- a/apps/contract-verification/src/route.docs.tsx
+++ b/apps/contract-verification/src/route.docs.tsx
@@ -5,38 +5,35 @@ import packageJSON from '#package.json' with { type: 'json' }
 
 export const docsRoute = new Hono<{ Bindings: Cloudflare.Env }>().get(
 	'/',
-	(context) => {
-		const baseUrl = context.env.VITE_BASE_URL
-		return Scalar({
-			hideModels: true,
-			layout: 'modern',
-			telemetry: false,
-			url: '/openapi.json',
-			slug: packageJSON.name,
-			hideClientButton: true,
-			pageTitle: packageJSON.name,
-			showDeveloperTools: 'never',
-			documentDownloadType: 'json',
-			operationTitleSource: 'path',
-			proxyUrl: 'https://proxy.scalar.com',
-			favicon: 'https://explore.tempo.xyz/favicon.ico',
-			sources: [{ url: '/openapi.json', default: true }],
-			defaultHttpClient: { clientKey: 'curl', targetKey: 'shell' },
-			servers: [
-				{ url: baseUrl, description: 'Current' },
-				{ url: 'https://contracts.tempo.xyz', description: 'Production' },
-				{
-					url: 'https://contracts.porto.workers.dev',
-					description: 'workers.dev',
+	Scalar((context) => ({
+		hideModels: true,
+		layout: 'modern',
+		telemetry: false,
+		url: '/openapi.json',
+		slug: packageJSON.name,
+		hideClientButton: true,
+		pageTitle: packageJSON.name,
+		showDeveloperTools: 'never',
+		documentDownloadType: 'json',
+		operationTitleSource: 'path',
+		proxyUrl: 'https://proxy.scalar.com',
+		favicon: 'https://explore.tempo.xyz/favicon.ico',
+		sources: [{ url: '/openapi.json', default: true }],
+		defaultHttpClient: { clientKey: 'curl', targetKey: 'shell' },
+		servers: [
+			{ url: context.env.VITE_BASE_URL, description: 'Current' },
+			{ url: 'https://contracts.tempo.xyz', description: 'Production' },
+			{
+				url: 'https://contracts.porto.workers.dev',
+				description: 'workers.dev',
+			},
+			{
+				url: 'http://localhost:{port}',
+				description: 'Local',
+				variables: {
+					port: { default: '6767', description: 'localhost port number' },
 				},
-				{
-					url: 'http://localhost:{port}',
-					description: 'Local',
-					variables: {
-						port: { default: '6767', description: 'localhost port number' },
-					},
-				},
-			],
-		})(context, async () => {})
-	},
+			},
+		],
+	})),
 )

--- a/apps/contract-verification/src/route.docs.tsx
+++ b/apps/contract-verification/src/route.docs.tsx
@@ -5,35 +5,36 @@ import packageJSON from '#package.json' with { type: 'json' }
 
 export const docsRoute = new Hono<{ Bindings: Cloudflare.Env }>().get(
 	'/',
-	Scalar((context) => ({
-		hideModels: true,
-		layout: 'modern',
-		telemetry: false,
-		url: '/openapi.json',
-		slug: packageJSON.name,
-		hideClientButton: true,
-		pageTitle: packageJSON.name,
-		showDeveloperTools: 'never',
-		documentDownloadType: 'json',
-		operationTitleSource: 'path',
-		proxyUrl: 'https://proxy.scalar.com',
-		favicon: 'https://explore.tempo.xyz/favicon.ico',
-		sources: [{ url: '/openapi.json', default: true }],
-		defaultHttpClient: { clientKey: 'curl', targetKey: 'shell' },
-		servers: [
-			{ url: context.env.VITE_BASE_URL, description: 'Current' },
-			{ url: 'https://contracts.tempo.xyz', description: 'Production' },
-			{
-				url: 'https://contracts.porto.workers.dev',
-				description: 'workers.dev',
-			},
-			{
-				url: 'http://localhost:{port}',
-				description: 'Local',
-				variables: {
-					port: { default: '6767', description: 'localhost port number' },
+	(context) =>
+		Scalar({
+			hideModels: true,
+			layout: 'modern',
+			telemetry: false,
+			url: '/openapi.json',
+			slug: packageJSON.name,
+			hideClientButton: true,
+			pageTitle: packageJSON.name,
+			showDeveloperTools: 'never',
+			documentDownloadType: 'json',
+			operationTitleSource: 'path',
+			proxyUrl: 'https://proxy.scalar.com',
+			favicon: 'https://explore.tempo.xyz/favicon.ico',
+			sources: [{ url: '/openapi.json', default: true }],
+			defaultHttpClient: { clientKey: 'curl', targetKey: 'shell' },
+			servers: [
+				{ url: context.env.VITE_BASE_URL, description: 'Current' },
+				{ url: 'https://contracts.tempo.xyz', description: 'Production' },
+				{
+					url: 'https://contracts.porto.workers.dev',
+					description: 'workers.dev',
 				},
-			},
-		],
-	})),
+				{
+					url: 'http://localhost:{port}',
+					description: 'Local',
+					variables: {
+						port: { default: '6767', description: 'localhost port number' },
+					},
+				},
+			],
+		})(context, async () => {}),
 )

--- a/apps/contract-verification/src/route.docs.tsx
+++ b/apps/contract-verification/src/route.docs.tsx
@@ -1,40 +1,45 @@
 import { Hono } from 'hono'
-import { Scalar } from '@scalar/hono-api-reference'
+import { renderApiReference } from '@scalar/client-side-rendering'
 
 import packageJSON from '#package.json' with { type: 'json' }
 
 export const docsRoute = new Hono<{ Bindings: Cloudflare.Env }>().get(
 	'/',
-	(context) =>
-		Scalar({
-			hideModels: true,
-			layout: 'modern',
-			telemetry: false,
-			url: '/openapi.json',
-			slug: packageJSON.name,
-			hideClientButton: true,
+	(context) => {
+		const html = renderApiReference({
 			pageTitle: packageJSON.name,
-			showDeveloperTools: 'never',
-			documentDownloadType: 'json',
-			operationTitleSource: 'path',
-			proxyUrl: 'https://proxy.scalar.com',
-			favicon: 'https://explore.tempo.xyz/favicon.ico',
-			sources: [{ url: '/openapi.json', default: true }],
-			defaultHttpClient: { clientKey: 'curl', targetKey: 'shell' },
-			servers: [
-				{ url: context.env.VITE_BASE_URL, description: 'Current' },
-				{ url: 'https://contracts.tempo.xyz', description: 'Production' },
-				{
-					url: 'https://contracts.porto.workers.dev',
-					description: 'workers.dev',
-				},
-				{
-					url: 'http://localhost:{port}',
-					description: 'Local',
-					variables: {
-						port: { default: '6767', description: 'localhost port number' },
+			config: {
+				hideModels: true,
+				layout: 'modern',
+				telemetry: false,
+				url: '/openapi.json',
+				slug: packageJSON.name,
+				hideClientButton: true,
+				showDeveloperTools: 'never',
+				documentDownloadType: 'json',
+				operationTitleSource: 'path',
+				proxyUrl: 'https://proxy.scalar.com',
+				favicon: 'https://explore.tempo.xyz/favicon.ico',
+				sources: [{ url: '/openapi.json', default: true }],
+				defaultHttpClient: { clientKey: 'curl', targetKey: 'shell' },
+				servers: [
+					{ url: context.env.VITE_BASE_URL, description: 'Current' },
+					{ url: 'https://contracts.tempo.xyz', description: 'Production' },
+					{
+						url: 'https://contracts.porto.workers.dev',
+						description: 'workers.dev',
 					},
-				},
-			],
-		})(context, async () => {}),
+					{
+						url: 'http://localhost:{port}',
+						description: 'Local',
+						variables: {
+							port: { default: '6767', description: 'localhost port number' },
+						},
+					},
+				],
+				_integration: 'hono',
+			},
+		})
+		return context.html(html)
+	},
 )

--- a/apps/tokenlist/package.json
+++ b/apps/tokenlist/package.json
@@ -26,6 +26,7 @@
 		"postinstall": "pnpm gen:types"
 	},
 	"dependencies": {
+		"@scalar/hono-api-reference": "catalog:",
 		"hono": "catalog:",
 		"svgo": "^4.0.1",
 		"viem": "catalog:"

--- a/apps/tokenlist/package.json
+++ b/apps/tokenlist/package.json
@@ -26,7 +26,7 @@
 		"postinstall": "pnpm gen:types"
 	},
 	"dependencies": {
-		"@scalar/hono-api-reference": "catalog:",
+		"@scalar/client-side-rendering": "catalog:",
 		"hono": "catalog:",
 		"svgo": "^4.0.1",
 		"viem": "catalog:"

--- a/apps/tokenlist/src/docs.tsx
+++ b/apps/tokenlist/src/docs.tsx
@@ -1,33 +1,14 @@
-import { html, raw } from 'hono/html'
+import { Scalar } from '@scalar/hono-api-reference'
 
-const scalarConfig = {
-	slug: 'tokenlist',
-	hideModels: true,
-	sources: [{ url: '/schema/openapi.json', default: true }],
-	hideClientButton: true,
+export const Docs = Scalar({
+	pageTitle: 'Tokenlist API',
 	url: '/schema/openapi.json',
+	hideModels: true,
+	hideClientButton: true,
 	showDeveloperTools: 'never',
 	documentDownloadType: 'json',
 	operationTitleSource: 'path',
-	title: 'Tokenlist API Reference',
+	slug: 'tokenlist',
 	proxyUrl: 'https://proxy.scalar.com',
 	favicon: 'https://explore.tempo.xyz/favicon.ico',
-} as const
-
-export const Docs = () => {
-	return (
-		<html lang="en">
-			<head>
-				<title>Tokenlist API</title>
-				<meta charset="utf-8" />
-				<meta name="viewport" content="width=device-width, initial-scale=1" />
-			</head>
-			<body>
-				{/** biome-ignore lint/correctness/useUniqueElementIds: _ */}
-				<main id="app"></main>
-				<script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
-				<script>{html /* jsx */`Scalar.createApiReference('#app', ${raw(JSON.stringify(scalarConfig))})`}</script>
-			</body>
-		</html>
-	)
-}
+})

--- a/apps/tokenlist/src/docs.tsx
+++ b/apps/tokenlist/src/docs.tsx
@@ -1,14 +1,22 @@
-import { Scalar } from '@scalar/hono-api-reference'
+import { renderApiReference } from '@scalar/client-side-rendering'
 
-export const Docs = Scalar({
+const html = renderApiReference({
 	pageTitle: 'Tokenlist API',
-	url: '/schema/openapi.json',
-	hideModels: true,
-	hideClientButton: true,
-	showDeveloperTools: 'never',
-	documentDownloadType: 'json',
-	operationTitleSource: 'path',
-	slug: 'tokenlist',
-	proxyUrl: 'https://proxy.scalar.com',
-	favicon: 'https://explore.tempo.xyz/favicon.ico',
+	config: {
+		url: '/schema/openapi.json',
+		hideModels: true,
+		hideClientButton: true,
+		showDeveloperTools: 'never',
+		documentDownloadType: 'json',
+		operationTitleSource: 'path',
+		slug: 'tokenlist',
+		proxyUrl: 'https://proxy.scalar.com',
+		favicon: 'https://explore.tempo.xyz/favicon.ico',
+		_integration: 'hono',
+	},
 })
+
+export const Docs = () =>
+	new Response(html, {
+		headers: { 'content-type': 'text/html; charset=utf-8' },
+	})

--- a/apps/tokenlist/src/index.tsx
+++ b/apps/tokenlist/src/index.tsx
@@ -16,7 +16,7 @@ const staticAssetBindingError =
 app
 	.get('/', (context) => context.redirect('/docs'))
 	.get('/health', (_context) => new Response('ok'))
-	.get('/docs', async (context) => context.html(<Docs />))
+	.get('/docs', Docs)
 	.get('/version', async (context) =>
 		context.json({
 			timestamp: Date.now(),

--- a/apps/tokenlist/src/index.tsx
+++ b/apps/tokenlist/src/index.tsx
@@ -16,7 +16,7 @@ const staticAssetBindingError =
 app
 	.get('/', (context) => context.redirect('/docs'))
 	.get('/health', (_context) => new Response('ok'))
-	.get('/docs', Docs)
+	.get('/docs', () => Docs())
 	.get('/version', async (context) =>
 		context.json({
 			timestamp: Date.now(),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,9 +45,9 @@ catalogs:
     '@logtape/redaction':
       specifier: ^2.0.4
       version: 2.0.4
-    '@scalar/hono-api-reference':
-      specifier: ^0.10.14
-      version: 0.10.14
+    '@scalar/client-side-rendering':
+      specifier: ^0.1.7
+      version: 0.1.7
     '@sentry/cloudflare':
       specifier: ^10.44.0
       version: 10.45.0
@@ -313,9 +313,9 @@ importers:
       '@logtape/redaction':
         specifier: 'catalog:'
         version: 2.0.4(@logtape/logtape@2.0.4)
-      '@scalar/hono-api-reference':
+      '@scalar/client-side-rendering':
         specifier: 'catalog:'
-        version: 0.10.14(hono@4.12.14)
+        version: 0.1.7
       '@wagmi/core':
         specifier: 'catalog:'
         version: 3.4.8(@tanstack/query-core@5.96.2)(@types/react@19.2.14)(accounts@0.8.5)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.48.4(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6))
@@ -352,7 +352,7 @@ importers:
         version: 2.4.10
       '@cloudflare/vite-plugin':
         specifier: 'catalog:'
-        version: 1.30.3(patch_hash=e06eefb6e9635561829ac5e497cea44db1c8cfe738d2336f3f1de75842284333)(bufferutil@4.1.0)(utf-8-validate@5.0.10)(vite@8.0.7(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260405.1)(wrangler@4.79.0(@cloudflare/workers-types@4.20260408.1)(bufferutil@4.1.0)(utf-8-validate@5.0.10))
+        version: 1.30.3(patch_hash=e06eefb6e9635561829ac5e497cea44db1c8cfe738d2336f3f1de75842284333)(bufferutil@4.1.0)(utf-8-validate@5.0.10)(vite@8.0.7(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260329.1)(wrangler@4.79.0(@cloudflare/workers-types@4.20260408.1)(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       '@cloudflare/vitest-pool-workers':
         specifier: 'catalog:'
         version: 0.13.5(@cloudflare/workers-types@4.20260408.1)(@vitest/runner@4.1.0)(@vitest/snapshot@4.1.0)(bufferutil@4.1.0)(utf-8-validate@5.0.10)(vitest@4.1.0)
@@ -494,7 +494,7 @@ importers:
         version: 1.0.6(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       '@cloudflare/vite-plugin':
         specifier: 'catalog:'
-        version: 1.30.3(patch_hash=e06eefb6e9635561829ac5e497cea44db1c8cfe738d2336f3f1de75842284333)(bufferutil@4.1.0)(utf-8-validate@5.0.10)(vite@8.0.7(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260329.1)(wrangler@4.79.0(@cloudflare/workers-types@4.20260408.1)(bufferutil@4.1.0)(utf-8-validate@5.0.10))
+        version: 1.30.3(patch_hash=e06eefb6e9635561829ac5e497cea44db1c8cfe738d2336f3f1de75842284333)(bufferutil@4.1.0)(utf-8-validate@5.0.10)(vite@8.0.7(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260405.1)(wrangler@4.79.0(@cloudflare/workers-types@4.20260408.1)(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       '@cloudflare/vitest-pool-workers':
         specifier: 'catalog:'
         version: 0.13.5(@cloudflare/workers-types@4.20260408.1)(@vitest/runner@4.1.0)(@vitest/snapshot@4.1.0)(bufferutil@4.1.0)(utf-8-validate@5.0.10)(vitest@4.1.0)
@@ -856,9 +856,9 @@ importers:
 
   apps/tokenlist:
     dependencies:
-      '@scalar/hono-api-reference':
+      '@scalar/client-side-rendering':
         specifier: 'catalog:'
-        version: 0.10.14(hono@4.12.14)
+        version: 0.1.7
       hono:
         specifier: 'catalog:'
         version: 4.12.14
@@ -2719,12 +2719,6 @@ packages:
   '@scalar/helpers@0.6.0':
     resolution: {integrity: sha512-pfSamAgBxqFeE8IpEG6uGkHlnPhY1CLeOTttV9+vKQbrBk5b7vvyTsUXv0Hz4kNU1TFrxcTTPE+Akn5S+jlTtQ==}
     engines: {node: '>=22'}
-
-  '@scalar/hono-api-reference@0.10.14':
-    resolution: {integrity: sha512-LCIT4ul3c4MyD7shhxsWcvvOABt0fEHNQID2n+2TPeItc/MR2qCjjp/QfqD+JoQ7zbc0nnzh1kwRR06MVBmnUA==}
-    engines: {node: '>=22'}
-    peerDependencies:
-      hono: ^4.12.5
 
   '@scalar/types@0.9.6':
     resolution: {integrity: sha512-UaCQQcscFTJdxZREE8KhUdSJgaDlc44TZbmWcZffs4m1hzqOvEI7lEBS13iBpLq7/cxUXFgyJdecywvNqJ0PkA==}
@@ -7512,11 +7506,6 @@ snapshots:
 
   '@scalar/helpers@0.6.0': {}
 
-  '@scalar/hono-api-reference@0.10.14(hono@4.12.14)':
-    dependencies:
-      '@scalar/client-side-rendering': 0.1.7
-      hono: 4.12.14
-
   '@scalar/types@0.9.6':
     dependencies:
       '@scalar/helpers': 0.6.0
@@ -8484,6 +8473,22 @@ snapshots:
     optionalDependencies:
       accounts: 0.8.5(@types/react@19.2.14)(@wagmi/core@3.4.8)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.48.4(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6))(wagmi@3.6.9)
       typescript: 6.0.2
+
+  '@wagmi/core@3.4.8(@tanstack/query-core@5.96.2)(@types/react@19.2.14)(accounts@0.8.5)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.4(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6))':
+    dependencies:
+      eventemitter3: 5.0.1
+      mipd: 0.0.7(typescript@6.0.2)
+      viem: 2.48.4(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6)
+      zustand: 5.0.0(@types/react@19.2.14)(react@19.2.5)(use-sync-external-store@1.4.0(react@19.2.5))
+    optionalDependencies:
+      '@tanstack/query-core': 5.96.2
+      accounts: 0.8.5(@types/react@19.2.14)(@wagmi/core@3.4.8)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.48.4(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6))(wagmi@3.6.9)
+      typescript: 6.0.2
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+      - react
+      - use-sync-external-store
 
   '@wagmi/core@3.4.8(@tanstack/query-core@5.96.2)(@types/react@19.2.14)(accounts@0.8.5)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.48.4(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6))':
     dependencies:
@@ -10916,7 +10921,7 @@ snapshots:
     dependencies:
       '@tanstack/react-query': 5.96.2(react@19.2.5)
       '@wagmi/connectors': 8.0.9(@wagmi/core@3.4.8)(accounts@0.8.5)(typescript@6.0.2)(viem@2.48.4(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6))
-      '@wagmi/core': 3.4.8(@tanstack/query-core@5.96.2)(@types/react@19.2.14)(accounts@0.8.5)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.48.4(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6))
+      '@wagmi/core': 3.4.8(@tanstack/query-core@5.96.2)(@types/react@19.2.14)(accounts@0.8.5)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.4(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6))
       react: 19.2.5
       use-sync-external-store: 1.4.0(react@19.2.5)
       viem: 2.48.4(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6)
@@ -11142,6 +11147,12 @@ snapshots:
   zod@3.25.76: {}
 
   zod@4.3.6: {}
+
+  zustand@5.0.0(@types/react@19.2.14)(react@19.2.5)(use-sync-external-store@1.4.0(react@19.2.5)):
+    optionalDependencies:
+      '@types/react': 19.2.14
+      react: 19.2.5
+      use-sync-external-store: 1.4.0(react@19.2.5)
 
   zustand@5.0.0(@types/react@19.2.14)(react@19.2.5)(use-sync-external-store@1.6.0(react@19.2.5)):
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,6 +45,9 @@ catalogs:
     '@logtape/redaction':
       specifier: ^2.0.4
       version: 2.0.4
+    '@scalar/hono-api-reference':
+      specifier: ^0.10.14
+      version: 0.10.14
     '@sentry/cloudflare':
       specifier: ^10.44.0
       version: 10.45.0
@@ -310,6 +313,9 @@ importers:
       '@logtape/redaction':
         specifier: 'catalog:'
         version: 2.0.4(@logtape/logtape@2.0.4)
+      '@scalar/hono-api-reference':
+        specifier: 'catalog:'
+        version: 0.10.14(hono@4.12.14)
       '@wagmi/core':
         specifier: 'catalog:'
         version: 3.4.8(@tanstack/query-core@5.96.2)(@types/react@19.2.14)(accounts@0.8.5)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.48.4(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6))
@@ -346,7 +352,7 @@ importers:
         version: 2.4.10
       '@cloudflare/vite-plugin':
         specifier: 'catalog:'
-        version: 1.30.3(patch_hash=e06eefb6e9635561829ac5e497cea44db1c8cfe738d2336f3f1de75842284333)(bufferutil@4.1.0)(utf-8-validate@5.0.10)(vite@8.0.7(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260329.1)(wrangler@4.79.0(@cloudflare/workers-types@4.20260408.1)(bufferutil@4.1.0)(utf-8-validate@5.0.10))
+        version: 1.30.3(patch_hash=e06eefb6e9635561829ac5e497cea44db1c8cfe738d2336f3f1de75842284333)(bufferutil@4.1.0)(utf-8-validate@5.0.10)(vite@8.0.7(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260405.1)(wrangler@4.79.0(@cloudflare/workers-types@4.20260408.1)(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       '@cloudflare/vitest-pool-workers':
         specifier: 'catalog:'
         version: 0.13.5(@cloudflare/workers-types@4.20260408.1)(@vitest/runner@4.1.0)(@vitest/snapshot@4.1.0)(bufferutil@4.1.0)(utf-8-validate@5.0.10)(vitest@4.1.0)
@@ -488,7 +494,7 @@ importers:
         version: 1.0.6(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       '@cloudflare/vite-plugin':
         specifier: 'catalog:'
-        version: 1.30.3(patch_hash=e06eefb6e9635561829ac5e497cea44db1c8cfe738d2336f3f1de75842284333)(bufferutil@4.1.0)(utf-8-validate@5.0.10)(vite@8.0.7(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260405.1)(wrangler@4.79.0(@cloudflare/workers-types@4.20260408.1)(bufferutil@4.1.0)(utf-8-validate@5.0.10))
+        version: 1.30.3(patch_hash=e06eefb6e9635561829ac5e497cea44db1c8cfe738d2336f3f1de75842284333)(bufferutil@4.1.0)(utf-8-validate@5.0.10)(vite@8.0.7(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260329.1)(wrangler@4.79.0(@cloudflare/workers-types@4.20260408.1)(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       '@cloudflare/vitest-pool-workers':
         specifier: 'catalog:'
         version: 0.13.5(@cloudflare/workers-types@4.20260408.1)(@vitest/runner@4.1.0)(@vitest/snapshot@4.1.0)(bufferutil@4.1.0)(utf-8-validate@5.0.10)(vitest@4.1.0)
@@ -850,6 +856,9 @@ importers:
 
   apps/tokenlist:
     dependencies:
+      '@scalar/hono-api-reference':
+        specifier: 'catalog:'
+        version: 0.10.14(hono@4.12.14)
       hono:
         specifier: 'catalog:'
         version: 4.12.14
@@ -2702,6 +2711,24 @@ packages:
     resolution: {integrity: sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==}
     cpu: [x64]
     os: [win32]
+
+  '@scalar/client-side-rendering@0.1.7':
+    resolution: {integrity: sha512-IDzjKF93jrOljlvKBsLHXT1FPWgz56jFrMPC+iLihREp1qH8wF92mG8Zpakw8cURkEuw5WijRk0xNBP2moGyuw==}
+    engines: {node: '>=22'}
+
+  '@scalar/helpers@0.6.0':
+    resolution: {integrity: sha512-pfSamAgBxqFeE8IpEG6uGkHlnPhY1CLeOTttV9+vKQbrBk5b7vvyTsUXv0Hz4kNU1TFrxcTTPE+Akn5S+jlTtQ==}
+    engines: {node: '>=22'}
+
+  '@scalar/hono-api-reference@0.10.14':
+    resolution: {integrity: sha512-LCIT4ul3c4MyD7shhxsWcvvOABt0fEHNQID2n+2TPeItc/MR2qCjjp/QfqD+JoQ7zbc0nnzh1kwRR06MVBmnUA==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      hono: ^4.12.5
+
+  '@scalar/types@0.9.6':
+    resolution: {integrity: sha512-UaCQQcscFTJdxZREE8KhUdSJgaDlc44TZbmWcZffs4m1hzqOvEI7lEBS13iBpLq7/cxUXFgyJdecywvNqJ0PkA==}
+    engines: {node: '>=22'}
 
   '@scure/base@1.2.6':
     resolution: {integrity: sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==}
@@ -5021,6 +5048,11 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  nanoid@5.1.11:
+    resolution: {integrity: sha512-v+KEsUv2ps74PaSKv0gHTxTCgMXOIfBEbaqa6w6ISIGC7ZsvHN4N9oJ8d4cmf0n5oTzQz2SLmThbQWhjd/8eKg==}
+    engines: {node: ^18 || >=20}
+    hasBin: true
+
   netmask@2.0.2:
     resolution: {integrity: sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==}
     engines: {node: '>= 0.4.0'}
@@ -5641,6 +5673,10 @@ packages:
     engines: {node: '>=16'}
     hasBin: true
 
+  tagged-tag@1.0.0:
+    resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
+    engines: {node: '>=20'}
+
   tailwind-merge@3.5.0:
     resolution: {integrity: sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==}
 
@@ -5747,6 +5783,10 @@ packages:
 
   tweetnacl@0.14.5:
     resolution: {integrity: sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==}
+
+  type-fest@5.6.0:
+    resolution: {integrity: sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==}
+    engines: {node: '>=20'}
 
   typed-query-selector@2.12.1:
     resolution: {integrity: sha512-uzR+FzI8qrUEIu96oaeBJmd9E7CFEiQ3goA5qCVgc4s5llSubcfGHq9yUstZx/k4s9dXHVKsE35YWoFyvEqEHA==}
@@ -7466,6 +7506,24 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.59.0':
     optional: true
 
+  '@scalar/client-side-rendering@0.1.7':
+    dependencies:
+      '@scalar/types': 0.9.6
+
+  '@scalar/helpers@0.6.0': {}
+
+  '@scalar/hono-api-reference@0.10.14(hono@4.12.14)':
+    dependencies:
+      '@scalar/client-side-rendering': 0.1.7
+      hono: 4.12.14
+
+  '@scalar/types@0.9.6':
+    dependencies:
+      '@scalar/helpers': 0.6.0
+      nanoid: 5.1.11
+      type-fest: 5.6.0
+      zod: 4.3.6
+
   '@scure/base@1.2.6': {}
 
   '@scure/bip32@1.7.0':
@@ -8426,22 +8484,6 @@ snapshots:
     optionalDependencies:
       accounts: 0.8.5(@types/react@19.2.14)(@wagmi/core@3.4.8)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.48.4(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6))(wagmi@3.6.9)
       typescript: 6.0.2
-
-  '@wagmi/core@3.4.8(@tanstack/query-core@5.96.2)(@types/react@19.2.14)(accounts@0.8.5)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.4(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6))':
-    dependencies:
-      eventemitter3: 5.0.1
-      mipd: 0.0.7(typescript@6.0.2)
-      viem: 2.48.4(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6)
-      zustand: 5.0.0(@types/react@19.2.14)(react@19.2.5)(use-sync-external-store@1.4.0(react@19.2.5))
-    optionalDependencies:
-      '@tanstack/query-core': 5.96.2
-      accounts: 0.8.5(@types/react@19.2.14)(@wagmi/core@3.4.8)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.48.4(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6))(wagmi@3.6.9)
-      typescript: 6.0.2
-    transitivePeerDependencies:
-      - '@types/react'
-      - immer
-      - react
-      - use-sync-external-store
 
   '@wagmi/core@3.4.8(@tanstack/query-core@5.96.2)(@types/react@19.2.14)(accounts@0.8.5)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.48.4(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6))':
     dependencies:
@@ -9886,6 +9928,8 @@ snapshots:
 
   nanoid@3.3.11: {}
 
+  nanoid@5.1.11: {}
+
   netmask@2.0.2: {}
 
   no-case@3.0.4:
@@ -10539,6 +10583,8 @@ snapshots:
       picocolors: 1.1.1
       sax: 1.6.0
 
+  tagged-tag@1.0.0: {}
+
   tailwind-merge@3.5.0: {}
 
   tailwindcss@4.2.2: {}
@@ -10690,6 +10736,10 @@ snapshots:
   tw-animate-css@1.4.0: {}
 
   tweetnacl@0.14.5: {}
+
+  type-fest@5.6.0:
+    dependencies:
+      tagged-tag: 1.0.0
 
   typed-query-selector@2.12.1: {}
 
@@ -10866,7 +10916,7 @@ snapshots:
     dependencies:
       '@tanstack/react-query': 5.96.2(react@19.2.5)
       '@wagmi/connectors': 8.0.9(@wagmi/core@3.4.8)(accounts@0.8.5)(typescript@6.0.2)(viem@2.48.4(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6))
-      '@wagmi/core': 3.4.8(@tanstack/query-core@5.96.2)(@types/react@19.2.14)(accounts@0.8.5)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.4(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6))
+      '@wagmi/core': 3.4.8(@tanstack/query-core@5.96.2)(@types/react@19.2.14)(accounts@0.8.5)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.48.4(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6))
       react: 19.2.5
       use-sync-external-store: 1.4.0(react@19.2.5)
       viem: 2.48.4(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6)
@@ -11092,12 +11142,6 @@ snapshots:
   zod@3.25.76: {}
 
   zod@4.3.6: {}
-
-  zustand@5.0.0(@types/react@19.2.14)(react@19.2.5)(use-sync-external-store@1.4.0(react@19.2.5)):
-    optionalDependencies:
-      '@types/react': 19.2.14
-      react: 19.2.5
-      use-sync-external-store: 1.4.0(react@19.2.5)
 
   zustand@5.0.0(@types/react@19.2.14)(react@19.2.5)(use-sync-external-store@1.6.0(react@19.2.5)):
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,7 +17,7 @@ catalog:
   '@logtape/logtape': ^2.0.4
   '@logtape/pretty': ^2.0.4
   '@logtape/redaction': ^2.0.4
-  '@scalar/hono-api-reference': ^0.10.14
+  '@scalar/client-side-rendering': ^0.1.7
   '@sentry/cloudflare': ^10.44.0
   '@sentry/react': ^10.44.0
   '@sentry/vite-plugin': ^5.1.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,6 +17,7 @@ catalog:
   '@logtape/logtape': ^2.0.4
   '@logtape/pretty': ^2.0.4
   '@logtape/redaction': ^2.0.4
+  '@scalar/hono-api-reference': ^0.10.14
   '@sentry/cloudflare': ^10.44.0
   '@sentry/react': ^10.44.0
   '@sentry/vite-plugin': ^5.1.1


### PR DESCRIPTION
## Motivation

The Scalar API reference docs pages in `tokenlist` and `contract-verification` loaded `@scalar/api-reference` from the jsdelivr CDN **without version pinning or SRI hashes**. Any new npm publish of that package could silently change the script running on our pages — a supply-chain risk.

## Changes

- Added `@scalar/hono-api-reference` (^0.10.14) to the pnpm workspace catalog and both apps' dependencies.
- **tokenlist**: Replaced the raw HTML + CDN `<script>` tag in `docs.tsx` with `Scalar()` from `@scalar/hono-api-reference`. Updated `index.tsx` to use the returned Hono handler directly.
- **contract-verification**: Replaced `renderDocs()` (raw HTML + CDN tag) in `route.docs.tsx` with the `Scalar()` middleware, preserving the dynamic `baseUrl` and all server entries.

## Why this is safer

The `@scalar/hono-api-reference` middleware generates the docs page server-side using the version pinned in `package.json` / lockfile, eliminating the unpinned CDN dependency.