### PR TITLE
Deploy internal perf image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git
+**/node_modules
+**/dist
+**/.wrangler
+**/.turbo
+**/.vite

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,6 +70,59 @@ jobs:
       app: perf
       environments: '[""]'
 
+  deploy-perf-internal:
+    name: Deploy Perf Internal
+    needs: verify
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          submodules: "recursive"
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Check for relevant changes
+        id: changes
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BEFORE_SHA: ${{ github.event.before }}
+          CURRENT_SHA: ${{ github.sha }}
+        run: |
+          if [[ "$EVENT_NAME" == 'workflow_dispatch' ]]; then
+            echo "relevant=true" >> $GITHUB_OUTPUT
+          elif git diff --name-only "$BEFORE_SHA" "$CURRENT_SHA" | grep -qE "^(apps/perf/|pnpm-lock.yaml|packages/)"; then
+            echo "relevant=true" >> $GITHUB_OUTPUT
+          else
+            echo "relevant=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Set up Docker Buildx
+        if: steps.changes.outputs.relevant == 'true'
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435
+
+      - name: Log in to GHCR
+        if: steps.changes.outputs.relevant == 'true'
+        uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Build and push image
+        if: steps.changes.outputs.relevant == 'true'
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83
+        with:
+          context: .
+          file: apps/perf/Dockerfile
+          push: true
+          tags: |
+            ghcr.io/tempoxyz/tempo-apps-internal-perf:latest
+            ghcr.io/tempoxyz/tempo-apps-internal-perf:${{ github.sha }}
+
   deploy-og:
     name: Deploy OG
     needs: verify

--- a/apps/perf/Dockerfile
+++ b/apps/perf/Dockerfile
@@ -1,0 +1,28 @@
+# syntax=docker/dockerfile:1
+
+FROM node:24.14.0-alpine AS build
+WORKDIR /app
+
+RUN corepack enable pnpm
+
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY patches ./patches
+COPY packages ./packages
+COPY apps/perf ./apps/perf
+
+RUN pnpm install --frozen-lockfile
+RUN pnpm --filter perf build
+
+FROM node:24.14.0-alpine AS runtime
+WORKDIR /app
+
+ENV NODE_ENV=production
+ENV PORT=3000
+
+COPY --from=build /app/apps/perf/dist ./dist
+COPY apps/perf/server.mjs ./server.mjs
+
+USER node
+EXPOSE 3000
+
+CMD ["node", "server.mjs"]

--- a/apps/perf/server.mjs
+++ b/apps/perf/server.mjs
@@ -1,0 +1,89 @@
+import { createReadStream } from 'node:fs'
+import { stat } from 'node:fs/promises'
+import { createServer } from 'node:http'
+import { extname, join, normalize } from 'node:path'
+import app from './dist/server/index.js'
+
+const port = Number.parseInt(process.env.PORT ?? '3000', 10)
+const clientDir = join(process.cwd(), 'dist/client')
+
+const contentTypes = {
+	'.css': 'text/css; charset=utf-8',
+	'.html': 'text/html; charset=utf-8',
+	'.js': 'text/javascript; charset=utf-8',
+	'.json': 'application/json; charset=utf-8',
+	'.png': 'image/png',
+	'.svg': 'image/svg+xml',
+	'.txt': 'text/plain; charset=utf-8',
+	'.webp': 'image/webp',
+}
+
+async function sendStatic(requestUrl, response) {
+	const pathname = decodeURIComponent(new URL(requestUrl, 'http://localhost').pathname)
+	const normalized = normalize(pathname).replace(/^(\.\.[/\\])+/, '')
+	const filePath = join(clientDir, normalized === '/' ? 'index.html' : normalized)
+
+	if (!filePath.startsWith(clientDir)) {
+		return false
+	}
+
+	try {
+		const file = await stat(filePath)
+		if (!file.isFile()) {
+			return false
+		}
+
+		response.writeHead(200, {
+			'content-length': file.size,
+			'content-type': contentTypes[extname(filePath)] ?? 'application/octet-stream',
+		})
+		createReadStream(filePath).pipe(response)
+		return true
+	} catch {
+		return false
+	}
+}
+
+function toFetchRequest(request) {
+	const url = new URL(request.url ?? '/', `http://${request.headers.host ?? 'localhost'}`)
+	return new Request(url, {
+		method: request.method,
+		headers: request.headers,
+		body: request.method === 'GET' || request.method === 'HEAD' ? undefined : request,
+		duplex: 'half',
+	})
+}
+
+async function sendFetchResponse(fetchResponse, response) {
+	response.writeHead(fetchResponse.status, Object.fromEntries(fetchResponse.headers))
+
+	if (!fetchResponse.body) {
+		response.end()
+		return
+	}
+
+	for await (const chunk of fetchResponse.body) {
+		response.write(chunk)
+	}
+	response.end()
+}
+
+createServer(async (request, response) => {
+	try {
+		if (request.url === '/health') {
+			response.writeHead(200, { 'content-type': 'text/plain; charset=utf-8' })
+			response.end('ok')
+			return
+		}
+
+		if (await sendStatic(request.url ?? '/', response)) {
+			return
+		}
+
+		await sendFetchResponse(await app.fetch(toFetchRequest(request), process.env), response)
+	} catch (error) {
+		console.error(error)
+		response.writeHead(500, { 'content-type': 'text/plain; charset=utf-8' })
+		response.end('Internal Server Error')
+	}
+}).listen(port, '0.0.0.0')


### PR DESCRIPTION
## Summary
- add a Dockerfile and Node server wrapper for the perf app internal Kubernetes deployment
- publish ghcr.io/tempoxyz/tempo-apps-internal-perf from the main workflow when perf changes
- keep the existing Cloudflare Worker deploy path unchanged

## Validation
- corepack pnpm --filter perf build
- node apps/perf/server.mjs + curl /health returned 200 OK
- workflow YAML parsed with PyYAML

Docker daemon is not available in the sandbox, so the image build is left to GitHub Actions.