### PR TITLE
feat(fee-payer): upgrade to accounts SDK relay handler

### DIFF
--- a/apps/fee-payer/package.json
+++ b/apps/fee-payer/package.json
@@ -32,7 +32,7 @@
 		"idxs": "catalog:",
 		"kysely": "catalog:",
 		"ox": "catalog:",
-		"tempo.ts": "catalog:",
+		"accounts": "catalog:",
 		"viem": "catalog:",
 		"zod": "catalog:"
 	},

--- a/apps/fee-payer/src/index.ts
+++ b/apps/fee-payer/src/index.ts
@@ -112,17 +112,21 @@ const relayHandler = Handler.relay({
 async function feePayerHandler(c: Context) {
 	const requestContext = getRequestContext(c.req.raw)
 	const apiKeyLabel = c.get('apiKeyRecord')?.label
+	const rpcMethod = c.get('rpcMethod') as string | undefined
 
-	c.executionCtx.waitUntil(
-		captureEvent({
-			distinctId: apiKeyLabel ?? requestContext.origin ?? 'unknown',
-			event: FeePayerEvents.SPONSORSHIP_REQUEST,
-			properties: {
-				...requestContext,
-				...(apiKeyLabel ? { apiKeyLabel } : {}),
-			},
-		}),
-	)
+	if (rpcMethod) {
+		c.executionCtx.waitUntil(
+			captureEvent({
+				distinctId: apiKeyLabel ?? requestContext.origin ?? 'unknown',
+				event: FeePayerEvents.SPONSORSHIP_REQUEST,
+				properties: {
+					...requestContext,
+					rpcMethod,
+					...(apiKeyLabel ? { apiKeyLabel } : {}),
+				},
+			}),
+		)
+	}
 
 	const raw = c.req.raw
 	const url = new URL(raw.url)

--- a/apps/fee-payer/src/index.ts
+++ b/apps/fee-payer/src/index.ts
@@ -90,11 +90,15 @@ app.get(
 	},
 )
 
+const sponsorAccount = privateKeyToAccount(
+	env.SPONSOR_PRIVATE_KEY as `0x${string}`,
+)
+
 const relayHandler = Handler.relay({
 	cors: false,
 	features: 'all',
 	feePayer: {
-		account: privateKeyToAccount(env.SPONSOR_PRIVATE_KEY as `0x${string}`),
+		account: sponsorAccount,
 		name: 'Tempo Sponsor',
 		url: 'https://sponsor.tempo.xyz',
 	},
@@ -102,10 +106,6 @@ const relayHandler = Handler.relay({
 		[tempo.id]: http(env.TEMPO_RPC_URL ?? tempo.rpcUrls.default.http[0]),
 		[tempoModerato.id]: http(tempoModerato.rpcUrls.default.http[0]),
 		[tempoDevnet.id]: http(tempoDevnet.rpcUrls.default.http[0]),
-	},
-	async onRequest(request) {
-		// ast-grep-ignore: no-console-log
-		console.info(`Sponsoring transaction: ${request.method}`)
 	},
 })
 
@@ -130,11 +130,9 @@ async function feePayerHandler(c: Context) {
 
 	const raw = c.req.raw
 	const url = new URL(raw.url)
-	if (url.pathname !== '/') {
-		url.pathname = '/'
-		return relayHandler.fetch(new Request(url, raw))
-	}
-	return relayHandler.fetch(raw)
+	const target =
+		url.pathname === '/' ? raw : new Request(new URL('/', url), raw)
+	return relayHandler.fetch(target)
 }
 
 // Keyed path: https://sponsor.tempo.xyz/tp_abc123

--- a/apps/fee-payer/src/index.ts
+++ b/apps/fee-payer/src/index.ts
@@ -1,17 +1,16 @@
 import { env } from 'cloudflare:workers'
 import { zValidator } from '@hono/zod-validator'
+import { Handler } from 'accounts/server'
 import { type Context, Hono } from 'hono'
 import { cache } from 'hono/cache'
 import { cors } from 'hono/cors'
 import { HTTPException } from 'hono/http-exception'
-import { Handler } from 'tempo.ts/server'
 import { http } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
-import type { Chain } from 'viem/chains'
+import { tempo, tempoDevnet, tempoModerato } from 'viem/chains'
 import * as z from 'zod'
 import { admin } from './lib/admin.js'
 import { apiKeyMiddleware } from './lib/api-key-middleware.js'
-import { tempoChain } from './lib/chain.js'
 import {
 	FeePayerEvents,
 	captureEvent,
@@ -91,37 +90,47 @@ app.get(
 	},
 )
 
+const relayHandler = Handler.relay({
+	cors: false,
+	features: 'all',
+	feePayer: {
+		account: privateKeyToAccount(env.SPONSOR_PRIVATE_KEY as `0x${string}`),
+		name: 'Tempo Sponsor',
+		url: 'https://sponsor.tempo.xyz',
+	},
+	transports: {
+		[tempo.id]: http(env.TEMPO_RPC_URL ?? tempo.rpcUrls.default.http[0]),
+		[tempoModerato.id]: http(tempoModerato.rpcUrls.default.http[0]),
+		[tempoDevnet.id]: http(tempoDevnet.rpcUrls.default.http[0]),
+	},
+	async onRequest(request) {
+		// ast-grep-ignore: no-console-log
+		console.info(`Sponsoring transaction: ${request.method}`)
+	},
+})
+
 async function feePayerHandler(c: Context) {
 	const requestContext = getRequestContext(c.req.raw)
 	const apiKeyLabel = c.get('apiKeyRecord')?.label
 
-	const handler = Handler.feePayer({
-		account: privateKeyToAccount(env.SPONSOR_PRIVATE_KEY as `0x${string}`),
-		chain: tempoChain as Chain,
-		transport: http(env.TEMPO_RPC_URL ?? tempoChain.rpcUrls.default.http[0]),
-		async onRequest(request) {
-			// ast-grep-ignore: no-console-log
-			console.info(`Sponsoring transaction: ${request.method}`)
-			c.executionCtx.waitUntil(
-				captureEvent({
-					distinctId: apiKeyLabel ?? requestContext.origin ?? 'unknown',
-					event: FeePayerEvents.SPONSORSHIP_REQUEST,
-					properties: {
-						...requestContext,
-						rpcMethod: request.method,
-						...(apiKeyLabel ? { apiKeyLabel } : {}),
-					},
-				}),
-			)
-		},
-	})
+	c.executionCtx.waitUntil(
+		captureEvent({
+			distinctId: apiKeyLabel ?? requestContext.origin ?? 'unknown',
+			event: FeePayerEvents.SPONSORSHIP_REQUEST,
+			properties: {
+				...requestContext,
+				...(apiKeyLabel ? { apiKeyLabel } : {}),
+			},
+		}),
+	)
+
 	const raw = c.req.raw
 	const url = new URL(raw.url)
 	if (url.pathname !== '/') {
 		url.pathname = '/'
-		return handler.fetch(new Request(url, raw))
+		return relayHandler.fetch(new Request(url, raw))
 	}
-	return handler.fetch(raw)
+	return relayHandler.fetch(raw)
 }
 
 // Keyed path: https://sponsor.tempo.xyz/tp_abc123

--- a/apps/fee-payer/src/lib/admin.ts
+++ b/apps/fee-payer/src/lib/admin.ts
@@ -14,7 +14,10 @@ const admin = new Hono()
 /** Reject early if the KV binding is not configured (non-mainnet envs). */
 admin.use('*', async (c, next) => {
 	if (!env.SponsorApiKeyStore) {
-		return c.json({ error: 'API key management not available in this environment' }, 503)
+		return c.json(
+			{ error: 'API key management not available in this environment' },
+			503,
+		)
 	}
 	const auth = c.req.header('Authorization')
 	if (!auth || auth !== `Bearer ${env.ADMIN_SECRET}`) {

--- a/apps/fee-payer/src/lib/rate-limit.ts
+++ b/apps/fee-payer/src/lib/rate-limit.ts
@@ -40,6 +40,7 @@ export async function rateLimitMiddleware(c: Context, next: Next) {
 		if (!rawBody.success) return c.json({ error: 'Bad request' }, 400)
 
 		const request = RpcRequest.from(rawBody.data)
+		c.set('rpcMethod', request.method)
 		const serialized = request.params?.[0]
 
 		if (

--- a/apps/fee-payer/src/lib/rate-limit.ts
+++ b/apps/fee-payer/src/lib/rate-limit.ts
@@ -51,10 +51,14 @@ export async function rateLimitMiddleware(c: Context, next: Next) {
 			const transaction = Transaction.deserialize(serialized) as {
 				from?: string
 				to?: string
+				calls?: Array<{ to?: string }>
 				gas?: bigint
 				maxFeePerGas?: bigint
 			}
 			const from = transaction.from
+			// Tempo envelopes nest the destination under `calls[0].to`; legacy
+			// envelopes use top-level `to`.
+			const to = transaction.calls?.[0]?.to ?? transaction.to
 
 			if (!from) {
 				return c.json(
@@ -70,8 +74,8 @@ export async function rateLimitMiddleware(c: Context, next: Next) {
 			const apiKey = c.get('apiKey') as string | undefined
 			const apiKeyRecord = c.get('apiKeyRecord') as ApiKeyRecord | undefined
 			if (apiKey && apiKeyRecord) {
-				if (apiKeyRecord.allowedDestinations.length > 0 && transaction.to) {
-					const dest = transaction.to.toLowerCase()
+				if (apiKeyRecord.allowedDestinations.length > 0 && to) {
+					const dest = to.toLowerCase()
 					const allowed = apiKeyRecord.allowedDestinations.some(
 						(a) => a.toLowerCase() === dest,
 					)

--- a/apps/fee-payer/test/api-keys.test.ts
+++ b/apps/fee-payer/test/api-keys.test.ts
@@ -3,7 +3,7 @@ import { Mnemonic } from 'ox'
 import { createClient, custom } from 'viem'
 import { sendTransactionSync } from 'viem/actions'
 import { tempo, tempoDevnet, tempoLocalnet, tempoModerato } from 'viem/chains'
-import { Account, withFeePayer } from 'viem/tempo'
+import { Account, withRelay } from 'viem/tempo'
 import { describe, expect, it } from 'vitest'
 
 const ADMIN_SECRET = 'test-admin-secret'
@@ -309,7 +309,7 @@ describe('API key sponsorship integration', () => {
 		const client = createClient({
 			account: userAccount,
 			chain: tempoChain,
-			transport: withFeePayer(tempoTransport(), feePayerTransport(`/${key}`), {
+			transport: withRelay(tempoTransport(), feePayerTransport(`/${key}`), {
 				policy: 'sign-and-broadcast',
 			}),
 		})

--- a/apps/fee-payer/test/api-keys.test.ts
+++ b/apps/fee-payer/test/api-keys.test.ts
@@ -205,8 +205,8 @@ describe('API key sponsorship integration', () => {
 		)
 		const { key } = (await createRes.json()) as { key: string }
 
-		// eth_chainId will get a MethodNotSupported from the fee payer handler
-		// (not a 401/403), proving the key middleware passed.
+		// eth_chainId should be proxied successfully (not a 401/403),
+		// proving the API key middleware passed.
 		const response = await exports.default.fetch(
 			feePayerRequest(`/${key}`, {
 				jsonrpc: '2.0',
@@ -216,9 +216,9 @@ describe('API key sponsorship integration', () => {
 		)
 		expect(response.status).toBe(200)
 		const data = (await response.json()) as {
-			error?: { name: string }
+			result?: string
 		}
-		expect(data.error?.name).toBe('RpcResponse.MethodNotSupportedError')
+		expect(data.result).toBeDefined()
 	})
 
 	it('open access still works without API key', async () => {

--- a/apps/fee-payer/test/api-keys.test.ts
+++ b/apps/fee-payer/test/api-keys.test.ts
@@ -1,75 +1,9 @@
 import { env, exports } from 'cloudflare:workers'
-import { Mnemonic } from 'ox'
-import { createClient, custom } from 'viem'
 import { sendTransactionSync } from 'viem/actions'
-import { tempo, tempoDevnet, tempoLocalnet, tempoModerato } from 'viem/chains'
-import { Account, withRelay } from 'viem/tempo'
 import { describe, expect, it } from 'vitest'
+import { buildSponsorClient, sponsorAddress, userAccount } from './helpers.js'
 
 const ADMIN_SECRET = 'test-admin-secret'
-
-const tempoChain = (() => {
-	const tempoEnv = env.TEMPO_ENV ?? 'localnet'
-	if (tempoEnv === 'moderato' || tempoEnv === 'testnet') return tempoModerato
-	if (tempoEnv === 'mainnet') return tempo
-	if (tempoEnv === 'devnet') return tempoDevnet
-	return tempoLocalnet
-})()
-
-const userAccount = Account.fromSecp256k1(
-	Mnemonic.toPrivateKey(
-		'test test test test test test test test test test test junk',
-		{ as: 'Hex', path: Mnemonic.path({ account: 9 }) },
-	),
-)
-
-const sponsorAddress = '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266'
-
-/** Routes RPC calls through the in-process fee-payer Worker at `path`. */
-function feePayerTransport(path: string) {
-	return custom({
-		async request({ method, params }) {
-			const response = await exports.default.fetch(
-				new Request(`https://fee-payer.test${path}`, {
-					method: 'POST',
-					headers: { 'Content-Type': 'application/json' },
-					body: JSON.stringify({ jsonrpc: '2.0', id: 1, method, params }),
-				}),
-			)
-			const data = (await response.json()) as {
-				result?: unknown
-				error?: string | { message?: string }
-			}
-			if (data.error) {
-				const message =
-					typeof data.error === 'string'
-						? data.error
-						: data.error.message || 'RPC Error'
-				throw new Error(message)
-			}
-			return data.result
-		},
-	})
-}
-
-/** Routes RPC calls directly to the configured Tempo node. */
-function tempoTransport() {
-	return custom({
-		async request({ method, params }) {
-			const response = await fetch(env.TEMPO_RPC_URL, {
-				method: 'POST',
-				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify({ jsonrpc: '2.0', id: 1, method, params }),
-			})
-			const data = (await response.json()) as {
-				result?: unknown
-				error?: { message: string }
-			}
-			if (data.error) throw new Error(data.error.message || 'RPC Error')
-			return data.result
-		},
-	})
-}
 
 function adminRequest(method: string, path: string, body?: unknown): Request {
 	return new Request(`https://fee-payer.test/admin${path}`, {
@@ -301,17 +235,6 @@ describe('API key sponsorship integration', () => {
 		expect(response.status).toBe(200)
 	})
 
-	/** Build a sponsorship client routed through `/${key}`. */
-	function buildSponsorClient(key: string) {
-		return createClient({
-			account: userAccount,
-			chain: tempoChain,
-			transport: withRelay(tempoTransport(), feePayerTransport(`/${key}`), {
-				policy: 'sign-and-broadcast',
-			}),
-		})
-	}
-
 	it('allows a sponsored transaction when destination is in allowedDestinations', async () => {
 		const to = '0x0000000000000000000000000000000000000002' as const
 		const createRes = await exports.default.fetch(
@@ -411,15 +334,7 @@ describe('API key sponsorship integration', () => {
 		// fee-payer Worker via the /tp_* API key path. This exercises the
 		// full middleware chain (apiKey + rateLimit) on a real sponsored
 		// fill + sign + broadcast.
-		const client = createClient({
-			account: userAccount,
-			chain: tempoChain,
-			transport: withRelay(tempoTransport(), feePayerTransport(`/${key}`), {
-				policy: 'sign-and-broadcast',
-			}),
-		})
-
-		const receipt = await sendTransactionSync(client, {
+		const receipt = await sendTransactionSync(buildSponsorClient(key), {
 			feePayer: true,
 			to: '0x0000000000000000000000000000000000000002',
 			value: 0n,

--- a/apps/fee-payer/test/api-keys.test.ts
+++ b/apps/fee-payer/test/api-keys.test.ts
@@ -38,9 +38,15 @@ function feePayerTransport(path: string) {
 			)
 			const data = (await response.json()) as {
 				result?: unknown
-				error?: { message: string }
+				error?: string | { message?: string }
 			}
-			if (data.error) throw new Error(data.error.message || 'RPC Error')
+			if (data.error) {
+				const message =
+					typeof data.error === 'string'
+						? data.error
+						: data.error.message || 'RPC Error'
+				throw new Error(message)
+			}
 			return data.result
 		},
 	})
@@ -293,6 +299,105 @@ describe('API key sponsorship integration', () => {
 		)
 		// Should reach the handler, not be rejected.
 		expect(response.status).toBe(200)
+	})
+
+	/** Build a sponsorship client routed through `/${key}`. */
+	function buildSponsorClient(key: string) {
+		return createClient({
+			account: userAccount,
+			chain: tempoChain,
+			transport: withRelay(tempoTransport(), feePayerTransport(`/${key}`), {
+				policy: 'sign-and-broadcast',
+			}),
+		})
+	}
+
+	it('allows a sponsored transaction when destination is in allowedDestinations', async () => {
+		const to = '0x0000000000000000000000000000000000000002' as const
+		const createRes = await exports.default.fetch(
+			adminRequest('POST', '/keys', {
+				label: 'Allowlist Match',
+				allowedDestinations: [to],
+			}),
+		)
+		const { key } = (await createRes.json()) as { key: string }
+
+		const receipt = await sendTransactionSync(buildSponsorClient(key), {
+			feePayer: true,
+			to,
+			value: 0n,
+		})
+
+		expect(receipt.status).toBe('success')
+		expect(receipt.feeToken).toMatch(/^0x[a-fA-F0-9]{40}$/)
+	})
+
+	it('rejects a sponsored transaction when destination is not in allowedDestinations', async () => {
+		const createRes = await exports.default.fetch(
+			adminRequest('POST', '/keys', {
+				label: 'Allowlist Mismatch',
+				allowedDestinations: ['0x0000000000000000000000000000000000000abc'],
+			}),
+		)
+		const { key } = (await createRes.json()) as { key: string }
+
+		await expect(
+			sendTransactionSync(buildSponsorClient(key), {
+				feePayer: true,
+				to: '0x0000000000000000000000000000000000000002',
+				value: 0n,
+			}),
+		).rejects.toThrow(/Destination address not allowed/)
+	})
+
+	it('rejects a sponsored transaction when dailyLimitUsd is exceeded', async () => {
+		const createRes = await exports.default.fetch(
+			adminRequest('POST', '/keys', {
+				label: 'Budget Exceeded',
+				dailyLimitUsd: '0.000001',
+			}),
+		)
+		const { key } = (await createRes.json()) as { key: string }
+
+		// Pre-seed today's spend above the limit.
+		const today = new Date().toISOString().slice(0, 10)
+		await env.SponsorApiKeyStore.put(`spend:${key}:${today}`, '1000000')
+
+		await expect(
+			sendTransactionSync(buildSponsorClient(key), {
+				feePayer: true,
+				to: '0x0000000000000000000000000000000000000002',
+				value: 0n,
+			}),
+		).rejects.toThrow(/Daily spend limit exceeded/)
+	})
+
+	it('records spend after a sponsored transaction under dailyLimitUsd', async () => {
+		const createRes = await exports.default.fetch(
+			adminRequest('POST', '/keys', {
+				label: 'Budget Under',
+				dailyLimitUsd: '100.00',
+			}),
+		)
+		const { key } = (await createRes.json()) as { key: string }
+
+		const receipt = await sendTransactionSync(buildSponsorClient(key), {
+			feePayer: true,
+			to: '0x0000000000000000000000000000000000000002',
+			value: 0n,
+		})
+		expect(receipt.status).toBe('success')
+
+		// recordSpend runs via ctx.waitUntil; poll briefly until it lands.
+		const today = new Date().toISOString().slice(0, 10)
+		let spend: string | null = null
+		for (let i = 0; i < 20; i++) {
+			spend = await env.SponsorApiKeyStore.get(`spend:${key}:${today}`)
+			if (spend) break
+			await new Promise((r) => setTimeout(r, 100))
+		}
+		expect(spend).not.toBeNull()
+		expect(BigInt(spend ?? '0')).toBeGreaterThan(0n)
 	})
 
 	it('sponsors a transaction routed through an API key path', async () => {

--- a/apps/fee-payer/test/api-keys.test.ts
+++ b/apps/fee-payer/test/api-keys.test.ts
@@ -1,7 +1,69 @@
-import { exports } from 'cloudflare:workers'
+import { env, exports } from 'cloudflare:workers'
+import { Mnemonic } from 'ox'
+import { createClient, custom } from 'viem'
+import { sendTransactionSync } from 'viem/actions'
+import { tempo, tempoDevnet, tempoLocalnet, tempoModerato } from 'viem/chains'
+import { Account, withFeePayer } from 'viem/tempo'
 import { describe, expect, it } from 'vitest'
 
 const ADMIN_SECRET = 'test-admin-secret'
+
+const tempoChain = (() => {
+	const tempoEnv = env.TEMPO_ENV ?? 'localnet'
+	if (tempoEnv === 'moderato' || tempoEnv === 'testnet') return tempoModerato
+	if (tempoEnv === 'mainnet') return tempo
+	if (tempoEnv === 'devnet') return tempoDevnet
+	return tempoLocalnet
+})()
+
+const userAccount = Account.fromSecp256k1(
+	Mnemonic.toPrivateKey(
+		'test test test test test test test test test test test junk',
+		{ as: 'Hex', path: Mnemonic.path({ account: 9 }) },
+	),
+)
+
+const sponsorAddress = '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266'
+
+/** Routes RPC calls through the in-process fee-payer Worker at `path`. */
+function feePayerTransport(path: string) {
+	return custom({
+		async request({ method, params }) {
+			const response = await exports.default.fetch(
+				new Request(`https://fee-payer.test${path}`, {
+					method: 'POST',
+					headers: { 'Content-Type': 'application/json' },
+					body: JSON.stringify({ jsonrpc: '2.0', id: 1, method, params }),
+				}),
+			)
+			const data = (await response.json()) as {
+				result?: unknown
+				error?: { message: string }
+			}
+			if (data.error) throw new Error(data.error.message || 'RPC Error')
+			return data.result
+		},
+	})
+}
+
+/** Routes RPC calls directly to the configured Tempo node. */
+function tempoTransport() {
+	return custom({
+		async request({ method, params }) {
+			const response = await fetch(env.TEMPO_RPC_URL, {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ jsonrpc: '2.0', id: 1, method, params }),
+			})
+			const data = (await response.json()) as {
+				result?: unknown
+				error?: { message: string }
+			}
+			if (data.error) throw new Error(data.error.message || 'RPC Error')
+			return data.result
+		},
+	})
+}
 
 function adminRequest(method: string, path: string, body?: unknown): Request {
 	return new Request(`https://fee-payer.test/admin${path}`, {
@@ -231,5 +293,37 @@ describe('API key sponsorship integration', () => {
 		)
 		// Should reach the handler, not be rejected.
 		expect(response.status).toBe(200)
+	})
+
+	it('sponsors a transaction routed through an API key path', async () => {
+		// Create a valid API key.
+		const createRes = await exports.default.fetch(
+			adminRequest('POST', '/keys', { label: 'Sponsorship Test' }),
+		)
+		const { key } = (await createRes.json()) as { key: string }
+
+		// Build a withRelay client whose relay transport hits the
+		// fee-payer Worker via the /tp_* API key path. This exercises the
+		// full middleware chain (apiKey + rateLimit) on a real sponsored
+		// fill + sign + broadcast.
+		const client = createClient({
+			account: userAccount,
+			chain: tempoChain,
+			transport: withFeePayer(tempoTransport(), feePayerTransport(`/${key}`), {
+				policy: 'sign-and-broadcast',
+			}),
+		})
+
+		const receipt = await sendTransactionSync(client, {
+			feePayer: true,
+			to: '0x0000000000000000000000000000000000000002',
+			value: 0n,
+		})
+
+		expect(receipt.transactionHash).toBeDefined()
+		expect(receipt.status).toBe('success')
+		expect(receipt.from.toLowerCase()).toBe(userAccount.address.toLowerCase())
+		expect(receipt.feePayer?.toLowerCase()).toBe(sponsorAddress.toLowerCase())
+		expect(receipt.feeToken).toMatch(/^0x[a-fA-F0-9]{40}$/)
 	})
 })

--- a/apps/fee-payer/test/e2e.test.ts
+++ b/apps/fee-payer/test/e2e.test.ts
@@ -206,6 +206,11 @@ describe('fee-payer integration', () => {
 			expect(receipt.transactionHash).toBeDefined()
 			expect(receipt.from.toLowerCase()).toBe(userAccount.address.toLowerCase())
 			expect(receipt.feePayer?.toLowerCase()).toBe(sponsorAddress.toLowerCase())
+			// Regression: the broadcast envelope must carry a feeToken the
+			// chain can charge. Without it the chain falls back to the
+			// sender's default account token and the tx reverts at
+			// validation with `insufficient liquidity in FeeAMM pool`.
+			expect(receipt.feeToken).toMatch(/^0x[a-fA-F0-9]{40}$/)
 
 			// Assert RPC methods sent to fee-payer service
 			const sponsorshipRequests = feePayerRequests.filter(
@@ -241,6 +246,11 @@ describe('fee-payer integration', () => {
 			expect(receipt.from.toLowerCase()).toBe(userAccount.address.toLowerCase())
 			expect(receipt.feePayer?.toLowerCase()).toBe(sponsorAddress.toLowerCase())
 			expect(receipt.status).toBe('success')
+			// Regression: the broadcast envelope must carry a feeToken the
+			// chain can charge. Without it the chain falls back to the
+			// sender's default account token and the tx reverts at
+			// validation with `insufficient liquidity in FeeAMM pool`.
+			expect(receipt.feeToken).toMatch(/^0x[a-fA-F0-9]{40}$/)
 
 			// Assert RPC methods sent to fee-payer service
 			const sponsorshipRequests = feePayerRequests.filter(

--- a/apps/fee-payer/test/e2e.test.ts
+++ b/apps/fee-payer/test/e2e.test.ts
@@ -2,29 +2,15 @@ import { env, exports } from 'cloudflare:workers'
 import { Mnemonic } from 'ox'
 import { createClient, custom, http, parseUnits } from 'viem'
 import { sendTransactionSync } from 'viem/actions'
-import { tempo, tempoDevnet, tempoLocalnet, tempoModerato } from 'viem/chains'
 import { Account, Actions, withRelay } from 'viem/tempo'
 import { beforeAll, describe, expect, it } from 'vitest'
-
-const tempoChain = (() => {
-	const tempoEnv = env.TEMPO_ENV ?? 'localnet'
-	if (tempoEnv === 'moderato' || tempoEnv === 'testnet') return tempoModerato
-	if (tempoEnv === 'mainnet') return tempo
-	if (tempoEnv === 'devnet') return tempoDevnet
-	return tempoLocalnet
-})()
-
-const testMnemonic =
-	'test test test test test test test test test test test junk'
-
-const sponsorAddress = '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266'
-
-const userAccount = Account.fromSecp256k1(
-	Mnemonic.toPrivateKey(testMnemonic, {
-		as: 'Hex',
-		path: Mnemonic.path({ account: 9 }),
-	}),
-)
+import {
+	sponsorAddress,
+	tempoChain,
+	tempoTransport,
+	testMnemonic,
+	userAccount,
+} from './helpers.js'
 
 function createFeePayerTransportWithSpy() {
 	const requests: Array<{ method: string; params: unknown }> = []
@@ -57,31 +43,6 @@ function createFeePayerTransportWithSpy() {
 	})
 
 	return { transport, requests }
-}
-
-function createTempoTransport() {
-	return custom({
-		async request({ method, params }) {
-			const response = await fetch(env.TEMPO_RPC_URL, {
-				method: 'POST',
-				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify({
-					jsonrpc: '2.0',
-					id: 1,
-					method,
-					params,
-				}),
-			})
-			const data = (await response.json()) as {
-				result?: unknown
-				error?: { code: number; message: string }
-			}
-			if (data.error) {
-				throw new Error(data.error.message || 'RPC Error')
-			}
-			return data.result
-		},
-	})
 }
 
 // Mint liquidity for fee tokens.
@@ -190,7 +151,7 @@ describe('fee-payer integration', () => {
 			const client = createClient({
 				account: userAccount,
 				chain: tempoChain,
-				transport: withRelay(createTempoTransport(), feePayerTransport, {
+				transport: withRelay(tempoTransport(), feePayerTransport, {
 					policy: 'sign-only',
 				}),
 			})
@@ -228,7 +189,7 @@ describe('fee-payer integration', () => {
 			const client = createClient({
 				account: userAccount,
 				chain: tempoChain,
-				transport: withRelay(createTempoTransport(), feePayerTransport, {
+				transport: withRelay(tempoTransport(), feePayerTransport, {
 					policy: 'sign-and-broadcast',
 				}),
 			})

--- a/apps/fee-payer/test/e2e.test.ts
+++ b/apps/fee-payer/test/e2e.test.ts
@@ -116,7 +116,7 @@ beforeAll(async () => {
 
 describe('fee-payer integration', () => {
 	describe('request handling', () => {
-		it('returns error for unsupported method', async () => {
+		it('proxies eth_chainId', async () => {
 			const response = await exports.default.fetch(
 				new Request('https://fee-payer.test/', {
 					method: 'POST',
@@ -131,10 +131,9 @@ describe('fee-payer integration', () => {
 
 			expect(response.status).toBe(200)
 			const data = (await response.json()) as {
-				error?: { code: number; name: string }
+				result?: string
 			}
-			expect(data.error).toBeDefined()
-			expect(data.error?.name).toBe('RpcResponse.MethodNotSupportedError')
+			expect(data.result).toBeDefined()
 		})
 
 		it('rejects eth_signTransaction', async () => {

--- a/apps/fee-payer/test/e2e.test.ts
+++ b/apps/fee-payer/test/e2e.test.ts
@@ -3,7 +3,7 @@ import { Mnemonic } from 'ox'
 import { createClient, custom, http, parseUnits } from 'viem'
 import { sendTransactionSync } from 'viem/actions'
 import { tempo, tempoDevnet, tempoLocalnet, tempoModerato } from 'viem/chains'
-import { Account, Actions, withFeePayer } from 'viem/tempo'
+import { Account, Actions, withRelay } from 'viem/tempo'
 import { beforeAll, describe, expect, it } from 'vitest'
 
 const tempoChain = (() => {
@@ -190,7 +190,7 @@ describe('fee-payer integration', () => {
 			const client = createClient({
 				account: userAccount,
 				chain: tempoChain,
-				transport: withFeePayer(createTempoTransport(), feePayerTransport, {
+				transport: withRelay(createTempoTransport(), feePayerTransport, {
 					policy: 'sign-only',
 				}),
 			})
@@ -228,7 +228,7 @@ describe('fee-payer integration', () => {
 			const client = createClient({
 				account: userAccount,
 				chain: tempoChain,
-				transport: withFeePayer(createTempoTransport(), feePayerTransport, {
+				transport: withRelay(createTempoTransport(), feePayerTransport, {
 					policy: 'sign-and-broadcast',
 				}),
 			})

--- a/apps/fee-payer/test/helpers.ts
+++ b/apps/fee-payer/test/helpers.ts
@@ -1,0 +1,82 @@
+import { env, exports } from 'cloudflare:workers'
+import { Mnemonic } from 'ox'
+import { createClient, custom } from 'viem'
+import { tempo, tempoDevnet, tempoLocalnet, tempoModerato } from 'viem/chains'
+import { Account, withRelay } from 'viem/tempo'
+
+export const tempoChain = (() => {
+	const e = env.TEMPO_ENV ?? 'localnet'
+	if (e === 'moderato' || e === 'testnet') return tempoModerato
+	if (e === 'mainnet') return tempo
+	if (e === 'devnet') return tempoDevnet
+	return tempoLocalnet
+})()
+
+export const testMnemonic =
+	'test test test test test test test test test test test junk'
+
+export const sponsorAddress = '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266'
+
+export const userAccount = Account.fromSecp256k1(
+	Mnemonic.toPrivateKey(testMnemonic, {
+		as: 'Hex',
+		path: Mnemonic.path({ account: 9 }),
+	}),
+)
+
+/** Routes RPC calls through the in-process fee-payer Worker at `path`. */
+export function feePayerTransport(path: string) {
+	return custom({
+		async request({ method, params }) {
+			const response = await exports.default.fetch(
+				new Request(`https://fee-payer.test${path}`, {
+					method: 'POST',
+					headers: { 'Content-Type': 'application/json' },
+					body: JSON.stringify({ jsonrpc: '2.0', id: 1, method, params }),
+				}),
+			)
+			const data = (await response.json()) as {
+				result?: unknown
+				error?: string | { message?: string }
+			}
+			if (data.error) {
+				const message =
+					typeof data.error === 'string'
+						? data.error
+						: data.error.message || 'RPC Error'
+				throw new Error(message)
+			}
+			return data.result
+		},
+	})
+}
+
+/** Routes RPC calls directly to the configured Tempo node. */
+export function tempoTransport() {
+	return custom({
+		async request({ method, params }) {
+			const response = await fetch(env.TEMPO_RPC_URL, {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ jsonrpc: '2.0', id: 1, method, params }),
+			})
+			const data = (await response.json()) as {
+				result?: unknown
+				error?: { message: string }
+			}
+			if (data.error) throw new Error(data.error.message || 'RPC Error')
+			return data.result
+		},
+	})
+}
+
+/** Build a sponsorship client routed through `/${key}`. */
+export function buildSponsorClient(key: string) {
+	return createClient({
+		account: userAccount,
+		chain: tempoChain,
+		transport: withRelay(tempoTransport(), feePayerTransport(`/${key}`), {
+			policy: 'sign-and-broadcast',
+		}),
+	})
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -133,8 +133,8 @@ catalogs:
       specifier: ^1.2.4
       version: 1.2.4
     accounts:
-      specifier: ~0.8.1
-      version: 0.8.5
+      specifier: ~0.12.1
+      version: 0.12.1
     animejs:
       specifier: ^4.3.6
       version: 4.3.6
@@ -217,8 +217,8 @@ catalogs:
       specifier: ^23.0.1
       version: 23.0.1
     viem:
-      specifier: ^2.48.4
-      version: 2.48.4
+      specifier: ^2.49.3
+      version: 2.49.3
     vite:
       specifier: ^8.0.7
       version: 8.0.7
@@ -312,7 +312,7 @@ importers:
         version: 2.0.4(@logtape/logtape@2.0.4)
       '@wagmi/core':
         specifier: 'catalog:'
-        version: 3.4.8(@tanstack/query-core@5.96.2)(@types/react@19.2.14)(accounts@0.8.5)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.48.4(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6))
+        version: 3.4.8(@tanstack/query-core@5.96.2)(@types/react@19.2.14)(accounts@0.8.5)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6))
       cbor-x:
         specifier: ^1.6.4
         version: 1.6.4
@@ -333,10 +333,10 @@ importers:
         version: 7.7.4
       viem:
         specifier: 'catalog:'
-        version: 2.48.4(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6)
+        version: 2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6)
       wagmi:
         specifier: 'catalog:'
-        version: 3.6.9(@tanstack/query-core@5.96.2)(@tanstack/react-query@5.96.2(react@19.2.5))(@types/react@19.2.14)(accounts@0.8.5)(react@19.2.5)(typescript@6.0.2)(viem@2.48.4(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6))
+        version: 3.6.9(@tanstack/query-core@5.96.2)(@tanstack/react-query@5.96.2(react@19.2.5))(@types/react@19.2.14)(accounts@0.8.5)(react@19.2.5)(typescript@6.0.2)(viem@2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6))
       zod:
         specifier: 'catalog:'
         version: 4.3.6
@@ -445,7 +445,7 @@ importers:
         version: 1.2.4(typescript@6.0.2)(zod@4.3.6)
       accounts:
         specifier: 'catalog:'
-        version: 0.8.5(@types/react@19.2.14)(@wagmi/core@3.4.8)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.48.4(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6))(wagmi@3.6.9)
+        version: 0.12.1(@types/react@19.2.14)(@wagmi/core@3.4.8)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6))(wagmi@3.6.9)
       animejs:
         specifier: 'catalog:'
         version: 4.3.6
@@ -475,10 +475,10 @@ importers:
         version: 0.1.1(typescript@6.0.2)
       viem:
         specifier: 'catalog:'
-        version: 2.48.4(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6)
+        version: 2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6)
       wagmi:
         specifier: 'catalog:'
-        version: 3.6.9(@tanstack/query-core@5.96.2)(@tanstack/react-query@5.96.2(react@19.2.5))(@types/react@19.2.14)(accounts@0.8.5)(react@19.2.5)(typescript@6.0.2)(viem@2.48.4(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6))
+        version: 3.6.9(@tanstack/query-core@5.96.2)(@tanstack/react-query@5.96.2(react@19.2.5))(@types/react@19.2.14)(accounts@0.12.1)(react@19.2.5)(typescript@6.0.2)(viem@2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6))
       zod:
         specifier: 'catalog:'
         version: 4.3.6
@@ -578,7 +578,7 @@ importers:
         version: 0.7.6(hono@4.12.14)(zod@4.3.6)
       accounts:
         specifier: 'catalog:'
-        version: 0.8.5(@types/react@19.2.14)(@wagmi/core@3.4.8)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.48.4(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6))(wagmi@3.6.9)
+        version: 0.12.1(@types/react@19.2.14)(@wagmi/core@3.4.8)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6))(wagmi@3.6.9)
       hono:
         specifier: 'catalog:'
         version: 4.12.14
@@ -593,7 +593,7 @@ importers:
         version: 0.14.20(typescript@6.0.2)(zod@4.3.6)
       viem:
         specifier: 'catalog:'
-        version: 2.48.4(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6)
+        version: 2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6)
       zod:
         specifier: 'catalog:'
         version: 4.3.6
@@ -645,13 +645,13 @@ importers:
         version: 19.2.5(react@19.2.5)
       tempo.ts:
         specifier: 'catalog:'
-        version: 0.14.2(typescript@6.0.2)(viem@2.48.4(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6))(zod@4.3.6)
+        version: 0.14.2(typescript@6.0.2)(viem@2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3))(zod@4.4.3)
       viem:
         specifier: 'catalog:'
-        version: 2.48.4(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6)
+        version: 2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3)
       wagmi:
         specifier: 'catalog:'
-        version: 3.6.9(@tanstack/query-core@5.96.2)(@tanstack/react-query@5.96.2(react@19.2.5))(@types/react@19.2.14)(accounts@0.8.5)(react@19.2.5)(typescript@6.0.2)(viem@2.48.4(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6))
+        version: 3.6.9(@tanstack/query-core@5.96.2)(@tanstack/react-query@5.96.2(react@19.2.5))(@types/react@19.2.14)(accounts@0.8.5)(react@19.2.5)(typescript@6.0.2)(viem@2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3))
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -679,7 +679,7 @@ importers:
     dependencies:
       accounts:
         specifier: 'catalog:'
-        version: 0.8.5(@types/react@19.2.14)(@wagmi/core@3.4.8)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.48.4(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6))(wagmi@3.6.9)
+        version: 0.12.1(@types/react@19.2.14)(@wagmi/core@3.4.8)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3))(wagmi@3.6.9)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: 'catalog:'
@@ -713,7 +713,7 @@ importers:
         version: 0.14.20(typescript@6.0.2)(zod@4.3.6)
       viem:
         specifier: 'catalog:'
-        version: 2.48.4(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6)
+        version: 2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6)
       zod:
         specifier: 'catalog:'
         version: 4.3.6
@@ -858,7 +858,7 @@ importers:
         version: 4.0.1
       viem:
         specifier: 'catalog:'
-        version: 2.48.4(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6)
+        version: 2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3)
     devDependencies:
       '@biomejs/biome':
         specifier: 'catalog:'
@@ -889,7 +889,7 @@ importers:
     dependencies:
       viem:
         specifier: 'catalog:'
-        version: 2.48.4(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6)
+        version: 2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3)
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -3612,6 +3612,32 @@ packages:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
     engines: {node: '>=6.5'}
 
+  accounts@0.12.1:
+    resolution: {integrity: sha512-vO3mJCPlL8RLFAKFjt/sfMWNJaiOY16G7fW1XbV3cNmHI3cXGxvXyhWkSV5qu2YYw2lXp1LxvGJ9mSd69dLfKQ==}
+    peerDependencies:
+      '@react-native-async-storage/async-storage': ^3.0.2
+      '@wagmi/core': '>=3.4.3'
+      expo-secure-store: ^55.0.12
+      expo-web-browser: ^55.0.13
+      react: '>=18'
+      viem: '>=2.43.3'
+      wagmi: '>=0.0.0'
+    peerDependenciesMeta:
+      '@react-native-async-storage/async-storage':
+        optional: true
+      '@wagmi/core':
+        optional: true
+      expo-secure-store:
+        optional: true
+      expo-web-browser:
+        optional: true
+      react:
+        optional: true
+      viem:
+        optional: true
+      wagmi:
+        optional: true
+
   accounts@0.8.5:
     resolution: {integrity: sha512-Y0q2zmRa5lDP5Bw3yK69ZMcn48wsrzfAhQGCVHX6X7vDl/jN2IjvGEpbNnWivTCXNrRUqJovvyDMMKeP2tGFjA==}
     peerDependencies:
@@ -4581,6 +4607,10 @@ packages:
     resolution: {integrity: sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==}
     engines: {node: '>=16.9.0'}
 
+  hono@4.12.18:
+    resolution: {integrity: sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==}
+    engines: {node: '>=16.9.0'}
+
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
@@ -4629,6 +4659,11 @@ packages:
 
   incur@0.3.25:
     resolution: {integrity: sha512-jrSkzauM42ilbQJ6THVkAY6dTulkyVW0sZpVHdA8gfiBwrLrLnLUf8U3bAOegAKBIMSOFgk1idchgu9xm9HMng==}
+    engines: {node: '>=22'}
+    hasBin: true
+
+  incur@0.4.5:
+    resolution: {integrity: sha512-4WFlqm5e+IKNoX+lDIjjpebO8ResPx3vPUBChxNfnNo3oGp0ooo6piiiTspOMub2dq2mcG/AmlUq0ejuGfKobg==}
     engines: {node: '>=22'}
     hasBin: true
 
@@ -4986,6 +5021,25 @@ packages:
 
   mlly@1.8.2:
     resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
+
+  mppx@0.6.24:
+    resolution: {integrity: sha512-3vqZ4Xvn5XcTQQFNOgLaROkjOibrkMOeX15nMYwwOsWhXVuSDfitZfDj+Mr1sqPkbHyfQqDrpq2b7CyZWsp0Ww==}
+    hasBin: true
+    peerDependencies:
+      '@modelcontextprotocol/sdk': '>=1.25.0'
+      elysia: '>=1'
+      express: '>=5'
+      hono: '>=4.12.18'
+      viem: '>=2.47.5'
+    peerDependenciesMeta:
+      '@modelcontextprotocol/sdk':
+        optional: true
+      elysia:
+        optional: true
+      express:
+        optional: true
+      hono:
+        optional: true
 
   mppx@0.6.5:
     resolution: {integrity: sha512-av6EDYiR7eqpRW3vERfEPPJITrRH3D5gyeATnQNU6CC/eI48FnwsS2shghdra1Ev5CgUDm5f1+sOlgpA/YPYYg==}
@@ -5856,8 +5910,8 @@ packages:
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
-  viem@2.48.4:
-    resolution: {integrity: sha512-mReP/rgY2P+WeeRSG4sUvccCLKfyAW1C73Y3KkobAqgzYmVna9qyUMNE44xIUkDtfvRuC33r24UhF4baBYovsg==}
+  viem@2.49.3:
+    resolution: {integrity: sha512-FlIXd2kRygDxJtvjtPp74vjmyOKMjKlXXgTNdMxr8h3kcDrQ4bYb9q1MpSWyCVa3L2NJc9gSv+u8HcHYIZQUkw==}
     peerDependencies:
       typescript: '>=5.0.4'
     peerDependenciesMeta:
@@ -6156,6 +6210,9 @@ packages:
 
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
   zustand@5.0.0:
     resolution: {integrity: sha512-LE+VcmbartOPM+auOjCCLQOsQ05zUTp8RkgwRzefUk+2jISdMMFnxvyTjA4YNWr5ZGXYbVsEMZosttuxUBkojQ==}
@@ -7228,7 +7285,7 @@ snapshots:
 
   '@modelcontextprotocol/server@2.0.0-alpha.2(@cfworker/json-schema@4.1.1)':
     dependencies:
-      zod: 4.3.6
+      zod: 4.4.3
     optionalDependencies:
       '@cfworker/json-schema': 4.1.1
 
@@ -8419,23 +8476,48 @@ snapshots:
   '@vue/shared@3.5.30':
     optional: true
 
-  '@wagmi/connectors@8.0.9(@wagmi/core@3.4.8)(accounts@0.8.5)(typescript@6.0.2)(viem@2.48.4(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6))':
+  '@wagmi/connectors@8.0.9(@wagmi/core@3.4.8)(accounts@0.12.1)(typescript@6.0.2)(viem@2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6))':
     dependencies:
-      '@wagmi/core': 3.4.8(@tanstack/query-core@5.96.2)(@types/react@19.2.14)(accounts@0.8.5)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.48.4(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6))
-      viem: 2.48.4(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6)
+      '@wagmi/core': 3.4.8(@tanstack/query-core@5.96.2)(@types/react@19.2.14)(accounts@0.12.1)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6))
+      viem: 2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6)
     optionalDependencies:
-      accounts: 0.8.5(@types/react@19.2.14)(@wagmi/core@3.4.8)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.48.4(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6))(wagmi@3.6.9)
+      accounts: 0.12.1(@types/react@19.2.14)(@wagmi/core@3.4.8)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6))(wagmi@3.6.9)
       typescript: 6.0.2
 
-  '@wagmi/core@3.4.8(@tanstack/query-core@5.96.2)(@types/react@19.2.14)(accounts@0.8.5)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.4(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6))':
+  '@wagmi/connectors@8.0.9(@wagmi/core@3.4.8)(accounts@0.12.1)(typescript@6.0.2)(viem@2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3))':
+    dependencies:
+      '@wagmi/core': 3.4.8(@tanstack/query-core@5.96.2)(@types/react@19.2.14)(accounts@0.12.1)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3))
+      viem: 2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3)
+    optionalDependencies:
+      accounts: 0.12.1(@types/react@19.2.14)(@wagmi/core@3.4.8)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3))(wagmi@3.6.9)
+      typescript: 6.0.2
+    optional: true
+
+  '@wagmi/connectors@8.0.9(@wagmi/core@3.4.8)(accounts@0.8.5)(typescript@6.0.2)(viem@2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6))':
+    dependencies:
+      '@wagmi/core': 3.4.8(@tanstack/query-core@5.96.2)(@types/react@19.2.14)(accounts@0.8.5)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6))
+      viem: 2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6)
+    optionalDependencies:
+      accounts: 0.8.5(@types/react@19.2.14)(@wagmi/core@3.4.8)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6))(wagmi@3.6.9)
+      typescript: 6.0.2
+
+  '@wagmi/connectors@8.0.9(@wagmi/core@3.4.8)(accounts@0.8.5)(typescript@6.0.2)(viem@2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3))':
+    dependencies:
+      '@wagmi/core': 3.4.8(@tanstack/query-core@5.96.2)(@types/react@19.2.14)(accounts@0.8.5)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3))
+      viem: 2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3)
+    optionalDependencies:
+      accounts: 0.8.5(@types/react@19.2.14)(@wagmi/core@3.4.8)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3))(wagmi@3.6.9)
+      typescript: 6.0.2
+
+  '@wagmi/core@3.4.8(@tanstack/query-core@5.96.2)(@types/react@19.2.14)(accounts@0.12.1)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6))':
     dependencies:
       eventemitter3: 5.0.1
       mipd: 0.0.7(typescript@6.0.2)
-      viem: 2.48.4(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6)
+      viem: 2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6)
       zustand: 5.0.0(@types/react@19.2.14)(react@19.2.5)(use-sync-external-store@1.4.0(react@19.2.5))
     optionalDependencies:
       '@tanstack/query-core': 5.96.2
-      accounts: 0.8.5(@types/react@19.2.14)(@wagmi/core@3.4.8)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.48.4(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6))(wagmi@3.6.9)
+      accounts: 0.12.1(@types/react@19.2.14)(@wagmi/core@3.4.8)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6))(wagmi@3.6.9)
       typescript: 6.0.2
     transitivePeerDependencies:
       - '@types/react'
@@ -8443,15 +8525,113 @@ snapshots:
       - react
       - use-sync-external-store
 
-  '@wagmi/core@3.4.8(@tanstack/query-core@5.96.2)(@types/react@19.2.14)(accounts@0.8.5)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.48.4(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6))':
+  '@wagmi/core@3.4.8(@tanstack/query-core@5.96.2)(@types/react@19.2.14)(accounts@0.12.1)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3))':
     dependencies:
       eventemitter3: 5.0.1
       mipd: 0.0.7(typescript@6.0.2)
-      viem: 2.48.4(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6)
+      viem: 2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3)
+      zustand: 5.0.0(@types/react@19.2.14)(react@19.2.5)(use-sync-external-store@1.4.0(react@19.2.5))
+    optionalDependencies:
+      '@tanstack/query-core': 5.96.2
+      accounts: 0.12.1(@types/react@19.2.14)(@wagmi/core@3.4.8)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3))(wagmi@3.6.9)
+      typescript: 6.0.2
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+      - react
+      - use-sync-external-store
+    optional: true
+
+  '@wagmi/core@3.4.8(@tanstack/query-core@5.96.2)(@types/react@19.2.14)(accounts@0.12.1)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6))':
+    dependencies:
+      eventemitter3: 5.0.1
+      mipd: 0.0.7(typescript@6.0.2)
+      viem: 2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6)
       zustand: 5.0.0(@types/react@19.2.14)(react@19.2.5)(use-sync-external-store@1.6.0(react@19.2.5))
     optionalDependencies:
       '@tanstack/query-core': 5.96.2
-      accounts: 0.8.5(@types/react@19.2.14)(@wagmi/core@3.4.8)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.48.4(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6))(wagmi@3.6.9)
+      accounts: 0.12.1(@types/react@19.2.14)(@wagmi/core@3.4.8)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6))(wagmi@3.6.9)
+      typescript: 6.0.2
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+      - react
+      - use-sync-external-store
+
+  '@wagmi/core@3.4.8(@tanstack/query-core@5.96.2)(@types/react@19.2.14)(accounts@0.12.1)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3))':
+    dependencies:
+      eventemitter3: 5.0.1
+      mipd: 0.0.7(typescript@6.0.2)
+      viem: 2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3)
+      zustand: 5.0.0(@types/react@19.2.14)(react@19.2.5)(use-sync-external-store@1.6.0(react@19.2.5))
+    optionalDependencies:
+      '@tanstack/query-core': 5.96.2
+      accounts: 0.12.1(@types/react@19.2.14)(@wagmi/core@3.4.8)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3))(wagmi@3.6.9)
+      typescript: 6.0.2
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+      - react
+      - use-sync-external-store
+    optional: true
+
+  '@wagmi/core@3.4.8(@tanstack/query-core@5.96.2)(@types/react@19.2.14)(accounts@0.8.5)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6))':
+    dependencies:
+      eventemitter3: 5.0.1
+      mipd: 0.0.7(typescript@6.0.2)
+      viem: 2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6)
+      zustand: 5.0.0(@types/react@19.2.14)(react@19.2.5)(use-sync-external-store@1.4.0(react@19.2.5))
+    optionalDependencies:
+      '@tanstack/query-core': 5.96.2
+      accounts: 0.8.5(@types/react@19.2.14)(@wagmi/core@3.4.8)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6))(wagmi@3.6.9)
+      typescript: 6.0.2
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+      - react
+      - use-sync-external-store
+
+  '@wagmi/core@3.4.8(@tanstack/query-core@5.96.2)(@types/react@19.2.14)(accounts@0.8.5)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3))':
+    dependencies:
+      eventemitter3: 5.0.1
+      mipd: 0.0.7(typescript@6.0.2)
+      viem: 2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3)
+      zustand: 5.0.0(@types/react@19.2.14)(react@19.2.5)(use-sync-external-store@1.4.0(react@19.2.5))
+    optionalDependencies:
+      '@tanstack/query-core': 5.96.2
+      accounts: 0.8.5(@types/react@19.2.14)(@wagmi/core@3.4.8)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3))(wagmi@3.6.9)
+      typescript: 6.0.2
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+      - react
+      - use-sync-external-store
+
+  '@wagmi/core@3.4.8(@tanstack/query-core@5.96.2)(@types/react@19.2.14)(accounts@0.8.5)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6))':
+    dependencies:
+      eventemitter3: 5.0.1
+      mipd: 0.0.7(typescript@6.0.2)
+      viem: 2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6)
+      zustand: 5.0.0(@types/react@19.2.14)(react@19.2.5)(use-sync-external-store@1.6.0(react@19.2.5))
+    optionalDependencies:
+      '@tanstack/query-core': 5.96.2
+      accounts: 0.8.5(@types/react@19.2.14)(@wagmi/core@3.4.8)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6))(wagmi@3.6.9)
+      typescript: 6.0.2
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+      - react
+      - use-sync-external-store
+
+  '@wagmi/core@3.4.8(@tanstack/query-core@5.96.2)(@types/react@19.2.14)(accounts@0.8.5)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3))':
+    dependencies:
+      eventemitter3: 5.0.1
+      mipd: 0.0.7(typescript@6.0.2)
+      viem: 2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3)
+      zustand: 5.0.0(@types/react@19.2.14)(react@19.2.5)(use-sync-external-store@1.6.0(react@19.2.5))
+    optionalDependencies:
+      '@tanstack/query-core': 5.96.2
+      accounts: 0.8.5(@types/react@19.2.14)(@wagmi/core@3.4.8)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3))(wagmi@3.6.9)
       typescript: 6.0.2
     transitivePeerDependencies:
       - '@types/react'
