### PR TITLE
fix(explorer): receipt shows $0 for small amounts and total ignores fee

### DIFF
--- a/apps/explorer/src/comps/Amount.tsx
+++ b/apps/explorer/src/comps/Amount.tsx
@@ -123,11 +123,16 @@ export namespace Amount {
 
 		const rawFormatted = Value.format(value, decimals)
 		const fullFormatted = PriceFormatter.formatAmount(rawFormatted)
-		const formatted = short
-			? PriceFormatter.formatAmountShort(rawFormatted, {
-					maximumFractionDigits: shortMaximumFractionDigits,
-				})
-			: fullFormatted
+		const numericValue = Number(rawFormatted)
+		const isCurrencySmall =
+			prefix === '$' && numericValue > 0 && numericValue < 0.01
+		const formatted = isCurrencySmall
+			? '<0.01'
+			: short
+				? PriceFormatter.formatAmountShort(rawFormatted, {
+						maximumFractionDigits: shortMaximumFractionDigits,
+					})
+				: fullFormatted
 		const isSmall = formatted.startsWith('<')
 
 		return (

--- a/apps/explorer/src/routes/_layout/receipt/$hash.tsx
+++ b/apps/explorer/src/routes/_layout/receipt/$hash.tsx
@@ -456,7 +456,7 @@ function Component() {
 		streamingTotal !== undefined
 			? streamingTotal
 			: eventsTotalDisplayValue !== undefined
-				? eventsTotalDisplayValue
+				? eventsTotalDisplayValue + fee
 				: previousTotal !== undefined
 					? previousTotal - previousFee + fee
 					: fee
@@ -477,7 +477,7 @@ function Component() {
 		streamingTotal !== undefined
 			? streamingTotal
 			: eventsTotalDisplayValue !== undefined
-				? eventsTotalDisplayValue
+				? eventsTotalDisplayValue + fee
 				: previousTotal !== undefined
 					? previousTotal
 					: total


### PR DESCRIPTION
Fixes two receipt bugs reported by the team:

**Bug 1: Send 0.001 USDC.e shows $0**
`Amount.Base` with `short=true` and `$` prefix rounds values < 0.01 to $0 because `formatAmountShort` uses `maximumFractionDigits: 2`. Now detects small currency values and shows `<$0.01` instead, matching `PriceFormatter.format` behavior.

**Bug 2: Fee is $0.07 but total is <$0.01**
When `eventsTotalDisplayValue` is computed from parsed transfer events, the total excluded the gas fee. Added `fee` to both `total` and `totalDisplayValue` in the events-total branch so total = transfer value + fee.

Receipt: https://explore.tempo.xyz/receipt/0x622f4090cd53b2c950beb67a5c88f8297780cafa0a4fe4512dd9d5be52b2c7fb