### PR TITLE
fix(perf): show target TPS in benchmark header

### DIFF
--- a/apps/perf/src/routes/benchmark.$id.tsx
+++ b/apps/perf/src/routes/benchmark.$id.tsx
@@ -132,6 +132,12 @@ function formatDuration(startedAt: string, finishedAt: string): string {
 	return remainingMinutes > 0 ? `${hours}h ${remainingMinutes}m` : `${hours}h`
 }
 
+function targetTpsLabel(run: BenchRun): string | undefined {
+	const targetTps = Number(run.config.target_tps ?? run.config.tps)
+	if (!Number.isFinite(targetTps) || targetTps <= 0) return undefined
+	return `Target TPS: ${formatTps(targetTps)}`
+}
+
 export const Route = createFileRoute('/benchmark/$id')({
 	component: RunDetailPage,
 	loader: async ({ params, context }) => {
@@ -408,6 +414,7 @@ export function BenchmarkRunDetail(
 	const ingressTpsPoints = counterRate(txgenCounterSeries.sent)
 	const settledTpsPoints = settledTps(blockRows)
 	const ingressEgressXMax = sharedXMax([ingressTpsPoints, settledTpsPoints])
+	const targetTps = targetTpsLabel(run)
 
 	return (
 		<div>
@@ -459,6 +466,7 @@ export function BenchmarkRunDetail(
 						<p className="mt-2 text-[14px] text-secondary">
 							{formatDate(run.startedAt)} · {run.blockCount} blocks ·{' '}
 							{formatDuration(run.startedAt, run.finishedAt)}
+							{targetTps && ` · ${targetTps}`}
 							{scenario && ` · ${scenario.workload}`}
 						</p>
 					</div>


### PR DESCRIPTION
Shows the benchmark run's configured target TPS in the header metadata when `target_tps` is present in the run config. Direct internal perf links previously only showed observed settled TPS, which made it harder to compare a run against the requested submission load.

## Screenshots

| Before | After |
|--------|-------|
| `May 28, 2026, 10:15 AM · 176 blocks · 3m 13s` | `May 28, 2026, 10:15 AM · 176 blocks · 3m 13s · Target TPS: 20,000` |