### PR TITLE
fix(explorer): render memos as separate lines

### DIFF
--- a/apps/explorer/src/comps/Receipt.tsx
+++ b/apps/explorer/src/comps/Receipt.tsx
@@ -6,7 +6,7 @@ import { Amount } from '#comps/Amount'
 import { Midcut } from 'midcut'
 import { ReceiptMark } from '#comps/ReceiptMark'
 import { useTokenListMembership } from '#comps/TokenListMembership'
-import { TxEventDescription } from '#comps/TxEventDescription'
+import { TxEventDescription, TxEventMemoLine } from '#comps/TxEventDescription'
 import type { KnownEvent } from '#lib/domain/known-events'
 import { DateFormatter, PriceFormatter } from '#lib/formatting'
 import { useCopy } from '#lib/hooks'
@@ -205,17 +205,15 @@ export function Receipt(props: Receipt.Props) {
 													)}
 												</div>
 											</div>
-											{event.note && (
-												<div className="flex flex-row items-center pl-[24px] gap-[11px] overflow-hidden">
-													<div className="border-l border-base-border pl-[10px] w-full">
-														{typeof event.note === 'string' ? (
-															<span
-																className="text-tertiary items-end overflow-hidden text-ellipsis whitespace-nowrap"
-																title={event.note}
-															>
-																{event.note}
-															</span>
-														) : (
+											{event.note &&
+												(typeof event.note === 'string' ? (
+													<TxEventMemoLine
+														memo={event.note}
+														className="pl-[24px]"
+													/>
+												) : (
+													<div className="flex flex-row items-center pl-[24px] gap-[11px] overflow-hidden">
+														<div className="border-l border-base-border pl-[10px] w-full">
 															<div className="flex flex-col gap-1 text-secondary text-[13px]">
 																{event.note.map(([label, part], index) => {
 																	const key = `${label}${index}`
@@ -245,10 +243,9 @@ export function Receipt(props: Receipt.Props) {
 																	)
 																})}
 															</div>
-														)}
+														</div>
 													</div>
-												</div>
-											)}
+												))}
 										</div>
 									</div>
 								)

--- a/apps/explorer/src/comps/TxEventDescription.tsx
+++ b/apps/explorer/src/comps/TxEventDescription.tsx
@@ -21,6 +21,35 @@ import {
 } from '#lib/formatting.ts'
 import { useLookupSignature } from '#lib/queries'
 
+export function TxEventMemoLine(
+	props: TxEventMemoLine.Props,
+): React.JSX.Element {
+	const { memo, className } = props
+	return (
+		<div
+			className={cx(
+				'flex min-w-0 items-center gap-2 text-[13px] text-secondary',
+				className,
+			)}
+		>
+			<span className="text-tertiary shrink-0">Memo:</span>
+			<span
+				className="min-w-0 overflow-hidden text-ellipsis whitespace-nowrap"
+				title={memo}
+			>
+				{memo}
+			</span>
+		</div>
+	)
+}
+
+export declare namespace TxEventMemoLine {
+	type Props = {
+		memo: string
+		className?: string | undefined
+	}
+}
+
 /**
  * Renders a contract call with decoded function name.
  * Fetches ABI from registry or extracts from bytecode using whatsabi.

--- a/apps/explorer/src/routes/_layout/tx/$hash.tsx
+++ b/apps/explorer/src/routes/_layout/tx/$hash.tsx
@@ -25,7 +25,7 @@ import { TokenIcon } from '#comps/TokenIcon'
 import { TxBalanceChanges } from '#comps/TxBalanceChanges'
 import { TxDecodedCalldata } from '#comps/TxDecodedCalldata'
 import { TxDecodedTopics } from '#comps/TxDecodedTopics'
-import { TxEventDescription } from '#comps/TxEventDescription'
+import { TxEventDescription, TxEventMemoLine } from '#comps/TxEventDescription'
 import { TxRawTransaction } from '#comps/TxRawTransaction'
 import { TxStateDiff } from '#comps/TxStateDiff'
 import { TxTraceTree } from '#comps/TxTraceTree'
@@ -350,15 +350,10 @@ function OverviewSection(props: {
 					<div className="flex flex-col gap-[6px]">
 						<TxEventDescription.ExpandGroup events={knownEvents} />
 						{memos.length > 0 && (
-							<div className="flex flex-row items-center gap-[11px] overflow-hidden">
-								<div className="border-l border-base-border pl-[10px] w-full">
-									<span
-										className="text-tertiary items-end overflow-hidden text-ellipsis whitespace-nowrap"
-										title={memos[0]}
-									>
-										{memos[0]}
-									</span>
-								</div>
+							<div className="flex flex-col gap-[4px] min-w-0">
+								{memos.map((memo, index) => (
+									<TxEventMemoLine key={`${memo}-${index}`} memo={memo} />
+								))}
 							</div>
 						)}
 					</div>


### PR DESCRIPTION
## Summary
- Add a shared Explorer memo line renderer that displays Memo: labels.
- Render transaction and receipt memos on separate lines instead of nested note text.

## Screenshots
Not captured; browser verification was skipped per request to focus on Explorer code changes.

## Validation
- pnpm --dir apps/explorer check:biome
- pnpm --dir apps/explorer check:types