### PR TITLE
fix: support fee payer API keys via bearer auth

### DIFF
--- a/apps/fee-payer/README.md
+++ b/apps/fee-payer/README.md
@@ -29,4 +29,5 @@ Environment variables:
 | Method | Route | Params |
 |--------|-------|--------|
 | GET | `/usage` | - optional: `blockTimestampFrom` (epoch seconds)<br>- optional: `blockTimestampTo` (epoch seconds) |
-| POST | `*` | JSON-RPC request body for fee sponsorship<br>Supported methods: `eth_signTransaction`, `eth_signRawTransaction`, `eth_sendRawTransaction`, `eth_sendRawTransactionSync` |
+| POST | `/` | JSON-RPC request body for fee sponsorship<br>Optional API key: `Authorization: Bearer tp_...`<br>Supported methods: `eth_signTransaction`, `eth_signRawTransaction`, `eth_sendRawTransaction`, `eth_sendRawTransactionSync` |
+| POST | `/:key` | JSON-RPC request body for fee sponsorship with an API key path, e.g. `/tp_...` |

--- a/apps/fee-payer/src/index.ts
+++ b/apps/fee-payer/src/index.ts
@@ -113,6 +113,7 @@ async function feePayerHandler(c: Context) {
 	const requestContext = getRequestContext(c.req.raw)
 	const apiKey = c.get('apiKey') as string | undefined
 	const apiKeyRecord = c.get('apiKeyRecord')
+	const apiKeySource = c.get('apiKeySource') as string | undefined
 	const apiKeyLabel = apiKeyRecord?.label
 	const rpcMethod = c.get('rpcMethod') as string | undefined
 	const estimatedFeeUsd = c.get('estimatedFeeUsd') as number | undefined
@@ -126,6 +127,7 @@ async function feePayerHandler(c: Context) {
 					...requestContext,
 					rpcMethod,
 					keyedRoute: Boolean(apiKey),
+					...(apiKeySource ? { apiKeySource } : {}),
 					...(apiKeyLabel ? { apiKeyLabel } : {}),
 					...(apiKeyRecord?.dailyLimitUsd
 						? { dailyLimitUsd: apiKeyRecord.dailyLimitUsd }
@@ -152,6 +154,11 @@ app.all(
 )
 
 // Open path: https://sponsor.tempo.xyz/
-app.all('/', rateLimitMiddleware({ keyed: false }), feePayerHandler)
+app.all(
+	'/',
+	apiKeyMiddleware,
+	rateLimitMiddleware({ keyed: false }),
+	feePayerHandler,
+)
 
 export default app

--- a/apps/fee-payer/src/lib/api-key-middleware.ts
+++ b/apps/fee-payer/src/lib/api-key-middleware.ts
@@ -5,25 +5,41 @@ declare module 'hono' {
 	interface ContextVariableMap {
 		apiKey: string
 		apiKeyRecord: ApiKeyRecord
+		apiKeySource: 'path' | 'authorization'
 	}
 }
 
+function getBearerToken(c: Context): string | undefined {
+	const auth = c.req.header('Authorization')
+	const match = auth?.match(/^Bearer\s+(.+)$/i)
+	return match?.[1]?.trim()
+}
+
 /**
- * Middleware that authenticates requests via a `tp_`-prefixed path segment.
+ * Middleware that authenticates requests via a `tp_`-prefixed path segment or
+ * Authorization bearer token.
  * e.g. `https://sponsor.tempo.xyz/tp_abc123`
+ * e.g. `Authorization: Bearer tp_abc123`
  *
  * When a valid API key is present, sets `apiKey` and `apiKeyRecord` on context.
  * Requests to `/` (no key) pass through unauthenticated (preserving open access).
  */
 export async function apiKeyMiddleware(c: Context, next: Next) {
 	const keyParam = c.req.param('key')
-	if (!keyParam) return next()
+	const bearerToken = getBearerToken(c)
+	if (keyParam && bearerToken && keyParam !== bearerToken) {
+		return c.json({ error: 'Conflicting API keys' }, 401)
+	}
 
-	const record = await getApiKey(keyParam)
+	const key = keyParam ?? bearerToken
+	if (!key) return next()
+
+	const record = await getApiKey(key)
 	if (!record) return c.json({ error: 'Invalid or revoked API key' }, 401)
 
-	c.set('apiKey', keyParam)
+	c.set('apiKey', key)
 	c.set('apiKeyRecord', record)
+	c.set('apiKeySource', keyParam ? 'path' : 'authorization')
 
 	await next()
 }

--- a/apps/fee-payer/src/lib/rate-limit.ts
+++ b/apps/fee-payer/src/lib/rate-limit.ts
@@ -8,6 +8,179 @@ import * as z from 'zod/mini'
 import type { ApiKeyRecord } from './api-keys.js'
 import { checkBudget, recordSpend } from './api-key-budget.js'
 
+type SponsorshipTransaction = {
+	from?: string
+	to?: string
+	calls?: Array<{ to?: string }>
+	gas?: bigint
+	maxFeePerGas?: bigint
+}
+
+type TransactionParseError = {
+	error: string
+	status: 400 | 502
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return Boolean(value && typeof value === 'object' && !Array.isArray(value))
+}
+
+function isTransactionParseError(
+	value: SponsorshipTransaction | TransactionParseError,
+): value is TransactionParseError {
+	return 'error' in value
+}
+
+function parseBigInt(value: unknown): bigint | null {
+	if (typeof value === 'bigint') return value
+	if (typeof value === 'number' && Number.isInteger(value)) return BigInt(value)
+	if (typeof value !== 'string') return null
+
+	try {
+		return BigInt(value)
+	} catch {
+		return null
+	}
+}
+
+function parseOptionalPositiveBigInt(
+	record: Record<string, unknown>,
+	field: 'gas' | 'maxFeePerGas',
+	status: TransactionParseError['status'],
+): bigint | undefined | TransactionParseError {
+	if (!Object.hasOwn(record, field)) return undefined
+
+	const parsed = parseBigInt(record[field])
+	if (parsed === null || parsed <= 0n) {
+		return { error: `Invalid ${field}`, status }
+	}
+
+	return parsed
+}
+
+function transactionFromRequest(
+	request: Record<string, unknown>,
+	status: TransactionParseError['status'] = 400,
+): SponsorshipTransaction | TransactionParseError {
+	const calls = Array.isArray(request.calls)
+		? request.calls.filter(isRecord).map((call) => ({
+				to: typeof call.to === 'string' ? call.to : undefined,
+			}))
+		: undefined
+
+	const gas = parseOptionalPositiveBigInt(request, 'gas', status)
+	if (typeof gas === 'object') return gas
+	const maxFeePerGas = parseOptionalPositiveBigInt(
+		request,
+		'maxFeePerGas',
+		status,
+	)
+	if (typeof maxFeePerGas === 'object') return maxFeePerGas
+
+	return {
+		from: typeof request.from === 'string' ? request.from : undefined,
+		to: typeof request.to === 'string' ? request.to : undefined,
+		calls,
+		gas,
+		maxFeePerGas,
+	}
+}
+
+function transactionFromFillResponse(
+	body: unknown,
+): SponsorshipTransaction | TransactionParseError | null {
+	if (!isRecord(body))
+		return { error: 'Malformed relay fill response', status: 502 }
+	if ('error' in body) return null
+	if (!isRecord(body.result) || !isRecord(body.result.tx)) {
+		return { error: 'Malformed relay fill response', status: 502 }
+	}
+
+	const transaction = transactionFromRequest(body.result.tx, 502)
+	if (isTransactionParseError(transaction)) {
+		return { error: 'Malformed relay fill response', status: 502 }
+	}
+	if (!transaction.gas || !transaction.maxFeePerGas) {
+		return { error: 'Malformed relay fill response', status: 502 }
+	}
+
+	return transaction
+}
+
+async function transactionFromResponse(
+	response: Response,
+): Promise<SponsorshipTransaction | TransactionParseError | null> {
+	try {
+		return transactionFromFillResponse(await response.clone().json())
+	} catch {
+		if (response.ok) {
+			return { error: 'Malformed relay fill response', status: 502 }
+		}
+		return null
+	}
+}
+
+function mergeTransactions(
+	request: SponsorshipTransaction,
+	filled: SponsorshipTransaction,
+): SponsorshipTransaction {
+	return {
+		...request,
+		...filled,
+		from: filled.from ?? request.from,
+		to: filled.to ?? request.to,
+		calls: filled.calls ?? request.calls,
+		gas: filled.gas ?? request.gas,
+		maxFeePerGas: filled.maxFeePerGas ?? request.maxFeePerGas,
+	}
+}
+
+async function enforceApiKeyControls(
+	c: Context,
+	apiKey: string,
+	apiKeyRecord: ApiKeyRecord,
+	transaction: SponsorshipTransaction,
+	opts: { recordSpend: boolean },
+): Promise<Response | null> {
+	// Tempo envelopes nest the destination under `calls[0].to`; legacy
+	// envelopes use top-level `to`.
+	const to = transaction.calls?.[0]?.to ?? transaction.to
+
+	if (apiKeyRecord.allowedDestinations.length > 0 && to) {
+		const dest = to.toLowerCase()
+		const allowed = apiKeyRecord.allowedDestinations.some(
+			(a) => a.toLowerCase() === dest,
+		)
+		if (!allowed) {
+			return c.json(
+				{ error: 'Destination address not allowed for this API key' },
+				403,
+			)
+		}
+	}
+
+	if (transaction.gas && transaction.maxFeePerGas) {
+		const budget = await checkBudget(
+			apiKey,
+			apiKeyRecord,
+			transaction.gas,
+			transaction.maxFeePerGas,
+		)
+		if (!budget.allowed) {
+			return c.json({ error: budget.reason }, 429)
+		}
+
+		if (opts.recordSpend) {
+			// Record spend after request completes successfully.
+			c.executionCtx.waitUntil(
+				recordSpend(apiKey, transaction.gas, transaction.maxFeePerGas),
+			)
+		}
+	}
+
+	return null
+}
+
 /**
  * Middleware that rate limits requests based on the transaction's `from` address.
  * Extracts the transaction from the RPC request and checks against the rate limiter.
@@ -23,17 +196,20 @@ import { checkBudget, recordSpend } from './api-key-budget.js'
  *  - Per-key daily spend budget
  *  - Allowed destination addresses
  *
- * Only applies to requests carrying a serialized 0x76 Tempo transaction.
- * Non-transaction RPC calls (e.g. eth_chainId) pass through to the handler.
+ * Applies to requests carrying a serialized 0x76/0x78 Tempo transaction or
+ * an `eth_fillTransaction` transaction object. Non-transaction RPC calls
+ * (e.g. eth_chainId) pass through to the handler.
  */
 export function rateLimitMiddleware(opts: { keyed: boolean }) {
 	return async (c: Context, next: Next) => {
-		const limiter = opts.keyed
+		const apiKey = c.get('apiKey') as string | undefined
+		const useKeyedLimiter = opts.keyed || Boolean(apiKey)
+		const limiter = useKeyedLimiter
 			? (env.KeyedAddressRateLimiter ?? env.AddressRateLimiter)
 			: env.AddressRateLimiter
 		if (!limiter) {
 			console.error(
-				`${opts.keyed ? 'KeyedAddressRateLimiter' : 'AddressRateLimiter'} binding is not configured`,
+				`${useKeyedLimiter ? 'KeyedAddressRateLimiter' : 'AddressRateLimiter'} binding is not configured`,
 			)
 			return c.json({ error: 'Service misconfigured' }, 503)
 		}
@@ -52,27 +228,37 @@ export function rateLimitMiddleware(opts: { keyed: boolean }) {
 			if (!rawBody.success) return c.json({ error: 'Bad request' }, 400)
 
 			const request = RpcRequest.from(rawBody.data)
-			c.set('rpcMethod', request.method)
-			const serialized = request.params?.[0]
-
-			if (
-				typeof serialized === 'string' &&
-				(serialized.startsWith('0x76') || serialized.startsWith('0x78'))
-			) {
-				if (!Hex.validate(serialized) || serialized.length < 100)
-					return c.json({ error: 'Bad request' }, 400)
-				const transaction = Transaction.deserialize(serialized) as {
-					from?: string
-					to?: string
-					calls?: Array<{ to?: string }>
-					gas?: bigint
-					maxFeePerGas?: bigint
+			const rpcMethod = rawBody.data.method
+			c.set('rpcMethod', rpcMethod)
+			const transactionParam = request.params?.[0]
+			const transaction = (() => {
+				if (
+					typeof transactionParam === 'string' &&
+					(transactionParam.startsWith('0x76') ||
+						transactionParam.startsWith('0x78'))
+				) {
+					if (!Hex.validate(transactionParam) || transactionParam.length < 100)
+						return 'malformed'
+					return Transaction.deserialize(
+						transactionParam,
+					) as SponsorshipTransaction
 				}
-				const from = transaction.from
-				// Tempo envelopes nest the destination under `calls[0].to`; legacy
-				// envelopes use top-level `to`.
-				const to = transaction.calls?.[0]?.to ?? transaction.to
 
+				if (rpcMethod === 'eth_fillTransaction' && isRecord(transactionParam)) {
+					return transactionFromRequest(transactionParam)
+				}
+
+				return null
+			})()
+
+			if (transaction === 'malformed')
+				return c.json({ error: 'Bad request' }, 400)
+			if (transaction && isTransactionParseError(transaction)) {
+				return c.json({ error: transaction.error }, transaction.status)
+			}
+
+			if (transaction) {
+				const from = transaction.from
 				if (!from) {
 					return c.json(
 						{ error: 'Unable to determine sender for rate limiting' },
@@ -92,39 +278,41 @@ export function rateLimitMiddleware(opts: { keyed: boolean }) {
 				}
 
 				// API-key-scoped checks: [REDACTED:api-key] allowlist + daily budget.
-				const apiKey = c.get('apiKey') as string | undefined
 				const apiKeyRecord = c.get('apiKeyRecord') as ApiKeyRecord | undefined
 				if (apiKey && apiKeyRecord) {
-					if (apiKeyRecord.allowedDestinations.length > 0 && to) {
-						const dest = to.toLowerCase()
-						const allowed = apiKeyRecord.allowedDestinations.some(
-							(a) => a.toLowerCase() === dest,
-						)
-						if (!allowed) {
-							return c.json(
-								{ error: 'Destination address not allowed for this API key' },
-								403,
-							)
-						}
-					}
+					const blocked = await enforceApiKeyControls(
+						c,
+						apiKey,
+						apiKeyRecord,
+						transaction,
+						{ recordSpend: rpcMethod !== 'eth_fillTransaction' },
+					)
+					if (blocked) return blocked
+				}
 
-					if (transaction.gas && transaction.maxFeePerGas) {
-						const budget = await checkBudget(
+				await next()
+
+				if (rpcMethod === 'eth_fillTransaction' && apiKey && apiKeyRecord) {
+					const filledTransaction = await transactionFromResponse(c.res)
+					if (filledTransaction && isTransactionParseError(filledTransaction)) {
+						c.res = c.json(
+							{ error: filledTransaction.error },
+							filledTransaction.status,
+						)
+						return
+					}
+					if (filledTransaction) {
+						const blocked = await enforceApiKeyControls(
+							c,
 							apiKey,
 							apiKeyRecord,
-							transaction.gas,
-							transaction.maxFeePerGas,
+							mergeTransactions(transaction, filledTransaction),
+							{ recordSpend: true },
 						)
-						if (!budget.allowed) {
-							return c.json({ error: budget.reason }, 429)
-						}
-
-						// Record spend after request completes successfully.
-						c.executionCtx.waitUntil(
-							recordSpend(apiKey, transaction.gas, transaction.maxFeePerGas),
-						)
+						if (blocked) c.res = blocked
 					}
 				}
+				return
 			}
 		} catch (error) {
 			console.error('Rate limit middleware error:', error)

--- a/apps/fee-payer/test/api-keys.test.ts
+++ b/apps/fee-payer/test/api-keys.test.ts
@@ -1,7 +1,12 @@
 import { env, exports } from 'cloudflare:workers'
 import { sendTransactionSync } from 'viem/actions'
 import { describe, expect, it } from 'vitest'
-import { buildSponsorClient, sponsorAddress, userAccount } from './helpers.js'
+import {
+	buildSponsorClient,
+	buildSponsorClientWithAuthorization,
+	sponsorAddress,
+	userAccount,
+} from './helpers.js'
 
 const ADMIN_SECRET = 'test-admin-secret'
 
@@ -16,12 +21,34 @@ function adminRequest(method: string, path: string, body?: unknown): Request {
 	})
 }
 
-function feePayerRequest(path: string, rpcBody: unknown): Request {
+function feePayerRequest(
+	path: string,
+	rpcBody: unknown,
+	headers: Record<string, string> = {},
+): Request {
 	return new Request(`https://fee-payer.test${path}`, {
 		method: 'POST',
-		headers: { 'Content-Type': 'application/json' },
+		headers: { 'Content-Type': 'application/json', ...headers },
 		body: JSON.stringify(rpcBody),
 	})
+}
+
+function fillTransactionBody(
+	transaction: Record<string, unknown>,
+): Record<string, unknown> {
+	return {
+		jsonrpc: '2.0',
+		id: 1,
+		method: 'eth_fillTransaction',
+		params: [
+			{
+				from: userAccount.address,
+				to: '0x0000000000000000000000000000000000000002',
+				value: '0x0',
+				...transaction,
+			},
+		],
+	}
 }
 
 describe('admin API key management', () => {
@@ -249,6 +276,75 @@ describe('API key sponsorship integration', () => {
 		expect(data.result).toBeDefined()
 	})
 
+	it('passes through with valid Authorization bearer API key', async () => {
+		const createRes = await exports.default.fetch(
+			adminRequest('POST', '/keys', { label: 'Valid Bearer Key' }),
+		)
+		const { key } = (await createRes.json()) as { key: string }
+
+		const response = await exports.default.fetch(
+			feePayerRequest(
+				'/',
+				{
+					jsonrpc: '2.0',
+					id: 1,
+					method: 'eth_chainId',
+				},
+				{ Authorization: `Bearer ${key}` },
+			),
+		)
+		expect(response.status).toBe(200)
+		const data = (await response.json()) as {
+			result?: string
+		}
+		expect(data.result).toBeDefined()
+	})
+
+	it('rejects requests with invalid Authorization bearer API key', async () => {
+		const response = await exports.default.fetch(
+			feePayerRequest(
+				'/',
+				{
+					jsonrpc: '2.0',
+					id: 1,
+					method: 'eth_chainId',
+				},
+				{ Authorization: 'Bearer tp_invalid_key_12345678' },
+			),
+		)
+		expect(response.status).toBe(401)
+		const data = (await response.json()) as { error: string }
+		expect(data.error).toBe('Invalid or revoked API key')
+	})
+
+	it('rejects requests with conflicting path and bearer API keys', async () => {
+		const firstCreateRes = await exports.default.fetch(
+			adminRequest('POST', '/keys', { label: 'Path Key' }),
+		)
+		const { key: pathKey } = (await firstCreateRes.json()) as { key: string }
+		const secondCreateRes = await exports.default.fetch(
+			adminRequest('POST', '/keys', { label: 'Bearer Key' }),
+		)
+		const { key: bearerKey } = (await secondCreateRes.json()) as {
+			key: string
+		}
+
+		const response = await exports.default.fetch(
+			feePayerRequest(
+				`/${pathKey}`,
+				{
+					jsonrpc: '2.0',
+					id: 1,
+					method: 'eth_chainId',
+				},
+				{ Authorization: `Bearer ${bearerKey}` },
+			),
+		)
+		expect(response.status).toBe(401)
+		const data = (await response.json()) as { error: string }
+		expect(data.error).toBe('Conflicting API keys')
+	})
+
 	it('open access still works without API key', async () => {
 		const response = await exports.default.fetch(
 			feePayerRequest('/', {
@@ -259,6 +355,63 @@ describe('API key sponsorship integration', () => {
 		)
 		// Should reach the handler, not be rejected.
 		expect(response.status).toBe(200)
+	})
+
+	it('rejects fill requests with invalid gas fields', async () => {
+		const createRes = await exports.default.fetch(
+			adminRequest('POST', '/keys', { label: 'Invalid Gas' }),
+		)
+		const { key } = (await createRes.json()) as { key: string }
+
+		for (const { transaction, error } of [
+			{ transaction: { gas: '-1' }, error: 'Invalid gas' },
+			{ transaction: { gas: 'not-a-number' }, error: 'Invalid gas' },
+			{
+				transaction: { gas: '0x5208', maxFeePerGas: '0x0' },
+				error: 'Invalid maxFeePerGas',
+			},
+		]) {
+			const response = await exports.default.fetch(
+				feePayerRequest('/', fillTransactionBody(transaction), {
+					Authorization: `Bearer ${key}`,
+				}),
+			)
+			expect(response.status).toBe(400)
+			const data = (await response.json()) as { error: string }
+			expect(data.error).toBe(error)
+		}
+	})
+
+	it('does not record spend when a keyed fill request fails', async () => {
+		const createRes = await exports.default.fetch(
+			adminRequest('POST', '/keys', {
+				label: 'Failed Fill Spend',
+				dailyLimitUsd: '100.00',
+			}),
+		)
+		const { key } = (await createRes.json()) as { key: string }
+
+		const response = await exports.default.fetch(
+			feePayerRequest(
+				'/',
+				fillTransactionBody({
+					to: 'not-an-address',
+					gas: '0x5208',
+					maxFeePerGas: '0x1',
+				}),
+				{ Authorization: `Bearer ${key}` },
+			),
+		)
+		expect(await response.text()).toMatch(/error|invalid|bad/i)
+
+		const today = new Date().toISOString().slice(0, 10)
+		for (let i = 0; i < 5; i++) {
+			await new Promise((r) => setTimeout(r, 100))
+			expect(
+				await env.SponsorApiKeyStore.get(`spend:${key}:${today}`),
+			).toBeNull()
+		}
+		expect(await env.SponsorApiKeyStore.get(`spend:${key}:lifetime`)).toBeNull()
 	})
 
 	it('allows a sponsored transaction when destination is in allowedDestinations', async () => {
@@ -376,7 +529,7 @@ describe('API key sponsorship integration', () => {
 		// First sponsored tx — lifetime starts from 0.
 		const r1 = await sendTransactionSync(buildSponsorClient(key), {
 			feePayer: true,
-			to: '0x0000000000000000000000000000000000000002',
+			to: '0x0000000000000000000000000000000000000003',
 			value: 0n,
 		})
 		expect(r1.status).toBe('success')
@@ -386,7 +539,7 @@ describe('API key sponsorship integration', () => {
 		// overwritten with the second-tx-only fee.
 		const r2 = await sendTransactionSync(buildSponsorClient(key), {
 			feePayer: true,
-			to: '0x0000000000000000000000000000000000000002',
+			to: '0x0000000000000000000000000000000000000004',
 			value: 0n,
 		})
 		expect(r2.status).toBe('success')
@@ -415,6 +568,28 @@ describe('API key sponsorship integration', () => {
 			to: '0x0000000000000000000000000000000000000002',
 			value: 0n,
 		})
+
+		expect(receipt.transactionHash).toBeDefined()
+		expect(receipt.status).toBe('success')
+		expect(receipt.from.toLowerCase()).toBe(userAccount.address.toLowerCase())
+		expect(receipt.feePayer?.toLowerCase()).toBe(sponsorAddress.toLowerCase())
+		expect(receipt.feeToken).toMatch(/^0x[a-fA-F0-9]{40}$/)
+	})
+
+	it('sponsors a transaction routed through an Authorization bearer API key', async () => {
+		const createRes = await exports.default.fetch(
+			adminRequest('POST', '/keys', { label: 'Bearer Sponsorship Test' }),
+		)
+		const { key } = (await createRes.json()) as { key: string }
+
+		const receipt = await sendTransactionSync(
+			buildSponsorClientWithAuthorization(key),
+			{
+				feePayer: true,
+				to: '0x0000000000000000000000000000000000000002',
+				value: 0n,
+			},
+		)
 
 		expect(receipt.transactionHash).toBeDefined()
 		expect(receipt.status).toBe('success')

--- a/apps/fee-payer/test/e2e.test.ts
+++ b/apps/fee-payer/test/e2e.test.ts
@@ -144,7 +144,7 @@ describe('fee-payer integration', () => {
 	})
 
 	describe('transaction sponsorship', () => {
-		it('sponsors transaction (sign-only via eth_signRawTransaction)', async () => {
+		it('sponsors transaction (sign-only via eth_fillTransaction)', async () => {
 			const { transport: feePayerTransport, requests: feePayerRequests } =
 				createFeePayerTransportWithSpy()
 
@@ -173,12 +173,14 @@ describe('fee-payer integration', () => {
 			// validation with `insufficient liquidity in FeeAMM pool`.
 			expect(receipt.feeToken).toMatch(/^0x[a-fA-F0-9]{40}$/)
 
-			// Assert RPC methods sent to fee-payer service
+			// Assert RPC method sent to fee-payer service. Current viem relay
+			// flow co-signs during fill, so no later raw transaction RPC is sent
+			// to the relay.
 			const sponsorshipRequests = feePayerRequests.filter(
-				(request) => request.method !== 'eth_fillTransaction',
+				(request) => request.method === 'eth_fillTransaction',
 			)
 			expect(sponsorshipRequests).toHaveLength(1)
-			expect(sponsorshipRequests[0].method).toBe('eth_signRawTransaction')
+			expect(sponsorshipRequests[0].method).toBe('eth_fillTransaction')
 			expect(sponsorshipRequests[0].params).toBeDefined()
 		})
 
@@ -213,12 +215,14 @@ describe('fee-payer integration', () => {
 			// validation with `insufficient liquidity in FeeAMM pool`.
 			expect(receipt.feeToken).toMatch(/^0x[a-fA-F0-9]{40}$/)
 
-			// Assert RPC methods sent to fee-payer service
+			// Assert RPC method sent to fee-payer service. Current viem relay
+			// flow co-signs during fill, so no later raw transaction RPC is sent
+			// to the relay.
 			const sponsorshipRequests = feePayerRequests.filter(
-				(request) => request.method !== 'eth_fillTransaction',
+				(request) => request.method === 'eth_fillTransaction',
 			)
 			expect(sponsorshipRequests).toHaveLength(1)
-			expect(sponsorshipRequests[0].method).toBe('eth_sendRawTransactionSync')
+			expect(sponsorshipRequests[0].method).toBe('eth_fillTransaction')
 			expect(sponsorshipRequests[0].params).toBeDefined()
 		})
 	})

--- a/apps/fee-payer/test/helpers.ts
+++ b/apps/fee-payer/test/helpers.ts
@@ -25,13 +25,16 @@ export const userAccount = Account.fromSecp256k1(
 )
 
 /** Routes RPC calls through the in-process fee-payer Worker at `path`. */
-export function feePayerTransport(path: string) {
+export function feePayerTransport(
+	path: string,
+	headers: Record<string, string> = {},
+) {
 	return custom({
 		async request({ method, params }) {
 			const response = await exports.default.fetch(
 				new Request(`https://fee-payer.test${path}`, {
 					method: 'POST',
-					headers: { 'Content-Type': 'application/json' },
+					headers: { 'Content-Type': 'application/json', ...headers },
 					body: JSON.stringify({ jsonrpc: '2.0', id: 1, method, params }),
 				}),
 			)
@@ -78,5 +81,20 @@ export function buildSponsorClient(key: string) {
 		transport: withRelay(tempoTransport(), feePayerTransport(`/${key}`), {
 			policy: 'sign-and-broadcast',
 		}),
+	})
+}
+
+/** Build a sponsorship client routed through `/` with an Authorization bearer key. */
+export function buildSponsorClientWithAuthorization(key: string) {
+	return createClient({
+		account: userAccount,
+		chain: tempoChain,
+		transport: withRelay(
+			tempoTransport(),
+			feePayerTransport('/', { Authorization: `Bearer ${key}` }),
+			{
+				policy: 'sign-and-broadcast',
+			},
+		),
 	})
 }


### PR DESCRIPTION
## Summary

Adds API-key authentication for fee-payer requests that pass `Authorization: Bearer tp_...` while preserving the existing `/tp_...` keyed path.

## Motivation

Clients should be able to use API-keyed fee sponsorship without embedding the key in the URL path, and keyed controls should apply consistently across the current `eth_fillTransaction` relay flow.

## Changes

- Added bearer-token API key lookup on `/` and conflict handling when path and bearer keys differ.
- Applied keyed limiter, allowlist, budget, analytics, and spend accounting to header-authenticated requests.
- Validated `eth_fillTransaction` gas fields and delayed spend recording until a successful filled response.
- Added tests for bearer-key access, invalid/conflicting keys, invalid gas fields, failed-fill spend behavior, and current relay RPC behavior.

## Testing

- `pnpm --filter fee-payer exec vitest --run test/api-keys.test.ts`
- `pnpm --filter fee-payer test`
- `pnpm --filter fee-payer check`
- `git diff --check`