### PR TITLE
feat(perf): clarify benchmark dashboard

### DIFF
--- a/apps/perf/src/comps/BenchmarkDashboard.tsx
+++ b/apps/perf/src/comps/BenchmarkDashboard.tsx
@@ -242,7 +242,7 @@ function ScenarioCard(props: {
 						<Stat label="TPS" value={formatTps(run.avgTps)} highlight />
 						<Stat label="Block Time" value={formatMs(run.avgBlockTimeMs)} />
 						<Stat label="Throughput" value={formatGas(run.avgGasPerSecond)} />
-						<Stat label="Peak" value={formatGas(run.peakGasPerSecond)} />
+						<Stat label="Peak Gas" value={formatGas(run.peakGasPerSecond)} />
 					</div>
 				</div>
 			) : (

--- a/apps/perf/src/comps/BenchmarkDashboard.tsx
+++ b/apps/perf/src/comps/BenchmarkDashboard.tsx
@@ -23,7 +23,7 @@ export function BenchmarkDashboard(
 	}
 
 	const runsWithData = latestRuns.filter((r) => r.avgTps > 0)
-	const peakTpsRun =
+	const averageTpsRun =
 		runsWithData.length > 0
 			? runsWithData.reduce((best, r) => (r.avgTps > best.avgTps ? r : best))
 			: null
@@ -51,15 +51,15 @@ export function BenchmarkDashboard(
 				</div>
 			)}
 
-			{/* Hero — peak TPS headline */}
+			{/* Hero — average TPS headline */}
 			<section className="mb-14">
 				<p className="text-[13px] font-medium uppercase tracking-wider text-tertiary">
-					Peak TPS
+					Average TPS
 				</p>
-				{peakTpsRun ? (
+				{averageTpsRun ? (
 					<>
 						<h2 className="mt-2 font-mono text-[56px] font-bold leading-none tracking-tight text-accent">
-							{formatTps(peakTpsRun.avgTps)}{' '}
+							{formatTps(averageTpsRun.avgTps)}{' '}
 							<span className="text-[28px] font-semibold text-tertiary">
 								TPS
 							</span>
@@ -67,17 +67,17 @@ export function BenchmarkDashboard(
 						<div className="mt-5 flex flex-wrap items-center gap-6">
 							<HeroStat
 								label="Throughput"
-								value={formatGas(peakTpsRun.peakGasPerSecond)}
+								value={formatGas(averageTpsRun.avgGasPerSecond)}
 							/>
 							<HeroStat
 								label="Block Time"
-								value={formatMs(peakTpsRun.avgBlockTimeMs)}
+								value={formatMs(averageTpsRun.avgBlockTimeMs)}
 							/>
 							<HeroStat
 								label="Workload"
 								value={
-									scenarios.find((s) => s.id === peakTpsRun.scenarioId)
-										?.label ?? peakTpsRun.scenarioId
+									scenarios.find((s) => s.id === averageTpsRun.scenarioId)
+										?.label ?? averageTpsRun.scenarioId
 								}
 							/>
 						</div>
@@ -141,7 +141,9 @@ export function BenchmarkDashboard(
 							</div>
 							<div className="flex items-center gap-1.5">
 								<span className="inline-block h-2.5 w-2.5 rounded-full bg-positive/50" />
-								<span className="text-[11px] text-tertiary">Mixed Workload</span>
+								<span className="text-[11px] text-tertiary">
+									Mixed Workload
+								</span>
 							</div>
 						</div>
 					</div>
@@ -154,7 +156,12 @@ export function BenchmarkDashboard(
 					title="TIP-20 Transfers"
 					subtitle="100% TIP-20 token transfers"
 				/>
-				<div className={cx('grid gap-4 sm:grid-cols-2', tip20Scenarios.length >= 3 && 'lg:grid-cols-3')}>
+				<div
+					className={cx(
+						'grid gap-4 sm:grid-cols-2',
+						tip20Scenarios.length >= 3 && 'lg:grid-cols-3',
+					)}
+				>
 					{tip20Scenarios.map((scenario) => (
 						<ScenarioCard
 							key={scenario.id}
@@ -171,7 +178,12 @@ export function BenchmarkDashboard(
 					title="Mixed Workloads"
 					subtitle="70% TIP-20, 10% MPP, 10% DEX, 10% ERC-20"
 				/>
-				<div className={cx('grid gap-4 sm:grid-cols-2', mixScenarios.length >= 3 && 'lg:grid-cols-3')}>
+				<div
+					className={cx(
+						'grid gap-4 sm:grid-cols-2',
+						mixScenarios.length >= 3 && 'lg:grid-cols-3',
+					)}
+				>
 					{mixScenarios.map((scenario) => (
 						<ScenarioCard
 							key={scenario.id}

--- a/apps/perf/src/lib/server/bench.ts
+++ b/apps/perf/src/lib/server/bench.ts
@@ -229,79 +229,25 @@ export const fetchAllLatestRuns = createServerFn({ method: 'GET' })
 		return latestRuns.filter((run): run is BenchRun => run !== null)
 	})
 
-function buildLatestRunQuery(feed: RunFeed, limit = 50): string {
-	const scenarioNames = SCENARIOS.map((s) => sqlString(s.scenarioName)).join(
-		', ',
-	)
-	const candidateLimit = Math.max(50, limit)
-
-	return `
-		WITH candidate_runs AS (
-			SELECT
-				r.run_id,
-				r.started_at,
-				r.finished_at,
-				r.git_sha,
-				r.git_ref,
-				r.mode,
-				r.scenario_name,
-				r.config.keys AS config_keys,
-				r.config.values AS config_values
-			FROM txgen_runs r
-			WHERE r.scenario_name IN (${scenarioNames})
-				${runFeedWhereClause(feed)}
-			ORDER BY r.started_at DESC
-			LIMIT ${candidateLimit}
+export const fetchReleaseRuns = createServerFn({ method: 'GET' }).handler(
+	async () => {
+		const runsByScenario = await Promise.all(
+			SCENARIOS.map(async (scenario) => {
+				const rows = await queryClickHouse<RunRow>(
+					buildRunsQuery(scenario.scenarioName, 'release'),
+				)
+				return rows.map((row) => toRun(row, scenario.id))
+			}),
 		)
-		SELECT
-			r.run_id,
-			r.started_at,
-			r.finished_at,
-			r.git_sha,
-			r.git_ref,
-			r.mode,
-			r.scenario_name,
-			r.config_keys,
-			r.config_values,
-			b.avg_tps,
-			b.avg_block_time_ms,
-			b.total_gas_used,
-			b.run_duration_secs,
-			b.peak_gas_per_second,
-			b.block_count
-		FROM candidate_runs r
-		LEFT JOIN (
-			SELECT
-				run_id,
-				avg(tx_count * 1000.0 / block_time_ms) AS avg_tps,
-				avg(block_time_ms) AS avg_block_time_ms,
-				sum(gas_used) AS total_gas_used,
-				sum(block_time_ms) / 1000.0 AS run_duration_secs,
-				max(gas_used * 1000.0 / block_time_ms) AS peak_gas_per_second,
-				count() AS block_count
-			FROM txgen_blocks
-			WHERE block_time_ms > 0
-				AND run_id IN (SELECT run_id FROM candidate_runs)
-			GROUP BY run_id
-		) b ON r.run_id = b.run_id
-		WHERE b.total_gas_used > 0
-		ORDER BY r.started_at DESC
-		LIMIT 1
-	`
-}
 
-export const fetchLatestRun = createServerFn({ method: 'GET' })
-	.inputValidator((input: RunFeed | undefined) => normalizeRunFeed(input))
-	.handler(async ({ data: feed }) => {
-		const rows = await queryClickHouse<RunRow>(buildLatestRunQuery(feed))
-		const latest = rows[0]
-		if (!latest) return null
-
-		const scenarioId =
-			SCENARIOS.find((s) => s.scenarioName === latest.scenario_name)?.id ?? ''
-
-		return toRun(latest, scenarioId)
-	})
+		return runsByScenario
+			.flat()
+			.sort(
+				(a, b) =>
+					new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime(),
+			)
+	},
+)
 
 export const fetchRunsForScenario = createServerFn({ method: 'POST' })
 	.inputValidator((input: RunsForScenarioInput) => ({

--- a/apps/perf/src/lib/server/bench.ts
+++ b/apps/perf/src/lib/server/bench.ts
@@ -62,13 +62,15 @@ const SCENARIOS: Array<{
 	{
 		id: 'mix-10k',
 		label: 'Mix — 10K TPS',
-		workload: '70% TIP-20 Transfers, 10% MPP Channels, 10% DEX Swaps, 10% ERC-20 Transfers',
+		workload:
+			'70% TIP-20 Transfers, 10% MPP Channels, 10% DEX Swaps, 10% ERC-20 Transfers',
 		scenarioName: 'mix-10k',
 	},
 	{
 		id: 'mix-20k',
 		label: 'Mix — 20K TPS',
-		workload: '70% TIP-20 Transfers, 10% MPP Channels, 10% DEX Swaps, 10% ERC-20 Transfers',
+		workload:
+			'70% TIP-20 Transfers, 10% MPP Channels, 10% DEX Swaps, 10% ERC-20 Transfers',
 		scenarioName: 'mix-20k',
 	},
 ]
@@ -225,6 +227,80 @@ export const fetchAllLatestRuns = createServerFn({ method: 'GET' })
 		)
 
 		return latestRuns.filter((run): run is BenchRun => run !== null)
+	})
+
+function buildLatestRunQuery(feed: RunFeed, limit = 50): string {
+	const scenarioNames = SCENARIOS.map((s) => sqlString(s.scenarioName)).join(
+		', ',
+	)
+	const candidateLimit = Math.max(50, limit)
+
+	return `
+		WITH candidate_runs AS (
+			SELECT
+				r.run_id,
+				r.started_at,
+				r.finished_at,
+				r.git_sha,
+				r.git_ref,
+				r.mode,
+				r.scenario_name,
+				r.config.keys AS config_keys,
+				r.config.values AS config_values
+			FROM txgen_runs r
+			WHERE r.scenario_name IN (${scenarioNames})
+				${runFeedWhereClause(feed)}
+			ORDER BY r.started_at DESC
+			LIMIT ${candidateLimit}
+		)
+		SELECT
+			r.run_id,
+			r.started_at,
+			r.finished_at,
+			r.git_sha,
+			r.git_ref,
+			r.mode,
+			r.scenario_name,
+			r.config_keys,
+			r.config_values,
+			b.avg_tps,
+			b.avg_block_time_ms,
+			b.total_gas_used,
+			b.run_duration_secs,
+			b.peak_gas_per_second,
+			b.block_count
+		FROM candidate_runs r
+		LEFT JOIN (
+			SELECT
+				run_id,
+				avg(tx_count * 1000.0 / block_time_ms) AS avg_tps,
+				avg(block_time_ms) AS avg_block_time_ms,
+				sum(gas_used) AS total_gas_used,
+				sum(block_time_ms) / 1000.0 AS run_duration_secs,
+				max(gas_used * 1000.0 / block_time_ms) AS peak_gas_per_second,
+				count() AS block_count
+			FROM txgen_blocks
+			WHERE block_time_ms > 0
+				AND run_id IN (SELECT run_id FROM candidate_runs)
+			GROUP BY run_id
+		) b ON r.run_id = b.run_id
+		WHERE b.total_gas_used > 0
+		ORDER BY r.started_at DESC
+		LIMIT 1
+	`
+}
+
+export const fetchLatestRun = createServerFn({ method: 'GET' })
+	.inputValidator((input: RunFeed | undefined) => normalizeRunFeed(input))
+	.handler(async ({ data: feed }) => {
+		const rows = await queryClickHouse<RunRow>(buildLatestRunQuery(feed))
+		const latest = rows[0]
+		if (!latest) return null
+
+		const scenarioId =
+			SCENARIOS.find((s) => s.scenarioName === latest.scenario_name)?.id ?? ''
+
+		return toRun(latest, scenarioId)
 	})
 
 export const fetchRunsForScenario = createServerFn({ method: 'POST' })

--- a/apps/perf/src/routes/__root.tsx
+++ b/apps/perf/src/routes/__root.tsx
@@ -6,6 +6,7 @@ import {
 	Link,
 	Outlet,
 	Scripts,
+	useRouterState,
 } from '@tanstack/react-router'
 import * as React from 'react'
 import SunIcon from '~icons/lucide/sun'
@@ -81,6 +82,11 @@ function RootDocument() {
 }
 
 function Header(): React.JSX.Element {
+	const pathname = useRouterState({
+		select: (state) => state.location.pathname,
+	})
+	const isMethodology = pathname === '/methodology'
+
 	return (
 		<header className="flex items-center justify-between py-8">
 			<Link to="/">
@@ -88,10 +94,12 @@ function Header(): React.JSX.Element {
 			</Link>
 			<div className="flex items-center gap-2">
 				<nav className="flex items-center gap-1 text-[14px] font-medium leading-[140%]">
-					<NavLink to="/" exact>
+					<NavLink to="/" active={!isMethodology}>
 						Dashboard
 					</NavLink>
-					<NavLink to="/methodology">Methodology</NavLink>
+					<NavLink to="/methodology" active={isMethodology}>
+						Methodology
+					</NavLink>
 				</nav>
 				<div className="mx-2 h-5 w-px bg-border" />
 				<ThemeToggle />
@@ -141,17 +149,17 @@ function Footer(): React.JSX.Element {
 
 function NavLink(props: {
 	to: string
-	exact?: boolean
+	active: boolean
 	children: React.ReactNode
 }): React.JSX.Element {
 	return (
 		<Link
 			to={props.to}
-			className="rounded-lg px-3 py-1.5 text-secondary transition-colors hover:text-primary"
-			activeProps={{
-				className: 'rounded-lg px-3 py-1.5 bg-accent-muted text-accent',
-			}}
-			activeOptions={props.exact ? { exact: true } : undefined}
+			className={
+				props.active
+					? 'rounded-lg bg-accent-muted px-3 py-1.5 text-accent transition-colors'
+					: 'rounded-lg px-3 py-1.5 text-secondary transition-colors hover:text-primary'
+			}
 		>
 			{props.children}
 		</Link>

--- a/apps/perf/src/routes/benchmark.$id.tsx
+++ b/apps/perf/src/routes/benchmark.$id.tsx
@@ -171,6 +171,8 @@ export declare namespace BenchmarkRunDetail {
 	type Props = {
 		id: string
 		showBackLink?: boolean | undefined
+		headerControls?: React.ReactNode | undefined
+		showRunSelect?: boolean | undefined
 	}
 }
 
@@ -459,33 +461,37 @@ export function BenchmarkRunDetail(
 							{scenario && ` · ${scenario.workload}`}
 						</p>
 					</div>
-					<div className="flex flex-col gap-2 sm:items-end">
-						<label htmlFor={runSelectId} className="sr-only">
-							Benchmark run
-						</label>
-						<select
-							id={runSelectId}
-							value={run.id}
-							disabled={runs.length <= 1}
-							onChange={(event) =>
-								navigate({
-									to: '/benchmark/$id',
-									params: { id: event.currentTarget.value },
-								})
-							}
-							className="w-full max-w-48 rounded-md border border-border bg-surface px-3 py-2 font-mono text-[13px] text-primary outline-none transition-colors hover:border-accent/50 focus:border-accent disabled:cursor-not-allowed disabled:text-tertiary sm:w-44"
-						>
-							{runs.length > 0 ? (
-								runs.map((option) => (
-									<option key={option.id} value={option.id}>
-										{runOptionLabel(option)}
-									</option>
-								))
-							) : (
-								<option value={run.id}>{runOptionLabel(run)}</option>
+					{props.headerControls
+						? props.headerControls
+						: props.showRunSelect !== false && (
+								<div className="flex flex-col gap-2 sm:items-end">
+									<label htmlFor={runSelectId} className="sr-only">
+										Benchmark run
+									</label>
+									<select
+										id={runSelectId}
+										value={run.id}
+										disabled={runs.length <= 1}
+										onChange={(event) =>
+											navigate({
+												to: '/benchmark/$id',
+												params: { id: event.currentTarget.value },
+											})
+										}
+										className="w-full max-w-48 rounded-md border border-border bg-surface px-3 py-2 font-mono text-[13px] text-primary outline-none transition-colors hover:border-accent/50 focus:border-accent disabled:cursor-not-allowed disabled:text-tertiary sm:w-44"
+									>
+										{runs.length > 0 ? (
+											runs.map((option) => (
+												<option key={option.id} value={option.id}>
+													{runOptionLabel(option)}
+												</option>
+											))
+										) : (
+											<option value={run.id}>{runOptionLabel(run)}</option>
+										)}
+									</select>
+								</div>
 							)}
-						</select>
-					</div>
 				</div>
 			</section>
 

--- a/apps/perf/src/routes/benchmark.$id.tsx
+++ b/apps/perf/src/routes/benchmark.$id.tsx
@@ -78,29 +78,6 @@ const COLORS = {
 	purple: '#a78bfa',
 }
 
-const NOISE_THRESHOLD = 0.02
-
-function Delta(props: {
-	current: number
-	previous: number
-	lowerIsBetter?: boolean | undefined
-}): React.JSX.Element | null {
-	if (props.previous === 0) return null
-	const ratio = (props.current - props.previous) / props.previous
-	if (Math.abs(ratio) < NOISE_THRESHOLD) {
-		return <span className="ml-1.5 text-[11px] text-tertiary">=</span>
-	}
-	const up = ratio > 0
-	const improved = props.lowerIsBetter ? !up : up
-	return (
-		<span
-			className={`ml-1.5 text-[11px] ${improved ? 'text-positive' : 'text-negative'}`}
-		>
-			{up ? '▲' : '▼'} {(Math.abs(ratio) * 100).toFixed(1)}%
-		</span>
-	)
-}
-
 function runOptionLabel(run: BenchRun): string {
 	const version =
 		run.ref && run.commit
@@ -219,11 +196,6 @@ export function BenchmarkRunDetail(
 
 	const scenario = getScenario(run.scenarioId)
 	const runs = scenarioRuns ?? []
-	const currentRunIndex = runs.findIndex(
-		(scenarioRun) => scenarioRun.id === run.id,
-	)
-	const previousRun =
-		currentRunIndex >= 0 ? runs[currentRunIndex + 1] : undefined
 	const m = metrics ?? []
 
 	// Builder phases (p50)
@@ -407,6 +379,10 @@ export function BenchmarkRunDetail(
 	const sharedGasLimit = Math.floor(refGasLimit / 10)
 	const generalGasLimit = 30_000_000
 	const paymentGasLimit = refGasLimit - sharedGasLimit - generalGasLimit
+	const hasLoadedPrimarySeries = metrics !== undefined && blocks !== undefined
+	const ingressTpsPoints = counterRate(txgenCounterSeries.sent)
+	const settledTpsPoints = settledTps(blockRows)
+	const ingressEgressYMax = sharedYMax([ingressTpsPoints, settledTpsPoints])
 
 	return (
 		<div>
@@ -495,598 +471,637 @@ export function BenchmarkRunDetail(
 				</div>
 			</section>
 
-			<section className="mb-10 grid grid-cols-2 gap-3 sm:grid-cols-4">
-				<MetricCard
-					label="Throughput"
-					value={formatGas(run.avgGasPerSecond)}
-					tooltip="Average gas per second across the entire run. Calculated as total gas used ÷ total run duration."
-					delta={
-						previousRun && (
-							<Delta
-								current={run.avgGasPerSecond}
-								previous={previousRun.avgGasPerSecond}
-							/>
-						)
-					}
-					accent
-				/>
-				<MetricCard
-					label="Peak"
-					value={formatGas(run.peakGasPerSecond)}
-					tooltip="Highest gas per second achieved by any single block, based on its gas usage and block time."
-					delta={
-						previousRun && (
-							<Delta
-								current={run.peakGasPerSecond}
-								previous={previousRun.peakGasPerSecond}
-							/>
-						)
-					}
-				/>
-				<MetricCard
-					label="Avg TPS"
-					value={formatTps(run.avgTps)}
-					tooltip="Average transactions per second across all blocks, based on transaction count and block time."
-					delta={
-						previousRun && (
-							<Delta current={run.avgTps} previous={previousRun.avgTps} />
-						)
-					}
-				/>
-				<MetricCard
-					label="Block Time"
-					value={formatMs(run.avgBlockTimeMs)}
-					tooltip="Average wall-clock time between consecutive blocks."
-					delta={
-						previousRun && (
-							<Delta
-								current={run.avgBlockTimeMs}
-								previous={previousRun.avgBlockTimeMs}
-								lowerIsBetter
-							/>
-						)
-					}
-				/>
+			<section className="mb-10 grid gap-3 lg:grid-cols-[minmax(0,1.35fr)_minmax(300px,0.65fr)]">
+				<PerformanceSummary run={run} />
+				<div className="grid grid-cols-2 gap-3">
+					<MetricCard
+						label="Blocks"
+						value={run.blockCount.toLocaleString()}
+						tooltip="Number of blocks produced during the benchmark run."
+					/>
+					<MetricCard
+						label="Block Time"
+						value={formatMs(run.avgBlockTimeMs)}
+						tooltip="Average wall-clock time between consecutive blocks."
+					/>
+					<MetricCard
+						label="Avg Gas/s"
+						value={formatGas(run.avgGasPerSecond, false)}
+						tooltip="Average gas per second across the entire run. Calculated as total gas used ÷ total run duration."
+					/>
+					<MetricCard
+						label="Peak Gas/s"
+						value={formatGas(run.peakGasPerSecond, false)}
+						tooltip="Highest gas per second achieved by any single block, based on its gas usage and block time."
+					/>
+				</div>
 			</section>
 
-			{blockRows.length > 0 && (
-				<section className="mb-10">
-					<SectionHeader
-						title="Blocks"
-						tooltip="Per-block metrics from the benchmark run."
-					/>
-					<div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+			<section className="mb-10">
+				<SectionHeader
+					title="Submitted / Settled TPS"
+					tooltip="Submitted transaction load compared with transactions settled into blocks."
+				/>
+				{hasLoadedPrimarySeries ? (
+					<div className="grid grid-cols-1 gap-3">
 						<TimeSeriesChart
-							title="Transactions per Block"
-							tooltip="Number of transactions included in each block."
+							title="Submitted TPS"
+							tooltip="Rate of transactions submitted by the load generator. This shows the input pulse."
 							showMean
 							series={[
 								{
-									label: 'Tx Count',
+									label: 'Submitted',
 									color: COLORS.blue,
-									data: blockRows.map((b) => ({
-										x: b.index,
-										y: b.txCount,
-									})),
+									data: ingressTpsPoints,
+								},
+							]}
+							formatValue={(v) => `${formatTps(v)}/s`}
+							yMax={ingressEgressYMax}
+						/>
+						<TimeSeriesChart
+							title="Settled TPS"
+							tooltip="Rate of transactions included in blocks, derived from per-block transaction count and block time."
+							showMean
+							series={[
+								{
+									label: 'Settled',
+									color: COLORS.green,
+									data: settledTpsPoints,
+								},
+							]}
+							formatValue={(v) => `${formatTps(v)}/s`}
+							yMax={ingressEgressYMax}
+						/>
+					</div>
+				) : (
+					<div className="grid grid-cols-1 gap-3">
+						<ChartLoadingCard title="Submitted TPS" />
+						<ChartLoadingCard title="Settled TPS" />
+					</div>
+				)}
+			</section>
+
+			<details className="group/details mb-14">
+				<summary className="mb-5 flex cursor-pointer list-none items-center gap-3 transition-colors marker:hidden">
+					<h3 className="shrink-0 text-[13px] font-normal tracking-wider text-tertiary uppercase group-hover/details:text-primary">
+						Detailed charts
+					</h3>
+					<div className="h-px flex-1 bg-border" />
+					<span className="rounded-md border border-border bg-surface px-3 py-1.5 text-[12px] text-secondary transition-colors group-hover/details:border-accent/50 group-hover/details:text-primary">
+						<span className="group-open/details:hidden">Show</span>
+						<span className="hidden group-open/details:inline">Hide</span>
+					</span>
+				</summary>
+				<div>
+					{blockRows.length > 0 && (
+						<section className="mb-10">
+							<SectionHeader
+								title="Blocks"
+								tooltip="Per-block metrics from the benchmark run."
+							/>
+							<div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+								<TimeSeriesChart
+									title="Transactions per Block"
+									tooltip="Number of transactions included in each block."
+									showMean
+									series={[
+										{
+											label: 'Tx Count',
+											color: COLORS.blue,
+											data: blockRows.map((b) => ({
+												x: b.index,
+												y: b.txCount,
+											})),
+										},
+									]}
+									formatValue={(v) => `${Math.round(v).toLocaleString()} txs`}
+									xFormat="block"
+								/>
+								<TimeSeriesChart
+									title="Gas Used per Block"
+									tooltip="Total gas consumed by all transactions in each block."
+									showMean
+									series={[
+										{
+											label: 'Gas Used',
+											color: COLORS.green,
+											data: blockRows.map((b) => ({
+												x: b.index,
+												y: b.gasUsed,
+											})),
+										},
+									]}
+									formatValue={(v) => formatGas(v, false)}
+									xFormat="block"
+									referenceBands={
+										refGasLimit > 0
+											? [
+													{
+														label: `General (${formatGas(generalGasLimit, false)})`,
+														from: 0,
+														to: generalGasLimit,
+														color: COLORS.blue,
+													},
+													{
+														label: `Payment (${formatGas(paymentGasLimit, false)})`,
+														from: generalGasLimit,
+														to: generalGasLimit + paymentGasLimit,
+														color: COLORS.orange,
+													},
+													{
+														label: `Shared (${formatGas(sharedGasLimit, false)})`,
+														from: generalGasLimit + paymentGasLimit,
+														to: refGasLimit,
+														color: COLORS.purple,
+													},
+												]
+											: undefined
+									}
+								/>
+								<TimeSeriesChart
+									title="Gas Fill %"
+									tooltip="Percentage of the block gas limit that was used."
+									showMean
+									series={[
+										{
+											label: 'Fill %',
+											color: COLORS.blue,
+											data: blockRows
+												.filter((b) => b.gasLimit > 0)
+												.map((b) => ({
+													x: b.index,
+													y: (b.gasUsed / b.gasLimit) * 100,
+												})),
+										},
+									]}
+									formatValue={(v) => `${v.toFixed(1)}%`}
+									yMax={100}
+									xFormat="block"
+									referenceBands={
+										refGasLimit > 0
+											? [
+													{
+														label: `General (${((generalGasLimit / refGasLimit) * 100).toFixed(0)}%)`,
+														from: 0,
+														to: (generalGasLimit / refGasLimit) * 100,
+														color: COLORS.blue,
+													},
+													{
+														label: `Payment (${((paymentGasLimit / refGasLimit) * 100).toFixed(0)}%)`,
+														from: (generalGasLimit / refGasLimit) * 100,
+														to:
+															((generalGasLimit + paymentGasLimit) /
+																refGasLimit) *
+															100,
+														color: COLORS.orange,
+													},
+													{
+														label: `Shared (${((sharedGasLimit / refGasLimit) * 100).toFixed(0)}%)`,
+														from:
+															((generalGasLimit + paymentGasLimit) /
+																refGasLimit) *
+															100,
+														to: 100,
+														color: COLORS.purple,
+													},
+												]
+											: undefined
+									}
+								/>
+								<TimeSeriesChart
+									title="RLP Block Size"
+									tooltip="RLP-encoded size of each block in kilobytes."
+									showMean
+									series={[
+										{
+											label: 'Size',
+											color: COLORS.green,
+											data: transformSamples(rlpSizeSeries, (v) => v / 1024),
+										},
+									]}
+									formatValue={(v) => `${v.toFixed(0)} KB`}
+									referenceBands={[
+										{
+											label: 'RLPx hard cap (16 MiB)',
+											from: 16 * 1024,
+											to: 16 * 1024 * 1.05,
+											color: COLORS.red,
+										},
+									]}
+								/>
+							</div>
+						</section>
+					)}
+
+					{(hasEngineApiTimings || hasServerWaitTimings) && (
+						<section className="mb-10">
+							<SectionHeader
+								title="Engine API Timing"
+								tooltip="Per-block timings reported by txgen for Engine API calls and server-side waits."
+							/>
+							<div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+								{hasEngineApiTimings && (
+									<TimeSeriesChart
+										title="Engine API Calls"
+										tooltip="Per-block Engine API client timings. Server latency is reported by the server and converted from microseconds to milliseconds."
+										showMean
+										series={[
+											{
+												label: 'New Payload',
+												color: COLORS.blue,
+												data: blockPoints(blockRows, (b) => b.newPayloadMs),
+											},
+											{
+												label: 'Forkchoice Updated',
+												color: COLORS.green,
+												data: blockPoints(
+													blockRows,
+													(b) => b.forkchoiceUpdatedMs,
+												),
+											},
+											{
+												label: 'Total Client Time',
+												color: COLORS.orange,
+												data: blockPoints(blockRows, (b) => {
+													if (
+														b.newPayloadMs == null ||
+														b.forkchoiceUpdatedMs == null
+													) {
+														return null
+													}
+													return b.newPayloadMs + b.forkchoiceUpdatedMs
+												}),
+											},
+											{
+												label: 'Server Latency',
+												color: COLORS.purple,
+												data: blockPoints(
+													blockRows,
+													(b) => b.newPayloadServerLatencyUs,
+													(us) => us / 1000,
+												),
+											},
+										]}
+										formatValue={(v) => `${v.toFixed(2)} ms`}
+										xFormat="block"
+									/>
+								)}
+								{hasServerWaitTimings && (
+									<TimeSeriesChart
+										title="Server Wait Timings"
+										tooltip="Server-side wait timings reported by the Engine API server, converted from microseconds to milliseconds."
+										showMean
+										series={[
+											{
+												label: 'Persistence Wait',
+												color: COLORS.blue,
+												data: blockPoints(
+													blockRows,
+													(b) => b.persistenceWaitUs,
+													(us) => us / 1000,
+												),
+											},
+											{
+												label: 'Execution Cache Wait',
+												color: COLORS.green,
+												data: blockPoints(
+													blockRows,
+													(b) => b.executionCacheWaitUs,
+													(us) => us / 1000,
+												),
+											},
+											{
+												label: 'Sparse Trie Wait',
+												color: COLORS.orange,
+												data: blockPoints(
+													blockRows,
+													(b) => b.sparseTrieWaitUs,
+													(us) => us / 1000,
+												),
+											},
+										]}
+										formatValue={(v) => `${v.toFixed(2)} ms`}
+										xFormat="block"
+									/>
+								)}
+							</div>
+						</section>
+					)}
+
+					<section className="mb-10">
+						<SectionHeader
+							title="Payload Build Duration"
+							tooltip="Total wall-clock time to build each block payload, from start to sealed block."
+						/>
+						<TimeSeriesChart
+							showMean
+							series={[
+								{
+									label: 'p50',
+									color: COLORS.blue,
+									data: transformSamples(buildDurP50, (v) => v * 1000),
+								},
+								{
+									label: 'p95',
+									color: COLORS.orange,
+									data: transformSamples(buildDurP95, (v) => v * 1000),
+								},
+							]}
+							formatValue={(v) => `${v.toFixed(1)} ms`}
+						/>
+					</section>
+
+					<section className="mb-10">
+						<SectionHeader
+							title="Build Phases (p50)"
+							tooltip="Top-level disjoint phases of block building. These sum to approximately the total payload build duration."
+						/>
+						<TimeSeriesChart
+							stacked
+							showMean
+							series={[
+								{
+									label: 'State Setup',
+									color: COLORS.purple,
+									data: transformSamples(stateSetupSeries, (v) => v * 1000),
+								},
+								{
+									label: 'System Tx Prep',
+									color: COLORS.red,
+									data: transformSamples(sysTxPrepSeries, (v) => v * 1000),
+								},
+								{
+									label: 'System Tx Exec',
+									color: COLORS.orange,
+									data: transformSamples(sysTxExecSeries, (v) => v * 1000),
+								},
+								{
+									label: 'Pool Fetch',
+									color: COLORS.green,
+									data: transformSamples(poolFetchSeries, (v) => v * 1000),
+								},
+								{
+									label: 'Tx Execution',
+									color: COLORS.blue,
+									data: transformSamples(txExecSeries, (v) => v * 1000),
+								},
+								{
+									label: 'Finalization',
+									color: COLORS.orange,
+									data: transformSamples(finalizationSeries, (v) => v * 1000),
+								},
+							]}
+							formatValue={(v) => `${v.toFixed(1)} ms`}
+						/>
+					</section>
+
+					<section className="mb-10">
+						<SectionHeader
+							title="Finalization Internals (p50)"
+							tooltip="Internal timings from block finalization. Hashed Post State converts raw state changes into a hashed representation. State Root (sync) computes the root synchronously and is near zero when the trie is precomputed in the background."
+						/>
+						<TimeSeriesChart
+							showMean
+							series={[
+								{
+									label: 'Finalization',
+									color: COLORS.orange,
+									data: transformSamples(finalizationSeries, (v) => v * 1000),
+								},
+								{
+									label: 'Hashed Post State',
+									color: COLORS.purple,
+									data: transformSamples(
+										hashedPostStateSeries,
+										(v) => v * 1000,
+									),
+								},
+								{
+									label: 'State Root (sync)',
+									color: COLORS.green,
+									data: transformSamples(stateRootSeries, (v) => v * 1000),
+								},
+							]}
+							formatValue={(v) => `${v.toFixed(1)} ms`}
+						/>
+					</section>
+
+					<section className="mb-10">
+						<SectionHeader
+							title="Throughput"
+							tooltip="Gas and transaction processing rates per block."
+						/>
+						<div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+							<TimeSeriesChart
+								title="Gas Throughput"
+								tooltip="Gas processed per second for each block, based on gas usage and block time."
+								showMean
+								series={[
+									{
+										label: 'Gas/s',
+										color: COLORS.blue,
+										data: blockPoints(blockRows, (b) => {
+											if (b.blockTimeMs == null || b.blockTimeMs <= 0)
+												return null
+											return (b.gasUsed * 1000) / b.blockTimeMs / 1e9
+										}),
+									},
+								]}
+								formatValue={(v) => `${v.toFixed(2)} Ggas/s`}
+								xFormat="block"
+							/>
+							<TimeSeriesChart
+								title="Txs per Block"
+								tooltip="Number of user transactions included in each block as reported by the builder."
+								showMean
+								series={[
+									{
+										label: 'Txs',
+										color: COLORS.green,
+										data: transformSamples(txsPerBlockSeries),
+									},
+								]}
+								formatValue={(v) => `${Math.round(v).toLocaleString()}`}
+							/>
+						</div>
+					</section>
+
+					<section className="mb-10">
+						<SectionHeader
+							title="Txgen"
+							tooltip="Transaction generator metrics — the load driver that submits transactions to the node."
+						/>
+						<div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+							<TimeSeriesChart
+								title={
+									hasTxgenTransactionCounters
+										? 'Transaction Send Rate'
+										: 'Block Send/Success/Failure Rates'
+								}
+								tooltip={
+									hasTxgenTransactionCounters
+										? 'Rate of transactions sent, confirmed as successful, or failed per second.'
+										: 'Rate of blocks sent, confirmed as successful, or failed per second.'
+								}
+								showMean
+								series={[
+									{
+										label: 'Sent',
+										color: COLORS.blue,
+										data: counterRate(txgenCounterSeries.sent),
+									},
+									{
+										label: 'Success',
+										color: COLORS.green,
+										data: counterRate(txgenCounterSeries.success),
+									},
+									{
+										label: 'Failed',
+										color: COLORS.red,
+										data: counterRate(txgenCounterSeries.failed),
+									},
+								]}
+								formatValue={(v) => `${Math.round(v).toLocaleString()}/s`}
+							/>
+							<TimeSeriesChart
+								title="Inflight"
+								tooltip="Number of transactions submitted but not yet included in a block."
+								series={[
+									{
+										label: 'Inflight',
+										color: COLORS.purple,
+										data: transformSamples(txgenInflightSeries),
+									},
+								]}
+								formatValue={(v) => Math.round(v).toLocaleString()}
+							/>
+						</div>
+					</section>
+
+					<section className="mb-10">
+						<SectionHeader
+							title="Txpool"
+							tooltip="Transaction pool state: pending (ready to execute), queued (future nonce), and basefee (underpaying current base fee). Includes AA 2D pending/queued gauges when present."
+						/>
+						<TimeSeriesChart
+							stacked
+							showMean
+							series={[
+								{
+									label: 'Basefee',
+									color: COLORS.orange,
+									data: transformSamples(basefeeSeries),
+								},
+								{
+									label: 'Queued',
+									color: COLORS.purple,
+									data: combineSamples([queuedSeries, aa2dQueuedSeries]),
+								},
+								{
+									label: 'Pending',
+									color: COLORS.blue,
+									data: combineSamples([pendingSeries, aa2dPendingSeries]),
 								},
 							]}
 							formatValue={(v) => `${Math.round(v).toLocaleString()} txs`}
-							xFormat="block"
+						/>
+					</section>
+
+					<section className="mb-10">
+						<SectionHeader
+							title="Skipped Transactions"
+							tooltip="Transactions skipped during block building due to nonce conflicts, validation failures, or sender mismatches. Shown as rate per second."
 						/>
 						<TimeSeriesChart
-							title="Gas Used per Block"
-							tooltip="Total gas consumed by all transactions in each block."
-							showMean
 							series={[
 								{
-									label: 'Gas Used',
-									color: COLORS.green,
-									data: blockRows.map((b) => ({
-										x: b.index,
-										y: b.gasUsed,
-									})),
+									label: 'Nonce Too Low',
+									color: COLORS.orange,
+									data: counterRate(skippedNonceSeries),
+								},
+								{
+									label: 'Invalid Tx',
+									color: COLORS.red,
+									data: counterRate(skippedInvalidSeries),
+								},
+								{
+									label: 'Sender Mismatch',
+									color: COLORS.purple,
+									data: counterRate(skippedSenderSeries),
 								},
 							]}
-							formatValue={(v) => formatGas(v, false)}
-							xFormat="block"
-							referenceBands={
-								refGasLimit > 0
-									? [
-											{
-												label: `General (${formatGas(generalGasLimit, false)})`,
-												from: 0,
-												to: generalGasLimit,
-												color: COLORS.blue,
-											},
-											{
-												label: `Payment (${formatGas(paymentGasLimit, false)})`,
-												from: generalGasLimit,
-												to: generalGasLimit + paymentGasLimit,
-												color: COLORS.orange,
-											},
-											{
-												label: `Shared (${formatGas(sharedGasLimit, false)})`,
-												from: generalGasLimit + paymentGasLimit,
-												to: refGasLimit,
-												color: COLORS.purple,
-											},
-										]
-									: undefined
-							}
+							formatValue={(v) => `${Math.round(v).toLocaleString()}/s`}
+						/>
+					</section>
+
+					<section className="mb-10">
+						<SectionHeader
+							title="Persistence (p50)"
+							tooltip="Time spent writing block state and trie updates to the database after each block is built."
 						/>
 						<TimeSeriesChart
-							title="Gas Fill %"
-							tooltip="Percentage of the block gas limit that was used."
-							showMean
 							series={[
 								{
-									label: 'Fill %',
+									label: 'Write State',
 									color: COLORS.blue,
-									data: blockRows
-										.filter((b) => b.gasLimit > 0)
-										.map((b) => ({
-											x: b.index,
-											y: (b.gasUsed / b.gasLimit) * 100,
-										})),
+									data: transformSamples(writeStateSeries, (v) => v * 1000),
+								},
+								{
+									label: 'Write Trie Updates',
+									color: COLORS.green,
+									data: transformSamples(writeTrieSeries, (v) => v * 1000),
+								},
+							]}
+							formatValue={(v) => `${v.toFixed(2)} ms`}
+						/>
+					</section>
+
+					<section className="mb-10">
+						<SectionHeader
+							title="Cache Hit Rates"
+							tooltip="Percentage of account and storage lookups served from the in-memory cache rather than disk."
+						/>
+						<TimeSeriesChart
+							series={[
+								{
+									label: 'Account Cache',
+									color: COLORS.blue,
+									data: cacheHitRate(accountHitsSeries, accountMissesSeries),
+								},
+								{
+									label: 'Storage Cache',
+									color: COLORS.green,
+									data: cacheHitRate(storageHitsSeries, storageMissesSeries),
 								},
 							]}
 							formatValue={(v) => `${v.toFixed(1)}%`}
 							yMax={100}
-							xFormat="block"
-							referenceBands={
-								refGasLimit > 0
-									? [
-											{
-												label: `General (${((generalGasLimit / refGasLimit) * 100).toFixed(0)}%)`,
-												from: 0,
-												to: (generalGasLimit / refGasLimit) * 100,
-												color: COLORS.blue,
-											},
-											{
-												label: `Payment (${((paymentGasLimit / refGasLimit) * 100).toFixed(0)}%)`,
-												from: (generalGasLimit / refGasLimit) * 100,
-												to:
-													((generalGasLimit + paymentGasLimit) / refGasLimit) *
-													100,
-												color: COLORS.orange,
-											},
-											{
-												label: `Shared (${((sharedGasLimit / refGasLimit) * 100).toFixed(0)}%)`,
-												from:
-													((generalGasLimit + paymentGasLimit) / refGasLimit) *
-													100,
-												to: 100,
-												color: COLORS.purple,
-											},
-										]
-									: undefined
-							}
+						/>
+					</section>
+
+					<section className="mb-14">
+						<SectionHeader
+							title="Memory"
+							tooltip="Process memory usage reported by jemalloc. Resident = physical RAM used; Allocated = bytes actively allocated by the application."
 						/>
 						<TimeSeriesChart
-							title="RLP Block Size"
-							tooltip="RLP-encoded size of each block in kilobytes."
-							showMean
 							series={[
 								{
-									label: 'Size',
-									color: COLORS.green,
-									data: transformSamples(rlpSizeSeries, (v) => v / 1024),
+									label: 'Resident',
+									color: COLORS.blue,
+									data: transformSamples(residentSeries),
 								},
-							]}
-							formatValue={(v) => `${v.toFixed(0)} KB`}
-							referenceBands={[
 								{
-									label: 'RLPx hard cap (16 MiB)',
-									from: 16 * 1024,
-									to: 16 * 1024 * 1.05,
-									color: COLORS.red,
+									label: 'Allocated',
+									color: COLORS.green,
+									data: transformSamples(allocatedSeries),
 								},
 							]}
+							formatValue={formatBytes}
 						/>
-					</div>
-				</section>
-			)}
-
-			{(hasEngineApiTimings || hasServerWaitTimings) && (
-				<section className="mb-10">
-					<SectionHeader
-						title="Engine API Timing"
-						tooltip="Per-block timings reported by txgen for Engine API calls and server-side waits."
-					/>
-					<div className="grid grid-cols-1 gap-3 md:grid-cols-2">
-						{hasEngineApiTimings && (
-							<TimeSeriesChart
-								title="Engine API Calls"
-								tooltip="Per-block Engine API client timings. Server latency is reported by the server and converted from microseconds to milliseconds."
-								showMean
-								series={[
-									{
-										label: 'New Payload',
-										color: COLORS.blue,
-										data: blockPoints(blockRows, (b) => b.newPayloadMs),
-									},
-									{
-										label: 'Forkchoice Updated',
-										color: COLORS.green,
-										data: blockPoints(blockRows, (b) => b.forkchoiceUpdatedMs),
-									},
-									{
-										label: 'Total Client Time',
-										color: COLORS.orange,
-										data: blockPoints(blockRows, (b) => {
-											if (
-												b.newPayloadMs == null ||
-												b.forkchoiceUpdatedMs == null
-											) {
-												return null
-											}
-											return b.newPayloadMs + b.forkchoiceUpdatedMs
-										}),
-									},
-									{
-										label: 'Server Latency',
-										color: COLORS.purple,
-										data: blockPoints(
-											blockRows,
-											(b) => b.newPayloadServerLatencyUs,
-											(us) => us / 1000,
-										),
-									},
-								]}
-								formatValue={(v) => `${v.toFixed(2)} ms`}
-								xFormat="block"
-							/>
-						)}
-						{hasServerWaitTimings && (
-							<TimeSeriesChart
-								title="Server Wait Timings"
-								tooltip="Server-side wait timings reported by the Engine API server, converted from microseconds to milliseconds."
-								showMean
-								series={[
-									{
-										label: 'Persistence Wait',
-										color: COLORS.blue,
-										data: blockPoints(
-											blockRows,
-											(b) => b.persistenceWaitUs,
-											(us) => us / 1000,
-										),
-									},
-									{
-										label: 'Execution Cache Wait',
-										color: COLORS.green,
-										data: blockPoints(
-											blockRows,
-											(b) => b.executionCacheWaitUs,
-											(us) => us / 1000,
-										),
-									},
-									{
-										label: 'Sparse Trie Wait',
-										color: COLORS.orange,
-										data: blockPoints(
-											blockRows,
-											(b) => b.sparseTrieWaitUs,
-											(us) => us / 1000,
-										),
-									},
-								]}
-								formatValue={(v) => `${v.toFixed(2)} ms`}
-								xFormat="block"
-							/>
-						)}
-					</div>
-				</section>
-			)}
-
-			<section className="mb-10">
-				<SectionHeader
-					title="Payload Build Duration"
-					tooltip="Total wall-clock time to build each block payload, from start to sealed block."
-				/>
-				<TimeSeriesChart
-					showMean
-					series={[
-						{
-							label: 'p50',
-							color: COLORS.blue,
-							data: transformSamples(buildDurP50, (v) => v * 1000),
-						},
-						{
-							label: 'p95',
-							color: COLORS.orange,
-							data: transformSamples(buildDurP95, (v) => v * 1000),
-						},
-					]}
-					formatValue={(v) => `${v.toFixed(1)} ms`}
-				/>
-			</section>
-
-			<section className="mb-10">
-				<SectionHeader
-					title="Build Phases (p50)"
-					tooltip="Top-level disjoint phases of block building. These sum to approximately the total payload build duration."
-				/>
-				<TimeSeriesChart
-					stacked
-					showMean
-					series={[
-						{
-							label: 'State Setup',
-							color: COLORS.purple,
-							data: transformSamples(stateSetupSeries, (v) => v * 1000),
-						},
-						{
-							label: 'System Tx Prep',
-							color: COLORS.red,
-							data: transformSamples(sysTxPrepSeries, (v) => v * 1000),
-						},
-						{
-							label: 'System Tx Exec',
-							color: COLORS.orange,
-							data: transformSamples(sysTxExecSeries, (v) => v * 1000),
-						},
-						{
-							label: 'Pool Fetch',
-							color: COLORS.green,
-							data: transformSamples(poolFetchSeries, (v) => v * 1000),
-						},
-						{
-							label: 'Tx Execution',
-							color: COLORS.blue,
-							data: transformSamples(txExecSeries, (v) => v * 1000),
-						},
-						{
-							label: 'Finalization',
-							color: COLORS.orange,
-							data: transformSamples(finalizationSeries, (v) => v * 1000),
-						},
-					]}
-					formatValue={(v) => `${v.toFixed(1)} ms`}
-				/>
-			</section>
-
-			<section className="mb-10">
-				<SectionHeader
-					title="Finalization Internals (p50)"
-					tooltip="Internal timings from block finalization. Hashed Post State converts raw state changes into a hashed representation. State Root (sync) computes the root synchronously and is near zero when the trie is precomputed in the background."
-				/>
-				<TimeSeriesChart
-					showMean
-					series={[
-						{
-							label: 'Finalization',
-							color: COLORS.orange,
-							data: transformSamples(finalizationSeries, (v) => v * 1000),
-						},
-						{
-							label: 'Hashed Post State',
-							color: COLORS.purple,
-							data: transformSamples(hashedPostStateSeries, (v) => v * 1000),
-						},
-						{
-							label: 'State Root (sync)',
-							color: COLORS.green,
-							data: transformSamples(stateRootSeries, (v) => v * 1000),
-						},
-					]}
-					formatValue={(v) => `${v.toFixed(1)} ms`}
-				/>
-			</section>
-
-			<section className="mb-10">
-				<SectionHeader
-					title="Throughput"
-					tooltip="Gas and transaction processing rates per block."
-				/>
-				<div className="grid grid-cols-1 gap-3 md:grid-cols-2">
-					<TimeSeriesChart
-						title="Gas Throughput"
-						tooltip="Gas processed per second for each block, based on gas usage and block time."
-						showMean
-						series={[
-							{
-								label: 'Gas/s',
-								color: COLORS.blue,
-								data: blockPoints(blockRows, (b) => {
-									if (b.blockTimeMs == null || b.blockTimeMs <= 0) return null
-									return (b.gasUsed * 1000) / b.blockTimeMs / 1e9
-								}),
-							},
-						]}
-						formatValue={(v) => `${v.toFixed(2)} Ggas/s`}
-						xFormat="block"
-					/>
-					<TimeSeriesChart
-						title="Txs per Block"
-						tooltip="Number of user transactions included in each block as reported by the builder."
-						showMean
-						series={[
-							{
-								label: 'Txs',
-								color: COLORS.green,
-								data: transformSamples(txsPerBlockSeries),
-							},
-						]}
-						formatValue={(v) => `${Math.round(v).toLocaleString()}`}
-					/>
+					</section>
 				</div>
-			</section>
-
-			<section className="mb-10">
-				<SectionHeader
-					title="Txgen"
-					tooltip="Transaction generator metrics — the load driver that submits transactions to the node."
-				/>
-				<div className="grid grid-cols-1 gap-3 md:grid-cols-2">
-					<TimeSeriesChart
-						title={
-							hasTxgenTransactionCounters
-								? 'Transaction Send Rate'
-								: 'Block Send/Success/Failure Rates'
-						}
-						tooltip={
-							hasTxgenTransactionCounters
-								? 'Rate of transactions sent, confirmed as successful, or failed per second.'
-								: 'Rate of blocks sent, confirmed as successful, or failed per second.'
-						}
-						showMean
-						series={[
-							{
-								label: 'Sent',
-								color: COLORS.blue,
-								data: counterRate(txgenCounterSeries.sent),
-							},
-							{
-								label: 'Success',
-								color: COLORS.green,
-								data: counterRate(txgenCounterSeries.success),
-							},
-							{
-								label: 'Failed',
-								color: COLORS.red,
-								data: counterRate(txgenCounterSeries.failed),
-							},
-						]}
-						formatValue={(v) => `${Math.round(v).toLocaleString()}/s`}
-					/>
-					<TimeSeriesChart
-						title="Inflight"
-						tooltip="Number of transactions submitted but not yet included in a block."
-						series={[
-							{
-								label: 'Inflight',
-								color: COLORS.purple,
-								data: transformSamples(txgenInflightSeries),
-							},
-						]}
-						formatValue={(v) => Math.round(v).toLocaleString()}
-					/>
-				</div>
-			</section>
-
-			<section className="mb-10">
-				<SectionHeader
-					title="Txpool"
-					tooltip="Transaction pool state: pending (ready to execute), queued (future nonce), and basefee (underpaying current base fee). Includes AA 2D pending/queued gauges when present."
-				/>
-				<TimeSeriesChart
-					stacked
-					showMean
-					series={[
-						{
-							label: 'Basefee',
-							color: COLORS.orange,
-							data: transformSamples(basefeeSeries),
-						},
-						{
-							label: 'Queued',
-							color: COLORS.purple,
-							data: combineSamples([queuedSeries, aa2dQueuedSeries]),
-						},
-						{
-							label: 'Pending',
-							color: COLORS.blue,
-							data: combineSamples([pendingSeries, aa2dPendingSeries]),
-						},
-					]}
-					formatValue={(v) => `${Math.round(v).toLocaleString()} txs`}
-				/>
-			</section>
-
-			<section className="mb-10">
-				<SectionHeader
-					title="Skipped Transactions"
-					tooltip="Transactions skipped during block building due to nonce conflicts, validation failures, or sender mismatches. Shown as rate per second."
-				/>
-				<TimeSeriesChart
-					series={[
-						{
-							label: 'Nonce Too Low',
-							color: COLORS.orange,
-							data: counterRate(skippedNonceSeries),
-						},
-						{
-							label: 'Invalid Tx',
-							color: COLORS.red,
-							data: counterRate(skippedInvalidSeries),
-						},
-						{
-							label: 'Sender Mismatch',
-							color: COLORS.purple,
-							data: counterRate(skippedSenderSeries),
-						},
-					]}
-					formatValue={(v) => `${Math.round(v).toLocaleString()}/s`}
-				/>
-			</section>
-
-			<section className="mb-10">
-				<SectionHeader
-					title="Persistence (p50)"
-					tooltip="Time spent writing block state and trie updates to the database after each block is built."
-				/>
-				<TimeSeriesChart
-					series={[
-						{
-							label: 'Write State',
-							color: COLORS.blue,
-							data: transformSamples(writeStateSeries, (v) => v * 1000),
-						},
-						{
-							label: 'Write Trie Updates',
-							color: COLORS.green,
-							data: transformSamples(writeTrieSeries, (v) => v * 1000),
-						},
-					]}
-					formatValue={(v) => `${v.toFixed(2)} ms`}
-				/>
-			</section>
-
-			<section className="mb-10">
-				<SectionHeader
-					title="Cache Hit Rates"
-					tooltip="Percentage of account and storage lookups served from the in-memory cache rather than disk."
-				/>
-				<TimeSeriesChart
-					series={[
-						{
-							label: 'Account Cache',
-							color: COLORS.blue,
-							data: cacheHitRate(accountHitsSeries, accountMissesSeries),
-						},
-						{
-							label: 'Storage Cache',
-							color: COLORS.green,
-							data: cacheHitRate(storageHitsSeries, storageMissesSeries),
-						},
-					]}
-					formatValue={(v) => `${v.toFixed(1)}%`}
-					yMax={100}
-				/>
-			</section>
-
-			<section className="mb-14">
-				<SectionHeader
-					title="Memory"
-					tooltip="Process memory usage reported by jemalloc. Resident = physical RAM used; Allocated = bytes actively allocated by the application."
-				/>
-				<TimeSeriesChart
-					series={[
-						{
-							label: 'Resident',
-							color: COLORS.blue,
-							data: transformSamples(residentSeries),
-						},
-						{
-							label: 'Allocated',
-							color: COLORS.green,
-							data: transformSamples(allocatedSeries),
-						},
-					]}
-					formatValue={formatBytes}
-				/>
-			</section>
+			</details>
 		</div>
 	)
 }
@@ -1155,6 +1170,28 @@ function blockPoints<T extends { index: number }>(
 			},
 		]
 	})
+}
+
+function settledTps(
+	blocks: Array<{ txCount: number; blockTimeMs: number | null }>,
+): Array<ChartPoint> {
+	let elapsedMs = 0
+	return blocks.flatMap((block) => {
+		if (block.blockTimeMs == null || block.blockTimeMs <= 0) return []
+		elapsedMs += block.blockTimeMs
+		return [
+			{
+				x: elapsedMs / 1000,
+				y: (block.txCount * 1000) / block.blockTimeMs,
+			},
+		]
+	})
+}
+
+function sharedYMax(series: Array<Array<ChartPoint>>): number | undefined {
+	const max = Math.max(...series.flat().map((point) => point.y))
+	if (!Number.isFinite(max) || max <= 0) return undefined
+	return max * 1.1
 }
 
 function formatBytes(bytes: number): string {
@@ -1234,7 +1271,6 @@ function MetricCard(props: {
 	value: string
 	accent?: boolean | undefined
 	tooltip?: string | undefined
-	delta?: React.ReactNode | undefined
 }): React.JSX.Element {
 	return (
 		<div className="card overflow-visible p-4">
@@ -1246,8 +1282,44 @@ function MetricCard(props: {
 				className={`mt-1 font-mono text-[18px] font-semibold ${props.accent ? 'text-accent' : 'text-primary'}`}
 			>
 				{props.value}
-				{props.delta}
 			</p>
+		</div>
+	)
+}
+
+function PerformanceSummary(props: { run: BenchRun }): React.JSX.Element {
+	return (
+		<div className="card overflow-visible p-5 sm:p-6">
+			<div>
+				<p className="text-[11px] font-normal uppercase tracking-wider text-tertiary">
+					Settled TPS
+					<InfoPill text="Average transactions per second that landed in blocks for this benchmark run." />
+				</p>
+				<div className="mt-2 flex flex-wrap items-end gap-x-3 gap-y-1">
+					<span className="font-mono text-[42px] leading-none font-semibold text-accent sm:text-[52px]">
+						{formatTps(props.run.avgTps)}
+					</span>
+					<span className="pb-1.5 text-[15px] font-medium text-secondary sm:text-[17px]">
+						TPS
+					</span>
+				</div>
+			</div>
+			<p className="mt-5 text-[13px] text-secondary">
+				Average settled throughput across{' '}
+				{props.run.blockCount.toLocaleString()} blocks over{' '}
+				{formatDuration(props.run.startedAt, props.run.finishedAt)}.
+			</p>
+		</div>
+	)
+}
+
+function ChartLoadingCard(props: { title: string }): React.JSX.Element {
+	return (
+		<div className="card flex h-52 flex-col p-5">
+			<p className="text-[12px] font-medium text-secondary">{props.title}</p>
+			<div className="flex flex-1 items-center justify-center text-[13px] text-tertiary">
+				Loading series...
+			</div>
 		</div>
 	)
 }

--- a/apps/perf/src/routes/benchmark.$id.tsx
+++ b/apps/perf/src/routes/benchmark.$id.tsx
@@ -164,11 +164,24 @@ function findSeries(
 
 function RunDetailPage(): React.JSX.Element {
 	const { id } = Route.useParams()
+	return <BenchmarkRunDetail id={id} showBackLink />
+}
+
+export declare namespace BenchmarkRunDetail {
+	type Props = {
+		id: string
+		showBackLink?: boolean | undefined
+	}
+}
+
+export function BenchmarkRunDetail(
+	props: BenchmarkRunDetail.Props,
+): React.JSX.Element {
 	const navigate = useNavigate()
 	const runSelectId = React.useId()
 	const { data: run } = useSuspenseQuery({
-		queryKey: ['run', id],
-		queryFn: () => fetchRun({ data: id }),
+		queryKey: ['run', props.id],
+		queryFn: () => fetchRun({ data: props.id }),
 	})
 
 	const runFeed = run && isTag(run.ref) ? 'release' : 'nightly'
@@ -182,14 +195,15 @@ function RunDetailPage(): React.JSX.Element {
 	})
 
 	const { data: metrics } = useQuery({
-		queryKey: ['metrics', id],
-		queryFn: () => fetchMetrics({ data: { runId: id, metrics: METRIC_NAMES } }),
+		queryKey: ['metrics', props.id],
+		queryFn: () =>
+			fetchMetrics({ data: { runId: props.id, metrics: METRIC_NAMES } }),
 		enabled: !!run,
 	})
 
 	const { data: blocks } = useQuery({
-		queryKey: ['blocks', id],
-		queryFn: () => fetchBlocks({ data: id }),
+		queryKey: ['blocks', props.id],
+		queryFn: () => fetchBlocks({ data: props.id }),
 		enabled: !!run,
 	})
 
@@ -394,14 +408,16 @@ function RunDetailPage(): React.JSX.Element {
 
 	return (
 		<div>
-			<div className="mb-4">
-				<Link
-					to="/"
-					className="text-[13px] text-tertiary transition-colors hover:text-primary"
-				>
-					← Dashboard
-				</Link>
-			</div>
+			{props.showBackLink && (
+				<div className="mb-4">
+					<Link
+						to="/"
+						className="text-[13px] text-tertiary transition-colors hover:text-primary"
+					>
+						← Dashboard
+					</Link>
+				</div>
+			)}
 
 			<section className="mb-8">
 				<div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">

--- a/apps/perf/src/routes/index.tsx
+++ b/apps/perf/src/routes/index.tsx
@@ -1,17 +1,45 @@
+import { useSuspenseQuery } from '@tanstack/react-query'
 import { createFileRoute } from '@tanstack/react-router'
-import { BenchmarkDashboard } from '#comps/BenchmarkDashboard'
-import { fetchAllLatestRuns } from '#lib/server/bench'
+import { fetchLatestRun, fetchRunsForScenario } from '#lib/server/bench'
+import { BenchmarkRunDetail } from '#routes/benchmark.$id'
 
 export const Route = createFileRoute('/')({
 	component: DashboardPage,
-	loader: ({ context }) => {
-		context.queryClient.ensureQueryData({
-			queryKey: ['latestRuns', 'release'],
-			queryFn: () => fetchAllLatestRuns({ data: 'release' }),
+	loader: async ({ context }) => {
+		const latestRun = await context.queryClient.ensureQueryData({
+			queryKey: ['latestRun', 'release'],
+			queryFn: () => fetchLatestRun({ data: 'release' }),
 		})
+
+		if (!latestRun) return
+
+		context.queryClient.setQueryData(['run', latestRun.id], latestRun)
+
+		if (latestRun.scenarioId) {
+			await context.queryClient.ensureQueryData({
+				queryKey: ['scenarioRuns', latestRun.scenarioId, 'release'],
+				queryFn: () =>
+					fetchRunsForScenario({
+						data: { scenarioId: latestRun.scenarioId, feed: 'release' },
+					}),
+			})
+		}
 	},
 })
 
 function DashboardPage(): React.JSX.Element {
-	return <BenchmarkDashboard feed="release" />
+	const { data: latestRun } = useSuspenseQuery({
+		queryKey: ['latestRun', 'release'],
+		queryFn: () => fetchLatestRun({ data: 'release' }),
+	})
+
+	if (!latestRun) {
+		return (
+			<div className="py-20 text-center text-secondary">
+				No release benchmarks found.
+			</div>
+		)
+	}
+
+	return <BenchmarkRunDetail id={latestRun.id} />
 }

--- a/apps/perf/src/routes/index.tsx
+++ b/apps/perf/src/routes/index.tsx
@@ -1,26 +1,45 @@
 import { useSuspenseQuery } from '@tanstack/react-query'
-import { createFileRoute } from '@tanstack/react-router'
-import { fetchLatestRun, fetchRunsForScenario } from '#lib/server/bench'
+import { createFileRoute, useNavigate } from '@tanstack/react-router'
+import * as React from 'react'
+import {
+	fetchReleaseRuns,
+	fetchRunsForScenario,
+	getScenarios,
+	type BenchRun,
+	type Scenario,
+} from '#lib/server/bench'
 import { BenchmarkRunDetail } from '#routes/benchmark.$id'
+
+type DashboardSearch = {
+	release?: string | undefined
+	scenario?: string | undefined
+}
 
 export const Route = createFileRoute('/')({
 	component: DashboardPage,
-	loader: async ({ context }) => {
-		const latestRun = await context.queryClient.ensureQueryData({
-			queryKey: ['latestRun', 'release'],
-			queryFn: () => fetchLatestRun({ data: 'release' }),
+	validateSearch: (search: Record<string, unknown>): DashboardSearch => ({
+		release: optionalSearchString(search.release),
+		scenario: optionalSearchString(search.scenario),
+	}),
+	loaderDeps: ({ search }) => search,
+	loader: async ({ context, deps }) => {
+		const releaseRuns = await context.queryClient.ensureQueryData({
+			queryKey: ['releaseRuns'],
+			queryFn: () => fetchReleaseRuns(),
 		})
 
-		if (!latestRun) return
+		const selected = selectBenchmarkRun(releaseRuns, deps)
+		const selectedRun = selected.run
+		if (!selectedRun) return
 
-		context.queryClient.setQueryData(['run', latestRun.id], latestRun)
+		context.queryClient.setQueryData(['run', selectedRun.id], selectedRun)
 
-		if (latestRun.scenarioId) {
+		if (selectedRun.scenarioId) {
 			await context.queryClient.ensureQueryData({
-				queryKey: ['scenarioRuns', latestRun.scenarioId, 'release'],
+				queryKey: ['scenarioRuns', selectedRun.scenarioId, 'release'],
 				queryFn: () =>
 					fetchRunsForScenario({
-						data: { scenarioId: latestRun.scenarioId, feed: 'release' },
+						data: { scenarioId: selectedRun.scenarioId, feed: 'release' },
 					}),
 			})
 		}
@@ -28,12 +47,21 @@ export const Route = createFileRoute('/')({
 })
 
 function DashboardPage(): React.JSX.Element {
-	const { data: latestRun } = useSuspenseQuery({
-		queryKey: ['latestRun', 'release'],
-		queryFn: () => fetchLatestRun({ data: 'release' }),
+	const navigate = useNavigate()
+	const search = Route.useSearch()
+	const scenarios = getScenarios()
+	const { data: releaseRuns } = useSuspenseQuery({
+		queryKey: ['releaseRuns'],
+		queryFn: () => fetchReleaseRuns(),
 	})
 
-	if (!latestRun) {
+	const releaseOptions = React.useMemo(
+		() => getReleaseOptions(releaseRuns),
+		[releaseRuns],
+	)
+	const selected = selectBenchmarkRun(releaseRuns, search)
+
+	if (!selected.run || !selected.release) {
 		return (
 			<div className="py-20 text-center text-secondary">
 				No release benchmarks found.
@@ -41,5 +69,233 @@ function DashboardPage(): React.JSX.Element {
 		)
 	}
 
-	return <BenchmarkRunDetail id={latestRun.id} />
+	const scenarioOptions = getScenarioOptions(selected.runsForRelease, scenarios)
+
+	function setRelease(release: string) {
+		const nextRuns = getRunsForRelease(releaseRuns, release)
+		const nextScenario = nextRuns.some(
+			(run) => run.scenarioId === selected.scenario,
+		)
+			? selected.scenario
+			: nextRuns[0]?.scenarioId
+
+		navigate({
+			to: '/',
+			search: { release, scenario: nextScenario },
+			resetScroll: false,
+		})
+	}
+
+	function setScenario(scenario: string) {
+		navigate({
+			to: '/',
+			search: { release: selected.release, scenario },
+			resetScroll: false,
+		})
+	}
+
+	return (
+		<BenchmarkRunDetail
+			id={selected.run.id}
+			headerControls={
+				<BenchmarkSelectors
+					releases={releaseOptions}
+					scenarios={scenarioOptions}
+					selectedRelease={selected.release}
+					selectedScenario={selected.scenario}
+					onReleaseChange={setRelease}
+					onScenarioChange={setScenario}
+				/>
+			}
+		/>
+	)
+}
+
+function optionalSearchString(value: unknown): string | undefined {
+	return typeof value === 'string' && value.length > 0 ? value : undefined
+}
+
+function isTagRef(ref: string): boolean {
+	return ref.startsWith('v')
+}
+
+function isCommitRef(ref: string): boolean {
+	return /^[0-9a-f]{7,40}$/i.test(ref)
+}
+
+function getReleaseKey(run: BenchRun): string {
+	if (run.commit) return run.commit
+	if (run.ref && isCommitRef(run.ref)) return run.ref.slice(0, 7)
+	return run.ref || run.id
+}
+
+function getReleaseLabel(run: BenchRun): string {
+	if (run.ref && isTagRef(run.ref)) return run.ref
+	if (run.ref && !isCommitRef(run.ref)) return run.ref
+	return run.commit || run.ref || run.id
+}
+
+function shouldReplaceReleaseLabel(current: string, next: string): boolean {
+	if (isTagRef(current)) return false
+	if (isTagRef(next)) return true
+	return isCommitRef(current) && !isCommitRef(next)
+}
+
+type ReleaseOption = {
+	value: string
+	label: string
+	startedAt: string
+}
+
+function getReleaseOptions(runs: Array<BenchRun>): Array<ReleaseOption> {
+	const releases = new Map<string, ReleaseOption>()
+
+	for (const run of runs) {
+		const value = getReleaseKey(run)
+		const label = getReleaseLabel(run)
+		const current = releases.get(value)
+
+		if (!current) {
+			releases.set(value, { value, label, startedAt: run.startedAt })
+			continue
+		}
+
+		releases.set(value, {
+			value,
+			label: shouldReplaceReleaseLabel(current.label, label)
+				? label
+				: current.label,
+			startedAt:
+				new Date(run.startedAt) > new Date(current.startedAt)
+					? run.startedAt
+					: current.startedAt,
+		})
+	}
+
+	return Array.from(releases.values()).sort(
+		(a, b) => new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime(),
+	)
+}
+
+function getRunsForRelease(
+	runs: Array<BenchRun>,
+	release: string,
+): Array<BenchRun> {
+	return runs
+		.filter((run) => getReleaseKey(run) === release)
+		.sort(
+			(a, b) =>
+				new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime(),
+		)
+}
+
+function selectBenchmarkRun(
+	runs: Array<BenchRun>,
+	search: DashboardSearch,
+): {
+	release: string | undefined
+	scenario: string | undefined
+	run: BenchRun | undefined
+	runsForRelease: Array<BenchRun>
+} {
+	const releaseOptions = getReleaseOptions(runs)
+	const selectedRelease = releaseOptions.find(
+		(option) =>
+			option.value === search.release || option.label === search.release,
+	)
+	const release = selectedRelease?.value ?? releaseOptions[0]?.value
+	if (!release) {
+		return {
+			release: undefined,
+			scenario: undefined,
+			run: undefined,
+			runsForRelease: [],
+		}
+	}
+
+	const runsForRelease = getRunsForRelease(runs, release)
+	const scenario = runsForRelease.some(
+		(run) => run.scenarioId === search.scenario,
+	)
+		? search.scenario
+		: runsForRelease[0]?.scenarioId
+
+	return {
+		release,
+		scenario,
+		run: runsForRelease.find((run) => run.scenarioId === scenario),
+		runsForRelease,
+	}
+}
+
+function getScenarioOptions(
+	runsForRelease: Array<BenchRun>,
+	scenarios: Array<Scenario>,
+): Array<Scenario> {
+	const availableScenarioIds = new Set(
+		runsForRelease.map((run) => run.scenarioId),
+	)
+	const knownScenarios = scenarios.filter((scenario) =>
+		availableScenarioIds.has(scenario.id),
+	)
+	const knownScenarioIds = new Set(
+		knownScenarios.map((scenario) => scenario.id),
+	)
+	const unknownScenarios = runsForRelease
+		.filter((run) => !knownScenarioIds.has(run.scenarioId))
+		.map((run) => ({
+			id: run.scenarioId,
+			label: run.scenarioId,
+			workload: run.scenarioId,
+		}))
+
+	return [...knownScenarios, ...unknownScenarios]
+}
+
+function BenchmarkSelectors(props: {
+	releases: Array<ReleaseOption>
+	scenarios: Array<Scenario>
+	selectedRelease: string
+	selectedScenario: string | undefined
+	onReleaseChange: (release: string) => void
+	onScenarioChange: (scenario: string) => void
+}): React.JSX.Element {
+	return (
+		<div className="grid w-full gap-2 sm:w-auto sm:grid-cols-2">
+			<label className="flex flex-col gap-1">
+				<span className="text-[11px] font-normal uppercase tracking-wider text-tertiary">
+					Release
+				</span>
+				<select
+					value={props.selectedRelease}
+					onChange={(event) => props.onReleaseChange(event.currentTarget.value)}
+					className="w-full rounded-md border border-border bg-surface px-3 py-2 font-mono text-[13px] text-primary outline-none transition-colors hover:border-accent/50 focus:border-accent sm:w-40"
+				>
+					{props.releases.map((release) => (
+						<option key={release.value} value={release.value}>
+							{release.label}
+						</option>
+					))}
+				</select>
+			</label>
+			<label className="flex flex-col gap-1">
+				<span className="text-[11px] font-normal uppercase tracking-wider text-tertiary">
+					Scenario
+				</span>
+				<select
+					value={props.selectedScenario ?? ''}
+					onChange={(event) =>
+						props.onScenarioChange(event.currentTarget.value)
+					}
+					className="w-full rounded-md border border-border bg-surface px-3 py-2 text-[13px] text-primary outline-none transition-colors hover:border-accent/50 focus:border-accent sm:w-48"
+				>
+					{props.scenarios.map((scenario) => (
+						<option key={scenario.id} value={scenario.id}>
+							{scenario.label}
+						</option>
+					))}
+				</select>
+			</label>
+		</div>
+	)
 }

--- a/apps/perf/src/routes/methodology.tsx
+++ b/apps/perf/src/routes/methodology.tsx
@@ -14,8 +14,8 @@ function MethodologyPage(): React.JSX.Element {
 			<div className="space-y-8 text-[14px] leading-relaxed text-secondary">
 				<Section title="Workload Composition">
 					<p>
-						Benchmarks run two workload types at varying target TPS levels
-						(10K, 20K, 40K):
+						Benchmarks run two workload types at varying target TPS levels (10K,
+						20K, 40K):
 					</p>
 					<div className="mt-3 card">
 						<div className="divide-y divide-dashed divide-border">

--- a/apps/perf/src/routes/methodology.tsx
+++ b/apps/perf/src/routes/methodology.tsx
@@ -14,8 +14,8 @@ function MethodologyPage(): React.JSX.Element {
 			<div className="space-y-8 text-[14px] leading-relaxed text-secondary">
 				<Section title="Workload Composition">
 					<p>
-						Benchmarks run two workload types at varying target TPS levels (10K,
-						20K, 40K):
+						Benchmarks run a TIP-20 transfer workload at varying target TPS
+						levels.
 					</p>
 					<div className="mt-3 card">
 						<div className="divide-y divide-dashed divide-border">
@@ -25,15 +25,6 @@ function MethodologyPage(): React.JSX.Element {
 								</span>
 								<span className="text-[13px] text-secondary">
 									100% TIP-20 token transfers (ERC-20 equivalent).
-								</span>
-							</div>
-							<div className="flex items-center gap-4 px-4.5 py-3">
-								<span className="shrink-0 text-[13px] font-medium text-primary w-28">
-									Mixed
-								</span>
-								<span className="text-[13px] text-secondary">
-									80% TIP-20 transfers, 20% MPP (multi-party payment) channel
-									operations (approve → open → close).
 								</span>
 							</div>
 						</div>


### PR DESCRIPTION
## Summary

- Rework the perf homepage into a single release/scenario dashboard.
- Show the latest release benchmark by default with release and scenario dropdowns.
- Keep Nightly unlinked while preserving the hidden nightly route.
- Replace the old peak/delta-heavy KPI row with a public-facing settled TPS summary and supporting tiles for blocks, block time, average gas, and peak gas.
- Add Submitted TPS and Settled TPS charts with loading states so ingress/egress behavior is visible without a temporary `No data` flash.
- Collapse lower diagnostic charts behind `Detailed charts` to reduce default page noise.
- Keep Dashboard selected for every non-methodology page.
- Remove the Mixed workload from the Methodology page.
- Preserve latest main's EIP-7934 block-size reference bands in the detailed RLP block-size chart.
- Accept `CLICKHOUSE_HOST` with or without an `https://` scheme so local preview does not build a malformed request path.

## Screenshots

| Before | After |
|--------|-------|
| Homepage showed a scenario comparison dashboard with a Peak TPS headline and all diagnostic charts visible by default. | Homepage shows a selected release/scenario benchmark, headline settled TPS, Submitted/Settled TPS charts, and collapsed detailed diagnostics. |

## Validation

- `pnpm --filter perf check` passed
- `pnpm --filter perf build` passed; Wrangler emitted a sandbox log-file permission warning while still exiting successfully
- `pnpm precommit` passed
- Browser verified the release/scenario dropdown flow locally
- Browser verified Submitted/Settled charts render after load on desktop/mobile
- Browser verified expanded `Detailed charts` no longer opens all tooltip popups on hover
- Browser verified the local ClickHouse path error no longer appears when `CLICKHOUSE_HOST` includes `https://`
- `pnpm check:types` fails in existing `apps/key-manager` type errors unrelated to this change: missing `accounts/server`, missing `Env.ALLOWED_ORIGINS`, implicit `origin` any, missing `Env.RP_ID`