### PR TITLE
feat(fee-payer): tighten mainnet rate limits with separate keyed bucket

### DIFF
--- a/apps/fee-payer/src/index.ts
+++ b/apps/fee-payer/src/index.ts
@@ -136,9 +136,14 @@ async function feePayerHandler(c: Context) {
 }
 
 // Keyed path: https://sponsor.tempo.xyz/tp_abc123
-app.all('/:key{tp_.+}', apiKeyMiddleware, rateLimitMiddleware, feePayerHandler)
+app.all(
+	'/:key{tp_.+}',
+	apiKeyMiddleware,
+	rateLimitMiddleware({ keyed: true }),
+	feePayerHandler,
+)
 
 // Open path: https://sponsor.tempo.xyz/
-app.all('/', rateLimitMiddleware, feePayerHandler)
+app.all('/', rateLimitMiddleware({ keyed: false }), feePayerHandler)
 
 export default app

--- a/apps/fee-payer/src/lib/rate-limit.ts
+++ b/apps/fee-payer/src/lib/rate-limit.ts
@@ -13,6 +13,11 @@ import { checkBudget, recordSpend } from './api-key-budget.js'
  * Fails closed: rejects requests when the binding is missing, the sender cannot
  * be identified, or the request body is malformed.
  *
+ * When `opts.keyed` is true, uses the `KeyedAddressRateLimiter` binding (looser
+ * limits, since per-key $ budget is the real ceiling). Otherwise uses the open
+ * `AddressRateLimiter` binding. Falls back to the open limiter when the keyed
+ * binding is not configured (non-mainnet envs).
+ *
  * When an API key is present (set by apiKeyMiddleware), also enforces:
  *  - Per-key daily spend budget
  *  - Allowed destination addresses
@@ -20,96 +25,103 @@ import { checkBudget, recordSpend } from './api-key-budget.js'
  * Only applies to requests carrying a serialized 0x76 Tempo transaction.
  * Non-transaction RPC calls (e.g. eth_chainId) pass through to the handler.
  */
