### PR TITLE
fix(explorer): Show loading state while fetching contract info

### DIFF
--- a/apps/explorer/src/comps/Contract.tsx
+++ b/apps/explorer/src/comps/Contract.tsx
@@ -42,6 +42,7 @@ export function ContractTabContent(props: {
 	address: Address.Address
 	abi?: Abi
 	docsUrl?: string
+	isLoadingContractInfo?: boolean
 	source?: ContractSource
 }) {
 	const { address, docsUrl, source } = props
@@ -67,7 +68,9 @@ export function ContractTabContent(props: {
 		return (
 			<div className="rounded-[10px] bg-card-header p-[18px] h-full">
 				<p className="text-sm font-medium text-tertiary">
-					No ABI available for this contract.
+					{props.isLoadingContractInfo
+						? `Loading contract information${ellipsis}`
+						: 'No ABI available for this contract.'}
 				</p>
 			</div>
 		)
@@ -267,6 +270,7 @@ export function InteractTabContent(props: {
 	address: Address.Address
 	abi?: Abi
 	docsUrl?: string
+	isLoadingContractInfo?: boolean
 }) {
 	const { address, docsUrl } = props
 	const publicClient = usePublicClient()
@@ -315,7 +319,7 @@ export function InteractTabContent(props: {
 		props.abi ??
 		getContractAbi(address)
 
-	if (isLoadingProxy) {
+	if (props.isLoadingContractInfo || isLoadingProxy) {
 		return (
 			<div className="rounded-[10px] bg-card-header p-[18px] h-full">
 				<p className="text-sm font-medium text-tertiary">

--- a/apps/explorer/src/routes/_layout/address/$address.tsx
+++ b/apps/explorer/src/routes/_layout/address/$address.tsx
@@ -967,6 +967,11 @@ function SectionsWrapper(props: {
 
 	const resolvedAbi =
 		resolvedContractSource?.abi ?? contractInfo?.abi ?? extractedAbiQuery.data
+	const isLoadingContractInfo =
+		isMounted &&
+		isContract &&
+		!resolvedAbi &&
+		(contractSourceQuery.isFetching || extractedAbiQuery.isFetching)
 
 	// Only auto-refresh on page 1 when transactions tab is active and live=true
 	const shouldAutoRefresh = page === 1 && isTransactionsTabActive && live
@@ -1665,6 +1670,7 @@ function SectionsWrapper(props: {
 									? resolvedContractSource.docsUrl
 									: contractInfo?.docsUrl
 							}
+							isLoadingContractInfo={isLoadingContractInfo}
 							source={resolvedContractSource}
 						/>
 					),
@@ -1683,6 +1689,7 @@ function SectionsWrapper(props: {
 									? resolvedContractSource.docsUrl
 									: contractInfo?.docsUrl
 							}
+							isLoadingContractInfo={isLoadingContractInfo}
 						/>
 					),
 				}

--- a/apps/explorer/src/routes/_layout/address/$address.tsx
+++ b/apps/explorer/src/routes/_layout/address/$address.tsx
@@ -968,10 +968,13 @@ function SectionsWrapper(props: {
 	const resolvedAbi =
 		resolvedContractSource?.abi ?? contractInfo?.abi ?? extractedAbiQuery.data
 	const isLoadingContractInfo =
-		isMounted &&
 		isContract &&
 		!resolvedAbi &&
-		(contractSourceQuery.isFetching || extractedAbiQuery.isFetching)
+		(!isMounted ||
+			contractSourceQuery.isLoading ||
+			contractSourceQuery.isFetching ||
+			extractedAbiQuery.isLoading ||
+			extractedAbiQuery.isFetching)
 
 	// Only auto-refresh on page 1 when transactions tab is active and live=true
 	const shouldAutoRefresh = page === 1 && isTransactionsTabActive && live


### PR DESCRIPTION
## Summary
- Show “Loading contract information…” while contract source or ABI lookup is still fetching
- Keep “No ABI available for this contract.” for the terminal empty state
- Apply the same loading state to the Interact tab while ABI lookup is pending

## Validation
- `corepack pnpm --filter explorer check:biome`
- `corepack pnpm --filter explorer check:types` (blocked by existing/generated type issues after postinstall could not complete direct `pnpm` child scripts in this sandbox; errors include missing Cloudflare worker types and unrelated unknown response typing)

Prompted by: @danrobinson