### PR TITLE
perf: filter benchmark listings to release runs only

### DIFF
--- a/apps/perf/src/lib/server/bench.ts
+++ b/apps/perf/src/lib/server/bench.ts
@@ -144,8 +144,8 @@ function normalizeRunFeed(feed: unknown): RunFeed {
 
 function runFeedWhereClause(feed: RunFeed): string {
 	return feed === 'release'
-		? "AND startsWith(r.git_ref, 'v')"
-		: "AND NOT startsWith(r.git_ref, 'v')"
+		? "AND r.metadata['run_type'] = 'release'"
+		: "AND r.metadata['run_type'] != 'release'"
 }
 
 function buildRunsQuery(


### PR DESCRIPTION
Only show runs with `metadata['run_type'] = 'release'` on the perf dashboard, so nightly and dispatch benchmark runs are excluded.

Depends on [tempoxyz/tempo#3981](https://github.com/tempoxyz/tempo/pull/3981) which wires `run_type` metadata into the txgen ClickHouse reporter during e2e bench runs.