### PR TITLE
Show sponsored transaction fees in explorer

### DIFF
--- a/apps/explorer/src/comps/Receipt.tsx
+++ b/apps/explorer/src/comps/Receipt.tsx
@@ -299,24 +299,19 @@ export function Receipt(props: Receipt.Props) {
 														</span>
 													)}
 												</span>
-												<div className="flex items-center gap-1">
-													{isSponsored && item.payer && (
+												<div className="flex items-center gap-2">
+													{isSponsored ? (
 														<>
-															<Link
-																to="/address/$address"
-																params={{ address: item.payer }}
-																className="text-accent press-down"
-															>
-																<Midcut
-																	value={item.payer}
-																	prefix="0x"
-																	min={4}
-																/>
-															</Link>
-															<span className="text-tertiary">paid</span>
+															<span className="text-tertiary line-through">
+																{formattedAmount}
+															</span>
+															<span className="text-base-content-positive">
+																Sponsored
+															</span>
 														</>
+													) : (
+														<span>{formattedAmount}</span>
 													)}
-													<span>{formattedAmount}</span>
 												</div>
 											</div>
 										)

--- a/apps/explorer/src/routes/_layout/receipt/$hash.tsx
+++ b/apps/explorer/src/routes/_layout/receipt/$hash.tsx
@@ -596,7 +596,7 @@ namespace TextRenderer {
 					format: 'short',
 				})
 				lines.push(leftRight(label.toUpperCase(), amount))
-				if (item.payer) lines.push(`${indent}Paid by: ${item.payer}`)
+				if (item.payer) lines.push(`${indent}Sponsored fee`)
 			}
 
 			lines.push('')


### PR DESCRIPTION
## Summary
- show sponsored fee breakdown rows as `Sponsored` instead of rendering the payer address plus `paid`
- update text receipt rendering to say `Sponsored fee` instead of `Paid by: <address>`

## Validation
- `corepack pnpm --filter explorer check:biome`
- `corepack pnpm --filter explorer check:types` *(fails on existing generated/Cloudflare typing issues unrelated to this change: `ExploreInput.tsx`, `Tip20ContractInfo.tsx`, `Cloudflare`/`KVNamespace`, etc.)*

Prompted by: @gakonst