### PR TITLE
feat(docs-mcp): proxy mcp.tempo.xyz to AI Search MCP endpoint

### DIFF
--- a/apps/docs-mcp/README.md
+++ b/apps/docs-mcp/README.md
@@ -7,9 +7,15 @@ non-owned sources by uploading their canonical Markdown pages into the
 instance's **built-in storage**, tagged with a `source` metadata field for
 filtering at query time.
 
-The MCP endpoint is exposed by AI Search itself
-(`https://<instance-id>.search.ai.cloudflare.com/mcp`) — this Worker is the
-ingest plane, not the query plane.
+The MCP endpoint is exposed by AI Search itself. This Worker also serves as
+a thin transparent proxy on `mcp.tempo.xyz` → the AI Search MCP upstream, so
+clients connect to a stable branded URL instead of the opaque
+`<instance-id>.search.ai.cloudflare.com` hostname.
+
+```
+MCP clients ──▶ https://mcp.tempo.xyz/ ──▶ AI Search MCP (proxied 1:1)
+Cron ──▶ docs-mcp Worker ──▶ AI Search items.upload() (ingest plane)
+```
 
 ## How it works
 
@@ -20,7 +26,7 @@ ingest plane, not the query plane.
                                 2. parse → page URLs
                                 3. for each page: GET <page>.md with
                                    If-None-Match (per-page ETag)
-                                4. 304 → skip; 200 → uploadAndPoll,
+                                4. 304 → skip; 200 → items.upload(),
                                    record { item id, etag } in KV
                                 5. diff against last sync, delete items
                                    that fell out of llms.txt
@@ -139,7 +145,7 @@ the auto-crawled `docs.tempo.xyz` entries.
 Query the MCP endpoint to confirm cross-source ranking works:
 
 ```bash
-curl https://<INSTANCE_ID>.search.ai.cloudflare.com/mcp \
+curl https://mcp.tempo.xyz/ \
   -H "Content-Type: application/json" \
   -H "Accept: application/json, text/event-stream" \
   -d '{
@@ -148,11 +154,11 @@ curl https://<INSTANCE_ID>.search.ai.cloudflare.com/mcp \
   }'
 ```
 
+Streamable HTTP MCP responses are server-sent events; strip the wrapper with
+`sed -n 's/^data: //p' | jq` if you want to pipe them into `jq`.
+
 ## Known limitations
 
-- **`uploadAndPoll` is sequential within a batch.** Page fetches are
-  concurrent (8 at a time), but indexing happens per page. For sources with
-  hundreds of changed pages, a forced sync may take several seconds.
 - **No backfill for orphaned items.** If KV is wiped, the next sync re-uploads
   every page but loses track of items that AI Search still has from previous
   runs. Recovery: re-run a forced sync, then prune from the AI Search dashboard

--- a/apps/docs-mcp/src/index.ts
+++ b/apps/docs-mcp/src/index.ts
@@ -1,16 +1,15 @@
 import { env } from 'cloudflare:workers'
 import { syncSource } from './lib/ingest.js'
 import { log } from './lib/log.js'
