### PR TITLE
feat(fee-payer): track lifetime spend per API key

### DIFF
--- a/apps/fee-payer/src/lib/admin.ts
+++ b/apps/fee-payer/src/lib/admin.ts
@@ -3,6 +3,11 @@ import { zValidator } from '@hono/zod-validator'
 import { Hono } from 'hono'
 import * as z from 'zod'
 import {
+	formatMicrodollarUsd,
+	getDailySpend,
+	getLifetimeSpend,
+} from './api-key-budget.js'
+import {
 	createApiKey,
 	listApiKeys,
 	revokeApiKey,
@@ -48,11 +53,19 @@ admin.post(
 	},
 )
 
-/** GET /admin/keys — list all API keys. */
+/** GET /admin/keys — list all API keys with daily + lifetime spend in USD. */
 admin.get('/keys', async (c) => {
 	const cursor = c.req.query('cursor') ?? undefined
 	const result = await listApiKeys(cursor)
-	return c.json(result)
+	const keys = await Promise.all(
+		result.keys.map(async ({ key, record }) => ({
+			key,
+			record,
+			dailySpentUsd: formatMicrodollarUsd(await getDailySpend(key)),
+			lifetimeSpentUsd: formatMicrodollarUsd(await getLifetimeSpend(key)),
+		})),
+	)
+	return c.json({ keys, cursor: result.cursor })
 })
 
 /** PATCH /admin/keys/:key — update an API key. */

