### PR TITLE
Fix perf TPS chart data loading

### DIFF
--- a/apps/perf/src/lib/server/bench.ts
+++ b/apps/perf/src/lib/server/bench.ts
@@ -41,6 +41,13 @@ export type MetricSeries = {
 	samples: Array<MetricSample>
 }
 
+type MetricRow = {
+	metric_name: string
+	labels_json: string
+	offset_ms: string
+	value: string
+}
+
 const SCENARIOS: Array<{
 	id: string
 	label: string
@@ -356,6 +363,101 @@ export const fetchMetrics = createServerFn({ method: 'POST' })
 				FROM txgen_metric_samples
 				WHERE run_id = selected_run_id
 					AND metric_name IN (${metricList})
+				GROUP BY
+					metric_name,
+					labels_json,
+					intDiv(toUInt64(offset_ms - min_offset), bucket_ms)
+			)
+			ORDER BY metric_name, labels_json, offset_ms
+		`)
+
+		const seriesMap = new Map<string, MetricSeries>()
+		for (const row of rows) {
+			const key = `${row.metric_name}::${row.labels_json}`
+			let series = seriesMap.get(key)
+			if (!series) {
+				series = {
+					name: row.metric_name,
+					labels: row.labels_json,
+					samples: [],
+				}
+				seriesMap.set(key, series)
+			}
+			series.samples.push({
+				offsetMs: Number(row.offset_ms),
+				value: Number(row.value),
+			})
+		}
+
+		return Array.from(seriesMap.values())
+	})
+
+/** Fetch per-second rates for cumulative counter metrics. */
+export const fetchMetricRates = createServerFn({ method: 'POST' })
+	.inputValidator((input: { runId: string; metrics: Array<string> }) => input)
+	.handler(async ({ data: { runId, metrics } }) => {
+		if (metrics.length === 0) return []
+
+		const run = sqlString(runId)
+		const metricList = metrics.map(sqlString).join(', ')
+		const rows = await queryClickHouse<MetricRow>(`
+			WITH
+				${run} AS selected_run_id,
+				(
+					SELECT min(offset_ms)
+					FROM txgen_metric_samples
+					WHERE run_id = selected_run_id
+						AND metric_name IN (${metricList})
+				) AS min_offset,
+				(
+					SELECT max(offset_ms)
+					FROM txgen_metric_samples
+					WHERE run_id = selected_run_id
+						AND metric_name IN (${metricList})
+				) AS max_offset,
+				greatest(1, toUInt64(ceil((max_offset - min_offset) / ${CHART_POINT_TARGET}.0))) AS bucket_ms
+			SELECT
+				metric_name,
+				labels_json,
+				bucket_offset_ms AS offset_ms,
+				bucket_value AS value
+			FROM (
+				SELECT
+					metric_name,
+					labels_json,
+					min(offset_ms) AS bucket_offset_ms,
+					avg(rate) AS bucket_value
+				FROM (
+					SELECT
+						metric_name,
+						labels_json,
+						offset_ms,
+						if(
+							prev_offset_ms IS NOT NULL
+								AND offset_ms > prev_offset_ms
+								AND value >= prev_value,
+							(value - prev_value) * 1000.0 / (offset_ms - prev_offset_ms),
+							NULL
+						) AS rate
+					FROM (
+						SELECT
+							metric_name,
+							labels_json,
+							offset_ms,
+							value,
+							lagInFrame(toNullable(offset_ms), 1, NULL) OVER series_window AS prev_offset_ms,
+							lagInFrame(toNullable(value), 1, NULL) OVER series_window AS prev_value
+						FROM txgen_metric_samples
+						WHERE run_id = selected_run_id
+							AND metric_name IN (${metricList})
+						WINDOW series_window AS (
+							PARTITION BY metric_name, labels_json
+							ORDER BY offset_ms
+							ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING
+						)
+					)
+				)
+				WHERE rate IS NOT NULL
 				GROUP BY
 					metric_name,
 					labels_json,

--- a/apps/perf/src/routes/benchmark.$id.tsx
+++ b/apps/perf/src/routes/benchmark.$id.tsx
@@ -5,6 +5,7 @@ import {
 	getScenario,
 	fetchRun,
 	fetchMetrics,
+	fetchMetricRates,
 	fetchBlocks,
 	fetchRunsForScenario,
 	type BenchRun,
@@ -54,6 +55,15 @@ const METRIC_NAMES = [
 	// Memory
 	'reth_jemalloc_resident',
 	'reth_jemalloc_allocated',
+]
+
+const PRIMARY_TPS_METRIC_NAMES = [
+	'txgen_transactions_sent_total',
+	'txgen_transactions_success_total',
+	'txgen_transactions_failed_total',
+	'txgen_blocks_sent_total',
+	'txgen_blocks_success_total',
+	'txgen_blocks_failed_total',
 ]
 
 const TEMPO_REPO = 'https://github.com/tempoxyz/tempo'
@@ -165,6 +175,7 @@ export function BenchmarkRunDetail(
 ): React.JSX.Element {
 	const navigate = useNavigate()
 	const runSelectId = React.useId()
+	const [showDetails, setShowDetails] = React.useState(false)
 	const { data: run } = useSuspenseQuery({
 		queryKey: ['run', props.id],
 		queryFn: () => fetchRun({ data: props.id }),
@@ -180,11 +191,20 @@ export function BenchmarkRunDetail(
 		enabled: !!run?.scenarioId,
 	})
 
-	const { data: metrics } = useQuery({
-		queryKey: ['metrics', props.id],
+	const { data: primaryMetrics } = useQuery({
+		queryKey: ['metricRates', props.id, 'primary-tps'],
+		queryFn: () =>
+			fetchMetricRates({
+				data: { runId: props.id, metrics: PRIMARY_TPS_METRIC_NAMES },
+			}),
+		enabled: !!run,
+	})
+
+	const { data: detailMetrics } = useQuery({
+		queryKey: ['metrics', props.id, 'details'],
 		queryFn: () =>
 			fetchMetrics({ data: { runId: props.id, metrics: METRIC_NAMES } }),
-		enabled: !!run,
+		enabled: !!run && showDetails,
 	})
 
 	const { data: blocks } = useQuery({
@@ -203,7 +223,8 @@ export function BenchmarkRunDetail(
 
 	const scenario = getScenario(run.scenarioId)
 	const runs = scenarioRuns ?? []
-	const m = metrics ?? []
+	const m = detailMetrics ?? []
+	const primaryM = primaryMetrics ?? []
 
 	// Builder phases (p50)
 	const buildDurP50 = findSeries(
@@ -293,6 +314,30 @@ export function BenchmarkRunDetail(
 				success: txgenBlocksSuccessSeries,
 				failed: txgenBlocksFailedSeries,
 			}
+	const primaryTxgenSentSeries = findSeries(
+		primaryM,
+		'txgen_transactions_sent_total',
+	)
+	const primaryTxgenSuccessSeries = findSeries(
+		primaryM,
+		'txgen_transactions_success_total',
+	)
+	const primaryTxgenFailedSeries = findSeries(
+		primaryM,
+		'txgen_transactions_failed_total',
+	)
+	const primaryTxgenBlocksSentSeries = findSeries(
+		primaryM,
+		'txgen_blocks_sent_total',
+	)
+	const hasPrimaryTxgenTransactionCounters = [
+		primaryTxgenSentSeries,
+		primaryTxgenSuccessSeries,
+		primaryTxgenFailedSeries,
+	].some(hasSamples)
+	const primarySubmittedSeries = hasPrimaryTxgenTransactionCounters
+		? primaryTxgenSentSeries
+		: primaryTxgenBlocksSentSeries
 
 	// Txpool
 	const pendingSeries = findSeries(
@@ -386,8 +431,9 @@ export function BenchmarkRunDetail(
 	const sharedGasLimit = Math.floor(refGasLimit / 10)
 	const generalGasLimit = 30_000_000
 	const paymentGasLimit = refGasLimit - sharedGasLimit - generalGasLimit
-	const hasLoadedPrimarySeries = metrics !== undefined && blocks !== undefined
-	const ingressTpsPoints = counterRate(txgenCounterSeries.sent)
+	const hasLoadedSubmittedSeries = primaryMetrics !== undefined
+	const hasLoadedSettledSeries = blocks !== undefined
+	const ingressTpsPoints = transformSamples(primarySubmittedSeries)
 	const settledTpsPoints = settledTps(blockRows)
 	const ingressEgressYMax = sharedYMax([ingressTpsPoints, settledTpsPoints])
 
@@ -509,8 +555,8 @@ export function BenchmarkRunDetail(
 					title="Submitted / Settled TPS"
 					tooltip="Submitted transaction load compared with transactions settled into blocks."
 				/>
-				{hasLoadedPrimarySeries ? (
-					<div className="grid grid-cols-1 gap-3">
+				<div className="grid grid-cols-1 gap-3">
+					{hasLoadedSubmittedSeries ? (
 						<TimeSeriesChart
 							title="Submitted TPS"
 							tooltip="Rate of transactions submitted by the load generator. This shows the input pulse."
@@ -525,6 +571,10 @@ export function BenchmarkRunDetail(
 							formatValue={(v) => `${formatTps(v)}/s`}
 							yMax={ingressEgressYMax}
 						/>
+					) : (
+						<ChartLoadingCard title="Submitted TPS" />
+					)}
+					{hasLoadedSettledSeries ? (
 						<TimeSeriesChart
 							title="Settled TPS"
 							tooltip="Rate of transactions included in blocks, derived from per-block transaction count and block time."
@@ -539,16 +589,18 @@ export function BenchmarkRunDetail(
 							formatValue={(v) => `${formatTps(v)}/s`}
 							yMax={ingressEgressYMax}
 						/>
-					</div>
-				) : (
-					<div className="grid grid-cols-1 gap-3">
-						<ChartLoadingCard title="Submitted TPS" />
+					) : (
 						<ChartLoadingCard title="Settled TPS" />
-					</div>
-				)}
+					)}
+				</div>
 			</section>
 
-			<details className="group/details mb-14">
+			<details
+				className="group/details mb-14"
+				onToggle={(event) => {
+					setShowDetails(event.currentTarget.open)
+				}}
+			>
 				<summary className="mb-5 flex cursor-pointer list-none items-center gap-3 transition-colors marker:hidden">
 					<h3 className="shrink-0 text-[13px] font-normal tracking-wider text-tertiary uppercase group-hover/details:text-primary">
 						Detailed charts


### PR DESCRIPTION
## Summary
- load submitted TPS from a small server-side rate query instead of the full detailed metrics payload
- let settled TPS render independently from block data
- defer detailed metrics fetching until the Detailed charts panel is opened

## Validation
- `corepack pnpm exec biome check apps/perf/src/routes/benchmark.$id.tsx apps/perf/src/lib/server/bench.ts`
- `corepack pnpm --filter perf exec tsgo --project tsconfig.json --noEmit`

Note: Cloudflare Workers observability was unavailable from the sandbox because `tempo-obs` returned a 403 auth error.