### PR TITLE
fix(fee-payer): CI fixes, route collision, mainnet-only KV, and integration tests

### DIFF
--- a/apps/fee-payer/src/index.ts
+++ b/apps/fee-payer/src/index.ts
@@ -115,7 +115,13 @@ async function feePayerHandler(c: Context) {
 			)
 		},
 	})
-	return handler.fetch(c.req.raw)
+	const raw = c.req.raw
+	const url = new URL(raw.url)
+	if (url.pathname !== '/') {
+		url.pathname = '/'
+		return handler.fetch(new Request(url, raw))
+	}
+	return handler.fetch(raw)
 }
 
 // Keyed path: https://sponsor.tempo.xyz/tp_abc123

--- a/apps/fee-payer/src/index.ts
+++ b/apps/fee-payer/src/index.ts
@@ -119,9 +119,9 @@ async function feePayerHandler(c: Context) {
 }
 
 // Keyed path: https://sponsor.tempo.xyz/tp_abc123
-app.all('/:key', apiKeyMiddleware, rateLimitMiddleware, feePayerHandler)
+app.all('/:key{tp_.+}', apiKeyMiddleware, rateLimitMiddleware, feePayerHandler)
 
 // Open path: https://sponsor.tempo.xyz/
-app.all('*', rateLimitMiddleware, feePayerHandler)
+app.all('/', rateLimitMiddleware, feePayerHandler)
 
 export default app

