### PR TITLE
docs: fix fee-payer supported methods

### DIFF
--- a/apps/fee-payer/README.md
+++ b/apps/fee-payer/README.md
@@ -29,4 +29,4 @@ Environment variables:
 | Method | Route | Params |
 |--------|-------|--------|
 | GET | `/usage` | - optional: `blockTimestampFrom` (epoch seconds)<br>- optional: `blockTimestampTo` (epoch seconds) |
-| POST | `*` | JSON-RPC request body for fee sponsorship<br>Supported methods: `eth_signTransaction`, `eth_signRawTransaction`, `eth_sendRawTransaction`, `eth_sendRawTransactionSync` |
+| POST | `*` | JSON-RPC request body for fee sponsorship<br>Supported sponsorship methods: `eth_signRawTransaction`, `eth_sendRawTransactionSync` (other JSON-RPC methods may be proxied, e.g. `eth_chainId`) |


### PR DESCRIPTION
## Summary
- remove `eth_signTransaction` / `eth_sendRawTransaction` from the fee-payer sponsorship method list
- clarify that other JSON-RPC methods may still be proxied, matching the existing `eth_chainId` test

## Validation
- `PATH="$PWD/.local-bin:$PATH" pnpm --filter fee-payer check` (passes; reports existing Biome warnings for non-null assertions in `apps/fee-payer/src/lib/api-key*.ts`)
- `PATH="$PWD/.local-bin:$PATH" pnpm --filter fee-payer test` (blocked: local Tempo started by Prool did not respond at `http://localhost:9545/1` after 10 retries)

Prompted by: @goksu