### PR TITLE
feat(tempo-snapshots-viewer): re-enable minimal preset selection

### DIFF
--- a/apps/tempo-snapshots-viewer/src/index.ts
+++ b/apps/tempo-snapshots-viewer/src/index.ts
@@ -2486,7 +2486,7 @@ async function handleUI(_req: Request, env: Env) {
       <div class="snapshot-status-note" id="snapshotStatusNote"></div>
 
       <div class="presets" id="presets">
-        <button class="preset" id="preset-minimal" disabled>
+        <button class="preset" onclick="selectPreset('minimal')" id="preset-minimal">
           <div class="preset-header">
             <span class="preset-radio"></span>
             <span class="preset-name">Minimal<span class="preset-modified-tag">(modified)</span></span>
@@ -3091,7 +3091,7 @@ async function handleUI(_req: Request, env: Env) {
 
     function selectPreset(name) {
       if (!hasActiveModularSnapshot()) return;
-      if (name !== 'archive') return;
+      if (name !== 'minimal' && name !== 'archive') return;
       activePreset = name;
       checkedComponents = new Set(PRESETS[name].checked);
       presetBaseComponents = new Set(PRESETS[name].checked);


### PR DESCRIPTION
## Summary

Re-enables the Minimal preset in the Tempo snapshots viewer so operators can select it once the upcoming `tempo download --minimal` release is available.

## Changes

- Makes the Minimal preset button selectable again.
- Allows `selectPreset` to accept `minimal` while leaving Full and custom component selection disabled.
- Keeps Archive as the default preset.

## Screenshots

| Before | After |
|--------|-------|
| Minimal preset disabled | Minimal preset selectable |

## Validation

- `pnpm --filter tempo-snapshots-viewer check`
- `pnpm check:types`
- `pnpm check`
- `pnpm --filter tempo-snapshots-viewer test`
- `pnpm precommit`

Note: `pnpm check` still reports existing fee-payer Biome warnings about non-null assertions, but exits successfully. Biome also auto-formats unrelated files on `main`; those incidental changes were intentionally left out of this PR.