@@ -8464,6 +8644,11 @@ snapshots:
       typescript: 6.0.2
       zod: 4.3.6
 
+  abitype@1.2.3(typescript@6.0.2)(zod@4.4.3):
+    optionalDependencies:
+      typescript: 6.0.2
+      zod: 4.4.3
+
   abitype@1.2.4(typescript@6.0.2)(zod@4.3.6):
     optionalDependencies:
       typescript: 6.0.2
@@ -8473,21 +8658,21 @@ snapshots:
     dependencies:
       event-target-shim: 5.0.1
 
-  accounts@0.8.5(@types/react@19.2.14)(@wagmi/core@3.4.8)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.48.4(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6))(wagmi@3.6.9):
+  accounts@0.12.1(@types/react@19.2.14)(@wagmi/core@3.4.8)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6))(wagmi@3.6.9):
     dependencies:
-      hono: 4.12.14
+      hono: 4.12.18
       idb-keyval: 6.2.2
       mipd: 0.0.7(typescript@6.0.2)
-      mppx: 0.6.5(hono@4.12.14)(typescript@6.0.2)(viem@2.48.4(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6))
+      mppx: 0.6.24(hono@4.12.18)(typescript@6.0.2)(viem@2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6))
       ox: 0.14.20(typescript@6.0.2)(zod@4.3.6)
       webauthx: 0.1.2(typescript@6.0.2)(zod@4.3.6)
       zod: 4.3.6
       zustand: 5.0.12(@types/react@19.2.14)(react@19.2.5)(use-sync-external-store@1.6.0(react@19.2.5))
     optionalDependencies:
