### PR TITLE
perf: remove 40k scenarios, fix mix workload description

### DIFF
--- a/apps/perf/src/comps/BenchmarkDashboard.tsx
+++ b/apps/perf/src/comps/BenchmarkDashboard.tsx
@@ -169,7 +169,7 @@ export function BenchmarkDashboard(
 			<section className="mb-14">
 				<SectionHeader
 					title="Mixed Workloads"
-					subtitle="70% TIP-20, 10% ERC-20, 10% MPP, 10% DEX"
+					subtitle="70% TIP-20, 10% MPP, 10% DEX, 10% ERC-20"
 				/>
 				<div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
 					{mixScenarios.map((scenario) => (

--- a/apps/perf/src/comps/BenchmarkDashboard.tsx
+++ b/apps/perf/src/comps/BenchmarkDashboard.tsx
@@ -141,7 +141,7 @@ export function BenchmarkDashboard(
 							</div>
 							<div className="flex items-center gap-1.5">
 								<span className="inline-block h-2.5 w-2.5 rounded-full bg-positive/50" />
-								<span className="text-[11px] text-tertiary">Mix (MPP)</span>
+								<span className="text-[11px] text-tertiary">Mixed Workload</span>
 							</div>
 						</div>
 					</div>
@@ -165,11 +165,11 @@ export function BenchmarkDashboard(
 				</div>
 			</section>
 
-			{/* Mix (MPP) workloads */}
+			{/* Mix workloads */}
 			<section className="mb-14">
 				<SectionHeader
 					title="Mixed Workloads"
-					subtitle="80% TIP-20 Transfers, 20% MPP Channels"
+					subtitle="70% TIP-20, 10% ERC-20, 10% MPP, 10% DEX"
 				/>
 				<div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
 					{mixScenarios.map((scenario) => (

--- a/apps/perf/src/lib/server/bench.ts
+++ b/apps/perf/src/lib/server/bench.ts
@@ -48,40 +48,16 @@ const SCENARIOS: Array<{
 	scenarioName: string
 }> = [
 	{
-		id: 'tip20-10k',
-		label: 'TIP-20 — 10K TPS',
-		workload: '100% TIP-20 Transfers',
-		scenarioName: 'tip20-10k',
-	},
-	{
 		id: 'tip20-20k',
 		label: 'TIP-20 — 20K TPS',
 		workload: '100% TIP-20 Transfers',
 		scenarioName: 'tip20-20k',
 	},
 	{
-		id: 'tip20-40k',
-		label: 'TIP-20 — 40K TPS',
-		workload: '100% TIP-20 Transfers',
-		scenarioName: 'tip20-40k',
-	},
-	{
-		id: 'mix-10k',
-		label: 'Mix — 10K TPS',
-		workload: '80% TIP-20 Transfers, 20% MPP Channels',
-		scenarioName: 'mix-10k',
-	},
-	{
 		id: 'mix-20k',
 		label: 'Mix — 20K TPS',
-		workload: '80% TIP-20 Transfers, 20% MPP Channels',
+		workload: '70% TIP-20 Transfers, 10% ERC-20 Transfers, 10% MPP Channels, 10% DEX Swaps',
 		scenarioName: 'mix-20k',
-	},
-	{
-		id: 'mix-40k',
-		label: 'Mix — 40K TPS',
-		workload: '80% TIP-20 Transfers, 20% MPP Channels',
-		scenarioName: 'mix-40k',
 	},
 ]
 

--- a/apps/perf/src/lib/server/bench.ts
+++ b/apps/perf/src/lib/server/bench.ts
@@ -48,10 +48,22 @@ const SCENARIOS: Array<{
 	scenarioName: string
 }> = [
 	{
+		id: 'tip20-10k',
+		label: 'TIP-20 — 10K TPS',
+		workload: '100% TIP-20 Transfers',
+		scenarioName: 'tip20-10k',
+	},
+	{
 		id: 'tip20-20k',
 		label: 'TIP-20 — 20K TPS',
 		workload: '100% TIP-20 Transfers',
 		scenarioName: 'tip20-20k',
+	},
+	{
+		id: 'mix-10k',
+		label: 'Mix — 10K TPS',
+		workload: '70% TIP-20 Transfers, 10% MPP Channels, 10% DEX Swaps, 10% ERC-20 Transfers',
+		scenarioName: 'mix-10k',
 	},
 	{
 		id: 'mix-20k',

--- a/apps/perf/src/lib/server/bench.ts
+++ b/apps/perf/src/lib/server/bench.ts
@@ -56,7 +56,7 @@ const SCENARIOS: Array<{
 	{
 		id: 'mix-20k',
 		label: 'Mix — 20K TPS',
-		workload: '70% TIP-20 Transfers, 10% ERC-20 Transfers, 10% MPP Channels, 10% DEX Swaps',
+		workload: '70% TIP-20 Transfers, 10% MPP Channels, 10% DEX Swaps, 10% ERC-20 Transfers',
 		scenarioName: 'mix-20k',
 	},
 ]


### PR DESCRIPTION
Removes 40k scenarios from the perf site, keeping **TIP-20 10K/20K** and **Mix 10K/20K**.

Fixes the mix workload description to match the actual `mix.yml` weights:
- 70% TIP-20 Transfers
- 10% MPP Channels (open/close)
- 10% DEX Swaps
- 10% ERC-20 Transfers