### PR TITLE
Prevent scrollbar layout shift in explorer

### DIFF
--- a/apps/explorer/src/routes/styles.css
+++ b/apps/explorer/src/routes/styles.css
@@ -126,6 +126,8 @@ html,
 @layer base {
 	html {
 		color-scheme: dark;
+		overflow-y: scroll;
+		scrollbar-gutter: stable;
 	}
 }
 


### PR DESCRIPTION
## Summary
- Reserve vertical scrollbar space in the explorer document so expanding transaction event details does not change page width.

## Verification
- PATH="$PWD/.codex-bin:$PATH" pnpm --filter explorer check

Prompted by: @shekhirin