### PR TITLE
Label MPP payments in explorer receipts

### DIFF
--- a/apps/explorer/src/lib/domain/known-events.ts
+++ b/apps/explorer/src/lib/domain/known-events.ts
@@ -5,7 +5,7 @@ import type { AbiEvent, Log, TransactionReceipt } from 'viem'
 import { decodeFunctionData, parseEventLogs, zeroAddress } from 'viem'
 import { Addresses } from 'viem/tempo'
 import { Abis, allAbis } from '#lib/abis'
-import { decodeMemoForDisplay } from '#lib/domain/memo'
+import { decodeMemoForDisplay, isMppAttributionMemo } from '#lib/domain/memo'
 import type * as Tip20 from './tip20'
 
 const abi = allAbis
@@ -349,6 +349,7 @@ function createDetectors(
 				const isFeeTransfer =
 					Address.isEqual(args.to, FEE_MANAGER) &&
 					!Address.isEqual(args.from, zeroAddress)
+				const isMppPayment = 'memo' in args && isMppAttributionMemo(args.memo)
 
 				if (isFeeTransfer) {
 					// When viewer mode is active, let feePayer detector handle fee transfers
@@ -369,7 +370,11 @@ function createDetectors(
 					parts: [
 						{
 							type: 'action',
-							value: VirtualAddress.validate(args.from) ? 'Forwarded' : 'Send',
+							value: isMppPayment
+								? 'MPP Payment'
+								: VirtualAddress.validate(args.from)
+									? 'Forwarded'
+									: 'Send',
 						},
 						{
 							type: 'amount',

--- a/apps/explorer/src/lib/domain/memo.ts
+++ b/apps/explorer/src/lib/domain/memo.ts
@@ -2,6 +2,7 @@ import type * as Hex from 'ox/Hex'
 import * as OxHex from 'ox/Hex'
 
 const decoder = new TextDecoder('utf-8', { fatal: true })
+const mppAttributionPrefix = '0xef1ed712'
 
 function hasControlCharacter(value: string): boolean {
 	for (let index = 0; index < value.length; index += 1) {
@@ -18,6 +19,8 @@ function hasControlCharacter(value: string): boolean {
  * Returns undefined for empty/binary payloads to avoid rendering gibberish.
  */
 export function decodeMemoForDisplay(memo: Hex.Hex): string | undefined {
+	if (isMppAttributionMemo(memo)) return undefined
+
 	const bytes = OxHex.toBytes(memo)
 
 	let start = 0
@@ -41,4 +44,12 @@ export function decodeMemoForDisplay(memo: Hex.Hex): string | undefined {
 	if (hasControlCharacter(normalized)) return undefined
 
 	return normalized
+}
+
+/** Returns true when a memo uses the MPP attribution memo format. */
+export function isMppAttributionMemo(memo: Hex.Hex): boolean {
+	return (
+		OxHex.size(memo) === 32 &&
+		memo.toLowerCase().startsWith(mppAttributionPrefix)
+	)
 }

--- a/apps/explorer/src/lib/domain/receipt.ts
+++ b/apps/explorer/src/lib/domain/receipt.ts
@@ -4,7 +4,7 @@ import type { AbiEvent, Log, TransactionReceipt } from 'viem'
 import { parseEventLogs, zeroAddress } from 'viem'
 import { Addresses } from 'viem/tempo'
 import { Abis } from '#lib/abis'
-import { decodeMemoForDisplay } from '#lib/domain/memo'
+import { decodeMemoForDisplay, isMppAttributionMemo } from '#lib/domain/memo'
 import type * as Tip20 from '#lib/domain/tip20'
 import { HexFormatter, PriceFormatter } from '#lib/formatting'
 
@@ -295,6 +295,8 @@ export namespace LineItems {
 						'memo' in event.args
 							? decodeMemoForDisplay(event.args.memo)
 							: undefined
+					const isMppPayment =
+						'memo' in event.args && isMppAttributionMemo(event.args.memo)
 
 					const { currency, decimals, symbol } = metadata
 
@@ -344,7 +346,7 @@ export namespace LineItems {
 							},
 							ui: {
 								bottom: [...(memo ? [{ left: `Memo: ${memo}` }] : [])],
-								left: `Send ${symbol} ${to ? `to ${HexFormatter.truncate(to)}` : ''}`,
+								left: `${isMppPayment ? 'MPP Payment' : `Send ${symbol}`} ${to ? `to ${HexFormatter.truncate(to)}` : ''}`,
 								right: decimals
 									? PriceFormatter.format(isCredit ? -amount : amount, decimals)
 									: '-',

--- a/apps/explorer/test/memo.test.ts
+++ b/apps/explorer/test/memo.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, it } from 'vitest'
+import type * as Hex from 'ox/Hex'
+import { encodeAbiParameters, encodeEventTopics } from 'viem'
+import { Abis } from '#lib/abis'
+import {
+	accountAddress,
+	getTokenMetadata,
+	mockLog,
+	mockReceipt,
+	recipientAddress,
+	userTokenAddress,
+} from '#lib/demo'
+import { parseKnownEvents } from '#lib/domain/known-events'
+import { decodeMemoForDisplay, isMppAttributionMemo } from '#lib/domain/memo'
+import { LineItems } from '#lib/domain/receipt'
+
+const mppAttributionMemo =
+	'0xef1ed712010102030405060708090a0000000000000000000000000000000000' as Hex.Hex
+const providedReceiptHash =
+	'0x0b854031dd4235d6c56024331323305c3db4444feaae885a2875e068f7fbd557' as Hex.Hex
+const providedReceiptSender =
+	'0xc3880847eb13415f567e1d7fddbd1999b46b5d45' as const
+const providedReceiptRecipient =
+	'0xca4e835f803cb0b7c428222b3a3b98518d4779fe' as const
+const providedReceiptToken =
+	'0x20c000000000000000000000b9537d11c60e8b50' as const
+const providedReceiptMemo =
+	'0xef1ed71201c62939e7f7496e1106ef00000000000000000000a166aee7e294f6' as Hex.Hex
+
+describe('MPP attribution memos', () => {
+	it('identifies and hides MPP attribution memos from generic memo display', () => {
+		expect({
+			isAttribution: isMppAttributionMemo(mppAttributionMemo),
+			display: decodeMemoForDisplay(mppAttributionMemo),
+		}).toMatchInlineSnapshot(`
+			{
+			  "display": undefined,
+			  "isAttribution": true,
+			}
+		`)
+	})
+
+	it('labels receipt transfers with MPP attribution memos as MPP payments', () => {
+		const hash = `0x${'7'.repeat(64)}` as const
+		const logs = [
+			mockLog(
+				{
+					address: userTokenAddress,
+					topics: encodeEventTopics({
+						abi: Abis.tip20,
+						eventName: 'Transfer',
+						args: {
+							from: accountAddress,
+							to: recipientAddress,
+						},
+					}) as [Hex.Hex, ...Hex.Hex[]],
+					data: encodeAbiParameters([{ type: 'uint256' }], [1_000_000n]),
+				},
+				hash,
+			),
+			mockLog(
+				{
+					address: userTokenAddress,
+					topics: encodeEventTopics({
+						abi: Abis.tip20,
+						eventName: 'TransferWithMemo',
+						args: {
+							from: accountAddress,
+							memo: mppAttributionMemo,
+							to: recipientAddress,
+						},
+					}) as [Hex.Hex, ...Hex.Hex[]],
+					data: encodeAbiParameters([{ type: 'uint256' }], [1_000_000n]),
+				},
+				hash,
+			),
+		]
+
+		const receipt = mockReceipt(logs, accountAddress, hash)
+		const lineItems = LineItems.fromReceipt(receipt, { getTokenMetadata })
+		const knownEvents = parseKnownEvents(receipt, { getTokenMetadata })
+
+		expect({
+			knownEvents: knownEvents.map((event) => ({
+				note: event.note,
+				parts: event.parts,
+				type: event.type,
+			})),
+			lineItems: lineItems.main.map((item) => item.ui),
+		}).toMatchInlineSnapshot(`
+			{
+			  "knownEvents": [
+			    {
+			      "note": undefined,
+			      "parts": [
+			        {
+			          "type": "action",
+			          "value": "MPP Payment",
+			        },
+			        {
+			          "type": "amount",
+			          "value": {
+			            "currency": "USD",
+			            "decimals": 6,
+			            "symbol": "USDC",
+			            "token": "0xdddddddddddddddddddddddddddddddddddddddd",
+			            "value": 1000000n,
+			          },
+			        },
+			        {
+			          "type": "text",
+			          "value": "to",
+			        },
+			        {
+			          "type": "account",
+			          "value": "0x9999999999999999999999999999999999999999",
+			        },
+			      ],
+			      "type": "send",
+			    },
+			  ],
+			  "lineItems": [
+			    {
+			      "bottom": [],
+			      "left": "MPP Payment to 0x9999…9999",
+			      "right": "$1",
+			    },
+			  ],
+			}
+		`)
+	})
+
+	it('labels the provided receipt hash fixture as an MPP payment', () => {
+		const logs = [
+			mockLog(
+				{
+					address: providedReceiptToken,
+					topics: encodeEventTopics({
+						abi: Abis.tip20,
+						eventName: 'Transfer',
+						args: {
+							from: providedReceiptSender,
+							to: providedReceiptRecipient,
+						},
+					}) as [Hex.Hex, ...Hex.Hex[]],
+					data: encodeAbiParameters([{ type: 'uint256' }], [5_000n]),
+				},
+				providedReceiptHash,
+			),
+			mockLog(
+				{
+					address: providedReceiptToken,
+					topics: encodeEventTopics({
+						abi: Abis.tip20,
+						eventName: 'TransferWithMemo',
+						args: {
+							from: providedReceiptSender,
+							memo: providedReceiptMemo,
+							to: providedReceiptRecipient,
+						},
+					}) as [Hex.Hex, ...Hex.Hex[]],
+					data: encodeAbiParameters([{ type: 'uint256' }], [5_000n]),
+				},
+				providedReceiptHash,
+			),
+		]
+		const receipt = mockReceipt(
+			logs,
+			providedReceiptSender,
+			providedReceiptHash,
+		)
+		const getProvidedTokenMetadata = () => ({
+			currency: 'USD',
+			decimals: 6,
+			logoURI: '',
+			name: 'Path USD',
+			symbol: 'pathUSD',
+			totalSupply: 0n,
+		})
+		const knownEvents = parseKnownEvents(receipt, {
+			getTokenMetadata: getProvidedTokenMetadata,
+		})
+		const lineItems = LineItems.fromReceipt(receipt, {
+			getTokenMetadata: getProvidedTokenMetadata,
+		})
+
+		expect({
+			firstEventAction: knownEvents[0]?.parts[0],
+			firstLineItem: lineItems.main[0]?.ui,
+			memoDisplay: decodeMemoForDisplay(providedReceiptMemo),
+		}).toMatchInlineSnapshot(`
+			{
+			  "firstEventAction": {
+			    "type": "action",
+			    "value": "MPP Payment",
+			  },
+			  "firstLineItem": {
+			    "bottom": [],
+			    "left": "MPP Payment to 0xca4e…79Fe",
+			    "right": "<$0.01",
+			  },
+			  "memoDisplay": undefined,
+			}
+		`)
+	})
+})


### PR DESCRIPTION
## Summary
- detect MPP attribution memos (`0xef1ed712...`) in explorer memo parsing
- label receipt transfer rows with those memos as `MPP Payment` instead of a generic token send
- add regression coverage for attribution memo display behavior

## Before / After
| Surface | Before | After |
| --- | --- | --- |
| Explorer receipt transfer with MPP attribution memo | `Send <token> to <address>` and no MPP-specific label | `MPP Payment to <address>` |

## Validation
- `corepack pnpm --dir apps/explorer exec vitest run test/memo.test.ts`
- `corepack pnpm --filter explorer check:types` did not complete because this fresh clone is missing generated Cloudflare types after workspace postinstall failed when subpackage scripts invoked `pnpm` directly (`pnpm: not found` in hook/script environment).

Prompted by: @brendanjryan