### PR TITLE
feat: add fee payer metrics emission

### DIFF
--- a/apps/fee-payer/env.d.ts
+++ b/apps/fee-payer/env.d.ts
@@ -17,3 +17,5 @@ declare namespace NodeJS {
 		readonly NODE_ENV: 'development' | 'production' | 'test'
 	}
 }
+
+declare const __BUILD_VERSION__: string

--- a/apps/fee-payer/package.json
+++ b/apps/fee-payer/package.json
@@ -33,6 +33,7 @@
 		"kysely": "catalog:",
 		"ox": "catalog:",
 		"accounts": "catalog:",
+		"cloudflare-worker-metrics": "catalog:",
 		"viem": "catalog:",
 		"zod": "catalog:"
 	},

--- a/apps/fee-payer/src/index.ts
+++ b/apps/fee-payer/src/index.ts
@@ -11,7 +11,6 @@ import { tempo, tempoDevnet, tempoModerato } from 'viem/chains'
 import * as z from 'zod'
 import { admin } from './lib/admin.js'
 import { apiKeyMiddleware } from './lib/api-key-middleware.js'
-import { tempoChain } from './lib/chain.js'
 import { metrics } from './lib/observability/metrics.js'
 import { httpMetrics } from './lib/observability/middleware.js'
 import {
@@ -98,9 +97,12 @@ app.get(
 const sponsorAccount = privateKeyToAccount(
 	env.SPONSOR_PRIVATE_KEY as `0x${string}`,
 )
+const relayChains = [tempo, tempoModerato, tempoDevnet] as const
+const DEFAULT_RELAY_CHAIN_ID = relayChains[0].id
 
 const relayHandler = Handler.relay({
 	cors: false,
+	chains: relayChains,
 	features: 'all',
 	feePayer: {
 		account: sponsorAccount,
@@ -120,6 +122,8 @@ async function feePayerHandler(c: Context) {
 	const apiKeyRecord = c.get('apiKeyRecord')
 	const apiKeyLabel = apiKeyRecord?.label
 	const rpcMethod = c.get('rpcMethod') as string | undefined
+	const rpcChainId =
+		(c.get('rpcChainId') as number | undefined) ?? DEFAULT_RELAY_CHAIN_ID
 	const estimatedFeeUsd = c.get('estimatedFeeUsd') as number | undefined
 	const keyedRoute = String(Boolean(apiKey))
 
@@ -127,7 +131,7 @@ async function feePayerHandler(c: Context) {
 		metrics.count('fee_payer_rpc_request_count', 1, {
 			rpc_method: rpcMethod,
 			keyed_route: keyedRoute,
-			chain_id: String(tempoChain.id),
+			chain_id: String(rpcChainId),
 		})
 		c.executionCtx.waitUntil(
 			captureEvent({
@@ -158,7 +162,7 @@ async function feePayerHandler(c: Context) {
 			metrics.count('fee_payer_sponsorship_response_count', 1, {
 				rpc_method: rpcMethod,
 				keyed_route: keyedRoute,
-				status: response.status,
+				status: await sponsorshipResponseStatus(response),
 			})
 		}
 		return response
@@ -167,11 +171,32 @@ async function feePayerHandler(c: Context) {
 			metrics.count('fee_payer_sponsorship_response_count', 1, {
 				rpc_method: rpcMethod,
 				keyed_route: keyedRoute,
-				status: 500,
+				status: 'error',
 			})
 		}
 		throw error
 	}
+}
+
+async function sponsorshipResponseStatus(
+	response: Response,
+): Promise<'success' | 'error'> {
+	if (!response.ok) return 'error'
+
+	try {
+		const body: unknown = await response.clone().json()
+		if (Array.isArray(body))
+			return body.some(hasJsonRpcError) ? 'error' : 'success'
+		return hasJsonRpcError(body) ? 'error' : 'success'
+	} catch {
+		return 'success'
+	}
+}
+
+function hasJsonRpcError(value: unknown): boolean {
+	if (!value || typeof value !== 'object') return false
+	if (!('error' in value)) return false
+	return (value as { error?: unknown }).error != null
 }
 
 // Keyed path: https://sponsor.tempo.xyz/tp_abc123

--- a/apps/fee-payer/src/index.ts
+++ b/apps/fee-payer/src/index.ts
@@ -11,6 +11,9 @@ import { tempo, tempoDevnet, tempoModerato } from 'viem/chains'
 import * as z from 'zod'
 import { admin } from './lib/admin.js'
 import { apiKeyMiddleware } from './lib/api-key-middleware.js'
+import { tempoChain } from './lib/chain.js'
+import { metrics } from './lib/observability/metrics.js'
+import { httpMetrics } from './lib/observability/middleware.js'
 import {
 	FeePayerEvents,
 	captureEvent,
@@ -29,6 +32,8 @@ app.onError((error, c) => {
 	console.error('Unexpected error:', error)
 	return c.text('Internal Server Error', 500)
 })
+
+app.use('*', httpMetrics())
 
 app.use(
 	'*',
@@ -116,8 +121,14 @@ async function feePayerHandler(c: Context) {
 	const apiKeyLabel = apiKeyRecord?.label
 	const rpcMethod = c.get('rpcMethod') as string | undefined
 	const estimatedFeeUsd = c.get('estimatedFeeUsd') as number | undefined
+	const keyedRoute = String(Boolean(apiKey))
 
 	if (rpcMethod) {
+		metrics.count('fee_payer_rpc_request_count', 1, {
+			rpc_method: rpcMethod,
+			keyed_route: keyedRoute,
+			chain_id: String(tempoChain.id),
+		})
 		c.executionCtx.waitUntil(
 			captureEvent({
 				distinctId: apiKeyLabel ?? requestContext.origin ?? 'unknown',
@@ -140,7 +151,27 @@ async function feePayerHandler(c: Context) {
 	const url = new URL(raw.url)
 	const target =
 		url.pathname === '/' ? raw : new Request(new URL('/', url), raw)
-	return relayHandler.fetch(target)
+
+	try {
+		const response = await relayHandler.fetch(target)
+		if (rpcMethod) {
+			metrics.count('fee_payer_sponsorship_response_count', 1, {
+				rpc_method: rpcMethod,
+				keyed_route: keyedRoute,
+				status: response.status,
+			})
+		}
+		return response
+	} catch (error) {
+		if (rpcMethod) {
+			metrics.count('fee_payer_sponsorship_response_count', 1, {
+				rpc_method: rpcMethod,
+				keyed_route: keyedRoute,
+				status: 500,
+			})
+		}
+		throw error
+	}
 }
 
 // Keyed path: https://sponsor.tempo.xyz/tp_abc123

--- a/apps/fee-payer/src/index.ts
+++ b/apps/fee-payer/src/index.ts
@@ -7,10 +7,10 @@ import { cors } from 'hono/cors'
 import { HTTPException } from 'hono/http-exception'
 import { http } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
-import { tempo, tempoDevnet, tempoModerato } from 'viem/chains'
 import * as z from 'zod'
 import { admin } from './lib/admin.js'
 import { apiKeyMiddleware } from './lib/api-key-middleware.js'
+import { tempoChain } from './lib/chain.js'
 import { httpMetrics, rpcMetrics } from './lib/observability/middleware.js'
 import {
 	FeePayerEvents,
@@ -96,12 +96,10 @@ app.get(
 const sponsorAccount = privateKeyToAccount(
 	env.SPONSOR_PRIVATE_KEY as `0x${string}`,
 )
-const relayChains = [tempo, tempoModerato, tempoDevnet] as const
-const DEFAULT_RELAY_CHAIN_ID = relayChains[0].id
 
 const relayHandler = Handler.relay({
 	cors: false,
-	chains: relayChains,
+	chains: [tempoChain],
 	features: 'all',
 	feePayer: {
 		account: sponsorAccount,
@@ -109,9 +107,9 @@ const relayHandler = Handler.relay({
 		url: 'https://sponsor.tempo.xyz',
 	},
 	transports: {
-		[tempo.id]: http(env.TEMPO_RPC_URL ?? tempo.rpcUrls.default.http[0]),
-		[tempoModerato.id]: http(tempoModerato.rpcUrls.default.http[0]),
-		[tempoDevnet.id]: http(tempoDevnet.rpcUrls.default.http[0]),
+		[tempoChain.id]: http(
+			env.TEMPO_RPC_URL ?? tempoChain.rpcUrls.default.http[0],
+		),
 	},
 })
 
@@ -153,7 +151,7 @@ async function feePayerHandler(c: Context) {
 // Keyed path: https://sponsor.tempo.xyz/tp_abc123
 app.all(
 	'/:key{tp_.+}',
-	rpcMetrics({ defaultChainId: DEFAULT_RELAY_CHAIN_ID, keyed: true }),
+	rpcMetrics({ keyed: true }),
 	apiKeyMiddleware,
 	rateLimitMiddleware({ keyed: true }),
 	feePayerHandler,
@@ -162,7 +160,7 @@ app.all(
 // Open path: https://sponsor.tempo.xyz/
 app.all(
 	'/',
-	rpcMetrics({ defaultChainId: DEFAULT_RELAY_CHAIN_ID, keyed: false }),
+	rpcMetrics({ keyed: false }),
 	rateLimitMiddleware({ keyed: false }),
 	feePayerHandler,
 )

--- a/apps/fee-payer/src/index.ts
+++ b/apps/fee-payer/src/index.ts
@@ -11,8 +11,7 @@ import { tempo, tempoDevnet, tempoModerato } from 'viem/chains'
 import * as z from 'zod'
 import { admin } from './lib/admin.js'
 import { apiKeyMiddleware } from './lib/api-key-middleware.js'
-import { metrics } from './lib/observability/metrics.js'
-import { httpMetrics } from './lib/observability/middleware.js'
+import { httpMetrics, rpcMetrics } from './lib/observability/middleware.js'
 import {
 	FeePayerEvents,
 	captureEvent,
@@ -122,17 +121,9 @@ async function feePayerHandler(c: Context) {
 	const apiKeyRecord = c.get('apiKeyRecord')
 	const apiKeyLabel = apiKeyRecord?.label
 	const rpcMethod = c.get('rpcMethod') as string | undefined
-	const rpcChainId =
-		(c.get('rpcChainId') as number | undefined) ?? DEFAULT_RELAY_CHAIN_ID
 	const estimatedFeeUsd = c.get('estimatedFeeUsd') as number | undefined
-	const keyedRoute = String(Boolean(apiKey))
 
 	if (rpcMethod) {
-		metrics.count('fee_payer_rpc_request_count', 1, {
-			rpc_method: rpcMethod,
-			keyed_route: keyedRoute,
-			chain_id: String(rpcChainId),
-		})
 		c.executionCtx.waitUntil(
 			captureEvent({
 				distinctId: apiKeyLabel ?? requestContext.origin ?? 'unknown',
@@ -156,58 +147,24 @@ async function feePayerHandler(c: Context) {
 	const target =
 		url.pathname === '/' ? raw : new Request(new URL('/', url), raw)
 
-	try {
-		const response = await relayHandler.fetch(target)
-		if (rpcMethod) {
-			metrics.count('fee_payer_sponsorship_response_count', 1, {
-				rpc_method: rpcMethod,
-				keyed_route: keyedRoute,
-				status: await sponsorshipResponseStatus(response),
-			})
-		}
-		return response
-	} catch (error) {
-		if (rpcMethod) {
-			metrics.count('fee_payer_sponsorship_response_count', 1, {
-				rpc_method: rpcMethod,
-				keyed_route: keyedRoute,
-				status: 'error',
-			})
-		}
-		throw error
-	}
-}
-
-async function sponsorshipResponseStatus(
-	response: Response,
-): Promise<'success' | 'error'> {
-	if (!response.ok) return 'error'
-
-	try {
-		const body: unknown = await response.clone().json()
-		if (Array.isArray(body))
-			return body.some(hasJsonRpcError) ? 'error' : 'success'
-		return hasJsonRpcError(body) ? 'error' : 'success'
-	} catch {
-		return 'success'
-	}
-}
-
-function hasJsonRpcError(value: unknown): boolean {
-	if (!value || typeof value !== 'object') return false
-	if (!('error' in value)) return false
-	return (value as { error?: unknown }).error != null
+	return relayHandler.fetch(target)
 }
 
 // Keyed path: https://sponsor.tempo.xyz/tp_abc123
 app.all(
 	'/:key{tp_.+}',
+	rpcMetrics({ defaultChainId: DEFAULT_RELAY_CHAIN_ID, keyed: true }),
 	apiKeyMiddleware,
 	rateLimitMiddleware({ keyed: true }),
 	feePayerHandler,
 )
 
 // Open path: https://sponsor.tempo.xyz/
-app.all('/', rateLimitMiddleware({ keyed: false }), feePayerHandler)
+app.all(
+	'/',
+	rpcMetrics({ defaultChainId: DEFAULT_RELAY_CHAIN_ID, keyed: false }),
+	rateLimitMiddleware({ keyed: false }),
+	feePayerHandler,
+)
 
 export default app

--- a/apps/fee-payer/src/lib/observability/metric-registry.ts
+++ b/apps/fee-payer/src/lib/observability/metric-registry.ts
@@ -20,6 +20,6 @@ export type MetricRegistry = {
 	fee_payer_sponsorship_response_count: {
 		rpc_method: string
 		keyed_route: string
-		status: number
+		status: string
 	}
 }

--- a/apps/fee-payer/src/lib/observability/metric-registry.ts
+++ b/apps/fee-payer/src/lib/observability/metric-registry.ts
@@ -1,0 +1,25 @@
+type HttpRouteTags = {
+	method: string
+	route: string
+}
+
+type RpcTags = {
+	rpc_method: string
+	keyed_route: string
+	chain_id: string
+}
+
+export type MetricRegistry = {
+	http_request_count: HttpRouteTags
+	http_response_count: HttpRouteTags & {
+		status: number
+		error_type?: string
+	}
+	http_response_duration_ms: HttpRouteTags
+	fee_payer_rpc_request_count: RpcTags
+	fee_payer_sponsorship_response_count: {
+		rpc_method: string
+		keyed_route: string
+		status: number
+	}
+}

--- a/apps/fee-payer/src/lib/observability/metrics.ts
+++ b/apps/fee-payer/src/lib/observability/metrics.ts
@@ -1,0 +1,53 @@
+import { env } from 'cloudflare:workers'
+import { createMetrics } from 'cloudflare-worker-metrics'
+import type { MetricRegistry } from './metric-registry.js'
+
+type FeePayerMetrics = Pick<
+	ReturnType<typeof createMetrics<MetricRegistry>>,
+	'count' | 'histogram' | 'flush'
+>
+
+const noop: FeePayerMetrics = {
+	count() {},
+	histogram() {},
+	flush() {},
+}
+
+function getFeePayerEnvironment(): 'mainnet' | 'testnet' {
+	return env.TEMPO_ENV === 'mainnet' ? 'mainnet' : 'testnet'
+}
+
+function metricsEnabled(): boolean {
+	return process.env.NODE_ENV !== 'test'
+}
+
+function getBuildVersion(): string {
+	return typeof __BUILD_VERSION__ === 'string' ? __BUILD_VERSION__ : 'dev'
+}
+
+function createFeePayerMetrics(): FeePayerMetrics {
+	if (!metricsEnabled()) return noop
+
+	const instance = createMetrics<MetricRegistry>({
+		globalTags: {
+			build_version: getBuildVersion(),
+			fee_payer_env: getFeePayerEnvironment(),
+		},
+	})
+
+	return {
+		count(name, value, tags) {
+			instance.count(name, value, tags)
+			instance.flush()
+		},
+		histogram(name, value, tags) {
+			instance.histogram(name, value, tags)
+			instance.flush()
+		},
+		flush() {
+			instance.flush()
+		},
+	}
+}
+
+export const metrics = createFeePayerMetrics()

--- a/apps/fee-payer/src/lib/observability/metrics.ts
+++ b/apps/fee-payer/src/lib/observability/metrics.ts
@@ -38,11 +38,9 @@ function createFeePayerMetrics(): FeePayerMetrics {
 	return {
 		count(name, value, tags) {
 			instance.count(name, value, tags)
-			instance.flush()
 		},
 		histogram(name, value, tags) {
 			instance.histogram(name, value, tags)
-			instance.flush()
 		},
 		flush() {
 			instance.flush()

--- a/apps/fee-payer/src/lib/observability/middleware.ts
+++ b/apps/fee-payer/src/lib/observability/middleware.ts
@@ -18,8 +18,11 @@ export function httpMetrics(): MiddlewareHandler {
 				method: c.req.method,
 				route: resolveRoute(c),
 			}
-			const errorType = thrown ? errorTypeOf(thrown) : undefined
-			const status = c.res?.status ?? statusFromError(thrown)
+			const error = thrown ?? c.error
+			const hasError = error !== undefined
+			const status = hasError
+				? statusFromError(error, c.res.status)
+				: c.res.status
 
 			metrics.count('http_request_count', 1, tags)
 			metrics.histogram(
@@ -30,7 +33,7 @@ export function httpMetrics(): MiddlewareHandler {
 			metrics.count('http_response_count', 1, {
 				...tags,
 				status,
-				...(errorType ? { error_type: errorType } : {}),
+				...(hasError ? { error_type: errorTypeOf(error) } : {}),
 			})
 			metrics.flush()
 		}
@@ -40,11 +43,13 @@ export function httpMetrics(): MiddlewareHandler {
 function resolveRoute(c: Context): string {
 	const routePath = c.req.routePath
 	if (routePath && routePath !== '/*') return routePath
+	if (routePath === '/*') return 'unmatched'
 	return new URL(c.req.url).pathname
 }
 
-function statusFromError(error: unknown): number {
+function statusFromError(error: unknown, responseStatus: number): number {
 	if (error instanceof HTTPException) return error.status
+	if (responseStatus >= 400) return responseStatus
 	return 500
 }
 

--- a/apps/fee-payer/src/lib/observability/middleware.ts
+++ b/apps/fee-payer/src/lib/observability/middleware.ts
@@ -1,0 +1,55 @@
+import type { Context, MiddlewareHandler } from 'hono'
+import { createMiddleware } from 'hono/factory'
+import { HTTPException } from 'hono/http-exception'
+import { metrics } from './metrics.js'
+
+export function httpMetrics(): MiddlewareHandler {
+	return createMiddleware(async (c, next) => {
+		const start = performance.now()
+		let thrown: unknown
+
+		try {
+			await next()
+		} catch (error) {
+			thrown = error
+			throw error
+		} finally {
+			const tags = {
+				method: c.req.method,
+				route: resolveRoute(c),
+			}
+			const errorType = thrown ? errorTypeOf(thrown) : undefined
+			const status = c.res?.status ?? statusFromError(thrown)
+
+			metrics.count('http_request_count', 1, tags)
+			metrics.histogram(
+				'http_response_duration_ms',
+				performance.now() - start,
+				tags,
+			)
+			metrics.count('http_response_count', 1, {
+				...tags,
+				status,
+				...(errorType ? { error_type: errorType } : {}),
+			})
+			metrics.flush()
+		}
+	})
+}
+
+function resolveRoute(c: Context): string {
+	const routePath = c.req.routePath
+	if (routePath && routePath !== '/*') return routePath
+	return new URL(c.req.url).pathname
+}
+
+function statusFromError(error: unknown): number {
+	if (error instanceof HTTPException) return error.status
+	return 500
+}
+
+function errorTypeOf(error: unknown): string {
+	if (error instanceof Error) return error.constructor.name
+	if (error === null) return 'null'
+	return typeof error
+}

--- a/apps/fee-payer/src/lib/observability/middleware.ts
+++ b/apps/fee-payer/src/lib/observability/middleware.ts
@@ -5,6 +5,7 @@ import { cloneRawRequest } from 'hono/request'
 import { Hex, RpcRequest } from 'ox'
 import { Transaction } from 'viem/tempo'
 import * as z from 'zod/mini'
+import { tempoChain } from '../chain.js'
 import { metrics } from './metrics.js'
 
 export function httpMetrics(): MiddlewareHandler {
@@ -44,17 +45,13 @@ export function httpMetrics(): MiddlewareHandler {
 	})
 }
 
-export function rpcMetrics(opts: {
-	defaultChainId: number
-	keyed: boolean
-}): MiddlewareHandler {
+export function rpcMetrics(opts: { keyed: boolean }): MiddlewareHandler {
 	return createMiddleware(async (c, next) => {
-		const rpc = await resolveRpcContext(c, opts.defaultChainId)
+		const rpc = await resolveRpcContext(c)
 		let thrown: unknown
 
 		if (rpc) {
 			c.set('rpcMethod', rpc.method)
-			c.set('rpcChainId', rpc.chainId)
 			metrics.count('fee_payer_rpc_request_count', 1, {
 				rpc_method: rpc.method,
 				keyed_route: String(opts.keyed),
@@ -85,8 +82,12 @@ export function rpcMetrics(opts: {
 function resolveRoute(c: Context): string {
 	const routePath = c.req.routePath
 	if (routePath && routePath !== '/*') return routePath
+	const path = new URL(c.req.url).pathname
+	if (path === '/') return '/'
+	if (path.startsWith('/tp_') && path.length > '/tp_'.length)
+		return '/:key{tp_.+}'
 	if (routePath === '/*') return 'unmatched'
-	return new URL(c.req.url).pathname
+	return path
 }
 
 function statusFromError(error: unknown, responseStatus: number): number {
@@ -108,7 +109,6 @@ type RpcMetricsContext = {
 
 async function resolveRpcContext(
 	c: Context,
-	defaultChainId: number,
 ): Promise<RpcMetricsContext | undefined> {
 	try {
 		const clonedRequest = await cloneRawRequest(c.req)
@@ -125,7 +125,7 @@ async function resolveRpcContext(
 
 		const request = RpcRequest.from(rawBody.data)
 		return {
-			chainId: resolveRpcChainId(request.params?.[0]) ?? defaultChainId,
+			chainId: resolveRpcChainId(request.params?.[0]) ?? tempoChain.id,
 			method: request.method,
 		}
 	} catch {

--- a/apps/fee-payer/src/lib/observability/middleware.ts
+++ b/apps/fee-payer/src/lib/observability/middleware.ts
@@ -1,6 +1,10 @@
 import type { Context, MiddlewareHandler } from 'hono'
 import { createMiddleware } from 'hono/factory'
 import { HTTPException } from 'hono/http-exception'
+import { cloneRawRequest } from 'hono/request'
+import { Hex, RpcRequest } from 'ox'
+import { Transaction } from 'viem/tempo'
+import * as z from 'zod/mini'
 import { metrics } from './metrics.js'
 
 export function httpMetrics(): MiddlewareHandler {
@@ -40,6 +44,44 @@ export function httpMetrics(): MiddlewareHandler {
 	})
 }
 
+export function rpcMetrics(opts: {
+	defaultChainId: number
+	keyed: boolean
+}): MiddlewareHandler {
+	return createMiddleware(async (c, next) => {
+		const rpc = await resolveRpcContext(c, opts.defaultChainId)
+		let thrown: unknown
+
+		if (rpc) {
+			c.set('rpcMethod', rpc.method)
+			c.set('rpcChainId', rpc.chainId)
+			metrics.count('fee_payer_rpc_request_count', 1, {
+				rpc_method: rpc.method,
+				keyed_route: String(opts.keyed),
+				chain_id: String(rpc.chainId),
+			})
+		}
+
+		try {
+			await next()
+		} catch (error) {
+			thrown = error
+			throw error
+		} finally {
+			if (rpc) {
+				metrics.count('fee_payer_sponsorship_response_count', 1, {
+					rpc_method: rpc.method,
+					keyed_route: String(opts.keyed),
+					status:
+						thrown || c.error
+							? 'error'
+							: await sponsorshipResponseStatus(c.res),
+				})
+			}
+		}
+	})
+}
+
 function resolveRoute(c: Context): string {
 	const routePath = c.req.routePath
 	if (routePath && routePath !== '/*') return routePath
@@ -57,4 +99,90 @@ function errorTypeOf(error: unknown): string {
 	if (error instanceof Error) return error.constructor.name
 	if (error === null) return 'null'
 	return typeof error
+}
+
+type RpcMetricsContext = {
+	chainId: number
+	method: string
+}
+
+async function resolveRpcContext(
+	c: Context,
+	defaultChainId: number,
+): Promise<RpcMetricsContext | undefined> {
+	try {
+		const clonedRequest = await cloneRawRequest(c.req)
+		const rawBody = z.safeParse(
+			z.object({
+				jsonrpc: z.string(),
+				id: z.number(),
+				method: z.string(),
+				params: z.optional(z.array(z.unknown())),
+			}),
+			await clonedRequest.json(),
+		)
+		if (!rawBody.success) return undefined
+
+		const request = RpcRequest.from(rawBody.data)
+		return {
+			chainId: resolveRpcChainId(request.params?.[0]) ?? defaultChainId,
+			method: request.method,
+		}
+	} catch {
+		return undefined
+	}
+}
+
+function resolveRpcChainId(params: unknown): number | undefined {
+	if (params && typeof params === 'object')
+		return resolveChainId((params as { chainId?: unknown }).chainId)
+
+	if (
+		typeof params === 'string' &&
+		(params.startsWith('0x76') || params.startsWith('0x78')) &&
+		Hex.validate(params)
+	) {
+		try {
+			const transaction = Transaction.deserialize(params) as {
+				chainId?: unknown
+			}
+			return resolveChainId(transaction.chainId)
+		} catch {
+			return undefined
+		}
+	}
+
+	return undefined
+}
+
+function resolveChainId(value: unknown): number | undefined {
+	if (typeof value === 'number') return value
+	if (typeof value === 'bigint') return Number(value)
+	if (typeof value === 'string') {
+		if (Hex.validate(value)) return Hex.toNumber(value)
+		const n = Number(value)
+		if (Number.isFinite(n)) return n
+	}
+	return undefined
+}
+
+async function sponsorshipResponseStatus(
+	response: Response,
+): Promise<'success' | 'error'> {
+	if (!response.ok) return 'error'
+
+	try {
+		const body: unknown = await response.clone().json()
+		if (Array.isArray(body))
+			return body.some(hasJsonRpcError) ? 'error' : 'success'
+		return hasJsonRpcError(body) ? 'error' : 'success'
+	} catch {
+		return 'success'
+	}
+}
+
+function hasJsonRpcError(value: unknown): boolean {
+	if (!value || typeof value !== 'object') return false
+	if (!('error' in value)) return false
+	return (value as { error?: unknown }).error != null
 }

--- a/apps/fee-payer/src/lib/rate-limit.ts
+++ b/apps/fee-payer/src/lib/rate-limit.ts
@@ -53,8 +53,6 @@ export function rateLimitMiddleware(opts: { keyed: boolean }) {
 
 			const request = RpcRequest.from(rawBody.data)
 			c.set('rpcMethod', request.method)
-			const requestChainId = resolveRequestChainId(request.params?.[0])
-			if (requestChainId !== undefined) c.set('rpcChainId', requestChainId)
 			const serialized = request.params?.[0]
 
 			if (
@@ -67,13 +65,9 @@ export function rateLimitMiddleware(opts: { keyed: boolean }) {
 					from?: string
 					to?: string
 					calls?: Array<{ to?: string }>
-					chainId?: unknown
 					gas?: bigint
 					maxFeePerGas?: bigint
 				}
-				const transactionChainId = resolveChainId(transaction.chainId)
-				if (transactionChainId !== undefined)
-					c.set('rpcChainId', transactionChainId)
 				const from = transaction.from
 				// Tempo envelopes nest the destination under `calls[0].to`; legacy
 				// envelopes use top-level `to`.
@@ -139,20 +133,4 @@ export function rateLimitMiddleware(opts: { keyed: boolean }) {
 
 		await next()
 	}
-}
-
-function resolveRequestChainId(params: unknown): number | undefined {
-	if (!params || typeof params !== 'object') return undefined
-	return resolveChainId((params as { chainId?: unknown }).chainId)
-}
-
-function resolveChainId(value: unknown): number | undefined {
-	if (typeof value === 'number') return value
-	if (typeof value === 'bigint') return Number(value)
-	if (typeof value === 'string') {
-		if (Hex.validate(value)) return Hex.toNumber(value)
-		const n = Number(value)
-		if (Number.isFinite(n)) return n
-	}
-	return undefined
 }

--- a/apps/fee-payer/src/lib/rate-limit.ts
+++ b/apps/fee-payer/src/lib/rate-limit.ts
@@ -53,6 +53,8 @@ export function rateLimitMiddleware(opts: { keyed: boolean }) {
 
 			const request = RpcRequest.from(rawBody.data)
 			c.set('rpcMethod', request.method)
+			const requestChainId = resolveRequestChainId(request.params?.[0])
+			if (requestChainId !== undefined) c.set('rpcChainId', requestChainId)
 			const serialized = request.params?.[0]
 
 			if (
@@ -65,9 +67,13 @@ export function rateLimitMiddleware(opts: { keyed: boolean }) {
 					from?: string
 					to?: string
 					calls?: Array<{ to?: string }>
+					chainId?: unknown
 					gas?: bigint
 					maxFeePerGas?: bigint
 				}
+				const transactionChainId = resolveChainId(transaction.chainId)
+				if (transactionChainId !== undefined)
+					c.set('rpcChainId', transactionChainId)
 				const from = transaction.from
 				// Tempo envelopes nest the destination under `calls[0].to`; legacy
 				// envelopes use top-level `to`.
@@ -133,4 +139,20 @@ export function rateLimitMiddleware(opts: { keyed: boolean }) {
 
 		await next()
 	}
+}
+
+function resolveRequestChainId(params: unknown): number | undefined {
+	if (!params || typeof params !== 'object') return undefined
+	return resolveChainId((params as { chainId?: unknown }).chainId)
+}
+
+function resolveChainId(value: unknown): number | undefined {
+	if (typeof value === 'number') return value
+	if (typeof value === 'bigint') return Number(value)
+	if (typeof value === 'string') {
+		if (Hex.validate(value)) return Hex.toNumber(value)
+		const n = Number(value)
+		if (Number.isFinite(n)) return n
+	}
+	return undefined
 }

--- a/apps/fee-payer/vite.config.ts
+++ b/apps/fee-payer/vite.config.ts
@@ -5,5 +5,14 @@ export default defineConfig({
 	resolve: {
 		tsconfigPaths: true,
 	},
+	define: {
+		__BUILD_VERSION__: JSON.stringify(
+			(
+				process.env.CF_PAGES_COMMIT_SHA ??
+				process.env.GITHUB_SHA ??
+				Date.now().toString()
+			).slice(0, 8),
+		),
+	},
 	plugins: [cloudflare()],
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,6 +138,9 @@ catalogs:
     animejs:
       specifier: ^4.3.6
       version: 4.3.6
+    cloudflare-worker-metrics:
+      specifier: ^1.4.0
+      version: 1.4.0
     cva:
       specifier: ^1.0.0-beta.4
       version: 1.0.0-beta.4
@@ -579,6 +582,9 @@ importers:
       accounts:
         specifier: 'catalog:'
         version: 0.12.1(@types/react@19.2.14)(@wagmi/core@3.4.8)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.50.4(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6))(wagmi@3.6.9)
+      cloudflare-worker-metrics:
+        specifier: 'catalog:'
+        version: 1.4.0
       hono:
         specifier: 'catalog:'
         version: 4.12.14
@@ -3965,6 +3971,10 @@ packages:
   clone@1.0.4:
     resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
     engines: {node: '>=0.8'}
+
+  cloudflare-worker-metrics@1.4.0:
+    resolution: {integrity: sha512-3QQucTpcWp98xlfImAcKiaoRCGUb4v3a7ZVWwJrqgRFWVbTinngfVCjMK9OlYLvls7FKcXNUOKKqC2qHrimUHg==}
+    engines: {node: '>=18'}
 
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
@@ -9148,6 +9158,8 @@ snapshots:
 
   clone@1.0.4:
     optional: true
+
+  cloudflare-worker-metrics@1.4.0: {}
 
   clsx@2.1.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -48,6 +48,7 @@ catalog:
   accounts: ~0.12.1
   abitype: ^1.2.4
   animejs: ^4.3.6
+  cloudflare-worker-metrics: ^1.4.0
   cva: ^1.0.0-beta.4
   dotenv: ^17.3.1
   eruda: ^3.4.3


### PR DESCRIPTION
## Summary

Adds basic operational metrics emission to the fee payer service using `cloudflare-worker-metrics`, matching the log-based metrics pipeline used by the wallet app.

## Motivation

The fee payer service needs low-cardinality request, response, and sponsorship metrics for operational dashboards and alerting across mainnet and testnet environments.

## Changes

- Added a typed fee-payer metric registry and metrics singleton with `build_version` and `fee_payer_env` global tags.
- Added Hono HTTP metrics for request count, response count, and response latency.
- Added fee-payer RPC request and sponsorship response counters tagged by RPC method, keyed route, chain ID, and status as applicable.
- Added `cloudflare-worker-metrics` to the workspace catalog and fee-payer dependencies.

## Testing

- `pnpm --filter fee-payer check:types`
- `pnpm --filter fee-payer check:biome` (exits successfully; reports existing warnings from untracked/local helper files and current API-key code)
- `pnpm --filter fee-payer test`
- `pnpm precommit`
- Attempted `pnpm check`; repo-wide type check is blocked by unrelated `apps/contract-verification` generated `Env` typing errors for existing bindings such as `CHAINS_CONFIG_URL` and `VERIFICATION_JOB_RUNNER`.