-export async function rateLimitMiddleware(c: Context, next: Next) {
-	if (!env.AddressRateLimiter) {
-		console.error('AddressRateLimiter binding is not configured')
-		return c.json({ error: 'Service misconfigured' }, 503)
-	}
+export function rateLimitMiddleware(opts: { keyed: boolean }) {
+	return async (c: Context, next: Next) => {
+		const limiter = opts.keyed
+			? (env.KeyedAddressRateLimiter ?? env.AddressRateLimiter)
+			: env.AddressRateLimiter
+		if (!limiter) {
+			console.error(
+				`${opts.keyed ? 'KeyedAddressRateLimiter' : 'AddressRateLimiter'} binding is not configured`,
+			)
+			return c.json({ error: 'Service misconfigured' }, 503)
+		}
 
-	try {
-		const clonedRequest = await cloneRawRequest(c.req)
-		const rawBody = z.safeParse(
-			z.object({
-				jsonrpc: z.string(),
-				id: z.number(),
-				method: z.string(),
-				params: z.optional(z.array(z.unknown())),
-			}),
-			await clonedRequest.json(),
-		)
-		if (!rawBody.success) return c.json({ error: 'Bad request' }, 400)
+		try {
+			const clonedRequest = await cloneRawRequest(c.req)
+			const rawBody = z.safeParse(
+				z.object({
+					jsonrpc: z.string(),
+					id: z.number(),
+					method: z.string(),
+					params: z.optional(z.array(z.unknown())),
+				}),
+				await clonedRequest.json(),
+			)
+			if (!rawBody.success) return c.json({ error: 'Bad request' }, 400)
 
-		const request = RpcRequest.from(rawBody.data)
-		c.set('rpcMethod', request.method)
-		const serialized = request.params?.[0]
+			const request = RpcRequest.from(rawBody.data)
+			c.set('rpcMethod', request.method)
+			const serialized = request.params?.[0]
 
-		if (
-			typeof serialized === 'string' &&
-			(serialized.startsWith('0x76') || serialized.startsWith('0x78'))
-		) {
-			if (!Hex.validate(serialized) || serialized.length < 100)
-				return c.json({ error: 'Bad request' }, 400)
-			const transaction = Transaction.deserialize(serialized) as {
-				from?: string
-				to?: string
-				calls?: Array<{ to?: string }>
-				gas?: bigint
-				maxFeePerGas?: bigint
-			}
-			const from = transaction.from
-			// Tempo envelopes nest the destination under `calls[0].to`; legacy
-			// envelopes use top-level `to`.
-			const to = transaction.calls?.[0]?.to ?? transaction.to
+			if (
+				typeof serialized === 'string' &&
+				(serialized.startsWith('0x76') || serialized.startsWith('0x78'))
+			) {
+				if (!Hex.validate(serialized) || serialized.length < 100)
+					return c.json({ error: 'Bad request' }, 400)
+				const transaction = Transaction.deserialize(serialized) as {
+					from?: string
+					to?: string
+					calls?: Array<{ to?: string }>
+					gas?: bigint
+					maxFeePerGas?: bigint
+				}
+				const from = transaction.from
+				// Tempo envelopes nest the destination under `calls[0].to`; legacy
+				// envelopes use top-level `to`.
+				const to = transaction.calls?.[0]?.to ?? transaction.to
 
-			if (!from) {
-				return c.json(
-					{ error: 'Unable to determine sender for rate limiting' },
-					400,
-				)
-			}
-
-			const { success } = await env.AddressRateLimiter.limit({ key: from })
-			if (!success) return c.json({ error: 'Rate limit exceeded' }, 429)
-
-			// API-key-scoped checks: destination allowlist + daily budget.
-			const apiKey = c.get('apiKey') as string | undefined
-			const apiKeyRecord = c.get('apiKeyRecord') as ApiKeyRecord | undefined
-			if (apiKey && apiKeyRecord) {
-				if (apiKeyRecord.allowedDestinations.length > 0 && to) {
-					const dest = to.toLowerCase()
-					const allowed = apiKeyRecord.allowedDestinations.some(
-						(a) => a.toLowerCase() === dest,
+				if (!from) {
+					return c.json(
+						{ error: 'Unable to determine sender for rate limiting' },
+						400,
 					)
-					if (!allowed) {
-						return c.json(
-							{ error: 'Destination address not allowed for this API key' },
-							403,
+				}
+
+				const { success } = await limiter.limit({ key: from })
+				if (!success) return c.json({ error: 'Rate limit exceeded' }, 429)
+
+				// API-key-scoped checks: [REDACTED:api-key] allowlist + daily budget.
+				const apiKey = c.get('apiKey') as string | undefined
+				const apiKeyRecord = c.get('apiKeyRecord') as ApiKeyRecord | undefined
+				if (apiKey && apiKeyRecord) {
+					if (apiKeyRecord.allowedDestinations.length > 0 && to) {
+						const dest = to.toLowerCase()
+						const allowed = apiKeyRecord.allowedDestinations.some(
+							(a) => a.toLowerCase() === dest,
+						)
+						if (!allowed) {
+							return c.json(
+								{ error: 'Destination address not allowed for this API key' },
+								403,
+							)
+						}
+					}
+
+					if (transaction.gas && transaction.maxFeePerGas) {
+						const budget = await checkBudget(
+							apiKey,
+							apiKeyRecord,
+							transaction.gas,
+							transaction.maxFeePerGas,
+						)
+						if (!budget.allowed) {
+							return c.json({ error: budget.reason }, 429)
+						}
+
+						// Record spend after request completes successfully.
+						c.executionCtx.waitUntil(
+							recordSpend(apiKey, transaction.gas, transaction.maxFeePerGas),
 						)
 					}
 				}
-
-				if (transaction.gas && transaction.maxFeePerGas) {
-					const budget = await checkBudget(
-						apiKey,
-						apiKeyRecord,
-						transaction.gas,
-						transaction.maxFeePerGas,
-					)
-					if (!budget.allowed) {
-						return c.json({ error: budget.reason }, 429)
-					}
-
-					// Record spend after request completes successfully.
-					c.executionCtx.waitUntil(
-						recordSpend(apiKey, transaction.gas, transaction.maxFeePerGas),
-					)
-				}
 			}
+		} catch (error) {
+			console.error('Rate limit middleware error:', error)
+			return c.json({ error: 'Bad request' }, 400)
 		}
-	} catch (error) {
-		console.error('Rate limit middleware error:', error)
-		return c.json({ error: 'Bad request' }, 400)
-	}
 
-	await next()
+		await next()
+	}
 }

--- a/apps/fee-payer/wrangler.json
+++ b/apps/fee-payer/wrangler.json
@@ -142,6 +142,14 @@
 					"name": "AddressRateLimiter",
 					"namespace_id": "888",
 					"simple": {
+						"limit": 30,
+						"period": 60
+					}
+				},
+				{
+					"name": "KeyedAddressRateLimiter",
+					"namespace_id": "889",
+					"simple": {
 						"limit": 1000,
 						"period": 60
 					}


### PR DESCRIPTION
## Summary

Split the mainnet rate-limit binding into two: strict open bucket (`/`) and looser keyed bucket (`/tp_…`) where the per-key daily $ budget is the real ceiling.

## Changes

- `wrangler.json` (mainnet only): `AddressRateLimiter` → **30 / 60s**, add `KeyedAddressRateLimiter` at **1000 / 60s**.
- `src/lib/rate-limit.ts`: convert middleware to factory `rateLimitMiddleware({ keyed })`; falls back to open limiter when keyed binding is absent.
- `src/index.ts`: pass `{ keyed: true }` / `{ keyed: false }` to the two routes.

## Testing

`pnpm check:types`, `pnpm check`, `pnpm test` (29/29) — all pass in `apps/fee-payer`.
