### PR TITLE
ci: add deploy job for mcp-docs-indexer

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -102,3 +102,14 @@ jobs:
     with:
       app: tempo-snapshots-viewer
       environments: '[""]'
+
+  deploy-mcp-docs-indexer:
+    name: Deploy MCP Docs Indexer
+    needs: verify
+    uses: ./.github/workflows/deploy.yml
+    secrets:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+    with:
+      app: mcp-docs-indexer
+      environments: '[""]'


### PR DESCRIPTION
## What

Adds a `deploy-mcp-docs-indexer` job to [.github/workflows/main.yml](https://github.com/tempoxyz/tempo-apps/blob/main/.github/workflows/main.yml) so the worker auto-deploys on push to `main`, like every other app in this repo.

## Why

`apps/mcp-docs-indexer` (formerly `docs-mcp`) has been deployed manually — every other app (explorer, fee-payer, contract-verification, key-manager, og, tokenlist, reth/tempo-snapshots-viewer) already has a `deploy-*` job. Now that the rename in #1032 has landed, a fresh `wrangler deploy` is needed to create the new Cloudflare Worker and migrate the `mcp.tempo.xyz` custom domain — automate it.

## Behavior after merge

The reusable [deploy.yml](https://github.com/tempoxyz/tempo-apps/blob/main/.github/workflows/deploy.yml) only runs `wrangler deploy` when the diff touches `apps/<app>/` or `pnpm-lock.yaml` (or the workflow is triggered via `workflow_dispatch`):

```yaml
if git diff --name-only "$BEFORE_SHA" "$CURRENT_SHA" | grep -qE "^(apps/${APP_NAME}/|pnpm-lock.yaml)"; then
  echo "relevant=true" >> $GITHUB_OUTPUT
```

So:

- **This PR's own merge does NOT deploy** — it only touches `.github/workflows/main.yml`.
- **The next merge that touches `apps/mcp-docs-indexer/` or `pnpm-lock.yaml` WILL deploy.** That'll happen automatically when #1033 (codemode) merges.
- **To force an immediate deploy** after this merges, trigger the `Main` workflow manually:
  ```bash
  gh workflow run Main --repo tempoxyz/tempo-apps --ref main
  ```
  `workflow_dispatch` bypasses the `git diff` check.

## What the first deploy does

Because the worker was renamed from `docs-mcp` → `mcp-docs-indexer` in #1032, the first `wrangler deploy` against the new code:

1. Creates a **new** Cloudflare Worker called `mcp-docs-indexer`.
2. Migrates the `mcp.tempo.xyz` custom-domain binding from the old worker to the new one (wrangler handles cutover automatically).
3. Cron starts on the new worker.
4. The old `docs-mcp` worker keeps running until manually deleted from the Cloudflare dashboard. Recommend verifying `mcp.tempo.xyz` works against the new worker, then deleting the old one.

## Verification

- [x] Job mirrors the existing `deploy-tempo-snapshots-viewer` block — only `app:` and `name:` differ
- [x] `environments: '[""]'` — single production deployment, no env suffix (same as contract-verification / key-manager / og / tokenlist / both snapshots-viewers)
- [x] No `pnpm-lock.yaml` or app-source changes, so this PR's own merge won't cause a deploy
