### PR TITLE
fix(perf): correct node configuration in methodology page

### DIFF
--- a/apps/perf/src/routes/methodology.tsx
+++ b/apps/perf/src/routes/methodology.tsx
@@ -69,8 +69,8 @@ function MethodologyPage(): React.JSX.Element {
 
 				<Section title="Node Configuration">
 					<p>
-						Benchmarks run in single-node dev mode on a dedicated bare-metal
-						server.
+						Benchmarks run two local validators in consensus on a dedicated
+						bare-metal server with 100 GiB pre-bloated state.
 					</p>
 				</Section>
 


### PR DESCRIPTION
The methodology page incorrectly stated benchmarks run in **single-node dev mode**. The actual `bench-e2e` workflow runs **two local validators in consensus** with 100 GiB pre-bloated state.

Also adds state bloat to the description since it's a key bench parameter (default 100 GiB).

Hardware specs (AMD EPYC 4585PX, 128 GB, NVMe via schelk) were already correct.