-      '@wagmi/core': 3.4.8(@tanstack/query-core@5.96.2)(@types/react@19.2.14)(accounts@0.8.5)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.48.4(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6))
+      '@wagmi/core': 3.4.8(@tanstack/query-core@5.96.2)(@types/react@19.2.14)(accounts@0.12.1)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6))
       react: 19.2.5
-      viem: 2.48.4(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6)
-      wagmi: 3.6.9(@tanstack/query-core@5.96.2)(@tanstack/react-query@5.96.2(react@19.2.5))(@types/react@19.2.14)(accounts@0.8.5)(react@19.2.5)(typescript@6.0.2)(viem@2.48.4(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6))
+      viem: 2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6)
+      wagmi: 3.6.9(@tanstack/query-core@5.96.2)(@tanstack/react-query@5.96.2(react@19.2.5))(@types/react@19.2.14)(accounts@0.12.1)(react@19.2.5)(typescript@6.0.2)(viem@2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6))
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - '@types/react'
@@ -8496,6 +8681,80 @@ snapshots:
       - immer
       - typescript
       - use-sync-external-store
+
+  accounts@0.12.1(@types/react@19.2.14)(@wagmi/core@3.4.8)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3))(wagmi@3.6.9):
+    dependencies:
+      hono: 4.12.18
+      idb-keyval: 6.2.2
+      mipd: 0.0.7(typescript@6.0.2)
+      mppx: 0.6.24(hono@4.12.18)(typescript@6.0.2)(viem@2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3))
+      ox: 0.14.20(typescript@6.0.2)(zod@4.3.6)
+      webauthx: 0.1.2(typescript@6.0.2)(zod@4.3.6)
+      zod: 4.3.6
+      zustand: 5.0.12(@types/react@19.2.14)(react@19.2.5)(use-sync-external-store@1.6.0(react@19.2.5))
+    optionalDependencies:
+      '@wagmi/core': 3.4.8(@tanstack/query-core@5.96.2)(@types/react@19.2.14)(accounts@0.12.1)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3))
+      react: 19.2.5
+      viem: 2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3)
+      wagmi: 3.6.9(@tanstack/query-core@5.96.2)(@tanstack/react-query@5.96.2(react@19.2.5))(@types/react@19.2.14)(accounts@0.12.1)(react@19.2.5)(typescript@6.0.2)(viem@2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3))
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - '@types/react'
+      - elysia
+      - express
+      - immer
+      - typescript
+      - use-sync-external-store
+
+  accounts@0.8.5(@types/react@19.2.14)(@wagmi/core@3.4.8)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6))(wagmi@3.6.9):
+    dependencies:
+      hono: 4.12.14
+      idb-keyval: 6.2.2
+      mipd: 0.0.7(typescript@6.0.2)
+      mppx: 0.6.5(hono@4.12.14)(typescript@6.0.2)(viem@2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6))
+      ox: 0.14.20(typescript@6.0.2)(zod@4.3.6)
+      webauthx: 0.1.2(typescript@6.0.2)(zod@4.3.6)
+      zod: 4.3.6
+      zustand: 5.0.12(@types/react@19.2.14)(react@19.2.5)(use-sync-external-store@1.6.0(react@19.2.5))
+    optionalDependencies:
+      '@wagmi/core': 3.4.8(@tanstack/query-core@5.96.2)(@types/react@19.2.14)(accounts@0.8.5)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6))
+      react: 19.2.5
+      viem: 2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6)
+      wagmi: 3.6.9(@tanstack/query-core@5.96.2)(@tanstack/react-query@5.96.2(react@19.2.5))(@types/react@19.2.14)(accounts@0.8.5)(react@19.2.5)(typescript@6.0.2)(viem@2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6))
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - '@types/react'
+      - elysia
+      - express
+      - immer
+      - typescript
+      - use-sync-external-store
+    optional: true
+
+  accounts@0.8.5(@types/react@19.2.14)(@wagmi/core@3.4.8)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3))(wagmi@3.6.9):
+    dependencies:
+      hono: 4.12.14
+      idb-keyval: 6.2.2
+      mipd: 0.0.7(typescript@6.0.2)
+      mppx: 0.6.5(hono@4.12.14)(typescript@6.0.2)(viem@2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3))
+      ox: 0.14.20(typescript@6.0.2)(zod@4.3.6)
+      webauthx: 0.1.2(typescript@6.0.2)(zod@4.3.6)
+      zod: 4.3.6
+      zustand: 5.0.12(@types/react@19.2.14)(react@19.2.5)(use-sync-external-store@1.6.0(react@19.2.5))
+    optionalDependencies:
+      '@wagmi/core': 3.4.8(@tanstack/query-core@5.96.2)(@types/react@19.2.14)(accounts@0.8.5)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3))
+      react: 19.2.5
+      viem: 2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3)
+      wagmi: 3.6.9(@tanstack/query-core@5.96.2)(@tanstack/react-query@5.96.2(react@19.2.5))(@types/react@19.2.14)(accounts@0.8.5)(react@19.2.5)(typescript@6.0.2)(viem@2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3))
+    transitivePeerDependencies:
+      - '@modelcontextprotocol/sdk'
+      - '@types/react'
+      - elysia
+      - express
+      - immer
+      - typescript
+      - use-sync-external-store
+    optional: true
 
   acorn@8.16.0: {}
 
