### PR TITLE
Reduce perf ClickHouse memory pressure

### DIFF
--- a/apps/perf/src/lib/server/bench.ts
+++ b/apps/perf/src/lib/server/bench.ts
@@ -82,6 +82,37 @@ const SCENARIOS: Array<{
 // limits when serialized as JSON, so fetch queries aggregate samples into this
 // many buckets before returning them to the app.
 const CHART_POINT_TARGET = 750
+const RUN_LIST_CACHE_TTL_MS = 60_000
+
+type CacheEntry<T> = {
+	expiresAt: number
+	value: T
+}
+
+const releaseRunsCache = new Map<string, CacheEntry<Array<BenchRun>>>()
+const scenarioRunsCache = new Map<string, CacheEntry<Array<BenchRun>>>()
+
+function getCached<T>(
+	cache: Map<string, CacheEntry<T>>,
+	key: string,
+): T | undefined {
+	const entry = cache.get(key)
+	if (!entry) return undefined
+	if (Date.now() > entry.expiresAt) {
+		cache.delete(key)
+		return undefined
+	}
+	return entry.value
+}
+
+function setCached<T>(
+	cache: Map<string, CacheEntry<T>>,
+	key: string,
+	value: T,
+): T {
+	cache.set(key, { value, expiresAt: Date.now() + RUN_LIST_CACHE_TTL_MS })
+	return value
+}
 
 function sqlString(value: string): string {
 	return `'${value.replaceAll('\\', '\\\\').replaceAll("'", "\\'")}'`
@@ -249,21 +280,29 @@ function buildRunsQuery(scenarioName: string, limit = 50): string {
 
 export const fetchReleaseRuns = createServerFn({ method: 'GET' }).handler(
 	async () => {
+		const cached = getCached(releaseRunsCache, 'all')
+		if (cached) return cached
+
 		const runsByScenario = await Promise.all(
 			SCENARIOS.map(async (scenario) => {
 				const rows = await queryClickHouse<RunRow>(
 					buildRunsQuery(scenario.scenarioName),
+					`release-runs:${scenario.scenarioName}`,
 				)
 				return rows.map((row) => toRun(row, scenario.id))
 			}),
 		)
 
-		return runsByScenario
-			.flat()
-			.sort(
-				(a, b) =>
-					new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime(),
-			)
+		return setCached(
+			releaseRunsCache,
+			'all',
+			runsByScenario
+				.flat()
+				.sort(
+					(a, b) =>
+						new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime(),
+				),
+		)
 	},
 )
 
@@ -274,18 +313,26 @@ export const fetchRunsForScenario = createServerFn({ method: 'POST' })
 	.handler(async ({ data: { scenarioId } }) => {
 		const config = SCENARIOS.find((s) => s.id === scenarioId)
 		if (!config) return []
+		const cached = getCached(scenarioRunsCache, scenarioId)
+		if (cached) return cached
 
 		const rows = await queryClickHouse<RunRow>(
 			buildRunsQuery(config.scenarioName),
+			`scenario-runs:${config.scenarioName}`,
 		)
-		return rows.map((row) => toRun(row, scenarioId))
+		return setCached(
+			scenarioRunsCache,
+			scenarioId,
+			rows.map((row) => toRun(row, scenarioId)),
+		)
 	})
 
 export const fetchRun = createServerFn({ method: 'POST' })
 	.inputValidator((input: string) => input)
 	.handler(async ({ data: runId }) => {
 		const run = sqlString(runId)
-		const runRows = await queryClickHouse<RunRow & { scenario_name: string }>(`
+		const runRows = await queryClickHouse<RunRow & { scenario_name: string }>(
+			`
 			SELECT
 				r.run_id,
 				r.started_at,
@@ -320,7 +367,9 @@ export const fetchRun = createServerFn({ method: 'POST' })
 			WHERE r.run_id = ${run}
 				AND r.metadata['run_type'] = 'release'
 			LIMIT 1
-		`)
+		`,
+			`run:${runId}`,
+		)
 
 		const runRow = runRows[0]
 		if (!runRow) return null
@@ -360,7 +409,8 @@ export const fetchMetrics = createServerFn({ method: 'POST' })
 			reason: string
 			offset_ms: string
 			value: string
-		}>(`
+		}>(
+			`
 			WITH
 				${run} AS selected_run_id,
 				(
@@ -411,7 +461,9 @@ export const fetchMetrics = createServerFn({ method: 'POST' })
 					intDiv(toUInt64(offset_ms - min_offset), bucket_ms)
 			)
 			ORDER BY metric_name, node, quantile, reason, offset_ms
-		`)
+		`,
+			`metrics:${runId}`,
+		)
 
 		const seriesMap = new Map<string, MetricSeries>()
 		for (const row of rows) {
@@ -462,7 +514,8 @@ export const fetchBlocks = createServerFn({ method: 'POST' })
 			persistence_wait_us: string | null
 			execution_cache_wait_us: string | null
 			sparse_trie_wait_us: string | null
-		}>(`
+		}>(
+			`
 			WITH
 				${run} AS selected_run_id,
 				(
@@ -513,7 +566,9 @@ export const fetchBlocks = createServerFn({ method: 'POST' })
 				GROUP BY intDiv(toUInt64(block_index), bucket_size)
 			)
 			ORDER BY block_index
-		`)
+		`,
+			`blocks:${runId}`,
+		)
 
 		return rows.map((row) => ({
 			index: Number(row.block_index),

--- a/apps/perf/src/lib/server/clickhouse.ts
+++ b/apps/perf/src/lib/server/clickhouse.ts
@@ -1,6 +1,23 @@
 import { env } from 'cloudflare:workers'
 import { request } from 'node:https'
 
+const MAX_CLICKHOUSE_RESPONSE_BYTES = 16 * 1024 * 1024
+
+type MemorySnapshot = {
+	rss: number
+	heapUsed: number
+}
+
+function memorySnapshot(): MemorySnapshot | undefined {
+	if (typeof process === 'undefined' || !process.memoryUsage) return undefined
+	const { rss, heapUsed } = process.memoryUsage()
+	return { rss, heapUsed }
+}
+
+function mib(bytes: number): number {
+	return Math.round(bytes / 1024 / 1024)
+}
+
 function httpsPost(
 	url: URL,
 	headers: Record<string, string>,
@@ -9,7 +26,20 @@ function httpsPost(
 	return new Promise((resolve, reject) => {
 		const req = request(url, { method: 'POST', headers }, (res) => {
 			const chunks: Array<Buffer> = []
-			res.on('data', (chunk: Buffer) => chunks.push(chunk))
+			let bytes = 0
+			res.on('data', (chunk: Buffer) => {
+				bytes += chunk.byteLength
+				if (bytes > MAX_CLICKHOUSE_RESPONSE_BYTES) {
+					req.destroy(
+						new Error(
+							`ClickHouse response exceeded ${MAX_CLICKHOUSE_RESPONSE_BYTES} bytes`,
+						),
+					)
+					return
+				}
+				chunks.push(chunk)
+			})
+			res.on('error', reject)
 			res.on('end', () => {
 				const text = Buffer.concat(chunks).toString()
 				if (res.statusCode && res.statusCode >= 400) {
@@ -35,7 +65,10 @@ function clickHouseUrl(host: string): URL {
 	return url
 }
 
-export async function queryClickHouse<T>(query: string): Promise<Array<T>> {
+export async function queryClickHouse<T>(
+	query: string,
+	label = 'query',
+): Promise<Array<T>> {
 	const {
 		CLICKHOUSE_HOST,
 		CLICKHOUSE_USER,
@@ -53,6 +86,8 @@ export async function queryClickHouse<T>(query: string): Promise<Array<T>> {
 		url.searchParams.set('database', CLICKHOUSE_DATABASE)
 	}
 
+	const startedAt = performance.now()
+	const before = memorySnapshot()
 	const text = await httpsPost(
 		url,
 		{
@@ -63,5 +98,16 @@ export async function queryClickHouse<T>(query: string): Promise<Array<T>> {
 	)
 
 	const result = JSON.parse(text) as { data: Array<T> }
+	const after = memorySnapshot()
+	console.info('[clickhouse] query complete', {
+		label,
+		rows: result.data.length,
+		responseMiB: mib(Buffer.byteLength(text)),
+		durationMs: Math.round(performance.now() - startedAt),
+		rssMiB: after ? mib(after.rss) : undefined,
+		heapUsedMiB: after ? mib(after.heapUsed) : undefined,
+		heapDeltaMiB:
+			before && after ? mib(after.heapUsed - before.heapUsed) : undefined,
+	})
 	return result.data
 }


### PR DESCRIPTION
## Summary
- Add a 16 MiB guardrail for ClickHouse JSON responses in the perf app
- Log ClickHouse query label, row count, response size, duration, RSS, heap used, and heap delta
- Add a 60s in-process cache for release/scenario run lists to avoid repeated dashboard queries rehydrating the same ClickHouse JSON

## Why
The internal perf pod normally sits around 185-220Mi and was OOMKilled under a 256Mi limit. The perf app buffers ClickHouse responses before JSON parsing, so repeated dashboard/detail requests need tighter guardrails and better memory visibility.

## Validation
- PATH=/home/agent/branches/tempoxyz/tempo-apps/node_modules/.bin:/home/agent/.local/bin:/home/agent/.codex/tmp/arg0/codex-arg0dL67jw:/usr/lib/node_modules/@openai/codex/node_modules/@openai/codex-linux-x64/vendor/x86_64-unknown-linux-musl/path:/home/agent/.cargo/bin:/home/agent/.local/bin:/home/agent/.foundry/bin:/home/agent/.bun/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin corepack pnpm --filter perf check:biome
- PATH=/home/agent/branches/tempoxyz/tempo-apps/node_modules/.bin:/home/agent/.local/bin:/home/agent/.codex/tmp/arg0/codex-arg0dL67jw:/usr/lib/node_modules/@openai/codex/node_modules/@openai/codex-linux-x64/vendor/x86_64-unknown-linux-musl/path:/home/agent/.cargo/bin:/home/agent/.local/bin:/home/agent/.foundry/bin:/home/agent/.bun/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin corepack pnpm --filter perf check:types
- PATH=/home/agent/branches/tempoxyz/tempo-apps/node_modules/.bin:/home/agent/.local/bin:/home/agent/.codex/tmp/arg0/codex-arg0dL67jw:/usr/lib/node_modules/@openai/codex/node_modules/@openai/codex-linux-x64/vendor/x86_64-unknown-linux-musl/path:/home/agent/.cargo/bin:/home/agent/.local/bin:/home/agent/.foundry/bin:/home/agent/.bun/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin corepack pnpm --filter perf build
- pre-commit hook passed via temporary pnpm wrapper around corepack pnpm