### PR TITLE
feat(explorer): micro-precision toggle for activity tab

### DIFF
--- a/apps/explorer/src/comps/Amount.tsx
+++ b/apps/explorer/src/comps/Amount.tsx
@@ -5,6 +5,7 @@ import { maxUint256 } from 'viem'
 import { Abis } from 'viem/tempo'
 import { useReadContracts } from 'wagmi'
 import { Hooks } from 'wagmi/tempo'
+import { useMicroPrecision } from '#comps/MicroPrecision.tsx'
 import { TokenIcon } from '#comps/TokenIcon.tsx'
 import { ellipsis } from '#lib/chars'
 import { isTip20Address } from '#lib/domain/tip20.ts'
@@ -121,16 +122,21 @@ export namespace Amount {
 				</span>
 			)
 
+		const microPrecision = useMicroPrecision()
 		const rawFormatted = Value.format(value, decimals)
 		const fullFormatted = PriceFormatter.formatAmount(rawFormatted)
 		const numericValue = Number(rawFormatted)
+		const smallThreshold = microPrecision ? 0.00001 : 0.01
+		const smallLabel = microPrecision ? '<0.00001' : '<0.01'
 		const isCurrencySmall =
-			prefix === '$' && numericValue > 0 && numericValue < 0.01
+			prefix === '$' && numericValue > 0 && numericValue < smallThreshold
+		const resolvedShortDigits =
+			shortMaximumFractionDigits ?? (microPrecision ? 5 : undefined)
 		const formatted = isCurrencySmall
-			? '<0.01'
+			? smallLabel
 			: short
 				? PriceFormatter.formatAmountShort(rawFormatted, {
-						maximumFractionDigits: shortMaximumFractionDigits,
+						maximumFractionDigits: resolvedShortDigits,
 					})
 				: fullFormatted
 		const isSmall = formatted.startsWith('<')

--- a/apps/explorer/src/comps/MicroPrecision.tsx
+++ b/apps/explorer/src/comps/MicroPrecision.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react'
+
+const MicroPrecisionContext = React.createContext(false)
+
+export function MicroPrecisionProvider(props: {
+	value: boolean
+	children: React.ReactNode
+}) {
+	return (
+		<MicroPrecisionContext.Provider value={props.value}>
+			{props.children}
+		</MicroPrecisionContext.Provider>
+	)
+}
+
+export function useMicroPrecision() {
+	return React.useContext(MicroPrecisionContext)
+}

--- a/apps/explorer/src/comps/TxTransactionRow.tsx
+++ b/apps/explorer/src/comps/TxTransactionRow.tsx
@@ -6,6 +6,7 @@ import * as React from 'react'
 import type { RpcTransaction as Transaction, TransactionReceipt } from 'viem'
 import type { GetBlockReturnType } from 'wagmi/actions'
 import { Amount } from '#comps/Amount'
+import { useMicroPrecision } from '#comps/MicroPrecision.tsx'
 import { useTokenListMembership } from '#comps/TokenListMembership'
 import { FormattedTimestamp, type TimeFormat } from '#comps/TimeFormat'
 import { TxEventDescription } from '#comps/TxEventDescription'
@@ -51,13 +52,20 @@ export function TransactionFee(props: { receipt?: TransactionReceipt }) {
 
 	if (!receipt) return <span className="text-tertiary">…</span>
 
+	const microPrecision = useMicroPrecision()
 	const feeRaw = Value.format(receipt.effectiveGasPrice * receipt.gasUsed, 18)
+	const feeNumber = Number(feeRaw)
 	const showUsdPrefix = TEMPO_FEE_TOKEN
 		? isTokenListed(TEMPO_CHAIN_ID, TEMPO_FEE_TOKEN)
 		: true
 	const feeDisplay = showUsdPrefix
-		? PriceFormatter.format(Number(feeRaw))
-		: PriceFormatter.formatAmountShort(feeRaw)
+		? microPrecision && feeNumber > 0 && feeNumber < 0.01
+			? `$${new Intl.NumberFormat('en-US', { minimumFractionDigits: 0, maximumFractionDigits: 5 }).format(feeNumber)}`
+			: PriceFormatter.format(feeNumber)
+		: PriceFormatter.formatAmountShort(
+				feeRaw,
+				microPrecision ? { maximumFractionDigits: 5 } : undefined,
+			)
 
 	return <span className="text-tertiary">{feeDisplay}</span>
 }

--- a/apps/explorer/src/routes/_layout/address/$address.tsx
+++ b/apps/explorer/src/routes/_layout/address/$address.tsx
@@ -19,6 +19,10 @@ import { Actions } from 'wagmi/tempo'
 import * as z from 'zod/mini'
 import { Amount } from '#comps/Amount'
 import { AccountCard } from '#comps/AccountCard'
+import {
+	MicroPrecisionProvider,
+	useMicroPrecision,
+} from '#comps/MicroPrecision.tsx'
 import { AddressCsvExportButton } from '#comps/AddressCsvExportButton'
 import { WalletActions } from '#comps/WalletActions'
 import { AddressCell } from '#comps/AddressCell'
