### PR TITLE
feat(explorer): support DEX OrderFlipped events

### DIFF
--- a/apps/explorer/src/lib/domain/contracts.ts
+++ b/apps/explorer/src/lib/domain/contracts.ts
@@ -9,7 +9,7 @@ import {
 } from 'viem'
 import { Abis, Addresses } from 'viem/tempo'
 import { getChainId, getPublicClient } from 'wagmi/actions'
-import { streamChannelAbi } from './known-events.ts'
+import { stablecoinDexAbi, streamChannelAbi } from './known-events.ts'
 import { isTip20Address } from '#lib/domain/tip20.ts'
 import { getWagmiConfig } from '#wagmi.config.ts'
 
@@ -256,7 +256,7 @@ export const systemContractRegistry = new Map<Address.Address, ContractInfo>(<
 			name: 'Stablecoin Exchange',
 			code: '0xef',
 			description: 'Enshrined DEX for stablecoin swaps',
-			abi: Abis.stablecoinDex,
+			abi: stablecoinDexAbi,
 			category: 'system',
 			docsUrl: 'https://docs.tempo.xyz/documentation/protocol/exchange',
 			address: Addresses.stablecoinDex,

--- a/apps/explorer/src/lib/domain/known-events.ts
+++ b/apps/explorer/src/lib/domain/known-events.ts
@@ -228,8 +228,32 @@ const zoneFactoryAbi = [
 	},
 ] as const
 
+const stablecoinDexTip1056Abi = [
+	{
+		type: 'event',
+		name: 'OrderFlipped',
+		inputs: [
+			{ indexed: true, name: 'orderId', type: 'uint128' },
+			{ indexed: true, name: 'maker', type: 'address' },
+			{ indexed: true, name: 'token', type: 'address' },
+			{ indexed: false, name: 'amount', type: 'uint128' },
+			{ indexed: false, name: 'isBid', type: 'bool' },
+			{ indexed: false, name: 'tick', type: 'int16' },
+			{ indexed: false, name: 'flipTick', type: 'int16' },
+		],
+		anonymous: false,
+	},
+] as const
+
+// TODO: Remove this local TIP-1056 ABI item once viem/tempo exports OrderFlipped in Abis.stablecoinDex.
+export const stablecoinDexAbi = [
+	...Abis.stablecoinDex,
+	...stablecoinDexTip1056Abi,
+] as const
+
 const abi = [
 	...Object.values(Abis).flat(),
+	...stablecoinDexTip1056Abi,
 	...streamChannelAbi,
 	...zonePortalAbi,
 	...zoneFactoryAbi,
@@ -859,6 +883,27 @@ function createDetectors(
 					],
 				}
 			}