@@ -9478,6 +9737,8 @@ snapshots:
 
   hono@4.12.14: {}
 
+  hono@4.12.18: {}
+
   html-escaper@2.0.2: {}
 
   html-void-elements@3.0.0: {}
@@ -9551,6 +9812,16 @@ snapshots:
       tokenx: 1.3.0
       yaml: 2.8.3
       zod: 4.3.6
+    optional: true
+
+  incur@0.4.5:
+    dependencies:
+      '@cfworker/json-schema': 4.1.1
+      '@modelcontextprotocol/server': 2.0.0-alpha.2(@cfworker/json-schema@4.1.1)
+      '@toon-format/toon': 2.1.0
+      tokenx: 1.3.0
+      yaml: 2.8.3
+      zod: 4.4.3
 
   inherits@2.0.4: {}
 
@@ -9866,16 +10137,51 @@ snapshots:
       pkg-types: 1.3.1
       ufo: 1.6.3
 
-  mppx@0.6.5(hono@4.12.14)(typescript@6.0.2)(viem@2.48.4(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6)):
+  mppx@0.6.24(hono@4.12.18)(typescript@6.0.2)(viem@2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6)):
+    dependencies:
+      incur: 0.4.5
+      ox: 0.14.20(typescript@6.0.2)(zod@4.4.3)
+      viem: 2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6)
+      zod: 4.4.3
+    optionalDependencies:
+      hono: 4.12.18
+    transitivePeerDependencies:
+      - typescript
+
+  mppx@0.6.24(hono@4.12.18)(typescript@6.0.2)(viem@2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3)):
+    dependencies:
+      incur: 0.4.5
+      ox: 0.14.20(typescript@6.0.2)(zod@4.4.3)
+      viem: 2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3)
+      zod: 4.4.3
+    optionalDependencies:
+      hono: 4.12.18
+    transitivePeerDependencies:
+      - typescript
+
+  mppx@0.6.5(hono@4.12.14)(typescript@6.0.2)(viem@2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6)):
     dependencies:
       incur: 0.3.25
       ox: 0.14.15(typescript@6.0.2)(zod@4.3.6)
