### PR TITLE
fix(mcp-docs-indexer): make logs scannable inline in Cloudflare Workers Logs

### DIFF
--- a/apps/mcp-docs-indexer/src/lib/log.test.ts
+++ b/apps/mcp-docs-indexer/src/lib/log.test.ts
@@ -15,36 +15,52 @@ afterEach(() => {
 	vi.useRealTimers()
 })
 
-function parseLine(spy: typeof infoSpy): Record<string, unknown> {
-	const arg = spy.mock.calls[0]?.[0]
-	expect(typeof arg).toBe('string')
-	return JSON.parse(arg as string)
+/**
+ * Each log call is `console.<level>(event, payload)`:
+ *   - first arg is the event string (used by Workers Logs for the inline
+ *     timeline summary)
+ *   - second arg is the structured payload object (indexed as searchable
+ *     properties)
+ */
+function callOf(spy: typeof infoSpy): {
+	event: string
+	payload: Record<string, unknown>
+} {
+	const args = spy.mock.calls[0]
+	expect(args).toBeDefined()
+	const [event, payload] = args as [string, Record<string, unknown>]
+	expect(typeof event).toBe('string')
+	expect(typeof payload).toBe('object')
+	return { event, payload }
 }
 
 describe('log', () => {
-	it('emits info as a single JSON line via console.info', () => {
+	it('emits info with the event string and a structured payload', () => {
 		log.info('cron.start', { sources: 4 })
 		expect(infoSpy).toHaveBeenCalledTimes(1)
-		const line = parseLine(infoSpy)
-		expect(line).toMatchObject({
+		const { event, payload } = callOf(infoSpy)
+		expect(event).toBe('cron.start')
+		expect(payload).toMatchObject({
 			level: 'info',
 			logger: 'mcp-docs-indexer',
 			event: 'cron.start',
 			sources: 4,
 		})
-		expect(typeof line.timestamp).toBe('string')
+		expect(typeof payload.timestamp).toBe('string')
 	})
 
 	it('routes warn through console.warn', () => {
 		log.warn('page.empty', { url: 'https://x/y' })
 		expect(warnSpy).toHaveBeenCalledTimes(1)
-		expect(parseLine(warnSpy).level).toBe('warn')
+		expect(callOf(warnSpy).payload.level).toBe('warn')
 	})
 
 	it('routes error through console.error', () => {
 		log.error('source.failed', { source: 'viem', error: 'oops' })
 		expect(errorSpy).toHaveBeenCalledTimes(1)
-		expect(parseLine(errorSpy)).toMatchObject({
+		const { event, payload } = callOf(errorSpy)
+		expect(event).toBe('source.failed')
+		expect(payload).toMatchObject({
 			level: 'error',
 			event: 'source.failed',
 			source: 'viem',

--- a/apps/mcp-docs-indexer/src/lib/log.ts
+++ b/apps/mcp-docs-indexer/src/lib/log.ts
@@ -1,10 +1,15 @@
 /**
- * Structured JSON logger. Each call emits a single JSON line that lands in
- * Cloudflare Workers Logs (observability.logs in wrangler.jsonc). Matches the
- * shape used in other apps in this repo (see contract-verification/src/lib/logger.ts).
+ * Structured logger for Cloudflare Workers Logs.
  *
- * Use `event` as a stable machine-friendly key (e.g. `cron.start`, `source.sync`)
- * and put variable values into `props`.
+ * Each call passes two args to console.*:
+ *   1. the event name as a plain string — Workers Logs displays this inline
+ *      in the timeline summary, so logs are scannable without expanding each
+ *      row.
+ *   2. an object with the structured fields — Workers Logs indexes these as
+ *      searchable properties under the log row.
+ *
+ * Use `event` as a stable machine-friendly key (e.g. `cron.start`,
+ * `source.sync`) and put variable values into `props`.
  */
 export type LogProps = Record<string, unknown>
 
@@ -13,16 +18,16 @@ function emit(
 	event: string,
 	props?: LogProps,
 ): void {
-	const line = JSON.stringify({
+	const payload = {
 		timestamp: new Date().toISOString(),
 		level,
 		logger: 'mcp-docs-indexer',
 		event,
 		...props,
-	})
-	if (level === 'error') console.error(line)
-	else if (level === 'warn') console.warn(line)
-	else console.info(line)
+	}
+	if (level === 'error') console.error(event, payload)
+	else if (level === 'warn') console.warn(event, payload)
+	else console.info(event, payload)
 }
 
 export const log = {


### PR DESCRIPTION
## What

Makes `mcp-docs-indexer` log lines display an inline summary in the Cloudflare Workers Logs timeline instead of just `timestamp [level]` with no message.

## Why

In `src/lib/log.ts`, the previous `emit()` did:

```ts
const line = JSON.stringify({ timestamp, level, logger, event, ...props })
console.info(line)
```

Cloudflare Workers Logs parses the JSON and indexes the fields fine, but the **timeline summary row stays empty** because the console call has no plain-string argument for it to use as the message. Every row has to be expanded to see what happened.

## Fix

Pass two args instead — the event name as a plain string first, the structured payload as an object second:

```ts
const payload = { timestamp, level, logger, event, ...props }
console.info(event, payload)
```

Workers Logs uses the first string argument as the inline summary and still indexes the object's fields as searchable properties.

| | Timeline summary | Searchable fields |
|---|---|---|
| **Before** | `10:00:38.912 [warn]` | yes |
| **After** | `10:00:38.912 [warn] page.fetch_failed` | yes |

## Verification

- [x] `pnpm --filter mcp-docs-indexer test` — 31/31 passing (log.test.ts updated to assert the new two-arg shape)
- [x] `pnpm --filter mcp-docs-indexer check` — biome + types clean
- [ ] Manual verify post-deploy — the next cron tick should produce rows with the event name visible in the timeline.

This PR will auto-deploy on merge via the new CI job from #1034.
