### PR TITLE
fix(fee-payer): drop apiKey credential from PostHog sponsorship event

### DIFF
--- a/apps/fee-payer/src/index.ts
+++ b/apps/fee-payer/src/index.ts
@@ -126,7 +126,6 @@ async function feePayerHandler(c: Context) {
 					...requestContext,
 					rpcMethod,
 					keyedRoute: Boolean(apiKey),
-					...(apiKey ? { apiKey } : {}),
 					...(apiKeyLabel ? { apiKeyLabel } : {}),
 					...(apiKeyRecord?.dailyLimitUsd
 						? { dailyLimitUsd: apiKeyRecord.dailyLimitUsd }


### PR DESCRIPTION
## Summary

Drop the raw `tp_*` API key from PostHog `SPONSORSHIP_REQUEST` event properties. The key is a bearer credential and would be visible to anyone with PostHog read access, enabling full impersonation of the partner until rotated.

## Motivation

PR #977 introduced an `apiKey` property on the sponsorship event. This needs to be removed before any keyed-path traffic flows to PostHog.

## Changes

- `src/index.ts`: remove the `apiKey` spread from the event properties block. `apiKeyLabel` continues to disambiguate per partner; `keyedRoute` indicates the request used the keyed path.

## Testing

`pnpm check:types`, `pnpm test` (31/31) — all pass. No behavior change beyond the omitted field.
