### PR TITLE
perf: add TPS, block time, gas throughput charts and reorganize blocks section

### DIFF
--- a/apps/perf/src/routes/benchmark.$id.tsx
+++ b/apps/perf/src/routes/benchmark.$id.tsx
@@ -552,6 +552,25 @@ function RunDetailPage(): React.JSX.Element {
 							xFormat="block"
 						/>
 						<TimeSeriesChart
+							title="Block Time"
+							tooltip="Wall-clock time for each block in milliseconds."
+							showMean
+							series={[
+								{
+									label: 'Block Time',
+									color: COLORS.orange,
+									data: blockRows
+										.filter((b) => b.blockTimeMs != null)
+										.map((b) => ({
+											x: b.index,
+											y: b.blockTimeMs as number,
+										})),
+								},
+							]}
+							formatValue={(v) => formatMs(v)}
+							xFormat="block"
+						/>
+						<TimeSeriesChart
 							title="Gas Used per Block"
 							tooltip="Total gas consumed by all transactions in each block."
 							showMean

--- a/apps/perf/src/routes/benchmark.$id.tsx
+++ b/apps/perf/src/routes/benchmark.$id.tsx
@@ -535,20 +535,20 @@ function RunDetailPage(): React.JSX.Element {
 					/>
 					<div className="grid grid-cols-1 gap-3 md:grid-cols-2">
 						<TimeSeriesChart
-							title="Transactions per Block"
-							tooltip="Number of transactions included in each block."
+							title="TPS"
+							tooltip="Transactions per second for each block, based on transaction count and block time."
 							showMean
 							series={[
 								{
-									label: 'Tx Count',
-									color: COLORS.blue,
-									data: blockRows.map((b) => ({
-										x: b.index,
-										y: b.txCount,
-									})),
+									label: 'TPS',
+									color: COLORS.purple,
+									data: blockPoints(blockRows, (b) => {
+										if (b.blockTimeMs == null || b.blockTimeMs <= 0) return null
+										return (b.txCount * 1000) / b.blockTimeMs
+									}),
 								},
 							]}
-							formatValue={(v) => `${Math.round(v).toLocaleString()} txs`}
+							formatValue={(v) => formatTps(v)}
 							xFormat="block"
 						/>
 						<TimeSeriesChart
@@ -568,6 +568,40 @@ function RunDetailPage(): React.JSX.Element {
 								},
 							]}
 							formatValue={(v) => formatMs(v)}
+							xFormat="block"
+						/>
+						<TimeSeriesChart
+							title="Gas Throughput"
+							tooltip="Gas processed per second for each block, based on gas usage and block time."
+							showMean
+							series={[
+								{
+									label: 'Gas/s',
+									color: COLORS.blue,
+									data: blockPoints(blockRows, (b) => {
+										if (b.blockTimeMs == null || b.blockTimeMs <= 0) return null
+										return (b.gasUsed * 1000) / b.blockTimeMs / 1e9
+									}),
+								},
+							]}
+							formatValue={(v) => `${v.toFixed(2)} Ggas/s`}
+							xFormat="block"
+						/>
+						<TimeSeriesChart
+							title="Transactions per Block"
+							tooltip="Number of transactions included in each block."
+							showMean
+							series={[
+								{
+									label: 'Tx Count',
+									color: COLORS.blue,
+									data: blockRows.map((b) => ({
+										x: b.index,
+										y: b.txCount,
+									})),
+								},
+							]}
+							formatValue={(v) => `${Math.round(v).toLocaleString()} txs`}
 							xFormat="block"
 						/>
 						<TimeSeriesChart
@@ -658,40 +692,6 @@ function RunDetailPage(): React.JSX.Element {
 										]
 									: undefined
 							}
-						/>
-						<TimeSeriesChart
-							title="TPS"
-							tooltip="Transactions per second for each block, based on transaction count and block time."
-							showMean
-							series={[
-								{
-									label: 'TPS',
-									color: COLORS.purple,
-									data: blockPoints(blockRows, (b) => {
-										if (b.blockTimeMs == null || b.blockTimeMs <= 0) return null
-										return (b.txCount * 1000) / b.blockTimeMs
-									}),
-								},
-							]}
-							formatValue={(v) => formatTps(v)}
-							xFormat="block"
-						/>
-						<TimeSeriesChart
-							title="Gas Throughput"
-							tooltip="Gas processed per second for each block, based on gas usage and block time."
-							showMean
-							series={[
-								{
-									label: 'Gas/s',
-									color: COLORS.blue,
-									data: blockPoints(blockRows, (b) => {
-										if (b.blockTimeMs == null || b.blockTimeMs <= 0) return null
-										return (b.gasUsed * 1000) / b.blockTimeMs / 1e9
-									}),
-								},
-							]}
-							formatValue={(v) => `${v.toFixed(2)} Ggas/s`}
-							xFormat="block"
 						/>
 						<TimeSeriesChart
 							title="RLP Block Size"

