### PR TITLE
fix: preserve fee-payer PostHog config

### DIFF
--- a/apps/fee-payer/test/api-keys.test.ts
+++ b/apps/fee-payer/test/api-keys.test.ts
@@ -1,7 +1,11 @@
 import { env, exports } from 'cloudflare:workers'
 import { sendTransactionSync } from 'viem/actions'
 import { describe, expect, it } from 'vitest'
-import { buildSponsorClient, sponsorAddress, userAccount } from './helpers.js'
+import {
+	buildSponsorClient,
+	createTestAccount,
+	sponsorAddress,
+} from './helpers.js'
 
 const ADMIN_SECRET = 'test-admin-secret'
 
@@ -270,12 +274,16 @@ describe('API key sponsorship integration', () => {
 			}),
 		)
 		const { key } = (await createRes.json()) as { key: string }
+		const account = createTestAccount()
 
-		const receipt = await sendTransactionSync(buildSponsorClient(key), {
-			feePayer: true,
-			to,
-			value: 0n,
-		})
+		const receipt = await sendTransactionSync(
+			buildSponsorClient(key, account),
+			{
+				feePayer: true,
+				to,
+				value: 0n,
+			},
+		)
 
 		expect(receipt.status).toBe('success')
 		expect(receipt.feeToken).toMatch(/^0x[a-fA-F0-9]{40}$/)
@@ -289,9 +297,10 @@ describe('API key sponsorship integration', () => {
 			}),
 		)
 		const { key } = (await createRes.json()) as { key: string }
