### PR TITLE
feat(explorer): support channel escrow ABI

### DIFF
--- a/apps/explorer/src/lib/domain/contracts.ts
+++ b/apps/explorer/src/lib/domain/contracts.ts
@@ -9,7 +9,12 @@ import {
 } from 'viem'
 import { Abis, Addresses } from 'viem/tempo'
 import { getChainId, getPublicClient } from 'wagmi/actions'
-import { stablecoinDexAbi, streamChannelAbi } from './known-events.ts'
+import {
+	stablecoinDexAbi,
+	streamChannelAbi,
+	tip20ChannelEscrowAbi,
+	tip20ChannelEscrowAddress,
+} from './known-events.ts'
 import { isTip20Address } from '#lib/domain/tip20.ts'
 import { getWagmiConfig } from '#wagmi.config.ts'
 
@@ -306,6 +311,18 @@ export const systemContractRegistry = new Map<Address.Address, ContractInfo>(<
 			abi: Abis.accountKeychain,
 			category: 'system',
 			address: Addresses.accountKeychain,
+		},
+	],
+	[
+		tip20ChannelEscrowAddress,
+		{
+			name: 'TIP-20 Channel Escrow',
+			code: '0xef',
+			description: 'Native TIP-20 payment channel escrow precompile',
+			abi: tip20ChannelEscrowAbi,
+			category: 'system',
+			docsUrl: 'https://tips.sh/1034-1',
+			address: tip20ChannelEscrowAddress,
 		},
 	],
 	[
@@ -886,6 +903,9 @@ export async function autoloadAbi(
 	address: Address.Address,
 	options: AutoloadAbiOptions = {},
 ): Promise<Abi | null> {
+	const knownAbi = getContractAbi(address)
+	if (knownAbi && knownAbi.length > 0) return knownAbi
+
 	const { followProxies = true, includeSourceVerified = true } = options
 	const config = getWagmiConfig()
 	const chainId = getChainId(config)

--- a/apps/explorer/src/lib/domain/known-events.ts
+++ b/apps/explorer/src/lib/domain/known-events.ts
@@ -2,10 +2,60 @@ import * as Address from 'ox/Address'
 import { VirtualAddress } from 'ox/tempo'
 import type * as Hex from 'ox/Hex'
 import type { AbiEvent, Log, TransactionReceipt } from 'viem'
-import { decodeFunctionData, parseEventLogs, zeroAddress } from 'viem'
+import { decodeFunctionData, parseAbi, parseEventLogs, zeroAddress } from 'viem'
 import { Abis, Addresses } from 'viem/tempo'
 import { decodeMemoForDisplay } from '#lib/domain/memo'
 import type * as Tip20 from './tip20'
+
+type TempoAbisWithTip1034 = typeof Abis & {
+	tip20ChannelEscrow?: typeof tip20ChannelEscrowFallbackAbi
+}
+
+type TempoAddressesWithTip1034 = typeof Addresses & {
+	tip20ChannelEscrow?: typeof TIP20_CHANNEL_ESCROW_ADDRESS
+}
+
+export const TIP20_CHANNEL_ESCROW_ADDRESS =
+	'0x4D50500000000000000000000000000000000000'
+
+const tip20ChannelEscrowFallbackAbi = parseAbi([
+	'struct ChannelDescriptor { address payer; address payee; address operator; address token; bytes32 salt; address authorizedSigner; bytes32 expiringNonceHash; }',
+	'struct ChannelState { uint96 settled; uint96 deposit; uint32 closeRequestedAt; }',
+	'function open(address payee, address operator, address token, bytes32 salt, address authorizedSigner, uint96 deposit) returns (bytes32 channelId)',
+	'function settle(ChannelDescriptor descriptor, uint96 cumulativeAmount, bytes signature)',
+	'function topUp(ChannelDescriptor descriptor, uint96 additionalDeposit)',
+	'function requestClose(ChannelDescriptor descriptor)',
+	'function close(ChannelDescriptor descriptor, uint96 cumulativeAmount, uint96 captureAmount, bytes signature)',
+	'function withdraw(ChannelDescriptor descriptor)',
+	'function channelId(ChannelDescriptor descriptor) view returns (bytes32)',
+	'function state(ChannelDescriptor descriptor) view returns (ChannelState)',
+	'event ChannelOpened(bytes32 indexed channelId, ChannelDescriptor descriptor, uint96 deposit)',
+	'event Settled(bytes32 indexed channelId, ChannelDescriptor descriptor, uint96 cumulativeAmount, uint96 deltaPaid, uint96 newSettled)',
+	'event TopUp(bytes32 indexed channelId, ChannelDescriptor descriptor, uint96 additionalDeposit, uint96 newDeposit)',
+	'event CloseRequested(bytes32 indexed channelId, ChannelDescriptor descriptor, uint32 closeRequestedAt)',
+	'event CloseRequestCancelled(bytes32 indexed channelId, ChannelDescriptor descriptor)',
+	'event ChannelClosed(bytes32 indexed channelId, ChannelDescriptor descriptor, uint96 settledToPayee, uint96 refundedToPayer)',
+	'event ChannelWithdrawn(bytes32 indexed channelId, ChannelDescriptor descriptor, uint96 refundedToPayer)',
+	'error InvalidPayee()',
+	'error InvalidToken()',
+	'error InvalidDeposit()',
+	'error ChannelAlreadyOpen(bytes32 channelId)',
+	'error ChannelNotOpen(bytes32 channelId)',
+	'error Unauthorized()',
+	'error InvalidSignature()',
+	'error InvalidCaptureAmount()',
+	'error InsufficientDeposit()',
+	'error CloseGracePeriodNotElapsed()',
+])
+
+export const tip20ChannelEscrowAbi = ((Abis as TempoAbisWithTip1034)
+	.tip20ChannelEscrow ??
+	tip20ChannelEscrowFallbackAbi) as typeof tip20ChannelEscrowFallbackAbi
+
+export const tip20ChannelEscrowAddress = ((
+	Addresses as TempoAddressesWithTip1034
+).tip20ChannelEscrow ??
+	TIP20_CHANNEL_ESCROW_ADDRESS) as typeof TIP20_CHANNEL_ESCROW_ADDRESS
 
 export const streamChannelAbi = [
 	{
@@ -253,6 +303,7 @@ export const stablecoinDexAbi = [
 
 const abi = [
 	...Object.values(Abis).flat(),
+	...tip20ChannelEscrowAbi,
 	...stablecoinDexTip1056Abi,
 	...streamChannelAbi,
 	...zonePortalAbi,

--- a/apps/explorer/test/tip20-channel-escrow.node.test.ts
+++ b/apps/explorer/test/tip20-channel-escrow.node.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+import { decodeFunctionData, encodeFunctionData, getAbiItem } from 'viem'
+import { autoloadAbi, getContractInfo } from '#lib/domain/contracts'
+import {
+	tip20ChannelEscrowAbi,
+	tip20ChannelEscrowAddress,
+} from '#lib/domain/known-events'
+
+describe('TIP-20 channel escrow ABI', () => {
+	it('registers the TIP-1034 precompile address for ABI rendering', () => {
+		const info = getContractInfo(tip20ChannelEscrowAddress)
+
+		expect(info?.name).toBe('TIP-20 Channel Escrow')
+		expect(info?.abi).toBe(tip20ChannelEscrowAbi)
+		expect(
+			getAbiItem({
+				abi: info?.abi ?? [],
+				name: 'close',
+			}),
+		).toBeDefined()
+	})
+
+	it('decodes descriptor-based channel calldata', () => {
+		const descriptor = {
+			payer: '0x1111111111111111111111111111111111111111',
+			payee: '0x2222222222222222222222222222222222222222',
+			operator: '0x3333333333333333333333333333333333333333',
+			token: '0x20c0000000000000000000000000000000000000',
+			salt: `0x${'4'.repeat(64)}` as const,
+			authorizedSigner: '0x5555555555555555555555555555555555555555',
+			expiringNonceHash: `0x${'6'.repeat(64)}` as const,
+		} as const
+
+		const data = encodeFunctionData({
+			abi: tip20ChannelEscrowAbi,
+			functionName: 'close',
+			args: [descriptor, 100n, 90n, '0x1234'],
+		})
+
+		const decoded = decodeFunctionData({
+			abi: tip20ChannelEscrowAbi,
+			data,
+		})
+
+		expect(decoded.functionName).toBe('close')
+		expect(decoded.args[0]).toMatchObject({
+			...descriptor,
+			token: '0x20C0000000000000000000000000000000000000',
+		})
+		expect(decoded.args[1]).toBe(100n)
+		expect(decoded.args[2]).toBe(90n)
+	})
+
+	it('returns known registry ABIs from autoload before network lookup', async () => {
+		await expect(autoloadAbi(tip20ChannelEscrowAddress)).resolves.toBe(
+			tip20ChannelEscrowAbi,
+		)
+	})
+})


### PR DESCRIPTION
## Summary
- add TIP-1034 TIP-20 channel escrow ABI/address support, preferring viem/tempo exports when available
- register the channel escrow precompile for explorer contract rendering
- return known registry ABIs from autoload before remote lookup so calldata decoding works for native precompiles
- add a focused node test for registration and descriptor calldata decoding

## Tests
- pnpm --filter explorer check
- pnpm --filter explorer check:types
- pnpm --filter explorer exec vitest run --config vitest.node.config.ts test/tip20-channel-escrow.node.test.ts

## Notes
- Root pnpm check still fails on existing unrelated issues in apps/fee-payer Biome warnings and apps/contract-verification Env type errors.