### PR TITLE
fix: align fee payer metric dimensions

### DIFF
--- a/apps/fee-payer/src/lib/observability/metric-registry.ts
+++ b/apps/fee-payer/src/lib/observability/metric-registry.ts
@@ -17,9 +17,7 @@ export type MetricRegistry = {
 	}
 	http_response_duration_ms: HttpRouteTags
 	fee_payer_rpc_request_count: RpcTags
-	fee_payer_sponsorship_response_count: {
-		rpc_method: string
-		keyed_route: string
+	fee_payer_sponsorship_response_count: RpcTags & {
 		status: string
 	}
 }

--- a/apps/fee-payer/src/lib/observability/metrics.ts
+++ b/apps/fee-payer/src/lib/observability/metrics.ts
@@ -1,4 +1,3 @@
-import { env } from 'cloudflare:workers'
 import { createMetrics } from 'cloudflare-worker-metrics'
 import type { MetricRegistry } from './metric-registry.js'
 
@@ -11,10 +10,6 @@ const noop: FeePayerMetrics = {
 	count() {},
 	histogram() {},
 	flush() {},
-}
-
-function getFeePayerEnvironment(): 'mainnet' | 'testnet' {
-	return env.TEMPO_ENV === 'mainnet' ? 'mainnet' : 'testnet'
 }
 
 function metricsEnabled(): boolean {
@@ -31,7 +26,6 @@ function createFeePayerMetrics(): FeePayerMetrics {
 	const instance = createMetrics<MetricRegistry>({
 		globalTags: {
 			build_version: getBuildVersion(),
-			fee_payer_env: getFeePayerEnvironment(),
 		},
 	})
 

--- a/apps/fee-payer/src/lib/observability/middleware.ts
+++ b/apps/fee-payer/src/lib/observability/middleware.ts
@@ -69,6 +69,7 @@ export function rpcMetrics(opts: { keyed: boolean }): MiddlewareHandler {
 				metrics.count('fee_payer_sponsorship_response_count', 1, {
 					rpc_method: rpc.method,
 					keyed_route: String(opts.keyed),
+					chain_id: String(rpc.chainId),
 					status:
 						thrown || c.error
 							? 'error'


### PR DESCRIPTION
## Summary

Adds `chain_id` to `fee_payer_sponsorship_response_count` and removes the redundant `fee_payer_env` global tag from fee-payer metrics.

## Motivation

Fee-payer alerting should use one canonical network dimension. `chain_id` identifies the routed/requested chain for RPC metrics, while the exporter-provided `script_name` identifies the Cloudflare Worker deployment. Keeping `fee_payer_env` alongside those labels added a coarse and redundant environment dimension.

## Changes

- Reused the existing RPC metric tag shape for `fee_payer_sponsorship_response_count`.
- Added `chain_id` to sponsorship response metric emissions from `rpcMetrics`.
- Removed the `fee_payer_env` global metric tag from the fee-payer metrics wrapper.

## Testing

- `pnpm exec biome check --write apps/fee-payer/src/lib/observability/metrics.ts apps/fee-payer/src/lib/observability/metric-registry.ts apps/fee-payer/src/lib/observability/middleware.ts`
- `pnpm --filter fee-payer check:types`
- `pnpm --filter fee-payer test` — 31 tests passed
- `pnpm check:types` currently fails on existing `apps/contract-verification` Env type errors unrelated to this PR.