--- a/apps/fee-payer/src/lib/api-key-budget.ts
+++ b/apps/fee-payer/src/lib/api-key-budget.ts
@@ -44,9 +44,13 @@ export function formatMicrodollarUsd(microdollars: bigint): string {
  * Increment the daily and lifetime spend counters for an API key.
  *
  * The daily key has a 24h TTL so it rolls over automatically; the lifetime key
- * has no TTL. The read-modify-write is not atomic — two concurrent
- * sponsorships for the same key can drop one increment. PostHog
- * `SPONSORSHIP_REQUEST` events remain the source of truth for audit.
+ * has no TTL. Reads and writes are parallelized — invoked from
+ * `ctx.waitUntil` so it does not block the response, but parallelism keeps the
+ * background work cheap.
+ *
+ * The read-modify-write is not atomic — two concurrent sponsorships for the
+ * same key can drop one increment. PostHog `SPONSORSHIP_REQUEST` events
+ * remain the source of truth for audit.
  */
 export async function recordSpend(
 	apiKey: string,
@@ -55,18 +59,22 @@ export async function recordSpend(
 ): Promise<void> {
 	const fee = attodollarToMicrodollar(gasUsed * effectiveGasPrice)
 
-	const dailyKey = dailySpendKvKey(apiKey)
-	const currentDaily = await getDailySpend(apiKey)
-	await env.SponsorApiKeyStore!.put(dailyKey, (currentDaily + fee).toString(), {
-		expirationTtl: 86_400,
-	})
+	const [currentDaily, currentLifetime] = await Promise.all([
+		getDailySpend(apiKey),
+		getLifetimeSpend(apiKey),
+	])
 
-	const lifetimeKey = lifetimeSpendKvKey(apiKey)
-	const currentLifetime = await getLifetimeSpend(apiKey)
-	await env.SponsorApiKeyStore!.put(
-		lifetimeKey,
-		(currentLifetime + fee).toString(),
-	)
+	await Promise.all([
+		env.SponsorApiKeyStore!.put(
+			dailySpendKvKey(apiKey),
+			(currentDaily + fee).toString(),
+			{ expirationTtl: 86_400 },
+		),
+		env.SponsorApiKeyStore!.put(
+			lifetimeSpendKvKey(apiKey),
+			(currentLifetime + fee).toString(),
+		),
+	])
 }
 
 /**

--- a/apps/fee-payer/src/lib/api-key-budget.ts
+++ b/apps/fee-payer/src/lib/api-key-budget.ts
@@ -1,5 +1,5 @@
 import { env } from 'cloudflare:workers'
-import { parseUnits, formatUnits } from 'viem'
+import { formatUnits, parseUnits } from 'viem'
 import type { ApiKeyRecord } from './api-keys.js'
 
 const MICRODOLLAR_DECIMALS = 6
@@ -12,30 +12,61 @@ function attodollarToMicrodollar(attodollars: bigint) {
 	)
 }
 
-function spendKvKey(apiKey: string) {
+function dailySpendKvKey(apiKey: string) {
 	const today = new Date().toISOString().slice(0, 10) // YYYY-MM-DD
 	return `spend:${apiKey}:${today}`
 }
 
-/** Read the current daily spend for an API key from KV. */
-async function getDailySpend(apiKey: string): Promise<bigint> {
-	const raw = await env.SponsorApiKeyStore!.get(spendKvKey(apiKey))
+function lifetimeSpendKvKey(apiKey: string) {
+	return `spend:${apiKey}:lifetime`
+}
+
+/** Read the current daily spend (microdollars) for an API key from KV. */
+export async function getDailySpend(apiKey: string): Promise<bigint> {
+	const raw = await env.SponsorApiKeyStore!.get(dailySpendKvKey(apiKey))
 	if (!raw) return 0n
 	return BigInt(raw)
 }
 
-/** Increment the daily spend for an API key. */
+/** Read the cumulative lifetime spend (microdollars) for an API key from KV. */
+export async function getLifetimeSpend(apiKey: string): Promise<bigint> {
+	const raw = await env.SponsorApiKeyStore!.get(lifetimeSpendKvKey(apiKey))
+	if (!raw) return 0n
+	return BigInt(raw)
+}
+
+/** Format a microdollar amount as a USD string (e.g. "1.234567"). */
+export function formatMicrodollarUsd(microdollars: bigint): string {
+	return formatUnits(microdollars, MICRODOLLAR_DECIMALS)
+}
+
+/**
+ * Increment the daily and lifetime spend counters for an API key.
+ *
+ * The daily key has a 24h TTL so it rolls over automatically; the lifetime key
+ * has no TTL. The read-modify-write is not atomic — two concurrent
+ * sponsorships for the same key can drop one increment. PostHog
+ * `SPONSORSHIP_REQUEST` events remain the source of truth for audit.
+ */
 export async function recordSpend(
 	apiKey: string,
 	gasUsed: bigint,
 	effectiveGasPrice: bigint,
 ): Promise<void> {
 	const fee = attodollarToMicrodollar(gasUsed * effectiveGasPrice)
-	const key = spendKvKey(apiKey)
-	const current = await getDailySpend(apiKey)
-	await env.SponsorApiKeyStore!.put(key, (current + fee).toString(), {
+
+	const dailyKey = dailySpendKvKey(apiKey)
+	const currentDaily = await getDailySpend(apiKey)
+	await env.SponsorApiKeyStore!.put(dailyKey, (currentDaily + fee).toString(), {
 		expirationTtl: 86_400,
 	})
+
+	const lifetimeKey = lifetimeSpendKvKey(apiKey)
+	const currentLifetime = await getLifetimeSpend(apiKey)
+	await env.SponsorApiKeyStore!.put(
+		lifetimeKey,
+		(currentLifetime + fee).toString(),
+	)
 }
 
 /**
@@ -59,7 +90,7 @@ export async function checkBudget(
 	if (currentSpend + txFee > limitMicroUsd) {
 		return {
 			allowed: false,
-			reason: `Daily spend limit exceeded (spent: $${formatUnits(currentSpend, MICRODOLLAR_DECIMALS)}, limit: $${record.dailyLimitUsd})`,
+			reason: `Daily spend limit exceeded (spent: $${formatMicrodollarUsd(currentSpend)}, limit: $${record.dailyLimitUsd})`,
 		}
 	}
 

--- a/apps/fee-payer/test/api-keys.test.ts
+++ b/apps/fee-payer/test/api-keys.test.ts
@@ -354,6 +354,50 @@ describe('API key sponsorship integration', () => {
 		expect(BigInt(lifetime ?? '0')).toBe(BigInt(spend ?? '0'))
 	})
 
+	it('accumulates lifetime spend across multiple sponsored transactions', async () => {
+		const createRes = await exports.default.fetch(
+			adminRequest('POST', '/keys', {
+				label: 'Lifetime Accumulation',
+				dailyLimitUsd: '100.00',
+			}),
+		)
+		const { key } = (await createRes.json()) as { key: string }
+
+		async function waitForLifetime(prev: bigint): Promise<bigint> {
+			for (let i = 0; i < 30; i++) {
+				const raw = await env.SponsorApiKeyStore.get(`spend:${key}:lifetime`)
+				if (raw && BigInt(raw) > prev) return BigInt(raw)
+				await new Promise((r) => setTimeout(r, 100))
+			}
+			throw new Error('lifetime spend never advanced')
+		}
+
+		// First sponsored tx — lifetime starts from 0.
+		const r1 = await sendTransactionSync(buildSponsorClient(key), {
+			feePayer: true,
+			to: '0x0000000000000000000000000000000000000002',
+			value: 0n,
+		})
+		expect(r1.status).toBe('success')
+		const afterFirst = await waitForLifetime(0n)
+
+		// Second sponsored tx — lifetime should strictly increase, not be
+		// overwritten with the second-tx-only fee.
+		const r2 = await sendTransactionSync(buildSponsorClient(key), {
+			feePayer: true,
+			to: '0x0000000000000000000000000000000000000002',
+			value: 0n,
+		})
+		expect(r2.status).toBe('success')
+		const afterSecond = await waitForLifetime(afterFirst)
+
+		expect(afterSecond).toBeGreaterThan(afterFirst)
+		// Lifetime should approximate the sum of the two individual fees; for
+		// identical no-op txs the second fee is ~equal to the first, so the
+		// total should be at least ~1.5× the first (allow slack for KV race).
+		expect(afterSecond).toBeGreaterThanOrEqual((afterFirst * 3n) / 2n)
+	})
+
 	it('sponsors a transaction routed through an API key path', async () => {
 		// Create a valid API key.
 		const createRes = await exports.default.fetch(

--- a/apps/fee-payer/test/api-keys.test.ts
+++ b/apps/fee-payer/test/api-keys.test.ts
@@ -107,7 +107,8 @@ describe('admin API key management', () => {
 			)
 			const { key } = (await createRes.json()) as { key: string }
 
-			// Seed both counters: 1.5 microdollars daily, 4.25 microdollars lifetime.
+			// Seed both counters: $1.50 daily (1.5M microdollars), $4.25 lifetime
+			// (4.25M microdollars).
 			const today = new Date().toISOString().slice(0, 10)
 			await env.SponsorApiKeyStore.put(`spend:${key}:${today}`, '1500000')
 			await env.SponsorApiKeyStore.put(`spend:${key}:lifetime`, '4250000')

--- a/apps/fee-payer/test/api-keys.test.ts
+++ b/apps/fee-payer/test/api-keys.test.ts
@@ -101,6 +101,31 @@ describe('admin API key management', () => {
 			expect(found).toBe(true)
 		})
 
+		it('returns daily + lifetime spend in USD on list', async () => {
+			const createRes = await exports.default.fetch(
+				adminRequest('POST', '/keys', { label: 'Spend Display' }),
+			)
+			const { key } = (await createRes.json()) as { key: string }
+
+			// Seed both counters: 1.5 microdollars daily, 4.25 microdollars lifetime.
+			const today = new Date().toISOString().slice(0, 10)
+			await env.SponsorApiKeyStore.put(`spend:${key}:${today}`, '1500000')
+			await env.SponsorApiKeyStore.put(`spend:${key}:lifetime`, '4250000')
+
+			const response = await exports.default.fetch(adminRequest('GET', '/keys'))
+			expect(response.status).toBe(200)
+			const data = (await response.json()) as {
+				keys: Array<{
+					key: string
+					dailySpentUsd: string
+					lifetimeSpentUsd: string
+				}>
+			}
+			const entry = data.keys.find((k) => k.key === key)
+			expect(entry?.dailySpentUsd).toBe('1.5')
+			expect(entry?.lifetimeSpentUsd).toBe('4.25')
+		})
+
 		it('updates a key', async () => {
 			const createRes = await exports.default.fetch(
 				adminRequest('POST', '/keys', { label: 'Update Me' }),
@@ -321,6 +346,12 @@ describe('API key sponsorship integration', () => {
 		}
 		expect(spend).not.toBeNull()
 		expect(BigInt(spend ?? '0')).toBeGreaterThan(0n)
+
+		// Lifetime spend is written alongside the daily counter and matches it
+		// when only one sponsored transaction has been recorded for this key.
+		const lifetime = await env.SponsorApiKeyStore.get(`spend:${key}:lifetime`)
+		expect(lifetime).not.toBeNull()
+		expect(BigInt(lifetime ?? '0')).toBe(BigInt(spend ?? '0'))
 	})
 
 	it('sponsors a transaction routed through an API key path', async () => {


### PR DESCRIPTION
## Summary

Track cumulative lifetime spend per API key alongside the existing daily counter, and surface both in `GET /admin/keys` as formatted USD strings.

## Motivation

Unblocks partner spend reporting (e.g. the API-key spreadsheet on the weekly note) — answers "how much have we spent sponsoring this partner?" without a separate query.

## Changes

- `src/lib/api-key-budget.ts`: add `spend:<key>:lifetime` KV counter (no TTL); export `getDailySpend`, `getLifetimeSpend`, and a `formatMicrodollarUsd` helper; `recordSpend` now writes both counters.
- `src/lib/admin.ts`: `GET /admin/keys` response now includes `dailySpentUsd` and `lifetimeSpentUsd` per key.
- `test/api-keys.test.ts`: extend existing record-spend test to assert the lifetime key; add a new test asserting the list endpoint returns formatted USD spend.

## Caveats

Read-modify-write on both counters is non-atomic — concurrent sponsorships for the same key can drop an increment. PostHog `SPONSORSHIP_REQUEST` events remain the source of truth for audit.

## Testing

`pnpm check:types`, `pnpm check`, `pnpm test` (30/30) — all pass in `apps/fee-payer`.
