### PR TITLE
fix(perf): remove ClickHouse response size cap

### DIFF
--- a/apps/perf/src/lib/server/clickhouse.ts
+++ b/apps/perf/src/lib/server/clickhouse.ts
@@ -32,6 +32,7 @@ function clickHouseUrl(host: string): URL {
 		: new URL(`https://${trimmedHost}`)
 
 	url.searchParams.set('default_format', 'JSON')
+	url.searchParams.set('max_result_bytes', '0')
 	return url
 }
 


### PR DESCRIPTION
## Summary
- remove the ClickHouse result-size cap for perf queries by setting max_result_bytes=0 on ClickHouse HTTP requests
- keeps the existing JSON format and credential handling unchanged

## Validation
- corepack pnpm --filter perf check:biome
- corepack pnpm --filter perf gen:types && corepack pnpm --filter perf check:types