-      viem: 2.48.4(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6)
+      viem: 2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6)
       zod: 4.3.6
     optionalDependencies:
       hono: 4.12.14
     transitivePeerDependencies:
       - typescript
+    optional: true
+
+  mppx@0.6.5(hono@4.12.14)(typescript@6.0.2)(viem@2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3)):
+    dependencies:
+      incur: 0.3.25
+      ox: 0.14.15(typescript@6.0.2)(zod@4.3.6)
+      viem: 2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3)
+      zod: 4.3.6
+    optionalDependencies:
+      hono: 4.12.14
+    transitivePeerDependencies:
+      - typescript
+    optional: true
 
   mrmime@2.0.1: {}
 
@@ -9967,6 +10273,7 @@ snapshots:
       typescript: 6.0.2
     transitivePeerDependencies:
       - zod
+    optional: true
 
   ox@0.14.20(typescript@6.0.2)(zod@4.3.6):
     dependencies:
@@ -9977,6 +10284,21 @@ snapshots:
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
       abitype: 1.2.3(typescript@6.0.2)(zod@4.3.6)
+      eventemitter3: 5.0.1
+    optionalDependencies:
+      typescript: 6.0.2
+    transitivePeerDependencies:
+      - zod
+
+  ox@0.14.20(typescript@6.0.2)(zod@4.4.3):
+    dependencies:
+      '@adraffy/ens-normalize': 1.11.1
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@6.0.2)(zod@4.4.3)
       eventemitter3: 5.0.1
     optionalDependencies:
       typescript: 6.0.2
