### PR TITLE
Label outbound address transfers as sent

### DIFF
--- a/apps/explorer/src/comps/TxTransactionRow.tsx
+++ b/apps/explorer/src/comps/TxTransactionRow.tsx
@@ -1,5 +1,5 @@
 import { Link } from '@tanstack/react-router'
-import * as Address from 'ox/Address'
+import type * as Address from 'ox/Address'
 import * as Hex from 'ox/Hex'
 import * as Value from 'ox/Value'
 import * as React from 'react'
@@ -10,6 +10,7 @@ import { useTokenListMembership } from '#comps/TokenListMembership'
 import { FormattedTimestamp, type TimeFormat } from '#comps/TimeFormat'
 import { TxEventDescription } from '#comps/TxEventDescription'
 import type { KnownEvent } from '#lib/domain/known-events'
+import { getPerspectiveEvent } from '#lib/domain/perspective-events'
 import {
 	calculateKnownEventsTotal,
 	NORMALIZED_KNOWN_EVENT_TOTAL_DECIMALS,
@@ -82,29 +83,6 @@ export function TransactionDescription(props: {
 			transformEvent={transformEvent}
 		/>
 	)
-}
-
-export function getPerspectiveEvent(
-	event: KnownEvent,
-	accountAddress?: Address.Address,
-) {
-	if (!accountAddress) return event
-	if (event.type !== 'send') return event
-	const toMatches =
-		event.meta?.to && Address.isEqual(event.meta.to, accountAddress)
-	const fromMatches =
-		event.meta?.from && Address.isEqual(event.meta.from, accountAddress)
-	if (!toMatches || fromMatches) return event
-
-	const sender = event.meta?.from
-	const updatedParts = event.parts.map((part) => {
-		if (part.type === 'action') return { ...part, value: 'Received' }
-		if (part.type === 'text' && part.value.toLowerCase() === 'to')
-			return { ...part, value: 'from' }
-		if (part.type === 'account' && sender) return { ...part, value: sender }
-		return part
-	})
-	return { ...event, parts: updatedParts }
 }
 
 export function TransactionTimestamp(props: {

--- a/apps/explorer/src/lib/domain/perspective-events.ts
+++ b/apps/explorer/src/lib/domain/perspective-events.ts
@@ -1,0 +1,33 @@
+import * as Address from 'ox/Address'
+import type { KnownEvent } from '#lib/domain/known-events'
+
+export function getPerspectiveEvent(
+	event: KnownEvent,
+	accountAddress?: Address.Address,
+) {
+	if (!accountAddress) return event
+	if (event.type !== 'send') return event
+	const toMatches =
+		event.meta?.to && Address.isEqual(event.meta.to, accountAddress)
+	const fromMatches =
+		event.meta?.from && Address.isEqual(event.meta.from, accountAddress)
+	if (fromMatches && !toMatches) {
+		const updatedParts = event.parts.map((part) =>
+			part.type === 'action' && part.value === 'Send'
+				? { ...part, value: 'Sent' }
+				: part,
+		)
+		return { ...event, parts: updatedParts }
+	}
+	if (!toMatches || fromMatches) return event
+
+	const sender = event.meta?.from
+	const updatedParts = event.parts.map((part) => {
+		if (part.type === 'action') return { ...part, value: 'Received' }
+		if (part.type === 'text' && part.value.toLowerCase() === 'to')
+			return { ...part, value: 'from' }
+		if (part.type === 'account' && sender) return { ...part, value: sender }
+		return part
+	})
+	return { ...event, parts: updatedParts }
+}

--- a/apps/explorer/src/routes/_layout/demo/address.tsx
+++ b/apps/explorer/src/routes/_layout/demo/address.tsx
@@ -11,12 +11,12 @@ import { RelativeTime } from '#comps/RelativeTime'
 import { Sections } from '#comps/Sections'
 import { TxEventDescription } from '#comps/TxEventDescription'
 import {
-	getPerspectiveEvent,
 	TransactionFee,
 	TransactionTimestamp,
 	TransactionTotal,
 } from '#comps/TxTransactionRow'
 import { cx } from '#lib/css'
+import { getPerspectiveEvent } from '#lib/domain/perspective-events'
 import {
 	accountAddress,
 	adminAddress,

--- a/apps/explorer/test/tx-transaction-row.test.ts
+++ b/apps/explorer/test/tx-transaction-row.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import { getPerspectiveEvent } from '../src/lib/domain/perspective-events'
+import type { KnownEvent } from '../src/lib/domain/known-events'
+
+const senderAddress = `0x${'a'.repeat(40)}` as const
+const recipientAddress = `0x${'b'.repeat(40)}` as const
+const tokenAddress = `0x${'c'.repeat(40)}` as const
+
+const sendEvent: KnownEvent = {
+	type: 'send',
+	parts: [
+		{ type: 'action', value: 'Send' },
+		{
+			type: 'amount',
+			value: {
+				token: tokenAddress,
+				value: 100n,
+				decimals: 6,
+				symbol: 'USDC',
+			},
+		},
+		{ type: 'text', value: 'to' },
+		{ type: 'account', value: recipientAddress },
+	],
+	meta: { from: senderAddress, to: recipientAddress },
+}
+
+describe('getPerspectiveEvent', () => {
+	it('labels outbound transfers as sent for the viewed address', () => {
+		const event = getPerspectiveEvent(sendEvent, senderAddress)
+
+		expect(event.parts[0]).toEqual({ type: 'action', value: 'Sent' })
+	})
+
+	it('labels inbound transfers as received for the viewed address', () => {
+		const event = getPerspectiveEvent(sendEvent, recipientAddress)
+
+		expect(event.parts[0]).toEqual({ type: 'action', value: 'Received' })
+		expect(event.parts[2]).toEqual({ type: 'text', value: 'from' })
+		expect(event.parts[3]).toEqual({ type: 'account', value: senderAddress })
+	})
+})


### PR DESCRIPTION
## Summary
- Move address-page perspective labeling into a pure helper
- Render outbound address-page transfer actions as `Sent` while preserving inbound `Received`
- Add focused coverage for outbound and inbound transfer labels

## Tests
- `corepack pnpm --filter explorer exec vitest run test/tx-transaction-row.test.ts`
- `corepack pnpm --filter explorer check:biome src/comps/TxTransactionRow.tsx src/lib/domain/perspective-events.ts src/routes/_layout/demo/address.tsx test/tx-transaction-row.test.ts`

## Notes
- `corepack pnpm --filter explorer check:types` still fails on existing unrelated type errors in ExploreInput, Tip20ContractInfo, Cloudflare worker typings, and api/code.