@@ -100,6 +104,7 @@ import ChevronLeft from '~icons/lucide/chevron-left'
 import ChevronRight from '~icons/lucide/chevron-right'
 import EyeIcon from '~icons/lucide/eye'
 import EyeOffIcon from '~icons/lucide/eye-off'
+import MicroscopeIcon from '~icons/lucide/microscope'
 import XIcon from '~icons/lucide/x'
 
 type TokenMetadata = Actions.token.getMetadata.ReturnValue
@@ -910,6 +915,7 @@ function SectionsWrapper(props: {
 	} = props
 	const { timeFormat, cycleTimeFormat, formatLabel } = useTimeFormat()
 	const { voucher } = Route.useSearch()
+	const [microPrecision, setMicroPrecision] = React.useState(false)
 
 	const after = React.useMemo(() => {
 		if (period === '24h') return Math.floor(Date.now() / 1000) - 86400
@@ -1317,6 +1323,12 @@ function SectionsWrapper(props: {
 					itemsLabel: 'transactions',
 					contextual: (
 						<div className="flex items-center justify-end gap-[8px]">
+							<MicroPrecisionToggle
+								enabled={microPrecision}
+								onToggle={() =>
+									setMicroPrecision((prev) => !prev)
+								}
+							/>
 							<TransactionFilters
 								status={status}
 								period={period}
@@ -1334,6 +1346,7 @@ function SectionsWrapper(props: {
 						</div>
 					),
 					content: transactionsError ?? (
+						<MicroPrecisionProvider value={microPrecision}>
 						<DataGrid
 							columns={{
 								stacked: transactionsColumns,
@@ -1413,6 +1426,7 @@ function SectionsWrapper(props: {
 									: 'No transactions found.'
 							}
 						/>
+						</MicroPrecisionProvider>
 					),
 				}
 			case 'holdings': {
@@ -1764,16 +1778,23 @@ function TransactionFeeCell(props: {
 	effectiveGasPrice: string
 }) {
 	const { isTokenListed } = useTokenListMembership()
+	const microPrecision = useMicroPrecision()
 	const fee =
 		Hex.toBigInt(props.gasUsed as Hex.Hex) *
 		Hex.toBigInt(props.effectiveGasPrice as Hex.Hex)
 	const feeRaw = formatUnits(fee, 18)
+	const feeNumber = Number(feeRaw)
 	const showUsdPrefix = TEMPO_FEE_TOKEN
 		? isTokenListed(TEMPO_CHAIN_ID, TEMPO_FEE_TOKEN)
 		: true
 	const feeDisplay = showUsdPrefix
-		? PriceFormatter.format(fee, { decimals: 18, format: 'short' })
-		: PriceFormatter.formatAmountShort(feeRaw)
+		? microPrecision && feeNumber > 0 && feeNumber < 0.01
+			? `$${new Intl.NumberFormat('en-US', { minimumFractionDigits: 0, maximumFractionDigits: 5 }).format(feeNumber)}`
+			: PriceFormatter.format(fee, { decimals: 18, format: 'short' })
+		: PriceFormatter.formatAmountShort(
+				feeRaw,
+				microPrecision ? { maximumFractionDigits: 5 } : undefined,
+			)
 	return <span className="text-tertiary">{feeDisplay}</span>
 }
 
@@ -2028,6 +2049,32 @@ function HoldingsFooter(props: {
 				</div>
 			)}
 		</div>
+	)
+}
+
+function MicroPrecisionToggle(props: {
+	enabled: boolean
+	onToggle: () => void
+}) {
+	const { enabled, onToggle } = props
+	return (
+		<button
+			type="button"
+			onClick={onToggle}
+			title={
+				enabled
+					? 'Hide micro amounts'
+					: 'Show micro amounts (5 decimals)'
+			}
+			className={cx(
+				'flex items-center gap-[6px] border rounded-[6px] px-[8px] py-[4px] text-[12px] cursor-pointer transition-colors',
+				enabled
+					? 'border-accent/20 text-accent bg-accent/5'
+					: 'border-transparent text-tertiary hover:text-secondary hover:bg-base-alt',
+			)}
+		>
+			<MicroscopeIcon className="w-[14px] h-[14px]" />
+		</button>
 	)
 }
 


### PR DESCRIPTION
## Summary

Adds a microscope icon toggle (🔬) in the transactions tab that switches between standard 2-decimal display and 5-decimal precision mode, making tips and sub-cent micro-transactions visible.

### When toggle is **off** (default)
- Amounts ≤ $0.01 show `<$0.01`
- Short format uses 2 decimal places

### When toggle is **on**
- Amounts ≤ $0.00001 show `<$0.00001`
- Short format uses 5 decimal places
- Sub-cent fees and totals display actual values

### Implementation
- `MicroPrecisionContext` (new) — React context so toggle state flows to `Amount.Base` and `TransactionFee` without prop drilling
- `MicroPrecisionToggle` button — follows existing filter button styling (`TransactionFilters` pattern)
- No new dependencies

### Files changed
| File | Change |
|------|--------|
| `comps/MicroPrecision.tsx` | New context + provider + hook |
| `comps/Amount.tsx` | Micro-aware threshold + fraction digits |
| `comps/TxTransactionRow.tsx` | Micro-aware fee formatting |
| `routes/_layout/address/$address.tsx` | Toggle state, button, provider wrapper |