### PR TITLE
docs: fix supported methods

### DIFF
--- a/apps/fee-payer/README.md
+++ b/apps/fee-payer/README.md
@@ -29,4 +29,4 @@ Environment variables:
 | Method | Route | Params |
 |--------|-------|--------|
 | GET | `/usage` | - optional: `blockTimestampFrom` (epoch seconds)<br>- optional: `blockTimestampTo` (epoch seconds) |
-| POST | `*` | JSON-RPC request body for fee sponsorship<br>Supported methods: `eth_signTransaction`, `eth_signRawTransaction`, `eth_sendRawTransaction`, `eth_sendRawTransactionSync` |
+| POST | `*` | JSON-RPC request body for fee sponsorship<br>Supported sponsorship methods: `eth_signRawTransaction`, `eth_sendRawTransactionSync` (other JSON-RPC methods may be proxied, e.g. `eth_chainId`) |


### PR DESCRIPTION
Removed `eth_signTransaction` from the supported methods list because the service explicitly rejects it (confirmed by [tests](https://github.com/tempoxyz/tempo-apps/blob/main/apps/fee-payer/test/e2e.test.ts#L100-L118)).

Actual sponsorship methods: `eth_signRawTransaction`, `eth_sendRawTransactionSync`