+
+			if (eventName === 'OrderFlipped')
+				return {
+					type: 'order flipped',
+					parts: [
+						{
+							type: 'action',
+							value: `Flip ${args.isBid ? 'Buy' : 'Sell'}`,
+						},
+						{
+							type: 'amount',
+							value: createAmount(args.amount, args.token),
+						},
+						{ type: 'text', value: 'at tick' },
+						{ type: 'tick', value: args.tick },
+					],
+					note: [
+						['Flip Tick', { type: 'tick', value: args.flipTick }],
+						['Order ID', { type: 'number', value: args.orderId }],
+					],
+				}
 
 			if (eventName === 'OrderFilled')
 				return {

--- a/apps/explorer/src/routes/_layout/demo/address.tsx
+++ b/apps/explorer/src/routes/_layout/demo/address.tsx
@@ -39,7 +39,11 @@ import {
 	userTokenAddress,
 	validatorTokenAddress,
 } from '#lib/demo'
-import { type KnownEvent, parseKnownEvents } from '#lib/domain/known-events'
+import {
+	type KnownEvent,
+	parseKnownEvents,
+	stablecoinDexAbi,
+} from '#lib/domain/known-events'
 import { useCopy, useMediaQuery } from '#lib/hooks'
 import CopyIcon from '~icons/lucide/copy'
 
@@ -330,7 +334,7 @@ function createMockTransactions(): MockTransactionData[] {
 				{
 					address: exchangeAddress,
 					topics: encodeEventTopics({
-						abi: Abis.stablecoinDex,
+						abi: stablecoinDexAbi,
 						eventName: 'OrderFilled',
 						args: {
 							orderId: 123n,
@@ -746,7 +750,7 @@ function createMockTransactions(): MockTransactionData[] {
 				{
 					address: exchangeAddress,
 					topics: encodeEventTopics({
-						abi: Abis.stablecoinDex,
+						abi: stablecoinDexAbi,
 						eventName: 'OrderPlaced',
 						args: {
 							orderId: 456n,
@@ -765,7 +769,7 @@ function createMockTransactions(): MockTransactionData[] {
 				{
 					address: exchangeAddress,
 					topics: encodeEventTopics({
-						abi: Abis.stablecoinDex,
+						abi: stablecoinDexAbi,
 						eventName: 'OrderFilled',
 						args: {
 							orderId: 456n,
@@ -775,6 +779,30 @@ function createMockTransactions(): MockTransactionData[] {
 					data: encodeAbiParameters(
 						[{ type: 'uint128' }, { type: 'bool' }],
 						[2500000n, false],
+					),
+				},
+				hash,
+			),
+			mockLog(
+				{
+					address: exchangeAddress,
+					topics: encodeEventTopics({
+						abi: stablecoinDexAbi,
+						eventName: 'OrderFlipped',
+						args: {
+							orderId: 456n,
+							maker: accountAddress,
+							token: baseTokenAddress,
+						},
+					}) as [Hex.Hex, ...Hex.Hex[]],
+					data: encodeAbiParameters(
+						[
+							{ type: 'uint128' },
+							{ type: 'bool' },
+							{ type: 'int16' },
+							{ type: 'int16' },
+						],
+						[5000000n, false, 99, 101],
 					),
 				},
 				hash,

--- a/apps/explorer/src/routes/_layout/demo/tx.tsx
+++ b/apps/explorer/src/routes/_layout/demo/tx.tsx
@@ -31,7 +31,7 @@ import {
 	validatorAddress,
 	validatorTokenAddress,
 } from '#lib/demo'
-import { parseKnownEvents } from '#lib/domain/known-events'
+import { parseKnownEvents, stablecoinDexAbi } from '#lib/domain/known-events'
 
 function loader() {
 	if (import.meta.env.VITE_ENABLE_DEMO !== 'true') throw notFound()
@@ -400,7 +400,7 @@ function loader() {
 			mockLog({
 				address: exchangeAddress,
 				topics: encodeEventTopics({
-					abi: Abis.stablecoinDex,
+					abi: stablecoinDexAbi,
 					eventName: 'PairCreated',
 					args: {
 						key: Hex.padLeft('0xabc', 32),
@@ -412,7 +412,7 @@ function loader() {
 			mockLog({
 				address: exchangeAddress,
 				topics: encodeEventTopics({
-					abi: Abis.stablecoinDex,
+					abi: stablecoinDexAbi,
 					eventName: 'OrderPlaced',
 					args: {
 						orderId: 123n,
@@ -429,7 +429,7 @@ function loader() {
 			mockLog({
 				address: exchangeAddress,
 				topics: encodeEventTopics({
-					abi: Abis.stablecoinDex,
+					abi: stablecoinDexAbi,
 					eventName: 'OrderFilled',
 					args: {
 						orderId: 123n,
@@ -444,7 +444,28 @@ function loader() {
 			mockLog({
 				address: exchangeAddress,
 				topics: encodeEventTopics({
-					abi: Abis.stablecoinDex,
+					abi: stablecoinDexAbi,
+					eventName: 'OrderFlipped',
+					args: {
+						orderId: 123n,
+						maker: makerAddress,
+						token: baseTokenAddress,
+					},
+				}) as [Hex.Hex, ...Hex.Hex[]],
+				data: encodeAbiParameters(
+					[
+						{ type: 'uint128' },
+						{ type: 'bool' },
+						{ type: 'int16' },
+						{ type: 'int16' },
+					],
+					[1000000n, false, 95, 100],
+				),
+			}),
+			mockLog({
+				address: exchangeAddress,
+				topics: encodeEventTopics({
+					abi: stablecoinDexAbi,
 					eventName: 'OrderCancelled',
 					args: {
 						orderId: 124n,

--- a/apps/explorer/test/known-events.test.ts
+++ b/apps/explorer/test/known-events.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from 'vitest'
+import * as Address from 'ox/Address'
 import type * as Hex from 'ox/Hex'
 import { encodeAbiParameters, encodeEventTopics, zeroHash } from 'viem'
-import { Abis } from 'viem/tempo'
+import { Abis, Addresses } from 'viem/tempo'
 import {
 	accountAddress,
 	getTokenMetadata,
@@ -10,7 +11,7 @@ import {
 	recipientAddress,
 	userTokenAddress,
 } from '#lib/demo'
-import { parseKnownEvents } from '#lib/domain/known-events'
+import { parseKnownEvents, stablecoinDexAbi } from '#lib/domain/known-events'
 
 const ZONE_5_PORTAL = '0x7069DeC4E64Fd07334A0933eDe836C17259c9B23' as const
 const UNKNOWN_ZONE_PORTAL = `0x${'8'.repeat(40)}` as const
@@ -55,6 +56,96 @@ const depositMadeAbi = [
 ] as const
 
 describe('parseKnownEvents', () => {
+	it('decodes stablecoin DEX OrderFlipped buy and sell events', () => {
+		const hash = `0x${'6'.repeat(64)}` as const
+		const amount = 1_000_000n
+		const token = Address.checksum(userTokenAddress)
+		const logs = [
+			mockLog(
+				{
+					address: Addresses.stablecoinDex,
+					topics: encodeEventTopics({
+						abi: stablecoinDexAbi,
+						eventName: 'OrderFlipped',
+						args: {
+							orderId: 123n,
+							maker: accountAddress,
+							token,
+						},
+					}) as [Hex.Hex, ...Hex.Hex[]],
+					data: encodeAbiParameters(
+						[
+							{ type: 'uint128' },
+							{ type: 'bool' },
+							{ type: 'int16' },
+							{ type: 'int16' },
+						],
+						[amount, true, 100, 98],
+					),
+				},
+				hash,
+			),
+			mockLog(
+				{
+					address: Addresses.stablecoinDex,
+					topics: encodeEventTopics({
+						abi: stablecoinDexAbi,
+						eventName: 'OrderFlipped',
+						args: {
+							orderId: 124n,
+							maker: accountAddress,
+							token,
+						},
+					}) as [Hex.Hex, ...Hex.Hex[]],
+					data: encodeAbiParameters(
+						[
+							{ type: 'uint128' },
+							{ type: 'bool' },
+							{ type: 'int16' },
+							{ type: 'int16' },
+						],
+						[amount, false, 98, 100],
+					),
+				},
+				hash,
+			),
+		]
+
+		const receipt = mockReceipt(logs, accountAddress, hash)
+		const knownEvents = parseKnownEvents(receipt, { getTokenMetadata })
+
+		expect(knownEvents).toHaveLength(2)
+		expect(knownEvents[0]).toMatchObject({
+			type: 'order flipped',
+			parts: [
+				{ type: 'action', value: 'Flip Buy' },
+				{
+					type: 'amount',
+					value: {
+						token,
+						value: amount,
+						symbol: 'USDC',
+					},
+				},
+				{ type: 'text', value: 'at tick' },
+				{ type: 'tick', value: 100 },
+			],
+			note: [
+				['Flip Tick', { type: 'tick', value: 98 }],
+				['Order ID', { type: 'number', value: 123n }],
+			],
+		})
+		expect(knownEvents[1]?.parts[0]).toEqual({
+			type: 'action',
+			value: 'Flip Sell',
+		})
+		expect(knownEvents[1]?.parts[3]).toEqual({ type: 'tick', value: 98 })
+		expect(knownEvents[1]?.note).toEqual([
+			['Flip Tick', { type: 'tick', value: 100 }],
+			['Order ID', { type: 'number', value: 124n }],
+		])
+	})
+
 	it('preserves tip20 approvals for zone portals', () => {
 		const hash = `0x${'4'.repeat(64)}` as const
 		const amount = 500_000n


### PR DESCRIPTION
## Summary

- add a temporary local TIP-1056 `OrderFlipped` ABI overlay for the
  Stablecoin DEX until `viem/tempo` exports it
- render `OrderFlipped` as `Flip Buy` / `Flip Sell` known events with amount,
  tick, flip tick, and order ID details
- expose the combined DEX ABI through the Stablecoin Exchange contract page and
  add demo/test coverage for the event

## Screenshots

No screenshots included. This is a decoder/ABI support change; the existing
transaction event UI is reused.

## Testing

- `pnpm --filter explorer check`
- `pnpm --filter explorer check:types`
- `pnpm --filter explorer exec vitest run --config /private/tmp/vitest-known-events.config.ts`

Known existing blockers:

- `pnpm --filter explorer test` fails before tests execute with
  `Missing "#tanstack-router-entry" specifier in "@tanstack/start-server-core" package`.
- Full repo `pnpm check` / `pnpm check:types` are blocked by unrelated
  `apps/contract-verification` Cloudflare binding type errors such as missing
  `CONTRACTS_DB`, `WHITELISTED_ORIGINS`, and `VERIFICATION_CONTAINER`.