+		const account = createTestAccount()
 
 		await expect(
-			sendTransactionSync(buildSponsorClient(key), {
+			sendTransactionSync(buildSponsorClient(key, account), {
 				feePayer: true,
 				to: '0x0000000000000000000000000000000000000002',
 				value: 0n,
@@ -311,9 +320,10 @@ describe('API key sponsorship integration', () => {
 		// Pre-seed today's spend above the limit.
 		const today = new Date().toISOString().slice(0, 10)
 		await env.SponsorApiKeyStore.put(`spend:${key}:${today}`, '1000000')
+		const account = createTestAccount()
 
 		await expect(
-			sendTransactionSync(buildSponsorClient(key), {
+			sendTransactionSync(buildSponsorClient(key, account), {
 				feePayer: true,
 				to: '0x0000000000000000000000000000000000000002',
 				value: 0n,
@@ -329,12 +339,16 @@ describe('API key sponsorship integration', () => {
 			}),
 		)
 		const { key } = (await createRes.json()) as { key: string }
+		const account = createTestAccount()
 
-		const receipt = await sendTransactionSync(buildSponsorClient(key), {
-			feePayer: true,
-			to: '0x0000000000000000000000000000000000000002',
-			value: 0n,
-		})
+		const receipt = await sendTransactionSync(
+			buildSponsorClient(key, account),
+			{
+				feePayer: true,
+				to: '0x0000000000000000000000000000000000000002',
+				value: 0n,
+			},
+		)
 		expect(receipt.status).toBe('success')
 
 		// recordSpend runs via ctx.waitUntil; poll briefly until it lands.
@@ -374,21 +388,27 @@ describe('API key sponsorship integration', () => {
 		}
 
 		// First sponsored tx — lifetime starts from 0.
-		const r1 = await sendTransactionSync(buildSponsorClient(key), {
-			feePayer: true,
-			to: '0x0000000000000000000000000000000000000002',
-			value: 0n,
-		})
+		const r1 = await sendTransactionSync(
+			buildSponsorClient(key, createTestAccount()),
+			{
+				feePayer: true,
+				to: '0x0000000000000000000000000000000000000002',
+				value: 0n,
+			},
+		)
 		expect(r1.status).toBe('success')
 		const afterFirst = await waitForLifetime(0n)
 
 		// Second sponsored tx — lifetime should strictly increase, not be
 		// overwritten with the second-tx-only fee.
-		const r2 = await sendTransactionSync(buildSponsorClient(key), {
-			feePayer: true,
-			to: '0x0000000000000000000000000000000000000002',
-			value: 0n,
-		})
+		const r2 = await sendTransactionSync(
+			buildSponsorClient(key, createTestAccount()),
+			{
+				feePayer: true,
+				to: '0x0000000000000000000000000000000000000002',
+				value: 0n,
+			},
+		)
 		expect(r2.status).toBe('success')
 		const afterSecond = await waitForLifetime(afterFirst)
 
@@ -405,20 +425,24 @@ describe('API key sponsorship integration', () => {
 			adminRequest('POST', '/keys', { label: 'Sponsorship Test' }),
 		)
 		const { key } = (await createRes.json()) as { key: string }
+		const account = createTestAccount()
 
 		// Build a withRelay client whose relay transport hits the
 		// fee-payer Worker via the /tp_* API key path. This exercises the
 		// full middleware chain (apiKey + rateLimit) on a real sponsored
 		// fill + sign + broadcast.
-		const receipt = await sendTransactionSync(buildSponsorClient(key), {
-			feePayer: true,
-			to: '0x0000000000000000000000000000000000000002',
-			value: 0n,
-		})
+		const receipt = await sendTransactionSync(
+			buildSponsorClient(key, account),
+			{
+				feePayer: true,
+				to: '0x0000000000000000000000000000000000000002',
+				value: 0n,
+			},
+		)
 
 		expect(receipt.transactionHash).toBeDefined()
 		expect(receipt.status).toBe('success')
-		expect(receipt.from.toLowerCase()).toBe(userAccount.address.toLowerCase())
+		expect(receipt.from.toLowerCase()).toBe(account.address.toLowerCase())
 		expect(receipt.feePayer?.toLowerCase()).toBe(sponsorAddress.toLowerCase())
 		expect(receipt.feeToken).toMatch(/^0x[a-fA-F0-9]{40}$/)
 	})

--- a/apps/fee-payer/test/e2e.test.ts
+++ b/apps/fee-payer/test/e2e.test.ts
@@ -6,10 +6,10 @@ import { Account, Actions, withRelay } from 'viem/tempo'
 import { beforeAll, describe, expect, it } from 'vitest'
 import {
 	sponsorAddress,
+	createTestAccount,
 	tempoChain,
 	tempoTransport,
 	testMnemonic,
-	userAccount,
 } from './helpers.js'
 
 function createFeePayerTransportWithSpy() {
@@ -147,9 +147,10 @@ describe('fee-payer integration', () => {
 		it('sponsors transaction (sign-only via eth_signRawTransaction)', async () => {
 			const { transport: feePayerTransport, requests: feePayerRequests } =
 				createFeePayerTransportWithSpy()
+			const account = createTestAccount()
 
 			const client = createClient({
-				account: userAccount,
+				account,
 				chain: tempoChain,
 				transport: withRelay(tempoTransport(), feePayerTransport, {
 					policy: 'sign-only',
@@ -165,7 +166,7 @@ describe('fee-payer integration', () => {
 			console.log(`Transaction hash: ${receipt.transactionHash}`)
 
 			expect(receipt.transactionHash).toBeDefined()
-			expect(receipt.from.toLowerCase()).toBe(userAccount.address.toLowerCase())
+			expect(receipt.from.toLowerCase()).toBe(account.address.toLowerCase())
 			expect(receipt.feePayer?.toLowerCase()).toBe(sponsorAddress.toLowerCase())
 			// Regression: the broadcast envelope must carry a feeToken the
 			// chain can charge. Without it the chain falls back to the
@@ -185,9 +186,10 @@ describe('fee-payer integration', () => {
 		it('sponsors and broadcasts transaction (sign-and-broadcast)', async () => {
 			const { transport: feePayerTransport, requests: feePayerRequests } =
 				createFeePayerTransportWithSpy()
+			const account = createTestAccount()
 
 			const client = createClient({
-				account: userAccount,
+				account,
 				chain: tempoChain,
 				transport: withRelay(tempoTransport(), feePayerTransport, {
 					policy: 'sign-and-broadcast',
@@ -204,7 +206,7 @@ describe('fee-payer integration', () => {
 
 			expect(receipt.transactionHash).toBeDefined()
 			expect(receipt.blockNumber).toBeGreaterThan(0n)
-			expect(receipt.from.toLowerCase()).toBe(userAccount.address.toLowerCase())
+			expect(receipt.from.toLowerCase()).toBe(account.address.toLowerCase())
 			expect(receipt.feePayer?.toLowerCase()).toBe(sponsorAddress.toLowerCase())
 			expect(receipt.status).toBe('success')
 			// Regression: the broadcast envelope must carry a feeToken the

--- a/apps/fee-payer/test/helpers.ts
+++ b/apps/fee-payer/test/helpers.ts
@@ -1,5 +1,5 @@
 import { env, exports } from 'cloudflare:workers'
-import { Mnemonic } from 'ox'
+import { Mnemonic, Secp256k1 } from 'ox'
 import { createClient, custom } from 'viem'
 import { tempo, tempoDevnet, tempoLocalnet, tempoModerato } from 'viem/chains'
 import { Account, withRelay } from 'viem/tempo'
@@ -23,6 +23,10 @@ export const userAccount = Account.fromSecp256k1(
 		path: Mnemonic.path({ account: 9 }),
 	}),
 )
+
+export function createTestAccount(): typeof userAccount {
+	return Account.fromSecp256k1(Secp256k1.randomPrivateKey())
+}
 
 /** Routes RPC calls through the in-process fee-payer Worker at `path`. */
 export function feePayerTransport(path: string) {
@@ -71,9 +75,12 @@ export function tempoTransport() {
 }
 
 /** Build a sponsorship client routed through `/${key}`. */
-export function buildSponsorClient(key: string) {
+export function buildSponsorClient(
+	key: string,
+	account: typeof userAccount = userAccount,
+) {
 	return createClient({
-		account: userAccount,
+		account,
 		chain: tempoChain,
 		transport: withRelay(tempoTransport(), feePayerTransport(`/${key}`), {
 			policy: 'sign-and-broadcast',

--- a/apps/fee-payer/wrangler.json
+++ b/apps/fee-payer/wrangler.json
@@ -43,8 +43,7 @@
 			"vars": {
 				"TEMPO_RPC_URL": "https://rpc.moderato.tempo.xyz",
 				"ALLOWED_ORIGINS": "*",
-				"TEMPO_ENV": "moderato",
-				"POSTHOG_API_KEY": ""
+				"TEMPO_ENV": "moderato"
 			},
 			"ratelimits": [
 				{
@@ -70,8 +69,7 @@
 			"vars": {
 				"TEMPO_RPC_URL": "https://rpc.devnet.tempoxyz.dev",
 				"ALLOWED_ORIGINS": "*",
-				"TEMPO_ENV": "devnet",
-				"POSTHOG_API_KEY": ""
+				"TEMPO_ENV": "devnet"
 			},
 			"ratelimits": [
 				{
@@ -102,8 +100,7 @@
 			"vars": {
 				"TEMPO_RPC_URL": "https://rpc.moderato.tempo.xyz",
 				"ALLOWED_ORIGINS": "*",
-				"TEMPO_ENV": "moderato",
-				"POSTHOG_API_KEY": ""
+				"TEMPO_ENV": "moderato"
 			},
 			"ratelimits": [
 				{
@@ -129,8 +126,7 @@
 			"workers_dev": false,
 			"vars": {
 				"ALLOWED_ORIGINS": "*",
-				"TEMPO_ENV": "mainnet",
-				"POSTHOG_API_KEY": ""
+				"TEMPO_ENV": "mainnet"
 			},
 			"kv_namespaces": [
 				{


### PR DESCRIPTION
## Summary

Removes empty fee-payer `POSTHOG_API_KEY` Wrangler vars so Cloudflare Worker secrets/vars can supply the PostHog project token. Stabilizes fee-payer sponsorship tests by avoiding deterministic sender reuse for broadcasted transactions.

## Motivation

`sponsor.tempo.xyz` was logging that PostHog capture was skipped because the Worker binding was empty. Fee-payer CI also reused a shared test account against persistent testnet state, which could trigger expiring nonce replay failures.

## Changes

- Removed empty `POSTHOG_API_KEY` entries from the fee-payer `privy`, `devnet`, `moderato`, and `mainnet` Wrangler env vars.
- Added a helper for fresh fee-payer test accounts.
- Updated sponsorship tests to use fresh accounts for broadcasted transactions and assert against the per-test sender.

## Testing

- `pnpm --filter fee-payer check`
- `pnpm --filter fee-payer test:moderato`
- `pnpm precommit`
- `pnpm check` still fails in `apps/contract-verification` typecheck due missing generated `Env` bindings, unrelated to this change.
- `pnpm --filter fee-payer test` still fails localnet sponsorship cases with `Chain 1337 not configured`; the CI/testnet nonce replay path is addressed by the fresh-account test changes.
