### PR TITLE
fix(explorer): use viem channel reserve ABI

### DIFF
--- a/apps/explorer/src/lib/abis.ts
+++ b/apps/explorer/src/lib/abis.ts
@@ -1,58 +1,7 @@
-import { parseAbi } from 'viem'
-import {
-	Abis as ViemTempoAbis,
-	Addresses as ViemTempoAddresses,
-} from 'viem/tempo'
+import { Abis as ViemTempoAbis, Channel as ViemTempoChannel } from 'viem/tempo'
 
-type TempoAbisWithTip1034 = typeof ViemTempoAbis & {
-	tip20ChannelEscrow?: typeof tip20ChannelEscrowFallbackAbi
-}
-
-type TempoAddressesWithTip1034 = typeof ViemTempoAddresses & {
-	tip20ChannelEscrow?: typeof TIP20_CHANNEL_ESCROW_ADDRESS
-}
-
-export const TIP20_CHANNEL_ESCROW_ADDRESS =
-	'0x4D50500000000000000000000000000000000000'
-
-const tip20ChannelEscrowFallbackAbi = parseAbi([
-	'struct ChannelDescriptor { address payer; address payee; address operator; address token; bytes32 salt; address authorizedSigner; bytes32 expiringNonceHash; }',
-	'struct ChannelState { uint96 settled; uint96 deposit; uint32 closeRequestedAt; }',
-	'function open(address payee, address operator, address token, bytes32 salt, address authorizedSigner, uint96 deposit) returns (bytes32 channelId)',
-	'function settle(ChannelDescriptor descriptor, uint96 cumulativeAmount, bytes signature)',
-	'function topUp(ChannelDescriptor descriptor, uint96 additionalDeposit)',
-	'function requestClose(ChannelDescriptor descriptor)',
-	'function close(ChannelDescriptor descriptor, uint96 cumulativeAmount, uint96 captureAmount, bytes signature)',
-	'function withdraw(ChannelDescriptor descriptor)',
-	'function channelId(ChannelDescriptor descriptor) view returns (bytes32)',
-	'function state(ChannelDescriptor descriptor) view returns (ChannelState)',
-	'event ChannelOpened(bytes32 indexed channelId, ChannelDescriptor descriptor, uint96 deposit)',
-	'event Settled(bytes32 indexed channelId, ChannelDescriptor descriptor, uint96 cumulativeAmount, uint96 deltaPaid, uint96 newSettled)',
-	'event TopUp(bytes32 indexed channelId, ChannelDescriptor descriptor, uint96 additionalDeposit, uint96 newDeposit)',
-	'event CloseRequested(bytes32 indexed channelId, ChannelDescriptor descriptor, uint32 closeRequestedAt)',
-	'event CloseRequestCancelled(bytes32 indexed channelId, ChannelDescriptor descriptor)',
-	'event ChannelClosed(bytes32 indexed channelId, ChannelDescriptor descriptor, uint96 settledToPayee, uint96 refundedToPayer)',
-	'event ChannelWithdrawn(bytes32 indexed channelId, ChannelDescriptor descriptor, uint96 refundedToPayer)',
-	'error InvalidPayee()',
-	'error InvalidToken()',
-	'error InvalidDeposit()',
-	'error ChannelAlreadyOpen(bytes32 channelId)',
-	'error ChannelNotOpen(bytes32 channelId)',
-	'error Unauthorized()',
-	'error InvalidSignature()',
-	'error InvalidCaptureAmount()',
-	'error InsufficientDeposit()',
-	'error CloseGracePeriodNotElapsed()',
-])
-
-export const tip20ChannelEscrowAbi = ((ViemTempoAbis as TempoAbisWithTip1034)
-	.tip20ChannelEscrow ??
-	tip20ChannelEscrowFallbackAbi) as typeof tip20ChannelEscrowFallbackAbi
-
-export const tip20ChannelEscrowAddress = ((
-	ViemTempoAddresses as TempoAddressesWithTip1034
-).tip20ChannelEscrow ??
-	TIP20_CHANNEL_ESCROW_ADDRESS) as typeof TIP20_CHANNEL_ESCROW_ADDRESS
+export const tip20ChannelReserveAbi = ViemTempoAbis.tip20ChannelReserve
+export const tip20ChannelReserveAddress = ViemTempoChannel.address
 
 export const streamChannelAbi = [
 	{
@@ -280,7 +229,6 @@ export const stablecoinDexAbi = ViemTempoAbis.stablecoinDex
 export const Abis = {
 	...ViemTempoAbis,
 	stablecoinDex: stablecoinDexAbi,
-	tip20ChannelEscrow: tip20ChannelEscrowAbi,
 	streamChannel: streamChannelAbi,
 	zonePortal: zonePortalAbi,
 	zoneFactory: zoneFactoryAbi,

--- a/apps/explorer/src/lib/domain/contracts.ts
+++ b/apps/explorer/src/lib/domain/contracts.ts
@@ -12,8 +12,8 @@ import {
 	Abis,
 	stablecoinDexAbi,
 	streamChannelAbi,
-	tip20ChannelEscrowAbi,
-	tip20ChannelEscrowAddress,
+	tip20ChannelReserveAbi,
+	tip20ChannelReserveAddress,
 } from '#lib/abis'
 import { getChainId, getPublicClient } from 'wagmi/actions'
 import { isTip20Address } from '#lib/domain/tip20.ts'
@@ -315,15 +315,15 @@ export const systemContractRegistry = new Map<Address.Address, ContractInfo>(<
 		},
 	],
 	[
-		tip20ChannelEscrowAddress,
+		tip20ChannelReserveAddress,
 		{
-			name: 'TIP-20 Channel Escrow',
+			name: 'TIP-20 Channel Reserve',
 			code: '0xef',
-			description: 'Native TIP-20 payment channel escrow precompile',
-			abi: tip20ChannelEscrowAbi,
+			description: 'Native TIP-20 payment channel reserve precompile',
+			abi: tip20ChannelReserveAbi,
 			category: 'system',
 			docsUrl: 'https://tips.sh/1034-1',
-			address: tip20ChannelEscrowAddress,
+			address: tip20ChannelReserveAddress,
 		},
 	],
 	[

--- a/apps/explorer/test/tip20-channel-reserve.node.test.ts
+++ b/apps/explorer/test/tip20-channel-reserve.node.test.ts
@@ -1,14 +1,23 @@
 import { describe, expect, it } from 'vitest'
 import { decodeFunctionData, encodeFunctionData, getAbiItem } from 'viem'
-import { tip20ChannelEscrowAbi, tip20ChannelEscrowAddress } from '#lib/abis'
+import {
+	Abis,
+	tip20ChannelReserveAbi,
+	tip20ChannelReserveAddress,
+} from '#lib/abis'
 import { autoloadAbi, getContractInfo } from '#lib/domain/contracts'
 
-describe('TIP-20 channel escrow ABI', () => {
-	it('registers the TIP-1034 precompile address for ABI rendering', () => {
-		const info = getContractInfo(tip20ChannelEscrowAddress)
+describe('TIP-20 channel reserve ABI', () => {
+	it('uses the Viem TIP-20 channel reserve ABI', () => {
+		expect(tip20ChannelReserveAbi).toBe(Abis.tip20ChannelReserve)
+		expect('tip20ChannelEscrow' in Abis).toBe(false)
+	})
 
-		expect(info?.name).toBe('TIP-20 Channel Escrow')
-		expect(info?.abi).toBe(tip20ChannelEscrowAbi)
+	it('registers the TIP-1034 precompile address for ABI rendering', () => {
+		const info = getContractInfo(tip20ChannelReserveAddress)
+
+		expect(info?.name).toBe('TIP-20 Channel Reserve')
+		expect(info?.abi).toBe(tip20ChannelReserveAbi)
 		expect(
 			getAbiItem({
 				abi: info?.abi ?? [],
@@ -29,13 +38,13 @@ describe('TIP-20 channel escrow ABI', () => {
 		} as const
 
 		const data = encodeFunctionData({
-			abi: tip20ChannelEscrowAbi,
+			abi: tip20ChannelReserveAbi,
 			functionName: 'close',
 			args: [descriptor, 100n, 90n, '0x1234'],
 		})
 
 		const decoded = decodeFunctionData({
-			abi: tip20ChannelEscrowAbi,
+			abi: tip20ChannelReserveAbi,
 			data,
 		})
 
@@ -49,8 +58,8 @@ describe('TIP-20 channel escrow ABI', () => {
 	})
 
 	it('returns known registry ABIs from autoload before network lookup', async () => {
-		await expect(autoloadAbi(tip20ChannelEscrowAddress)).resolves.toBe(
-			tip20ChannelEscrowAbi,
+		await expect(autoloadAbi(tip20ChannelReserveAddress)).resolves.toBe(
+			tip20ChannelReserveAbi,
 		)
 	})
 })


### PR DESCRIPTION
## Summary
- replace the local TIP-20 channel escrow ABI fallback with Viem's channel reserve ABI
- register the system contract with the Viem channel address
- rename the node ABI coverage to assert the Viem reserve export

## Tests
- pnpm check
- pnpm check:types
- pnpm --filter explorer check:env

Note: pnpm --filter explorer test still fails before tests with Missing "#tanstack-start-entry" specifier in @tanstack/start-server-core.