### PR TITLE
feat(explorer): support TIP-1026 token logos

### DIFF
--- a/apps/explorer/src/comps/AccountCard.tsx
+++ b/apps/explorer/src/comps/AccountCard.tsx
@@ -21,6 +21,7 @@ export function AccountCard(props: AccountCard.Props) {
 		hideHoldings,
 		accountType,
 		isToken,
+		tokenLogoURI,
 		tokenName,
 		virtualAddressParts,
 	} = props
@@ -48,6 +49,7 @@ export function AccountCard(props: AccountCard.Props) {
 									address={address as Address.Address}
 									name={tokenName}
 									className="size-4"
+									logoURI={tokenLogoURI}
 								/>
 								<span className="text-primary">{tokenName}</span>
 							</>
@@ -187,6 +189,7 @@ export declare namespace AccountCard {
 		hideHoldings?: boolean | undefined
 		accountType?: AccountType | undefined
 		isToken?: boolean | undefined
+		tokenLogoURI?: string | undefined
 		tokenName?: string | undefined
 		virtualAddressParts?:
 			| {

--- a/apps/explorer/src/comps/TokenIcon.tsx
+++ b/apps/explorer/src/comps/TokenIcon.tsx
@@ -1,18 +1,32 @@
 import type { Address } from 'ox'
+import * as React from 'react'
 import { cx } from '#lib/css'
+import { resolveLogoURI } from '#lib/domain/tip20'
 import { TOKENLIST_BASE_URL } from '#lib/tokenlist'
 import { getTempoChain } from '#wagmi.config'
 
 const TOKEN_ICON_BASE_URL = `${TOKENLIST_BASE_URL}/icon/${getTempoChain().id}`
 
 export function TokenIcon(props: TokenIcon.Props) {
-	const { address, className } = props
+	const { address, className, logoURI } = props
+	const fallbackSrc = `${TOKEN_ICON_BASE_URL}/${address}`
+	const primarySrc = resolveLogoURI(logoURI)
+	const [src, setSrc] = React.useState(primarySrc ?? fallbackSrc)
+
+	React.useEffect(() => {
+		setSrc(primarySrc ?? fallbackSrc)
+	}, [primarySrc, fallbackSrc])
+
 	return (
 		<img
-			src={`${TOKEN_ICON_BASE_URL}/${address}`}
+			src={src}
 			alt=""
 			className={cx('size-4 rounded-full shrink-0', className)}
 			onError={(e) => {
+				if (e.currentTarget.src !== fallbackSrc) {
+					setSrc(fallbackSrc)
+					return
+				}
 				e.currentTarget.style.display = 'none'
 			}}
 		/>
@@ -24,5 +38,6 @@ export namespace TokenIcon {
 		address: Address.Address
 		name?: string
 		className?: string
+		logoURI?: string | null | undefined
 	}
 }

--- a/apps/explorer/src/comps/WalletActions.tsx
+++ b/apps/explorer/src/comps/WalletActions.tsx
@@ -98,6 +98,7 @@ export function WalletActions(
 								connectors={supported}
 								symbol={props.symbol}
 								decimals={props.decimals}
+								image={props.image}
 							/>,
 							<SetAsFeeToken
 								key="fee"
@@ -133,5 +134,6 @@ export declare namespace WalletActions {
 		address: Address.Address
 		symbol?: string | undefined
 		decimals?: number | undefined
+		image?: string | undefined
 	}
 }

--- a/apps/explorer/src/lib/domain/tip20.ts
+++ b/apps/explorer/src/lib/domain/tip20.ts
@@ -1,6 +1,7 @@
 import type { Address } from 'ox'
 import type { Log } from 'viem'
 import { parseEventLogs } from 'viem'
+import { readContract, readContracts } from 'wagmi/actions'
 import { Abis } from 'viem/tempo'
 import { Actions } from 'wagmi/tempo'
 import type { Config } from 'wagmi'
@@ -19,6 +20,67 @@ export type Metadata = Actions.token.getMetadata.ReturnValue
 export type GetTip20MetadataFn = (
 	address: Address.Address,
 ) => Metadata | undefined
+
+export const logoUriAbi = [
+	{
+		type: 'function',
+		name: 'logoURI',
+		stateMutability: 'view',
+		inputs: [],
+		outputs: [{ type: 'string' }],
+	},
+] as const
+
+export function resolveLogoURI(logoURI: string | null | undefined) {
+	if (!logoURI) return undefined
+	const trimmed = logoURI.trim()
+	if (!trimmed) return undefined
+
+	if (trimmed.startsWith('ipfs://')) {
+		const path = trimmed.slice('ipfs://'.length).replace(/^ipfs\//, '')
+		if (!path) return undefined
+		return `https://ipfs.io/ipfs/${path}`
+	}
+
+	return trimmed
+}
+
+export async function fetchLogoURI(
+	config: Config,
+	token: Address.Address,
+): Promise<string | undefined> {
+	const logoURI = await readContract(config, {
+		address: token,
+		abi: logoUriAbi,
+		functionName: 'logoURI',
+	}).catch(() => undefined)
+
+	return typeof logoURI === 'string' ? logoURI : undefined
+}
+
+export async function fetchLogoURIs(
+	config: Config,
+	tokens: Address.Address[],
+): Promise<Map<string, string>> {
+	if (tokens.length === 0) return new Map()
+
+	const results = await readContracts(config, {
+		contracts: tokens.map((token) => ({
+			address: token,
+			abi: logoUriAbi,
+			functionName: 'logoURI',
+		})),
+	}).catch(() => [])
+
+	const logoURIs = new Map<string, string>()
+	for (const [index, result] of results.entries()) {
+		const logoURI = result.result
+		if (typeof logoURI === 'string' && logoURI.trim()) {
+			logoURIs.set(tokens[index].toLowerCase(), logoURI)
+		}
+	}
+	return logoURIs
+}
 
 export async function metadataFromLogs(
 	logs: Log[],

--- a/apps/explorer/src/lib/server/tokens.ts
+++ b/apps/explorer/src/lib/server/tokens.ts
@@ -4,6 +4,7 @@ import { getChainId } from 'wagmi/actions'
 import * as z from 'zod/mini'
 import { getAccountTag } from '#lib/account'
 import { TOKEN_COUNT_MAX } from '#lib/constants'
+import { fetchLogoURIs } from '#lib/domain/tip20'
 import {
 	fetchGenesisBlockTimestamp,
 	fetchTokenCreatedMetadata,
@@ -19,6 +20,7 @@ export type Token = {
 	symbol: string
 	name: string
 	currency: string
+	logoURI?: string | undefined
 	createdAt?: number | undefined
 	holdersCount?: number
 	holdersCountCapped?: boolean
@@ -142,7 +144,13 @@ export const fetchTokens = createServerFn({ method: 'POST' })
 
 		const tokenMetadata = new Map<
 			string,
-			{ name: string; symbol: string; currency: string; createdAt?: number }
+			{
+				name: string
+				symbol: string
+				currency: string
+				logoURI?: string | undefined
+				createdAt?: number
+			}
 		>()
 		const createdAtByAddress = new Map<string, number>()
 		let genesisCreatedAt: number | undefined
@@ -150,42 +158,47 @@ export const fetchTokens = createServerFn({ method: 'POST' })
 		const holdersCounts = new Map<string, { count: number; capped: boolean }>()
 
 		if (pageAddresses.length > 0) {
-			const [metadataResult, genesisTimestampResult, perTokenResults] =
-				await Promise.all([
-					fetchTokenCreatedMetadata(chainId, pageAddresses).catch((error) => {
-						console.error('Failed to fetch token metadata:', error)
-						return []
-					}),
-					hasGenesisTokens
-						? fetchGenesisBlockTimestamp(chainId).catch((error) => {
-								console.error('Failed to fetch genesis block timestamp:', error)
-								return null
-							})
-						: Promise.resolve(null),
-					Promise.allSettled(
-						pageAddresses.map(async (address) => ({
+			const [
+				metadataResult,
+				genesisTimestampResult,
+				logoURIs,
+				perTokenResults,
+			] = await Promise.all([
+				fetchTokenCreatedMetadata(chainId, pageAddresses).catch((error) => {
+					console.error('Failed to fetch token metadata:', error)
+					return []
+				}),
+				hasGenesisTokens
+					? fetchGenesisBlockTimestamp(chainId).catch((error) => {
+							console.error('Failed to fetch genesis block timestamp:', error)
+							return null
+						})
+					: Promise.resolve(null),
+				fetchLogoURIs(config, pageAddresses),
+				Promise.allSettled(
+					pageAddresses.map(async (address) => ({
+						address,
+						transferAggregate: await fetchTokenTransferAggregate(
 							address,
-							transferAggregate: await fetchTokenTransferAggregate(
-								address,
-								chainId,
-							).catch((error) => {
-								console.error(
-									`Failed to fetch transfer aggregate for ${address}:`,
-									error,
-								)
-								return {
-									oldestTimestamp: undefined,
-									latestTimestamp: undefined,
-								}
-							}),
-							holdersCount: await fetchTokenHoldersCount(
-								address,
-								chainId,
-								TOKEN_COUNT_MAX,
-							),
-						})),
-					),
-				])
+							chainId,
+						).catch((error) => {
+							console.error(
+								`Failed to fetch transfer aggregate for ${address}:`,
+								error,
+							)
+							return {
+								oldestTimestamp: undefined,
+								latestTimestamp: undefined,
+							}
+						}),
+						holdersCount: await fetchTokenHoldersCount(
+							address,
+							chainId,
+							TOKEN_COUNT_MAX,
+						),
+					})),
+				),
+			])
 
 			genesisCreatedAt = parseTimestamp(
 				genesisTimestampResult == null
@@ -220,6 +233,20 @@ export const fetchTokens = createServerFn({ method: 'POST' })
 				}
 
 				holdersCounts.set(addressKey, result.value.holdersCount)
+				const logoURI = logoURIs.get(addressKey)
+				if (logoURI) {
+					const metadata = tokenMetadata.get(addressKey)
+					if (metadata) {
+						metadata.logoURI = logoURI
+					} else {
+						tokenMetadata.set(addressKey, {
+							name: '',
+							symbol: '',
+							currency: '',
+							logoURI,
+						})
+					}
+				}
 			}
 		}
 
@@ -237,6 +264,7 @@ export const fetchTokens = createServerFn({ method: 'POST' })
 					symbol: metadata?.symbol || entry.symbol,
 					name: metadata?.name || entry.name,
 					currency: metadata?.currency || inferTokenCurrency(entry),
+					logoURI: metadata?.logoURI,
 					createdAt:
 						createdAtByAddress.get(addressKey) ??
 						metadata?.createdAt ??

--- a/apps/explorer/src/lib/tempo-address.ts
+++ b/apps/explorer/src/lib/tempo-address.ts
@@ -17,7 +17,6 @@ export function normalizeSearchInput(input: string): string {
 	const query = input.trim()
 	if (!query) return ''
 	if (TempoAddress.validate(query)) return TempoAddress.parse(query).address
-	if (Address.validate(query, { strict: false }))
-		return Address.checksum(query)
+	if (Address.validate(query, { strict: false })) return Address.checksum(query)
 	return query
 }

--- a/apps/explorer/src/routes/_layout/address/$address.tsx
+++ b/apps/explorer/src/routes/_layout/address/$address.tsx
@@ -254,6 +254,12 @@ export const Route = createFileRoute('/_layout/address/$address')({
 					.catch(() => null),
 				QUERY_TIMEOUT_MS,
 			)
+			const tokenLogoURIPromise = isKnownTokenAddress
+				? timeout(
+						Tip20.fetchLogoURI(config as Config, address as Address.Address),
+						QUERY_TIMEOUT_MS,
+					)
+				: Promise.resolve(undefined)
 
 			const historySources = historySourcesForAddress(
 				address as Address.Address,
@@ -319,12 +325,14 @@ export const Route = createFileRoute('/_layout/address/$address')({
 				transactionsData,
 				balancesResult,
 				tokenMetadata,
+				tokenLogoURI,
 				ogMeta,
 			] = await Promise.all([
 				contractBytecodePromise,
 				transactionsPromise,
 				balancesPromise,
 				tokenMetadataPromise,
+				tokenLogoURIPromise,
 				ogMetaPromise,
 			])
 
@@ -349,6 +357,7 @@ export const Route = createFileRoute('/_layout/address/$address')({
 				accountType,
 				isToken,
 				tokenMetadata,
+				tokenLogoURI,
 				contractInfo,
 				contractSource,
 				transactionsData,
@@ -498,6 +507,7 @@ function RouteComponent() {
 		accountType,
 		isToken,
 		tokenMetadata,
+		tokenLogoURI,
 		account,
 		contractInfo,
 		contractSource,
@@ -673,6 +683,7 @@ function RouteComponent() {
 				addressMetadata={addressMetadata}
 				isToken={isToken}
 				tokenMetadata={tokenMetadata}
+				tokenLogoURI={tokenLogoURI}
 			/>
 			<SectionsWrapper
 				address={address}
@@ -780,6 +791,7 @@ function AccountCardWithTimestamps(props: {
 	accountType?: AccountType
 	addressMetadata?: Awaited<ReturnType<typeof fetchAddressMetadata>>
 	isToken?: boolean
+	tokenLogoURI?: string | undefined
 	tokenMetadata?: TokenMetadata | null
 }) {
 	const {
@@ -788,6 +800,7 @@ function AccountCardWithTimestamps(props: {
 		accountType: initialAccountType,
 		addressMetadata,
 		isToken,
+		tokenLogoURI,
 		tokenMetadata,
 	} = props
 
@@ -846,6 +859,7 @@ function AccountCardWithTimestamps(props: {
 				hideHoldings={isTip20}
 				accountType={resolvedAccountType}
 				isToken={isToken}
+				tokenLogoURI={tokenLogoURI}
 				tokenName={tokenMetadata?.name}
 				virtualAddressParts={virtualAddressParts}
 			/>
@@ -855,6 +869,7 @@ function AccountCardWithTimestamps(props: {
 						address={address}
 						symbol={tokenMetadata?.symbol}
 						decimals={tokenMetadata?.decimals}
+						image={Tip20.resolveLogoURI(tokenLogoURI)}
 					/>
 				</ClientOnly>
 			)}

--- a/apps/explorer/src/routes/_layout/tokens.tsx
+++ b/apps/explorer/src/routes/_layout/tokens.tsx
@@ -164,6 +164,7 @@ function TokensPage() {
 												<TokenIcon
 													address={token.address}
 													name={token.symbol}
+													logoURI={token.logoURI}
 												/>
 												{token.symbol}
 											</span>,

--- a/apps/explorer/test/tip20-logo-uri.node.test.ts
+++ b/apps/explorer/test/tip20-logo-uri.node.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { resolveLogoURI } from '#lib/domain/tip20'
+
+describe('TIP-20 logoURI helpers', () => {
+	it('returns undefined for empty logo URIs', () => {
+		expect(resolveLogoURI(undefined)).toBeUndefined()
+		expect(resolveLogoURI('')).toBeUndefined()
+		expect(resolveLogoURI('   ')).toBeUndefined()
+	})
+
+	it('passes through browser-native image URI schemes', () => {
+		expect(resolveLogoURI('https://example.com/logo.png')).toBe(
+			'https://example.com/logo.png',
+		)
+		expect(resolveLogoURI('data:image/png;base64,abc')).toBe(
+			'data:image/png;base64,abc',
+		)
+	})
+
+	it('normalizes IPFS URIs to an HTTP gateway URL', () => {
+		expect(resolveLogoURI('ipfs://bafybeigdyr/logo.png')).toBe(
+			'https://ipfs.io/ipfs/bafybeigdyr/logo.png',
+		)
+		expect(resolveLogoURI('ipfs://ipfs/bafybeigdyr/logo.png')).toBe(
+			'https://ipfs.io/ipfs/bafybeigdyr/logo.png',
+		)
+	})
+})


### PR DESCRIPTION
## Summary
- read TIP-1026 logoURI metadata for Explorer token surfaces
- use on-chain logoURI first, with tokenlist icon fallback on load failure
- batch token list logoURI reads through readContracts and pass images to wallet add flow

## Screenshots
N/A - no stable token with on-chain logoURI was available locally to capture a meaningful before/after.

## Testing
- pnpm --filter explorer check
- pnpm --filter explorer exec vitest run test/tip20-logo-uri.node.test.ts --config vitest.node.config.ts