### PR TITLE
ci: deploy perf from main workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,6 +59,17 @@ jobs:
       app: key-manager
       environments: '[""]'
 
+  deploy-perf:
+    name: Deploy Perf
+    needs: verify
+    uses: ./.github/workflows/deploy.yml
+    secrets:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+    with:
+      app: perf
+      environments: '[""]'
+
   deploy-og:
     name: Deploy OG
     needs: verify


### PR DESCRIPTION
## Summary

- Add the `perf` workspace to the main deployment workflow.
- Reuse the existing shared Cloudflare deploy workflow with the default Wrangler environment.

## Why

`apps/perf` was included in PR preview deployments, but not in the `main` workflow, so merges to `apps/perf` did not update `https://perf.porto.workers.dev/`.

This deploys the default Worker named `perf`; the repo does not configure a `perf.tempo.xyz` route for this app.

## Validation

- `pnpm --filter perf build`
- `pnpm --filter perf check:types`
- `git diff --check -- .github/workflows/main.yml`
- Ruby YAML parse for `.github/workflows/main.yml`
