### PR TITLE
Deploy nextfork explorer

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
     with:
       app: explorer
-      environments: '["testnet","mainnet","devnet"]'
+      environments: '["testnet","mainnet","devnet","nextfork"]'
 
   deploy-fee-payer:
     name: Deploy Fee Payer

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -60,6 +60,8 @@ jobs:
           - app: explorer
             env: devnet
           - app: explorer
+            env: nextfork
+          - app: explorer
             env: mainnet
           #### fee-payer
           - app: fee-payer


### PR DESCRIPTION
## Summary
- add `nextfork` to the explorer production deploy matrix in `main.yml`
- add `nextfork` to the explorer PR preview deploy matrix

## Context
The nextfork explorer environment was added in tempoxyz/tempo-apps#1029, but the GitHub Actions deploy matrices still only listed testnet, mainnet, and devnet. That means merges would not deploy `explorer-nextfork`.

## Validation
- parsed `.github/workflows/main.yml` and `.github/workflows/pull-request.yml` with PyYAML
- `git diff --check`
- pre-commit hook: yaml/toml/eof/private-key/secret checks