--- a/apps/perf/src/routes/benchmark.$id.tsx
+++ b/apps/perf/src/routes/benchmark.$id.tsx
@@ -660,6 +660,40 @@ function RunDetailPage(): React.JSX.Element {
 							}
 						/>
 						<TimeSeriesChart
+							title="TPS"
+							tooltip="Transactions per second for each block, based on transaction count and block time."
+							showMean
+							series={[
+								{
+									label: 'TPS',
+									color: COLORS.purple,
+									data: blockPoints(blockRows, (b) => {
+										if (b.blockTimeMs == null || b.blockTimeMs <= 0) return null
+										return (b.txCount * 1000) / b.blockTimeMs
+									}),
+								},
+							]}
+							formatValue={(v) => formatTps(v)}
+							xFormat="block"
+						/>
+						<TimeSeriesChart
+							title="Gas Throughput"
+							tooltip="Gas processed per second for each block, based on gas usage and block time."
+							showMean
+							series={[
+								{
+									label: 'Gas/s',
+									color: COLORS.blue,
+									data: blockPoints(blockRows, (b) => {
+										if (b.blockTimeMs == null || b.blockTimeMs <= 0) return null
+										return (b.gasUsed * 1000) / b.blockTimeMs / 1e9
+									}),
+								},
+							]}
+							formatValue={(v) => `${v.toFixed(2)} Ggas/s`}
+							xFormat="block"
+						/>
+						<TimeSeriesChart
 							title="RLP Block Size"
 							tooltip="RLP-encoded size of each block in kilobytes."
 							showMean
@@ -871,44 +905,7 @@ function RunDetailPage(): React.JSX.Element {
 				/>
 			</section>
 
-			<section className="mb-10">
-				<SectionHeader
-					title="Throughput"
-					tooltip="Gas and transaction processing rates per block."
-				/>
-				<div className="grid grid-cols-1 gap-3 md:grid-cols-2">
-					<TimeSeriesChart
-						title="Gas Throughput"
-						tooltip="Gas processed per second for each block, based on gas usage and block time."
-						showMean
-						series={[
-							{
-								label: 'Gas/s',
-								color: COLORS.blue,
-								data: blockPoints(blockRows, (b) => {
-									if (b.blockTimeMs == null || b.blockTimeMs <= 0) return null
-									return (b.gasUsed * 1000) / b.blockTimeMs / 1e9
-								}),
-							},
-						]}
-						formatValue={(v) => `${v.toFixed(2)} Ggas/s`}
-						xFormat="block"
-					/>
-					<TimeSeriesChart
-						title="Txs per Block"
-						tooltip="Number of user transactions included in each block as reported by the builder."
-						showMean
-						series={[
-							{
-								label: 'Txs',
-								color: COLORS.green,
-								data: transformSamples(txsPerBlockSeries),
-							},
-						]}
-						formatValue={(v) => `${Math.round(v).toLocaleString()}`}
-					/>
-				</div>
-			</section>
+
 
 			<section className="mb-10">
 				<SectionHeader

--- a/apps/perf/src/routes/benchmark.$id.tsx
+++ b/apps/perf/src/routes/benchmark.$id.tsx
@@ -262,12 +262,6 @@ function RunDetailPage(): React.JSX.Element {
 		{ quantile: '0.5' },
 	)
 
-	// Throughput
-	const txsPerBlockSeries = findSeries(
-		m,
-		'reth_tempo_payload_builder_total_transactions_last',
-	)
-
 	// Block headroom
 	const rlpSizeSeries = findSeries(
 		m,


### PR DESCRIPTION
Consolidates block-level charts into the Blocks section and reorders them:

1. **TPS** — transactions per second per block (new)
2. **Block Time** — wall-clock ms per block (new)
3. **Gas Throughput** — Ggas/s per block (moved from standalone Throughput section)
4. **Transactions per Block** — existing
5. **Gas Used per Block** — existing
6. **Gas Fill %** — existing
7. **RLP Block Size** — existing

Removes the old standalone Throughput section since its charts now live in Blocks.