### PR TITLE
docs: fix fee payer supported methods

### DIFF
--- a/apps/fee-payer/README.md
+++ b/apps/fee-payer/README.md
@@ -29,4 +29,4 @@ Environment variables:
 | Method | Route | Params |
 |--------|-------|--------|
 | GET | `/usage` | - optional: `blockTimestampFrom` (epoch seconds)<br>- optional: `blockTimestampTo` (epoch seconds) |
-| POST | `*` | JSON-RPC request body for fee sponsorship<br>Supported methods: `eth_signTransaction`, `eth_signRawTransaction`, `eth_sendRawTransaction`, `eth_sendRawTransactionSync` |
+| POST | `*` | JSON-RPC request body for fee sponsorship<br>Supported sponsorship methods: `eth_signRawTransaction`, `eth_sendRawTransactionSync` (other JSON-RPC methods may be proxied, e.g. `eth_chainId`) |


### PR DESCRIPTION
## Summary
- Update the fee-payer README to list only actual sponsorship methods.
- Note that other JSON-RPC methods, such as `eth_chainId`, may still be proxied.

## Validation
- Confirmed against `apps/fee-payer/test/e2e.test.ts`: `eth_signTransaction` is rejected, `eth_signRawTransaction` is used for sign-only sponsorship, and `eth_sendRawTransactionSync` is used for sign-and-broadcast sponsorship.
- `corepack pnpm --filter fee-payer check:biome` passed with existing warnings.
- `corepack pnpm --filter fee-payer check:types` failed because Worker env types are missing; workspace postinstall could not run because nested scripts require a global `pnpm` shim unavailable in this sandbox.

Prompted by: @goksu