+import { proxyMcp } from './lib/proxy.js'
 import { isForcedHour } from './lib/schedule.js'
 import { SOURCES } from './lib/sources.js'
 
 export default {
-	async fetch() {
-		return new Response('docs-mcp: cron-only ingest worker\n', {
-			headers: { 'content-type': 'text/plain' },
-		})
+	async fetch(req) {
+		return proxyMcp(req, env.AI_SEARCH_MCP_URL)
 	},
-	async scheduled(event, _env, ctx) {
+	async scheduled(event) {
 		const startedAt = performance.now()
 		// Once per UTC day, bypass all ETag caches as a backstop for sources
 		// whose llms.txt ETag doesn't track page changes correctly.
@@ -23,34 +22,27 @@ export default {
 			force,
 		})
 
-		ctx.waitUntil(
-			(async () => {
-				const instance = env.AI_SEARCH.get(env.AI_SEARCH_INSTANCE_ID)
-				const reports = []
-				for (const source of SOURCES) {
-					const report = await syncSource({
-						source,
-						instance,
-						etagCache: env.ETAG_CACHE,
-						force,
-					})
-					if (report.status === 'error') {
-						log.error('source.failed', report)
-					} else {
-						log.info('source.complete', report)
-					}
-					reports.push(report)
-				}
-				log.info('cron.complete', {
-					cron: event.cron,
-					duration_ms: Math.round(performance.now() - startedAt),
-					sources: reports.length,
-					synced: reports.filter((r) => r.status === 'synced').length,
-					unchanged: reports.filter((r) => r.status === 'unchanged').length,
-					errors: reports.filter((r) => r.status === 'error').length,
-					force,
-				})
-			})(),
-		)
+		const instance = env.AI_SEARCH.get(env.AI_SEARCH_INSTANCE_ID)
+		const reports = []
+		for (const source of SOURCES) {
+			const report = await syncSource({
+				source,
+				instance,
+				etagCache: env.ETAG_CACHE,
+				force,
+			})
+			if (report.status === 'error') log.error('source.failed', report)
+			else log.info('source.complete', report)
+			reports.push(report)
+		}
+		log.info('cron.complete', {
+			cron: event.cron,
+			duration_ms: Math.round(performance.now() - startedAt),
+			sources: reports.length,
+			synced: reports.filter((r) => r.status === 'synced').length,
+			unchanged: reports.filter((r) => r.status === 'unchanged').length,
+			errors: reports.filter((r) => r.status === 'error').length,
+			force,
+		})
 	},
 } satisfies ExportedHandler<Env>

--- a/apps/docs-mcp/src/lib/ingest.test.ts
+++ b/apps/docs-mcp/src/lib/ingest.test.ts
@@ -23,17 +23,13 @@ function fakeInstance(opts?: { deleteFails?: Set<string> }): {
 	const deletes: string[] = []
 	const instance = {
 		items: {
-			uploadAndPoll: async (
+			upload: async (
 				key: string,
 				content: string,
 				options?: { metadata?: Record<string, unknown> },
 			) => {
 				uploads.push({ key, content, metadata: options?.metadata })
-				return {
-					id: `item-${key}`,
-					key,
-					status: 'completed',
-				}
+				return { id: `item-${key}`, key }
 			},
 			delete: async (id: string) => {
 				if (opts?.deleteFails?.has(id)) throw new Error(`boom: ${id}`)

--- a/apps/docs-mcp/src/lib/ingest.ts
+++ b/apps/docs-mcp/src/lib/ingest.ts
@@ -203,7 +203,11 @@ async function syncPage(args: {
 			return { key, outcome: 'failed', entry: prev }
 		}
 
-		const item = await instance.items.uploadAndPoll(key, content, {
+		// Use upload() not uploadAndPoll(): we don't need to block on indexing
+		// completion (AI Search indexes in the background). Polling per page
+		// serializes with our 8-way concurrency and trips the internal poll
+		// timeout, causing whole batches to fail.
+		const item = await instance.items.upload(key, content, {
 			metadata: { source: source.id, url },
 		})
 		const etag = res.headers.get('etag') ?? undefined

--- a/apps/docs-mcp/src/lib/proxy.test.ts
+++ b/apps/docs-mcp/src/lib/proxy.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { proxyMcp } from './proxy.js'
+
+describe('proxyMcp', () => {
+	const upstream = 'https://99c10de8.search.ai.cloudflare.com'
+	const realFetch = globalThis.fetch
+
+	beforeEach(() => {
+		vi.restoreAllMocks()
+	})
+
+	afterEach(() => {
+		globalThis.fetch = realFetch
+	})
+
+	it('forwards method, path, query, and body to the upstream origin', async () => {
+		const seen: { url?: string; init?: RequestInit } = {}
+		globalThis.fetch = vi.fn(async (url: RequestInfo, init?: RequestInit) => {
+			seen.url = String(url)
+			seen.init = init
+			return new Response('{"ok":true}', {
+				status: 200,
+				headers: { 'content-type': 'application/json' },
+			})
+		}) as unknown as typeof fetch
+
+		const req = new Request('https://mcp.tempo.xyz/mcp?x=1', {
+			method: 'POST',
+			headers: {
+				'content-type': 'application/json',
+				accept: 'text/event-stream',
+			},
+			body: '{"jsonrpc":"2.0","id":1,"method":"tools/list"}',
+		})
+		const res = await proxyMcp(req, upstream)
+		expect(res.status).toBe(200)
+		expect(await res.text()).toBe('{"ok":true}')
+		expect(seen.url).toBe(`${upstream}/mcp?x=1`)
+		expect(seen.init?.method).toBe('POST')
+		const headers = new Headers(seen.init?.headers as HeadersInit)
+		expect(headers.get('content-type')).toBe('application/json')
+		expect(headers.get('accept')).toBe('text/event-stream')
+		expect(headers.get('host')).toBeNull()
+	})
+
+	it('strips Cloudflare hop headers before forwarding', async () => {
+		let forwarded: Headers | undefined
+		globalThis.fetch = vi.fn(async (_url: RequestInfo, init?: RequestInit) => {
+			forwarded = new Headers(init?.headers as HeadersInit)
+			return new Response('ok')
+		}) as unknown as typeof fetch
+
+		const req = new Request('https://mcp.tempo.xyz/mcp', {
+			method: 'GET',
+			headers: {
+				'cf-connecting-ip': '1.2.3.4',
+				'cf-ray': 'abc',
+				'x-forwarded-for': '1.2.3.4',
+			},
+		})
+		await proxyMcp(req, upstream)
+		expect(forwarded?.get('cf-connecting-ip')).toBeNull()
+		expect(forwarded?.get('cf-ray')).toBeNull()
+		expect(forwarded?.get('x-forwarded-for')).toBeNull()
+	})
+
+	it('honours an upstream that already includes a path', async () => {
+		let seenUrl = ''
+		globalThis.fetch = vi.fn(async (url: RequestInfo) => {
+			seenUrl = String(url)
+			return new Response('ok')
+		}) as unknown as typeof fetch
+
+		const req = new Request('https://mcp.tempo.xyz/anything', { method: 'GET' })
+		await proxyMcp(req, `${upstream}/mcp`)
+		expect(seenUrl).toBe(`${upstream}/mcp`)
+	})
+})

--- a/apps/docs-mcp/src/lib/proxy.ts
+++ b/apps/docs-mcp/src/lib/proxy.ts
@@ -1,0 +1,49 @@
+/**
+ * Transparent proxy from this worker (mcp.tempo.xyz) to the Cloudflare AI
+ * Search MCP endpoint. AI Search assigns each instance an opaque hostname
+ * like `<uuid>.search.ai.cloudflare.com`; we surface a stable, brandable
+ * URL by forwarding the request 1:1 (method, headers, body, response stream).
+ *
+ * Notes:
+ * - Preserves the incoming path so /mcp, /sse, etc. all forward correctly.
+ * - Streams responses so MCP server-sent events flow through untouched.
+ * - Does not add auth: the upstream AI Search MCP endpoint is public.
+ */
+export async function proxyMcp(
+	req: Request,
+	upstreamBase: string,
+): Promise<Response> {
+	const incoming = new URL(req.url)
+	const upstream = new URL(upstreamBase)
+	// Keep upstream base path if it has one (e.g. ".../mcp"); otherwise
+	// forward the incoming path verbatim. We compose by appending the
+	// incoming path to the upstream origin if the upstream URL is just an
+	// origin, or replace the path if it's a specific endpoint.
+	const target =
+		upstream.pathname === '/' || upstream.pathname === ''
+			? new URL(incoming.pathname + incoming.search, upstream.origin)
+			: new URL(upstream.toString())
+
+	const headers = new Headers(req.headers)
+	headers.delete('host')
+	// Drop hop-by-hop and Cloudflare-specific headers that should not be
+	// forwarded blindly to a different origin.
+	headers.delete('cf-connecting-ip')
+	headers.delete('cf-ipcountry')
+	headers.delete('cf-ray')
+	headers.delete('cf-visitor')
+	headers.delete('x-forwarded-for')
+	headers.delete('x-forwarded-proto')
+	headers.delete('x-real-ip')
+
+	const init: RequestInit = {
+		method: req.method,
+		headers,
+		redirect: 'manual',
+	}
+	if (req.method !== 'GET' && req.method !== 'HEAD') {
+		init.body = req.body
+	}
+
+	return fetch(target.toString(), init)
+}

--- a/apps/docs-mcp/wrangler.jsonc
+++ b/apps/docs-mcp/wrangler.jsonc
@@ -37,6 +37,17 @@
 	"vars": {
 		// AI Search instance id within the namespace. Must already exist and
 		// be created after 2026-04-16 to have built-in storage support.
-		"AI_SEARCH_INSTANCE_ID": "tempo-global"
-	}
+		"AI_SEARCH_INSTANCE_ID": "tempo-global",
+		// Public MCP endpoint URL for the AI Search instance above. We
+		// transparently proxy mcp.tempo.xyz -> this upstream so clients
+		// connect to a stable branded URL instead of the opaque hostname.
+		"AI_SEARCH_MCP_URL": "https://99c10de8-0264-4978-8212-176265f5de96.search.ai.cloudflare.com/mcp"
+	},
+	"routes": [
+		{
+			"pattern": "mcp.tempo.xyz",
+			"zone_name": "tempo.xyz",
+			"custom_domain": true
+		}
+	]
 }


### PR DESCRIPTION
## What

Make `mcp.tempo.xyz` a real MCP endpoint by transparently proxying it to the Cloudflare AI Search MCP upstream.

Until now the custom domain landed on the docs-mcp worker but the worker only returned a health string. AI Search exposes each instance under an opaque hostname like `<uuid>.search.ai.cloudflare.com`; this PR surfaces a stable branded URL instead.

## Changes

- New `src/lib/proxy.ts`: forwards method, path, query, headers, and body 1:1 to the upstream. Streams the response so MCP server-sent events flow through untouched. Strips `host`, `cf-*`, and `x-forwarded-*` hop headers.
- `src/index.ts`: `fetch()` now delegates to `proxyMcp`.
- `wrangler.jsonc`: adds `AI_SEARCH_MCP_URL` var.
- Drive-by: cron ingest uses `instance.items.upload()` instead of `uploadAndPoll()`. Per-page polling serialized with our 8-way concurrency and tripped the internal poll timeout on large batches. Indexing still happens in the background.
- Drive-by: `scheduled()` awaits work directly instead of using `ctx.waitUntil`, so failures surface in logs.

## Verification

```bash
curl -s https://mcp.tempo.xyz/mcp \
  -H 'content-type: application/json' \
  -H 'accept: application/json, text/event-stream' \
  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
```

Returns the `search` tool. `tools/call` returns ranked results across viem, wagmi, vocs, mpp.dev, and docs.tempo.xyz.

- `pnpm --filter docs-mcp test` — 31 passing (3 new proxy tests)
- `pnpm check` — green
- Deployed manually as version `65042cce-891e-48e1-b877-2ba58fa6df6a`; `mcp.tempo.xyz` verified live.