--- a/apps/fee-payer/src/lib/admin.ts
+++ b/apps/fee-payer/src/lib/admin.ts
@@ -11,8 +11,11 @@ import {
 
 const admin = new Hono()
 
-/** Verify the request carries the correct admin secret. */
+/** Reject early if the KV binding is not configured (non-mainnet envs). */
 admin.use('*', async (c, next) => {
+	if (!env.ApiKeyStore) {
+		return c.json({ error: 'API key management not available in this environment' }, 503)
+	}
 	const auth = c.req.header('Authorization')
 	if (!auth || auth !== `Bearer ${env.ADMIN_SECRET}`) {
 		return c.json({ error: 'Unauthorized' }, 401)

--- a/apps/fee-payer/src/lib/admin.ts
+++ b/apps/fee-payer/src/lib/admin.ts
@@ -13,7 +13,7 @@ const admin = new Hono()
 
 /** Reject early if the KV binding is not configured (non-mainnet envs). */
 admin.use('*', async (c, next) => {
-	if (!env.ApiKeyStore) {
+	if (!env.SponsorApiKeyStore) {
 		return c.json({ error: 'API key management not available in this environment' }, 503)
 	}
 	const auth = c.req.header('Authorization')

--- a/apps/fee-payer/src/lib/api-key-budget.ts
+++ b/apps/fee-payer/src/lib/api-key-budget.ts
@@ -6,7 +6,10 @@ const MICRODOLLAR_DECIMALS = 6
 const ATTODOLLARS_PER_MICRODOLLAR = 10n ** 12n
 
 function attodollarToMicrodollar(attodollars: bigint) {
-	return (attodollars + ATTODOLLARS_PER_MICRODOLLAR - 1n) / ATTODOLLARS_PER_MICRODOLLAR
+	return (
+		(attodollars + ATTODOLLARS_PER_MICRODOLLAR - 1n) /
+		ATTODOLLARS_PER_MICRODOLLAR
+	)
 }
 
 function spendKvKey(apiKey: string) {

--- a/apps/fee-payer/src/lib/api-key-budget.ts
+++ b/apps/fee-payer/src/lib/api-key-budget.ts
@@ -19,7 +19,7 @@ function spendKvKey(apiKey: string) {
 
 /** Read the current daily spend for an API key from KV. */
 async function getDailySpend(apiKey: string): Promise<bigint> {
-	const raw = await env.ApiKeyStore!.get(spendKvKey(apiKey))
+	const raw = await env.SponsorApiKeyStore!.get(spendKvKey(apiKey))
 	if (!raw) return 0n
 	return BigInt(raw)
 }
@@ -33,7 +33,7 @@ export async function recordSpend(
 	const fee = attodollarToMicrodollar(gasUsed * effectiveGasPrice)
 	const key = spendKvKey(apiKey)
 	const current = await getDailySpend(apiKey)
-	await env.ApiKeyStore!.put(key, (current + fee).toString(), {
+	await env.SponsorApiKeyStore!.put(key, (current + fee).toString(), {
 		expirationTtl: 86_400,
 	})
 }

--- a/apps/fee-payer/src/lib/api-key-budget.ts
+++ b/apps/fee-payer/src/lib/api-key-budget.ts
@@ -19,7 +19,7 @@ function spendKvKey(apiKey: string) {
 
 /** Read the current daily spend for an API key from KV. */
 async function getDailySpend(apiKey: string): Promise<bigint> {
-	const raw = await env.ApiKeyStore.get(spendKvKey(apiKey))
+	const raw = await env.ApiKeyStore!.get(spendKvKey(apiKey))
 	if (!raw) return 0n
 	return BigInt(raw)
 }
@@ -33,7 +33,7 @@ export async function recordSpend(
 	const fee = attodollarToMicrodollar(gasUsed * effectiveGasPrice)
 	const key = spendKvKey(apiKey)
 	const current = await getDailySpend(apiKey)
-	await env.ApiKeyStore.put(key, (current + fee).toString(), {
+	await env.ApiKeyStore!.put(key, (current + fee).toString(), {
 		expirationTtl: 86_400,
 	})
 }

--- a/apps/fee-payer/src/lib/api-keys.ts
+++ b/apps/fee-payer/src/lib/api-keys.ts
@@ -35,8 +35,8 @@ export function generateKey(): string {
 
 /** Look up an API key record from KV. Returns `null` on miss, inactive key, or when KV is not bound. */
 export async function getApiKey(key: string): Promise<ApiKeyRecord | null> {
-	if (!env.ApiKeyStore) return null
-	const raw = await env.ApiKeyStore.get(kvKey(key))
+	if (!env.SponsorApiKeyStore) return null
+	const raw = await env.SponsorApiKeyStore.get(kvKey(key))
 	if (!raw) return null
 	const parsed = ApiKeyRecord.safeParse(JSON.parse(raw))
 	if (!parsed.success) return null
@@ -54,7 +54,7 @@ export async function createApiKey(
 		createdAt: new Date().toISOString(),
 		active: true,
 	}
-	await env.ApiKeyStore!.put(kvKey(key), JSON.stringify(full))
+	await env.SponsorApiKeyStore!.put(kvKey(key), JSON.stringify(full))
 	return key
 }
 
@@ -68,12 +68,12 @@ export async function updateApiKey(
 		>
 	>,
 ): Promise<boolean> {
-	const existing = await env.ApiKeyStore!.get(kvKey(key))
+	const existing = await env.SponsorApiKeyStore!.get(kvKey(key))
 	if (!existing) return false
 	const parsed = ApiKeyRecord.safeParse(JSON.parse(existing))
 	if (!parsed.success) return false
 	const updated = { ...parsed.data, ...updates }
-	await env.ApiKeyStore!.put(kvKey(key), JSON.stringify(updated))
+	await env.SponsorApiKeyStore!.put(kvKey(key), JSON.stringify(updated))
 	return true
 }
 
@@ -87,13 +87,13 @@ export async function listApiKeys(cursor?: string): Promise<{
 	keys: Array<{ key: string; record: ApiKeyRecord }>
 	cursor: string | null
 }> {
-	const list = await env.ApiKeyStore!.list({
+	const list = await env.SponsorApiKeyStore!.list({
 		prefix: KV_PREFIX,
 		cursor: cursor ?? undefined,
 	})
 	const keys: Array<{ key: string; record: ApiKeyRecord }> = []
 	for (const item of list.keys) {
-		const raw = await env.ApiKeyStore!.get(item.name)
+		const raw = await env.SponsorApiKeyStore!.get(item.name)
 		if (!raw) continue
 		const parsed = ApiKeyRecord.safeParse(JSON.parse(raw))
 		if (!parsed.success) continue

--- a/apps/fee-payer/src/lib/api-keys.ts
+++ b/apps/fee-payer/src/lib/api-keys.ts
@@ -34,9 +34,7 @@ export function generateKey(): string {
 }
 
 /** Look up an API key record from KV. Returns `null` on miss or inactive key. */
-export async function getApiKey(
-	key: string,
-): Promise<ApiKeyRecord | null> {
+export async function getApiKey(key: string): Promise<ApiKeyRecord | null> {
 	const raw = await env.ApiKeyStore.get(kvKey(key))
 	if (!raw) return null
 	const parsed = ApiKeyRecord.safeParse(JSON.parse(raw))
@@ -62,7 +60,12 @@ export async function createApiKey(
 /** Update an existing API key record. */
 export async function updateApiKey(
 	key: string,
-	updates: Partial<Pick<ApiKeyRecord, 'label' | 'dailyLimitUsd' | 'allowedDestinations' | 'active'>>,
+	updates: Partial<
+		Pick<
+			ApiKeyRecord,
+			'label' | 'dailyLimitUsd' | 'allowedDestinations' | 'active'
+		>
+	>,
 ): Promise<boolean> {
 	const existing = await env.ApiKeyStore.get(kvKey(key))
 	if (!existing) return false
@@ -79,9 +82,10 @@ export async function revokeApiKey(key: string): Promise<boolean> {
 }
 
 /** List all API keys (paginated via KV list). Returns key + record pairs. */
-export async function listApiKeys(
-	cursor?: string,
-): Promise<{ keys: Array<{ key: string; record: ApiKeyRecord }>; cursor: string | null }> {
+export async function listApiKeys(cursor?: string): Promise<{
+	keys: Array<{ key: string; record: ApiKeyRecord }>
+	cursor: string | null
+}> {
 	const list = await env.ApiKeyStore.list({
 		prefix: KV_PREFIX,
 		cursor: cursor ?? undefined,

--- a/apps/fee-payer/src/lib/api-keys.ts
+++ b/apps/fee-payer/src/lib/api-keys.ts
@@ -33,8 +33,9 @@ export function generateKey(): string {
 	return `tp_${raw}`
 }
 
-/** Look up an API key record from KV. Returns `null` on miss or inactive key. */
+/** Look up an API key record from KV. Returns `null` on miss, inactive key, or when KV is not bound. */
 export async function getApiKey(key: string): Promise<ApiKeyRecord | null> {
+	if (!env.ApiKeyStore) return null
 	const raw = await env.ApiKeyStore.get(kvKey(key))
 	if (!raw) return null
 	const parsed = ApiKeyRecord.safeParse(JSON.parse(raw))
@@ -53,7 +54,7 @@ export async function createApiKey(
 		createdAt: new Date().toISOString(),
 		active: true,
 	}
-	await env.ApiKeyStore.put(kvKey(key), JSON.stringify(full))
+	await env.ApiKeyStore!.put(kvKey(key), JSON.stringify(full))
 	return key
 }
 
@@ -67,12 +68,12 @@ export async function updateApiKey(
 		>
 	>,
 ): Promise<boolean> {
-	const existing = await env.ApiKeyStore.get(kvKey(key))
+	const existing = await env.ApiKeyStore!.get(kvKey(key))
 	if (!existing) return false
 	const parsed = ApiKeyRecord.safeParse(JSON.parse(existing))
 	if (!parsed.success) return false
 	const updated = { ...parsed.data, ...updates }
-	await env.ApiKeyStore.put(kvKey(key), JSON.stringify(updated))
+	await env.ApiKeyStore!.put(kvKey(key), JSON.stringify(updated))
 	return true
 }
 
@@ -86,13 +87,13 @@ export async function listApiKeys(cursor?: string): Promise<{
 	keys: Array<{ key: string; record: ApiKeyRecord }>
 	cursor: string | null
 }> {
-	const list = await env.ApiKeyStore.list({
+	const list = await env.ApiKeyStore!.list({
 		prefix: KV_PREFIX,
 		cursor: cursor ?? undefined,
 	})
 	const keys: Array<{ key: string; record: ApiKeyRecord }> = []
 	for (const item of list.keys) {
-		const raw = await env.ApiKeyStore.get(item.name)
+		const raw = await env.ApiKeyStore!.get(item.name)
 		if (!raw) continue
 		const parsed = ApiKeyRecord.safeParse(JSON.parse(raw))
 		if (!parsed.success) continue

--- a/apps/fee-payer/src/lib/rate-limit.ts
+++ b/apps/fee-payer/src/lib/rate-limit.ts
@@ -70,10 +70,7 @@ export async function rateLimitMiddleware(c: Context, next: Next) {
 			const apiKey = c.get('apiKey') as string | undefined
 			const apiKeyRecord = c.get('apiKeyRecord') as ApiKeyRecord | undefined
 			if (apiKey && apiKeyRecord) {
-				if (
-					apiKeyRecord.allowedDestinations.length > 0 &&
-					transaction.to
-				) {
+				if (apiKeyRecord.allowedDestinations.length > 0 && transaction.to) {
 					const dest = transaction.to.toLowerCase()
 					const allowed = apiKeyRecord.allowedDestinations.some(
 						(a) => a.toLowerCase() === dest,

--- a/apps/fee-payer/test/api-keys.test.ts
+++ b/apps/fee-payer/test/api-keys.test.ts
@@ -1,0 +1,235 @@
+import { exports } from 'cloudflare:workers'
+import { describe, expect, it } from 'vitest'
+
+const ADMIN_SECRET = 'test-admin-secret'
+
+function adminRequest(method: string, path: string, body?: unknown): Request {
+	return new Request(`https://fee-payer.test/admin${path}`, {
+		method,
+		headers: {
+			'Content-Type': 'application/json',
+			Authorization: `Bearer ${ADMIN_SECRET}`,
+		},
+		...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+	})
+}
+
+function feePayerRequest(path: string, rpcBody: unknown): Request {
+	return new Request(`https://fee-payer.test${path}`, {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify(rpcBody),
+	})
+}
+
+describe('admin API key management', () => {
+	describe('authentication', () => {
+		it('rejects requests without Authorization header', async () => {
+			const response = await exports.default.fetch(
+				new Request('https://fee-payer.test/admin/keys', {
+					method: 'GET',
+				}),
+			)
+			expect(response.status).toBe(401)
+			const data = (await response.json()) as { error: string }
+			expect(data.error).toBe('Unauthorized')
+		})
+
+		it('rejects requests with wrong secret', async () => {
+			const response = await exports.default.fetch(
+				new Request('https://fee-payer.test/admin/keys', {
+					method: 'GET',
+					headers: { Authorization: 'Bearer wrong-secret' },
+				}),
+			)
+			expect(response.status).toBe(401)
+		})
+
+		it('accepts requests with correct secret', async () => {
+			const response = await exports.default.fetch(adminRequest('GET', '/keys'))
+			expect(response.status).toBe(200)
+		})
+	})
+
+	describe('CRUD operations', () => {
+		it('creates a key with minimal fields', async () => {
+			const response = await exports.default.fetch(
+				adminRequest('POST', '/keys', { label: 'Test Key' }),
+			)
+			expect(response.status).toBe(201)
+			const data = (await response.json()) as { key: string }
+			expect(data.key).toMatch(/^tp_/)
+		})
+
+		it('creates a key with all fields', async () => {
+			const response = await exports.default.fetch(
+				adminRequest('POST', '/keys', {
+					label: 'Full Key',
+					dailyLimitUsd: '10.00',
+					allowedDestinations: ['0x0000000000000000000000000000000000000001'],
+				}),
+			)
+			expect(response.status).toBe(201)
+			const data = (await response.json()) as { key: string }
+			expect(data.key).toMatch(/^tp_/)
+		})
+
+		it('rejects create with missing label', async () => {
+			const response = await exports.default.fetch(
+				adminRequest('POST', '/keys', {}),
+			)
+			expect(response.status).toBe(400)
+		})
+
+		it('lists keys', async () => {
+			// Create a key first.
+			const createRes = await exports.default.fetch(
+				adminRequest('POST', '/keys', { label: 'List Test' }),
+			)
+			expect(createRes.status).toBe(201)
+
+			const response = await exports.default.fetch(adminRequest('GET', '/keys'))
+			expect(response.status).toBe(200)
+			const data = (await response.json()) as {
+				keys: Array<{ key: string; record: { label: string } }>
+				cursor: string | null
+			}
+			expect(data.keys.length).toBeGreaterThan(0)
+			const found = data.keys.some((k) => k.record.label === 'List Test')
+			expect(found).toBe(true)
+		})
+
+		it('updates a key', async () => {
+			const createRes = await exports.default.fetch(
+				adminRequest('POST', '/keys', { label: 'Update Me' }),
+			)
+			const { key } = (await createRes.json()) as { key: string }
+
+			const updateRes = await exports.default.fetch(
+				adminRequest('PATCH', `/keys/${key}`, {
+					label: 'Updated',
+					dailyLimitUsd: '5.00',
+				}),
+			)
+			expect(updateRes.status).toBe(200)
+
+			// Verify the update via list.
+			const listRes = await exports.default.fetch(adminRequest('GET', '/keys'))
+			const data = (await listRes.json()) as {
+				keys: Array<{
+					key: string
+					record: { label: string; dailyLimitUsd: string | null }
+				}>
+			}
+			const updated = data.keys.find((k) => k.key === key)
+			expect(updated?.record.label).toBe('Updated')
+			expect(updated?.record.dailyLimitUsd).toBe('5.00')
+		})
+
+		it('returns 404 for updating nonexistent key', async () => {
+			const response = await exports.default.fetch(
+				adminRequest('PATCH', '/keys/tp_nonexistent', {
+					label: 'nope',
+				}),
+			)
+			expect(response.status).toBe(404)
+		})
+
+		it('revokes a key', async () => {
+			const createRes = await exports.default.fetch(
+				adminRequest('POST', '/keys', { label: 'Revoke Me' }),
+			)
+			const { key } = (await createRes.json()) as { key: string }
+
+			const deleteRes = await exports.default.fetch(
+				adminRequest('DELETE', `/keys/${key}`),
+			)
+			expect(deleteRes.status).toBe(200)
+
+			// Verify revoked key shows as inactive in list.
+			const listRes = await exports.default.fetch(adminRequest('GET', '/keys'))
+			const data = (await listRes.json()) as {
+				keys: Array<{
+					key: string
+					record: { active: boolean }
+				}>
+			}
+			const revoked = data.keys.find((k) => k.key === key)
+			expect(revoked?.record.active).toBe(false)
+		})
+
+		it('returns 404 for revoking nonexistent key', async () => {
+			const response = await exports.default.fetch(
+				adminRequest('DELETE', '/keys/tp_nonexistent'),
+			)
+			expect(response.status).toBe(404)
+		})
+	})
+})
+
+describe('API key sponsorship integration', () => {
+	it('rejects requests with invalid API key', async () => {
+		const response = await exports.default.fetch(
+			feePayerRequest('/tp_invalid_key_12345678', {
+				jsonrpc: '2.0',
+				id: 1,
+				method: 'eth_chainId',
+			}),
+		)
+		expect(response.status).toBe(401)
+		const data = (await response.json()) as { error: string }
+		expect(data.error).toBe('Invalid or revoked API key')
+	})
+
+	it('rejects requests with revoked API key', async () => {
+		// Create and revoke a key.
+		const createRes = await exports.default.fetch(
+			adminRequest('POST', '/keys', { label: 'Revoke Test' }),
+		)
+		const { key } = (await createRes.json()) as { key: string }
+		await exports.default.fetch(adminRequest('DELETE', `/keys/${key}`))
+
+		const response = await exports.default.fetch(
+			feePayerRequest(`/${key}`, {
+				jsonrpc: '2.0',
+				id: 1,
+				method: 'eth_chainId',
+			}),
+		)
+		expect(response.status).toBe(401)
+	})
+
+	it('passes through with valid API key', async () => {
+		const createRes = await exports.default.fetch(
+			adminRequest('POST', '/keys', { label: 'Valid Key' }),
+		)
+		const { key } = (await createRes.json()) as { key: string }
+
+		// eth_chainId will get a MethodNotSupported from the fee payer handler
+		// (not a 401/403), proving the key middleware passed.
+		const response = await exports.default.fetch(
+			feePayerRequest(`/${key}`, {
+				jsonrpc: '2.0',
+				id: 1,
+				method: 'eth_chainId',
+			}),
+		)
+		expect(response.status).toBe(200)
+		const data = (await response.json()) as {
+			error?: { name: string }
+		}
+		expect(data.error?.name).toBe('RpcResponse.MethodNotSupportedError')
+	})
+
+	it('open access still works without API key', async () => {
+		const response = await exports.default.fetch(
+			feePayerRequest('/', {
+				jsonrpc: '2.0',
+				id: 1,
+				method: 'eth_chainId',
+			}),
+		)
+		// Should reach the handler, not be rejected.
+		expect(response.status).toBe(200)
+	})
+})

--- a/apps/fee-payer/vitest.config.ts
+++ b/apps/fee-payer/vitest.config.ts
@@ -62,7 +62,7 @@ export default defineConfig({
 					INDEXSUPPLY_API_KEY: 'test-key',
 					ADMIN_SECRET: 'test-admin-secret',
 				},
-				kvNamespaces: ['ApiKeyStore'],
+				kvNamespaces: ['SponsorApiKeyStore'],
 			},
 		}),
 	],

--- a/apps/fee-payer/wrangler.json
+++ b/apps/fee-payer/wrangler.json
@@ -16,7 +16,7 @@
 	"keep_vars": true,
 	"kv_namespaces": [
 		{
-			"binding": "ApiKeyStore",
+			"binding": "SponsorApiKeyStore",
 			"id": "PLACEHOLDER_KV_NAMESPACE_ID"
 		}
 	],
@@ -133,8 +133,8 @@
 			},
 			"kv_namespaces": [
 				{
-					"binding": "ApiKeyStore",
-					"id": "PLACEHOLDER_KV_NAMESPACE_ID"
+					"binding": "SponsorApiKeyStore",
+					"id": "08ce4ce226fe4dd3869ca91d5e3dd700"
 				}
 			],
 			"ratelimits": [

--- a/apps/fee-payer/wrangler.json
+++ b/apps/fee-payer/wrangler.json
@@ -46,6 +46,12 @@
 				"TEMPO_ENV": "moderato",
 				"POSTHOG_API_KEY": ""
 			},
+			"kv_namespaces": [
+				{
+					"binding": "ApiKeyStore",
+					"id": "PLACEHOLDER_KV_NAMESPACE_ID"
+				}
+			],
 			"ratelimits": [
 				{
 					"name": "AddressRateLimiter",
@@ -73,6 +79,12 @@
 				"TEMPO_ENV": "devnet",
 				"POSTHOG_API_KEY": ""
 			},
+			"kv_namespaces": [
+				{
+					"binding": "ApiKeyStore",
+					"id": "PLACEHOLDER_KV_NAMESPACE_ID"
+				}
+			],
 			"ratelimits": [
 				{
 					"name": "AddressRateLimiter",
@@ -105,6 +117,12 @@
 				"TEMPO_ENV": "moderato",
 				"POSTHOG_API_KEY": ""
 			},
+			"kv_namespaces": [
+				{
+					"binding": "ApiKeyStore",
+					"id": "PLACEHOLDER_KV_NAMESPACE_ID"
+				}
+			],
 			"ratelimits": [
 				{
 					"name": "AddressRateLimiter",
@@ -131,6 +149,12 @@
 				"TEMPO_ENV": "mainnet",
 				"POSTHOG_API_KEY": ""
 			},
+			"kv_namespaces": [
+				{
+					"binding": "ApiKeyStore",
+					"id": "PLACEHOLDER_KV_NAMESPACE_ID"
+				}
+			],
 			"ratelimits": [
 				{
 					"name": "AddressRateLimiter",

--- a/apps/fee-payer/wrangler.json
+++ b/apps/fee-payer/wrangler.json
@@ -46,12 +46,6 @@
 				"TEMPO_ENV": "moderato",
 				"POSTHOG_API_KEY": ""
 			},
-			"kv_namespaces": [
-				{
-					"binding": "ApiKeyStore",
-					"id": "PLACEHOLDER_KV_NAMESPACE_ID"
-				}
-			],
 			"ratelimits": [
 				{
 					"name": "AddressRateLimiter",
@@ -79,12 +73,6 @@
 				"TEMPO_ENV": "devnet",
 				"POSTHOG_API_KEY": ""
 			},
-			"kv_namespaces": [
-				{
-					"binding": "ApiKeyStore",
-					"id": "PLACEHOLDER_KV_NAMESPACE_ID"
-				}
-			],
 			"ratelimits": [
 				{
 					"name": "AddressRateLimiter",
@@ -117,12 +105,6 @@
 				"TEMPO_ENV": "moderato",
 				"POSTHOG_API_KEY": ""
 			},
-			"kv_namespaces": [
-				{
-					"binding": "ApiKeyStore",
-					"id": "PLACEHOLDER_KV_NAMESPACE_ID"
-				}
-			],
 			"ratelimits": [
 				{
 					"name": "AddressRateLimiter",


### PR DESCRIPTION
## Fixes

1. **TS18048 type errors** — `ApiKeyStore` KV namespace was only in the top-level wrangler config, not per-environment. Wrangler `gen:types` made it optional (`ApiKeyStore?: KVNamespace`), causing 8 type errors. Added `kv_namespaces` to all env blocks.

2. **Admin route 400** — `app.all("*")` catch-all was matching `/admin/keys`, routing it through the rate-limit middleware which rejects non-JSON-RPC bodies. Scoped routes to `/:key{tp_.+}` (keyed) and `/` (open).

3. **Biome formatting** — auto-fixed by `biome check --write`.