@@ -10598,12 +10920,12 @@ snapshots:
       - bare-abort-controller
       - react-native-b4a
 
-  tempo.ts@0.14.2(typescript@6.0.2)(viem@2.48.4(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6))(zod@4.3.6):
+  tempo.ts@0.14.2(typescript@6.0.2)(viem@2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3))(zod@4.4.3):
     dependencies:
       '@remix-run/fetch-router': 0.17.0
-      ox: 0.14.20(typescript@6.0.2)(zod@4.3.6)
+      ox: 0.14.20(typescript@6.0.2)(zod@4.4.3)
     optionalDependencies:
-      viem: 2.48.4(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6)
+      viem: 2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3)
     transitivePeerDependencies:
       - typescript
       - zod
@@ -10792,7 +11114,7 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  viem@2.48.4(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6):
+  viem@2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6):
     dependencies:
       '@noble/curves': 1.9.1
       '@noble/hashes': 1.8.0
@@ -10801,6 +11123,23 @@ snapshots:
       abitype: 1.2.3(typescript@6.0.2)(zod@4.3.6)
       isows: 1.0.7(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       ox: 0.14.20(typescript@6.0.2)(zod@4.3.6)
+      ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+    optionalDependencies:
+      typescript: 6.0.2
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - zod
+
+  viem@2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3):
+    dependencies:
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@6.0.2)(zod@4.4.3)
+      isows: 1.0.7(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10))
+      ox: 0.14.20(typescript@6.0.2)(zod@4.4.3)
       ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
     optionalDependencies:
       typescript: 6.0.2
