### PR TITLE
Hide peak gas/s from perf landing summary

### DIFF
--- a/apps/perf/src/routes/benchmark.$id.tsx
+++ b/apps/perf/src/routes/benchmark.$id.tsx
@@ -174,6 +174,7 @@ export declare namespace BenchmarkRunDetail {
 		showBackLink?: boolean | undefined
 		headerControls?: React.ReactNode | undefined
 		showRunSelect?: boolean | undefined
+		showPeakGasSummary?: boolean | undefined
 	}
 }
 
@@ -514,11 +515,13 @@ export function BenchmarkRunDetail(
 						value={formatGas(run.avgGasPerSecond, false)}
 						tooltip="Average gas per second across the entire run. Calculated as total gas used ÷ total run duration."
 					/>
-					<MetricCard
-						label="Peak Gas/s"
-						value={formatGas(run.peakGasPerSecond, false)}
-						tooltip="Highest gas per second achieved by any single block, based on its gas usage and block time."
-					/>
+					{props.showPeakGasSummary !== false && (
+						<MetricCard
+							label="Peak Gas/s"
+							value={formatGas(run.peakGasPerSecond, false)}
+							tooltip="Highest gas per second achieved by any single block, based on its gas usage and block time."
+						/>
+					)}
 				</div>
 			</section>
 

--- a/apps/perf/src/routes/index.tsx
+++ b/apps/perf/src/routes/index.tsx
@@ -97,6 +97,7 @@ function DashboardPage(): React.JSX.Element {
 	return (
 		<BenchmarkRunDetail
 			id={selected.run.id}
+			showPeakGasSummary={false}
 			headerControls={
 				<BenchmarkSelectors
 					releases={releaseOptions}


### PR DESCRIPTION
## Summary
- Hide Peak Gas/s from the top-level perf landing summary row
- Keep Peak Gas/s visible on direct benchmark detail pages and in the throughput dashboard

## Test
- PATH="/tmp/codex-bin:/home/agent/.local/bin:/home/agent/.codex/tmp/arg0/codex-arg0xKne1H:/usr/lib/node_modules/@openai/codex/node_modules/@openai/codex-linux-x64/vendor/x86_64-unknown-linux-musl/path:/home/agent/.cargo/bin:/home/agent/.local/bin:/home/agent/.foundry/bin:/home/agent/.bun/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" pnpm --filter perf check