### PR TITLE
feat(fee-payer): enrich PostHog sponsorship event with spend fields

### DIFF
--- a/apps/fee-payer/src/index.ts
+++ b/apps/fee-payer/src/index.ts
@@ -111,8 +111,11 @@ const relayHandler = Handler.relay({
 
 async function feePayerHandler(c: Context) {
 	const requestContext = getRequestContext(c.req.raw)
-	const apiKeyLabel = c.get('apiKeyRecord')?.label
+	const apiKey = c.get('apiKey') as string | undefined
+	const apiKeyRecord = c.get('apiKeyRecord')
+	const apiKeyLabel = apiKeyRecord?.label
 	const rpcMethod = c.get('rpcMethod') as string | undefined
+	const estimatedFeeUsd = c.get('estimatedFeeUsd') as number | undefined
 
 	if (rpcMethod) {
 		c.executionCtx.waitUntil(
@@ -122,7 +125,13 @@ async function feePayerHandler(c: Context) {
 				properties: {
 					...requestContext,
 					rpcMethod,
+					keyedRoute: Boolean(apiKey),
+					...(apiKey ? { apiKey } : {}),
 					...(apiKeyLabel ? { apiKeyLabel } : {}),
+					...(apiKeyRecord?.dailyLimitUsd
+						? { dailyLimitUsd: apiKeyRecord.dailyLimitUsd }
+						: {}),
+					...(estimatedFeeUsd !== undefined ? { estimatedFeeUsd } : {}),
 				},
 			}),
 		)

--- a/apps/fee-payer/src/lib/rate-limit.ts
+++ b/apps/fee-payer/src/lib/rate-limit.ts
@@ -2,6 +2,7 @@ import { env } from 'cloudflare:workers'
 import type { Context, Next } from 'hono'
 import { cloneRawRequest } from 'hono/request'
 import { Hex, RpcRequest } from 'ox'
+import { formatUnits } from 'viem'
 import { Transaction } from 'viem/tempo'
 import * as z from 'zod/mini'
 import type { ApiKeyRecord } from './api-keys.js'
@@ -81,6 +82,14 @@ export function rateLimitMiddleware(opts: { keyed: boolean }) {
 
 				const { success } = await limiter.limit({ key: from })
 				if (!success) return c.json({ error: 'Rate limit exceeded' }, 429)
+
+				// Expose an upper-bound fee estimate for analytics. This is
+				// `gasLimit * maxFeePerGas` (the user's authorized ceiling),
+				// not the actual fee paid — see dashboard note.
+				if (transaction.gas && transaction.maxFeePerGas) {
+					const feeAtto = transaction.gas * transaction.maxFeePerGas
+					c.set('estimatedFeeUsd', Number(formatUnits(feeAtto, 18)))
+				}
 
 				// API-key-scoped checks: [REDACTED:api-key] allowlist + daily budget.
 				const apiKey = c.get('apiKey') as string | undefined


### PR DESCRIPTION
## Summary

Adds spend-related properties to the existing `fee_payer.sponsorship_request` PostHog event so we can build a per-key spend dashboard for `sponsor.tempo.xyz` on mainnet without introducing a new event or extra RPC calls.

## Motivation

Today the event captures `rpcMethod`, `apiKeyLabel`, `origin`, and `environment` — but no dollar amount. The actual fee is computed in `recordSpend` for budget enforcement but only written to KV. With no $ field in PostHog, we can't answer "how much are we sponsoring per key on mainnet?" from analytics.

## Changes

- `src/lib/rate-limit.ts`: after deserializing the tx, set `estimatedFeeUsd` (computed as `gasLimit * maxFeePerGas`, attodollars → USD via `formatUnits`) on the Hono context. No analytics calls live in this file.
- `src/index.ts`: enrich the existing `fee_payer.sponsorship_request` capture in `feePayerHandler` with `estimatedFeeUsd`, `apiKey` (full `tp_…`), `dailyLimitUsd`, and `keyedRoute`. `apiKeyLabel` continues to be sent when present.

### Caveat

`estimatedFeeUsd` is an **upper bound** — it's what the user authorized (`gasLimit × maxFeePerGas`), not the receipt fee the sponsor actually paid. Real spend is typically 2–10× lower. We accept this tradeoff to avoid a per-request `eth_getTransactionReceipt` call. The dashboard will surface this caveat.

## Testing

- `pnpm check:types` — clean
- `pnpm check:biome` — no new warnings (12 pre-existing, all in `test-sponsor-manual.ts`)
- `pnpm test` — 31/31 pass, including all `api-keys`, `rate-limit`, and `e2e` suites