@@ -10862,14 +11201,84 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
-  wagmi@3.6.9(@tanstack/query-core@5.96.2)(@tanstack/react-query@5.96.2(react@19.2.5))(@types/react@19.2.14)(accounts@0.8.5)(react@19.2.5)(typescript@6.0.2)(viem@2.48.4(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6)):
+  wagmi@3.6.9(@tanstack/query-core@5.96.2)(@tanstack/react-query@5.96.2(react@19.2.5))(@types/react@19.2.14)(accounts@0.12.1)(react@19.2.5)(typescript@6.0.2)(viem@2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6)):
     dependencies:
       '@tanstack/react-query': 5.96.2(react@19.2.5)
-      '@wagmi/connectors': 8.0.9(@wagmi/core@3.4.8)(accounts@0.8.5)(typescript@6.0.2)(viem@2.48.4(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6))
-      '@wagmi/core': 3.4.8(@tanstack/query-core@5.96.2)(@types/react@19.2.14)(accounts@0.8.5)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.48.4(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6))
+      '@wagmi/connectors': 8.0.9(@wagmi/core@3.4.8)(accounts@0.12.1)(typescript@6.0.2)(viem@2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6))
+      '@wagmi/core': 3.4.8(@tanstack/query-core@5.96.2)(@types/react@19.2.14)(accounts@0.12.1)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6))
       react: 19.2.5
       use-sync-external-store: 1.4.0(react@19.2.5)
