### PR TITLE
veria(contract-verification): fix partial verification poisoning

### DIFF
--- a/apps/contract-verification/src/lib/bytecode-matching.ts
+++ b/apps/contract-verification/src/lib/bytecode-matching.ts
@@ -317,19 +317,45 @@ export function getVyperImmutableReferences(
 
 /**
  * Check if bytecode has CBOR auxdata with a content hash.
- * We don't fully decode CBOR, just check for presence of IPFS/bzzr markers.
+ * Solidity stores content hashes under ipfs/bzzr keys. Newer Vyper versions
+ * store an integrity hash as the first CBOR array entry.
  */
-export function hasContentHash(bytecode: string): boolean {
-	const { auxdata } = splitAuxdata(bytecode)
+export function hasContentHash(
+	bytecode: string,
+	auxdataStyle: AuxdataStyle = AuxdataStyle.SOLIDITY,
+): boolean {
+	const { auxdata } = splitAuxdata(bytecode, auxdataStyle)
 	if (!auxdata) return false
 
-	// Look for IPFS marker: "ipfs" in CBOR = 64697066735822 (text string with length)
-	// Look for bzzr0/bzzr1 markers
+	try {
+		const decoded = CBOR.decode(Hex.toBytes(`0x${auxdata}`)) as unknown
+		if (decoded instanceof Map) {
+			return decoded.has('ipfs') || decoded.has('bzzr0') || decoded.has('bzzr1')
+		}
+		if (typeof decoded === 'object' && decoded !== null) {
+			if (Array.isArray(decoded)) {
+				return (
+					auxdataStyle === AuxdataStyle.VYPER && typeof decoded[0] === 'string'
+				)
+			}
+
+			return (
+				Object.hasOwn(decoded, 'ipfs') ||
+				Object.hasOwn(decoded, 'bzzr0') ||
+				Object.hasOwn(decoded, 'bzzr1')
+			)
+		}
+	} catch {
+		// Fall back to marker checks below.
+	}
+
+	// Look for IPFS marker: "ipfs" in CBOR = 6469706673.
+	// Look for bzzr0/bzzr1 markers by their ASCII hex encodings.
 	const lower = auxdata.toLowerCase()
 	return (
 		lower.includes('6970667358') || // ipfs
-		lower.includes('62zzr0') || // bzzr0
-		lower.includes('62zzr1') // bzzr1
+		lower.includes('627a7a7230') || // bzzr0
+		lower.includes('627a7a7231') // bzzr1
 	)
 }
 
@@ -842,7 +868,7 @@ export function matchBytecode(
 
 	if (doBytecodesMatch) {
 		// Check if this is a "perfect" match (has valid content hash) or "partial" (no hash)
-		const isPerfect = hasContentHash(recompiledBytecode)
+		const isPerfect = hasContentHash(recompiledBytecode, auxdataStyle)
 
 		// For creation bytecode, also extract constructor arguments
 		if (isCreation && abi) {

--- a/apps/contract-verification/src/route.lookup.ts
+++ b/apps/contract-verification/src/route.lookup.ts
@@ -267,13 +267,23 @@ function applyFieldSelection(
 function buildVerifiedMinimalResponse(row: {
 	matchId: number
 	runtimeMatch: boolean
+	runtimeMetadataMatch: boolean | null
 	creationMatch: boolean
+	creationMetadataMatch: boolean | null
 	chainId: number
 	address: ArrayBuffer
 	verifiedAt: string
 }): MinimalLookupResponse {
-	const runtimeMatchStatus = row.runtimeMatch ? 'exact_match' : 'match'
-	const creationMatchStatus = row.creationMatch ? 'exact_match' : 'match'
+	const runtimeMatchStatus = row.runtimeMatch
+		? row.runtimeMetadataMatch
+			? 'exact_match'
+			: 'match'
+		: 'match'
+	const creationMatchStatus = row.creationMatch
+		? row.creationMetadataMatch
+			? 'exact_match'
+			: 'match'
+		: 'match'
 	const matchStatus =
 		runtimeMatchStatus === 'exact_match' ||
 		creationMatchStatus === 'exact_match'
@@ -532,7 +542,9 @@ lookupRoute
 						matchId: verifiedContractsTable.id,
 						verifiedAt: verifiedContractsTable.createdAt,
 						runtimeMatch: verifiedContractsTable.runtimeMatch,
+						runtimeMetadataMatch: verifiedContractsTable.runtimeMetadataMatch,
 						creationMatch: verifiedContractsTable.creationMatch,
+						creationMetadataMatch: verifiedContractsTable.creationMetadataMatch,
 						chainId: contractDeploymentsTable.chainId,
 						address: contractDeploymentsTable.address,
 					})
@@ -569,7 +581,9 @@ lookupRoute
 						buildVerifiedMinimalResponse({
 							matchId: row.matchId,
 							runtimeMatch: row.runtimeMatch,
+							runtimeMetadataMatch: row.runtimeMetadataMatch,
 							creationMatch: row.creationMatch,
+							creationMetadataMatch: row.creationMetadataMatch,
 							chainId: row.chainId,
 							address: row.address as ArrayBuffer,
 							verifiedAt: row.verifiedAt,
@@ -729,7 +743,9 @@ lookupRoute
 			const minimalResponse = buildVerifiedMinimalResponse({
 				matchId: row.matchId,
 				runtimeMatch: row.runtimeMatch,
+				runtimeMetadataMatch: row.runtimeMetadataMatch,
 				creationMatch: row.creationMatch,
+				creationMetadataMatch: row.creationMetadataMatch,
 				chainId: row.chainId,
 				address: row.address as ArrayBuffer,
 				verifiedAt: row.verifiedAt,
@@ -1054,7 +1070,9 @@ lookupAllChainContractsRoute.get('/:chainId', async (context) => {
 						address: contractDeploymentsTable.address,
 						verifiedAt: verifiedContractsTable.createdAt,
 						runtimeMatch: verifiedContractsTable.runtimeMatch,
+						runtimeMetadataMatch: verifiedContractsTable.runtimeMetadataMatch,
 						creationMatch: verifiedContractsTable.creationMatch,
+						creationMetadataMatch: verifiedContractsTable.creationMetadataMatch,
 					})
 					.from(verifiedContractsTable)
 					.innerJoin(
@@ -1106,7 +1124,9 @@ lookupAllChainContractsRoute.get('/:chainId', async (context) => {
 			buildVerifiedMinimalResponse({
 				matchId: row.matchId,
 				runtimeMatch: row.runtimeMatch,
+				runtimeMetadataMatch: row.runtimeMetadataMatch,
 				creationMatch: row.creationMatch,
+				creationMetadataMatch: row.creationMetadataMatch,
 				chainId: row.chainId,
 				address: row.address as ArrayBuffer,
 				verifiedAt: row.verifiedAt,

--- a/apps/contract-verification/src/route.verify-legacy.ts
+++ b/apps/contract-verification/src/route.verify-legacy.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono'
 import * as z from 'zod/mini'
 import { Address, Hex } from 'ox'
-import { and, eq } from 'drizzle-orm'
+import { and, eq, or } from 'drizzle-orm'
 import { getRandom } from '@cloudflare/containers'
 import { createPublicClient, http, keccak256 } from 'viem'
 
@@ -142,13 +142,16 @@ legacyVerifyRoute.post('/vyper', async (context) => {
 			)
 		}
 
-		// Check if already verified
+		// Exact verifications are terminal, but partial matches must not block
+		// a later exact verification from replacing them.
 		const db = getDb(context.env.CONTRACTS_DB)
 		const addressBytes = Hex.toBytes(address)
 
-		const existingVerification = await db
+		const existingExactVerificationRows = await db
 			.select({
 				matchId: verifiedContractsTable.id,
+				runtimeMetadataMatch: verifiedContractsTable.runtimeMetadataMatch,
+				creationMetadataMatch: verifiedContractsTable.creationMetadataMatch,
 			})
 			.from(verifiedContractsTable)
 			.innerJoin(
@@ -159,11 +162,15 @@ legacyVerifyRoute.post('/vyper', async (context) => {
 				and(
 					eq(contractDeploymentsTable.chainId, chainId),
 					eq(contractDeploymentsTable.address, addressBytes),
+					or(
+						eq(verifiedContractsTable.runtimeMetadataMatch, true),
+						eq(verifiedContractsTable.creationMetadataMatch, true),
+					),
 				),
 			)
 			.limit(1)
 
-		if (existingVerification.length > 0) {
+		if (existingExactVerificationRows.length > 0) {
 			return context.json({
 				result: [{ address, chainId: chain, status: 'perfect' }],
 			})
@@ -425,7 +432,11 @@ legacyVerifyRoute.post('/vyper', async (context) => {
 
 		// Get or create deployment
 		const existingDeployment = await db
-			.select({ id: contractDeploymentsTable.id })
+			.select({
+				id: contractDeploymentsTable.id,
+				contractId: contractDeploymentsTable.contractId,
+				transactionHash: contractDeploymentsTable.transactionHash,
+			})
 			.from(contractDeploymentsTable)
 			.where(
 				and(
@@ -438,6 +449,36 @@ legacyVerifyRoute.post('/vyper', async (context) => {
 		let deploymentId: string
 		if (existingDeployment.length > 0 && existingDeployment[0]) {
 			deploymentId = existingDeployment[0].id
+			const deploymentUpdates: Partial<
+				typeof contractDeploymentsTable.$inferInsert
+			> = {}
+
+			if (
+				creationTransactionMetadata &&
+				existingDeployment[0].transactionHash === null
+			) {
+				Object.assign(deploymentUpdates, {
+					transactionHash: creationTransactionMetadata.transactionHash,
+					blockNumber: creationTransactionMetadata.blockNumber,
+					transactionIndex: creationTransactionMetadata.transactionIndex,
+					deployer: creationTransactionMetadata.deployer,
+				})
+			}
+
+			if (isExactMatch && existingDeployment[0].contractId !== contractId) {
+				deploymentUpdates.contractId = contractId
+			}
+
+			if (Object.keys(deploymentUpdates).length > 0) {
+				await db
+					.update(contractDeploymentsTable)
+					.set({
+						...deploymentUpdates,
+						updatedAt: new Date().toISOString(),
+						updatedBy: auditUser,
+					})
+					.where(eq(contractDeploymentsTable.id, deploymentId))
+			}
 		} else {
 			deploymentId = globalThis.crypto.randomUUID()
 			await db.insert(contractDeploymentsTable).values({
@@ -608,27 +649,73 @@ legacyVerifyRoute.post('/vyper', async (context) => {
 		}
 		// ast-grep-ignore-end
 
-		// Insert verified contract
-		await db
-			.insert(verifiedContractsTable)
-			.values({
-				deploymentId,
-				compilationId,
-				creationMatch: false,
-				runtimeMatch: true,
-				runtimeMetadataMatch: isExactMatch,
-				runtimeValues:
-					Object.keys(runtimeMatchResult.transformationValues).length > 0
-						? JSON.stringify(runtimeMatchResult.transformationValues)
-						: null,
-				runtimeTransformations:
-					runtimeMatchResult.transformations.length > 0
-						? JSON.stringify(runtimeMatchResult.transformations)
-						: null,
-				createdBy: auditUser,
-				updatedBy: auditUser,
+		const runtimeValues =
+			Object.keys(runtimeMatchResult.transformationValues).length > 0
+				? JSON.stringify(runtimeMatchResult.transformationValues)
+				: null
+		const runtimeTransformations =
+			runtimeMatchResult.transformations.length > 0
+				? JSON.stringify(runtimeMatchResult.transformations)
+				: null
+
+		const existingVerifiedContracts = await db
+			.select({
+				id: verifiedContractsTable.id,
+				compilationId: verifiedContractsTable.compilationId,
+				runtimeMetadataMatch: verifiedContractsTable.runtimeMetadataMatch,
+				creationMetadataMatch: verifiedContractsTable.creationMetadataMatch,
 			})
-			.onConflictDoNothing()
+			.from(verifiedContractsTable)
+			.where(eq(verifiedContractsTable.deploymentId, deploymentId))
+
+		const existingExactVerifiedContract = existingVerifiedContracts.find(
+			(verification) =>
+				verification.runtimeMetadataMatch === true ||
+				verification.creationMetadataMatch === true,
+		)
+		const existingSameCompilationVerification = existingVerifiedContracts.find(
+			(verification) => verification.compilationId === compilationId,
+		)
+		const existingVerification =
+			existingSameCompilationVerification ?? existingVerifiedContracts.at(0)
+
+		if (
+			!existingExactVerifiedContract &&
+			existingVerification &&
+			isExactMatch
+		) {
+			await db
+				.update(verifiedContractsTable)
+				.set({
+					compilationId,
+					creationMatch: false,
+					creationValues: null,
+					creationTransformations: null,
+					creationMetadataMatch: null,
+					runtimeMatch: true,
+					runtimeMetadataMatch: true,
+					runtimeValues,
+					runtimeTransformations,
+					updatedAt: new Date().toISOString(),
+					updatedBy: auditUser,
+				})
+				.where(eq(verifiedContractsTable.id, existingVerification.id))
+		} else if (!existingExactVerifiedContract && !existingVerification) {
+			await db
+				.insert(verifiedContractsTable)
+				.values({
+					deploymentId,
+					compilationId,
+					creationMatch: false,
+					runtimeMatch: true,
+					runtimeMetadataMatch: isExactMatch,
+					runtimeValues,
+					runtimeTransformations,
+					createdBy: auditUser,
+					updatedBy: auditUser,
+				})
+				.onConflictDoNothing()
+		}
 
 		// Return legacy Sourcify format
 		return context.json({

--- a/apps/contract-verification/src/route.verify.ts
+++ b/apps/contract-verification/src/route.verify.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono'
 import * as z from 'zod/mini'
 import { Address, Hex } from 'ox'
-import { and, eq, isNull } from 'drizzle-orm'
+import { and, eq, isNull, or } from 'drizzle-orm'
 import type { BatchItem } from 'drizzle-orm/batch'
 
 import { getRandom } from '@cloudflare/containers'
@@ -221,12 +221,13 @@ verifyRoute
 			const db = getDb(context.env.CONTRACTS_DB)
 			const addressBytes = Hex.toBytes(address)
 
-			// Check if already verified
-			const existingVerification = await db
+			// Exact verifications are terminal, but partial matches must not block
+			// a later exact verification from replacing them.
+			const existingExactVerification = await db
 				.select({
 					matchId: verifiedContractsTable.id,
-					runtimeMatch: verifiedContractsTable.runtimeMatch,
-					creationMatch: verifiedContractsTable.creationMatch,
+					runtimeMetadataMatch: verifiedContractsTable.runtimeMetadataMatch,
+					creationMetadataMatch: verifiedContractsTable.creationMetadataMatch,
 				})
 				.from(verifiedContractsTable)
 				.innerJoin(
@@ -237,14 +238,20 @@ verifyRoute
 					and(
 						eq(contractDeploymentsTable.chainId, chainId),
 						eq(contractDeploymentsTable.address, addressBytes),
+						or(
+							eq(verifiedContractsTable.runtimeMetadataMatch, true),
+							eq(verifiedContractsTable.creationMetadataMatch, true),
+						),
 					),
 				)
 				.limit(1)
 
-			if (existingVerification.length > 0) {
-				const existing = existingVerification.at(0)
-				const runtimeMatch = existing?.runtimeMatch ? 'exact matches' : 'match'
-				const creationMatch = existing?.creationMatch
+			if (existingExactVerification.length > 0) {
+				const existing = existingExactVerification.at(0)
+				const runtimeMatch = existing?.runtimeMetadataMatch
+					? 'exact matches'
+					: 'match'
+				const creationMatch = existing?.creationMetadataMatch
 					? 'exact matches'
 					: 'match'
 				return sourcifyError(
@@ -1016,6 +1023,7 @@ async function runVerificationJob(
 		const existingDeployment = await db
 			.select({
 				id: contractDeploymentsTable.id,
+				contractId: contractDeploymentsTable.contractId,
 				transactionHash: contractDeploymentsTable.transactionHash,
 			})
 			.from(contractDeploymentsTable)
@@ -1029,17 +1037,32 @@ async function runVerificationJob(
 
 		if (existingDeployment.length > 0 && existingDeployment[0]) {
 			deploymentId = existingDeployment[0].id
+			const deploymentUpdates: Partial<
+				typeof contractDeploymentsTable.$inferInsert
+			> = {}
+
 			if (
 				creationTransactionMetadata &&
 				existingDeployment[0].transactionHash === null
 			) {
+				Object.assign(deploymentUpdates, {
+					transactionHash: creationTransactionMetadata.transactionHash,
+					blockNumber: creationTransactionMetadata.blockNumber,
+					transactionIndex: creationTransactionMetadata.transactionIndex,
+					deployer: creationTransactionMetadata.deployer,
+				})
+			}
+
+			if (isExactMatch && existingDeployment[0].contractId !== contractId) {
+				deploymentUpdates.contractId = contractId
+			}
+
+			if (Object.keys(deploymentUpdates).length > 0) {
 				await db
 					.update(contractDeploymentsTable)
 					.set({
-						transactionHash: creationTransactionMetadata.transactionHash,
-						blockNumber: creationTransactionMetadata.blockNumber,
-						transactionIndex: creationTransactionMetadata.transactionIndex,
-						deployer: creationTransactionMetadata.deployer,
+						...deploymentUpdates,
+						updatedAt: new Date().toISOString(),
 						updatedBy: auditUser,
 					})
 					.where(eq(contractDeploymentsTable.id, deploymentId))
@@ -1261,35 +1284,89 @@ async function runVerificationJob(
 			)
 		}
 
-		// Insert verified contract with transformation data
-		await db
-			.insert(verifiedContractsTable)
-			.values({
-				deploymentId,
-				compilationId,
-				creationMatch: false,
-				runtimeMatch: true,
-				runtimeMetadataMatch: isExactMatch,
-				runtimeValues:
-					Object.keys(runtimeMatchResult.transformationValues).length > 0
-						? JSON.stringify(runtimeMatchResult.transformationValues)
-						: null,
-				runtimeTransformations:
-					runtimeMatchResult.transformations.length > 0
-						? JSON.stringify(runtimeMatchResult.transformations)
-						: null,
-				createdBy: auditUser,
-				updatedBy: auditUser,
-			})
-			.onConflictDoNothing()
+		const runtimeValues =
+			Object.keys(runtimeMatchResult.transformationValues).length > 0
+				? JSON.stringify(runtimeMatchResult.transformationValues)
+				: null
+		const runtimeTransformations =
+			runtimeMatchResult.transformations.length > 0
+				? JSON.stringify(runtimeMatchResult.transformations)
+				: null
 
-		const verificationResult = await db
-			.select({ id: verifiedContractsTable.id })
+		const existingVerifiedContracts = await db
+			.select({
+				id: verifiedContractsTable.id,
+				compilationId: verifiedContractsTable.compilationId,
+				runtimeMetadataMatch: verifiedContractsTable.runtimeMetadataMatch,
+				creationMetadataMatch: verifiedContractsTable.creationMetadataMatch,
+			})
 			.from(verifiedContractsTable)
 			.where(eq(verifiedContractsTable.deploymentId, deploymentId))
-			.limit(1)
 
-		const verifiedContractId = verificationResult.at(0)?.id ?? null
+		const existingExactVerification = existingVerifiedContracts.find(
+			(verification) =>
+				verification.runtimeMetadataMatch === true ||
+				verification.creationMetadataMatch === true,
+		)
+		const existingSameCompilationVerification = existingVerifiedContracts.find(
+			(verification) => verification.compilationId === compilationId,
+		)
+		const existingVerification =
+			existingSameCompilationVerification ?? existingVerifiedContracts.at(0)
+
+		let verifiedContractId: number | null = null
+
+		if (existingExactVerification) {
+			verifiedContractId = existingExactVerification.id
+		} else if (existingVerification && isExactMatch) {
+			await db
+				.update(verifiedContractsTable)
+				.set({
+					compilationId,
+					creationMatch: false,
+					creationValues: null,
+					creationTransformations: null,
+					creationMetadataMatch: null,
+					runtimeMatch: true,
+					runtimeMetadataMatch: true,
+					runtimeValues,
+					runtimeTransformations,
+					updatedAt: new Date().toISOString(),
+					updatedBy: auditUser,
+				})
+				.where(eq(verifiedContractsTable.id, existingVerification.id))
+			verifiedContractId = existingVerification.id
+		} else if (existingVerification) {
+			verifiedContractId = existingVerification.id
+		} else {
+			await db
+				.insert(verifiedContractsTable)
+				.values({
+					deploymentId,
+					compilationId,
+					creationMatch: false,
+					runtimeMatch: true,
+					runtimeMetadataMatch: isExactMatch,
+					runtimeValues,
+					runtimeTransformations,
+					createdBy: auditUser,
+					updatedBy: auditUser,
+				})
+				.onConflictDoNothing()
+
+			const verificationResult = await db
+				.select({ id: verifiedContractsTable.id })
+				.from(verifiedContractsTable)
+				.where(
+					and(
+						eq(verifiedContractsTable.deploymentId, deploymentId),
+						eq(verifiedContractsTable.compilationId, compilationId),
+					),
+				)
+				.limit(1)
+
+			verifiedContractId = verificationResult.at(0)?.id ?? null
+		}
 
 		// Mark job as completed (clear any stale timeout/error fields)
 		await db

--- a/apps/contract-verification/test/e2e/verification.test.ts
+++ b/apps/contract-verification/test/e2e/verification.test.ts
@@ -45,6 +45,29 @@ function changeSolidityMetadataHash(bytecode: `0x${string}`): `0x${string}` {
 	)}` as `0x${string}`
 }
 
+function solcOutputWithRuntimeBytecode(bytecode: `0x${string}`): unknown {
+	return {
+		...counterFixture.solcOutput,
+		contracts: {
+			...counterFixture.solcOutput.contracts,
+			'Counter.sol': {
+				...counterFixture.solcOutput.contracts['Counter.sol'],
+				Counter: {
+					...counterFixture.solcOutput.contracts['Counter.sol'].Counter,
+					evm: {
+						...counterFixture.solcOutput.contracts['Counter.sol'].Counter.evm,
+						deployedBytecode: {
+							...counterFixture.solcOutput.contracts['Counter.sol'].Counter.evm
+								.deployedBytecode,
+							object: bytecode.slice(2),
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
 describe('full verification flow', () => {
 	type VerifyRequestBody = Parameters<typeof runVerificationJob>[4]
 
@@ -121,14 +144,17 @@ describe('full verification flow', () => {
 		address: `0x${string}`
 		body?: VerifyRequestBody
 		onchainRuntimeBytecode?: `0x${string}`
+		compileOutput?: unknown
+		jobId?: string
 	}) {
 		const body = options.body ?? verifyRequestBody
 		const onchainRuntimeBytecode =
 			options.onchainRuntimeBytecode ?? counterFixture.onchainRuntimeBytecode
+		const compileOutput = options.compileOutput ?? counterFixture.solcOutput
 
 		await runVerificationJob(
 			env,
-			globalThis.crypto.randomUUID(),
+			options.jobId ?? globalThis.crypto.randomUUID(),
 			counterFixture.chainId,
 			options.address,
 			body,
@@ -141,7 +167,7 @@ describe('full verification flow', () => {
 					fetch: async (request) => {
 						const url = new URL(request.url)
 						if (request.method === 'POST' && url.pathname === '/compile') {
-							return Response.json(counterFixture.solcOutput, { status: 200 })
+							return Response.json(compileOutput, { status: 200 })
 						}
 
 						throw new Error(
@@ -320,6 +346,72 @@ describe('full verification flow', () => {
 		expect(linkedSources).toStrictEqual([
 			{ path: 'Counter.sol', content: counterSource },
 		])
+	})
+
+	it('allows exact verification to supersede an existing partial match for the same contract', async () => {
+		const partialBody = {
+			...verifyRequestBody,
+			stdJsonInput: {
+				...verifyRequestBody.stdJsonInput,
+				sources: {
+					'Counter.sol': { content: 'contract Counter { }' },
+				},
+			},
+		}
+
+		await runVerificationForAddress({
+			address: counterFixture.address,
+			body: partialBody,
+			compileOutput: solcOutputWithRuntimeBytecode(
+				changeSolidityMetadataHash(counterFixture.onchainRuntimeBytecode),
+			),
+		})
+
+		const db = drizzle(env.CONTRACTS_DB)
+		const partialVerified = await db.select().from(DB.verifiedContractsTable)
+		expect(partialVerified).toHaveLength(1)
+		expect(
+			getFirst(partialVerified, 'partial verified').runtimeMetadataMatch,
+		).toBe(false)
+		const contractSchema = z.object({
+			runtimeMatch: z.string(),
+			sources: z.record(z.string(), z.object({ content: z.string() })),
+		})
+
+		const partialLookupResponse = await exports.default.fetch(
+			new Request(
+				`https://test.local/v2/contract/${counterFixture.chainId}/${counterFixture.address}?fields=sources`,
+			),
+		)
+		expect(partialLookupResponse.status).toBe(200)
+		const partialContract = z.parse(
+			contractSchema,
+			await partialLookupResponse.json(),
+		)
+		expect(partialContract.runtimeMatch).toBe('match')
+		expect(partialContract.sources['Counter.sol']?.content).toBe(
+			'contract Counter { }',
+		)
+
+		const exactVerificationId = await createVerificationJob()
+		await runVerificationForAddress({
+			address: counterFixture.address,
+			jobId: exactVerificationId,
+		})
+
+		const verified = await db.select().from(DB.verifiedContractsTable)
+		expect(verified).toHaveLength(1)
+		expect(getFirst(verified, 'verified').runtimeMetadataMatch).toBe(true)
+
+		const lookupResponse = await exports.default.fetch(
+			new Request(
+				`https://test.local/v2/contract/${counterFixture.chainId}/${counterFixture.address}?fields=sources`,
+			),
+		)
+		expect(lookupResponse.status).toBe(200)
+		const contract = z.parse(contractSchema, await lookupResponse.json())
+		expect(contract.runtimeMatch).toBe('exact_match')
+		expect(contract.sources['Counter.sol']?.content).toBe(counterSource)
 	})
 
 	it('strips prototype pollution keys from persisted compiler settings', async () => {


### PR DESCRIPTION
Allow exact verification attempts to supersede existing partial matches instead of treating partial rows as terminal verified state.

Fixes VERIA-79

Amp-Thread-ID: https://ampcode.com/threads/T-019e2341-b82d-7522-9c7e-05a4da04f32a
Co-authored-by: Amp <amp@ampcode.com>
