### PR TITLE
feat(fee-payer): enable Smart Placement on mainnet

### DIFF
--- a/apps/fee-payer/wrangler.json
+++ b/apps/fee-payer/wrangler.json
@@ -118,6 +118,7 @@
 		},
 		"mainnet": {
 			"name": "fee-payer-mainnet",
+			"placement": { "mode": "smart" },
 			"routes": [
 				{
 					"pattern": "sponsor.tempo.xyz",


### PR DESCRIPTION
## Summary

Enables [Cloudflare Smart Placement](https://developers.cloudflare.com/workers/configuration/smart-placement/) on the `mainnet` env (`sponsor.tempo.xyz`) so the Worker runs near the Tempo RPC origin instead of the user.

## Motivation

`eth_fillTransaction` on the relay does multiple subrequests per call — chain fill, token-metadata multicall on KV miss, tokenlist fetch on KV miss, and an optional `tempo_simulateV1` for balance diffs. Each hop costs the full Worker↔origin round-trip. For users far from the RPC origin, those hops dominate end-to-end latency.

Smart Placement adaptively relocates the isolate per-PoP, trading one slightly slower user↔Worker hop for `N` much faster Worker↔origin hops. CF keeps the Worker local where the origin is already close, so US-region users should see ~no change while EU/APAC users should see a meaningful p50/p95 drop.

Local measurement against `sponsor.tempo.xyz` today (US, 10 iterations, `balanceDiffs: false`): p50 ≈ 107ms, avg ≈ 147ms, p95 ≈ 447ms. The biggest opportunity is reducing the cross-region tail.

## Changes

- `apps/fee-payer/wrangler.json`: add `"placement": { "mode": "smart" }` to the `mainnet` env only. Other envs (`privy`, `devnet`, `moderato`) keep default edge placement.

## Testing

- Config-only change; no runtime behavior change in the Worker code.
- `pnpm check:biome` clean on the modified file.
- Post-deploy validation: compare p50/p95 by region in the CF dashboard → Worker → Observability over ~24h. Expect EU/APAC to drop; US to stay flat. Smart Placement is reversible — remove the line to revert.