-      viem: 2.48.4(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6)
+      viem: 2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6)
+    optionalDependencies:
+      typescript: 6.0.2
+    transitivePeerDependencies:
+      - '@base-org/account'
+      - '@coinbase/wallet-sdk'
+      - '@metamask/connect-evm'
+      - '@safe-global/safe-apps-provider'
+      - '@safe-global/safe-apps-sdk'
+      - '@tanstack/query-core'
+      - '@types/react'
+      - '@walletconnect/ethereum-provider'
+      - accounts
+      - immer
+      - porto
+
+  wagmi@3.6.9(@tanstack/query-core@5.96.2)(@tanstack/react-query@5.96.2(react@19.2.5))(@types/react@19.2.14)(accounts@0.12.1)(react@19.2.5)(typescript@6.0.2)(viem@2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3)):
+    dependencies:
+      '@tanstack/react-query': 5.96.2(react@19.2.5)
+      '@wagmi/connectors': 8.0.9(@wagmi/core@3.4.8)(accounts@0.12.1)(typescript@6.0.2)(viem@2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3))
+      '@wagmi/core': 3.4.8(@tanstack/query-core@5.96.2)(@types/react@19.2.14)(accounts@0.12.1)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3))
+      react: 19.2.5
+      use-sync-external-store: 1.4.0(react@19.2.5)
+      viem: 2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3)
+    optionalDependencies:
+      typescript: 6.0.2
+    transitivePeerDependencies:
+      - '@base-org/account'
+      - '@coinbase/wallet-sdk'
+      - '@metamask/connect-evm'
+      - '@safe-global/safe-apps-provider'
+      - '@safe-global/safe-apps-sdk'
+      - '@tanstack/query-core'
+      - '@types/react'
+      - '@walletconnect/ethereum-provider'
+      - accounts
+      - immer
+      - porto
+    optional: true
+
+  wagmi@3.6.9(@tanstack/query-core@5.96.2)(@tanstack/react-query@5.96.2(react@19.2.5))(@types/react@19.2.14)(accounts@0.8.5)(react@19.2.5)(typescript@6.0.2)(viem@2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6)):
+    dependencies:
+      '@tanstack/react-query': 5.96.2(react@19.2.5)
+      '@wagmi/connectors': 8.0.9(@wagmi/core@3.4.8)(accounts@0.8.5)(typescript@6.0.2)(viem@2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6))
+      '@wagmi/core': 3.4.8(@tanstack/query-core@5.96.2)(@types/react@19.2.14)(accounts@0.8.5)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6))
+      react: 19.2.5
+      use-sync-external-store: 1.4.0(react@19.2.5)
+      viem: 2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6)
+    optionalDependencies:
+      typescript: 6.0.2
+    transitivePeerDependencies:
+      - '@base-org/account'
+      - '@coinbase/wallet-sdk'
+      - '@metamask/connect-evm'
+      - '@safe-global/safe-apps-provider'
+      - '@safe-global/safe-apps-sdk'
+      - '@tanstack/query-core'
+      - '@types/react'
+      - '@walletconnect/ethereum-provider'
+      - accounts
+      - immer
+      - porto
+
+  wagmi@3.6.9(@tanstack/query-core@5.96.2)(@tanstack/react-query@5.96.2(react@19.2.5))(@types/react@19.2.14)(accounts@0.8.5)(react@19.2.5)(typescript@6.0.2)(viem@2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3)):
+    dependencies:
+      '@tanstack/react-query': 5.96.2(react@19.2.5)
+      '@wagmi/connectors': 8.0.9(@wagmi/core@3.4.8)(accounts@0.8.5)(typescript@6.0.2)(viem@2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3))
+      '@wagmi/core': 3.4.8(@tanstack/query-core@5.96.2)(@types/react@19.2.14)(accounts@0.8.5)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3))
+      react: 19.2.5
+      use-sync-external-store: 1.4.0(react@19.2.5)
+      viem: 2.49.3(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3)
     optionalDependencies:
       typescript: 6.0.2
     transitivePeerDependencies:
@@ -11092,6 +11501,8 @@ snapshots:
   zod@3.25.76: {}
 
   zod@4.3.6: {}
+
+  zod@4.4.3: {}
 
   zustand@5.0.0(@types/react@19.2.14)(react@19.2.5)(use-sync-external-store@1.4.0(react@19.2.5)):
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -576,6 +576,9 @@ importers:
       '@hono/zod-validator':
         specifier: 'catalog:'
         version: 0.7.6(hono@4.12.14)(zod@4.3.6)
+      accounts:
+        specifier: 'catalog:'
+        version: 0.8.5(@types/react@19.2.14)(@wagmi/core@3.4.8)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.48.4(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6))(wagmi@3.6.9)
       hono:
         specifier: 'catalog:'
         version: 4.12.14
@@ -588,9 +591,6 @@ importers:
       ox:
         specifier: 'catalog:'
         version: 0.14.20(typescript@6.0.2)(zod@4.3.6)
-      tempo.ts:
-        specifier: 'catalog:'
-        version: 0.14.2(typescript@6.0.2)(viem@2.48.4(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6))(zod@4.3.6)
       viem:
         specifier: 'catalog:'
         version: 2.48.4(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -45,7 +45,7 @@ catalog:
   '@vitejs/plugin-react': ^6.0.1
   '@vitest/ui': 4.1.0
   '@wagmi/core': ^3.4.8
-  accounts: ~0.8.1
+  accounts: ~0.12.1
   abitype: ^1.2.4
   animejs: ^4.3.6
   cva: ^1.0.0-beta.4
@@ -74,7 +74,7 @@ catalog:
   typed-query-selector: ^2.12.1
   typescript: ^6.0.2
   unplugin-icons: ^23.0.1
-  viem: ^2.48.4
+  viem: ^2.49.3
   vite: ^8.0.7
   vite-plugin-devtools-json: ^1.0.0
   vitest: 4.1.0
@@ -112,6 +112,7 @@ workspaceConcurrency: -1
 
 minimumReleaseAge: 1440
 minimumReleaseAgeExclude:
+  - 'accounts'
   - 'ox'
   - 'viem'
   - 'wagmi'


### PR DESCRIPTION
## Summary

Replaces `Handler.feePayer` from `tempo.ts/server` with `Handler.relay` from `accounts/server` (same handler wallet-next uses).

### Why

The old `tempo.ts` handler lacks fee token resolution — clients had to manually set `feeToken` on the chain config or the transaction would be sent without one, causing FeeAMM swap errors even when validators accept pathUSD.

### What changes

- **Dependency**: `tempo.ts` → `accounts` (already in workspace catalog at `~0.8.1`)
- **Handler**: `Handler.feePayer()` → `Handler.relay()` with `features: "all"`
- **Multi-chain**: Transports for mainnet, moderato, and devnet (resolves chain from tx `chainId`)
- **Fee token resolution**: Relay auto-detects the best fee token from sender balances
- **Auto-swap**: Built-in cross-token fee payment when needed
- **Simulation**: Balance diffs + fee breakdown in `eth_fillTransaction` responses

### Handler config

```ts
Handler.relay({
  cors: false,
  features: "all",
  feePayer: {
    account: privateKeyToAccount(env.SPONSOR_PRIVATE_KEY),
    name: "Tempo Sponsor",
    url: "https://sponsor.tempo.xyz",
  },
  transports: {
    [tempo.id]: http(env.TEMPO_RPC_URL ?? ...),
    [tempoModerato.id]: http(...),
    [tempoDevnet.id]: http(...),
  },
})
```

### Backward-compatible

- API key auth, admin endpoints, rate limiting — all unchanged
- Open access at `/` still works
- Keyed access at `/tp_*` still works