### PR TITLE
Fix explorer receipt total amount decimals

### DIFF
--- a/apps/explorer/src/comps/Receipt.tsx
+++ b/apps/explorer/src/comps/Receipt.tsx
@@ -166,6 +166,14 @@ export function Receipt(props: Receipt.Props) {
 										: TEMPO_FEE_TOKEN
 											? isTokenListed(TEMPO_CHAIN_ID, TEMPO_FEE_TOKEN)
 											: true
+								const sideAmount =
+									displayTotalAmount ??
+									(event.type === 'swap' && firstAmountPart?.type === 'amount'
+										? firstAmountPart.value
+										: amountParts.length === 1 &&
+												firstAmountPart?.type === 'amount'
+											? firstAmountPart.value
+											: undefined)
 								const totalAmountBigInt = displayTotalAmount
 									? displayTotalAmount.value
 									: event.type === 'swap' && amountParts.length > 0
@@ -197,7 +205,14 @@ export function Receipt(props: Receipt.Props) {
 													<TxEventDescription event={event} />
 												</div>
 												<div className="flex items-start justify-end shrink leading-[24px]">
-													{totalAmountBigInt > 0n && (
+													{sideAmount && sideAmount.value > 0n ? (
+														<Amount
+															{...sideAmount}
+															infinite={null}
+															prefix={showUsdPrefix ? '$' : undefined}
+															short
+														/>
+													) : totalAmountBigInt > 0n ? (
 														<Amount.Base
 															decimals={decimals}
 															infinite={null}
@@ -205,7 +220,7 @@ export function Receipt(props: Receipt.Props) {
 															short
 															value={totalAmountBigInt}
 														/>
-													)}
+													) : null}
 												</div>
 											</div>
 											{event.note &&

--- a/apps/explorer/src/comps/Receipt.tsx
+++ b/apps/explorer/src/comps/Receipt.tsx
@@ -8,6 +8,7 @@ import { ReceiptMark } from '#comps/ReceiptMark'
 import { useTokenListMembership } from '#comps/TokenListMembership'
 import { TxEventDescription, TxEventMemoLine } from '#comps/TxEventDescription'
 import type { KnownEvent } from '#lib/domain/known-events'
+import { DEFAULT_KNOWN_EVENT_AMOUNT_DECIMALS } from '#lib/domain/known-event-totals'
 import { DateFormatter, PriceFormatter } from '#lib/formatting'
 import { useCopy } from '#lib/hooks'
 import {
@@ -177,10 +178,12 @@ export function Receipt(props: Receipt.Props) {
 												return sum
 											}, 0n)
 								const decimals = displayTotalAmount
-									? (displayTotalAmount.decimals ?? 6)
+									? (displayTotalAmount.decimals ??
+										DEFAULT_KNOWN_EVENT_AMOUNT_DECIMALS)
 									: firstAmountPart?.type === 'amount'
-										? (firstAmountPart.value.decimals ?? 6)
-										: 6
+										? (firstAmountPart.value.decimals ??
+											DEFAULT_KNOWN_EVENT_AMOUNT_DECIMALS)
+										: DEFAULT_KNOWN_EVENT_AMOUNT_DECIMALS
 
 								return (
 									<div

--- a/apps/explorer/src/lib/domain/known-event-totals.ts
+++ b/apps/explorer/src/lib/domain/known-event-totals.ts
@@ -1,6 +1,7 @@
 import type { KnownEvent } from '#lib/domain/known-events'
 
 export const NORMALIZED_KNOWN_EVENT_TOTAL_DECIMALS = 18
+export const DEFAULT_KNOWN_EVENT_AMOUNT_DECIMALS = 18
 
 type Amount = NonNullable<KnownEvent['totalAmount']>
 type AmountPart = KnownEvent['parts'][number] & { type: 'amount' }
@@ -15,7 +16,7 @@ function toBigInt(value: bigint | string | number): bigint {
 }
 
 function normalizeAmount(amountValue: Amount): bigint {
-	const decimals = amountValue.decimals ?? 6
+	const decimals = amountValue.decimals ?? DEFAULT_KNOWN_EVENT_AMOUNT_DECIMALS
 	const value = toBigInt(amountValue.value as bigint | string | number)
 	const decimalDelta = NORMALIZED_KNOWN_EVENT_TOTAL_DECIMALS - decimals
 

--- a/apps/explorer/src/lib/og.ts
+++ b/apps/explorer/src/lib/og.ts
@@ -18,6 +18,7 @@ import {
 	parseKnownEvents,
 	preferredEventsFilter,
 } from '#lib/domain/known-events'
+import { DEFAULT_KNOWN_EVENT_AMOUNT_DECIMALS } from '#lib/domain/known-event-totals'
 import * as Tip20 from '#lib/domain/tip20'
 import { DateFormatter, HexFormatter } from '#lib/formatting'
 import {
@@ -78,7 +79,10 @@ export function buildOgImageUrl(data: TxDataQuery, hash: string): string {
 		let amount = ''
 		if (amountPart?.type === 'amount') {
 			const val = Number(
-				Value.format(amountPart.value.value, amountPart.value.decimals ?? 6),
+				Value.format(
+					amountPart.value.value,
+					amountPart.value.decimals ?? DEFAULT_KNOWN_EVENT_AMOUNT_DECIMALS,
+				),
 			)
 			amount = val > 0 && val < 0.01 ? '<$0.01' : `$${val.toFixed(0)}`
 		}
@@ -105,7 +109,7 @@ function formatPartForOgClient(part: KnownEventPart): string {
 		case 'text':
 			return part.value
 		case 'amount':
-			return `${Value.format(part.value.value, part.value.decimals ?? 6)} ${part.value.symbol || ''}`
+			return `${Value.format(part.value.value, part.value.decimals ?? DEFAULT_KNOWN_EVENT_AMOUNT_DECIMALS)} ${part.value.symbol || ''}`
 		case 'account':
 			return HexFormatter.truncate(part.value)
 		case 'token':

--- a/apps/explorer/src/routes/_layout/receipt/$hash.tsx
+++ b/apps/explorer/src/routes/_layout/receipt/$hash.tsx
@@ -327,14 +327,20 @@ export const Route = createFileRoute('/_layout/receipt/$hash')({
 			search.set('date', ogTimestamp.date)
 			search.set('time', ogTimestamp.time)
 
-			const gasUsed = BigInt(loaderData.receipt.gasUsed ?? 0)
-			const gasPrice = BigInt(
-				loaderData.receipt.effectiveGasPrice ??
-					loaderData.transaction.gasPrice ??
-					0,
-			)
-			const feeAmount = gasUsed * gasPrice
-			const fee = Number(Value.format(feeAmount, 18))
+			const feePrice = loaderData.lineItems.feeTotals?.[0]?.price
+			const fee = feePrice
+				? Number(Value.format(feePrice.amount, feePrice.decimals))
+				: Number(
+						Value.format(
+							BigInt(loaderData.receipt.gasUsed ?? 0) *
+								BigInt(
+									loaderData.receipt.effectiveGasPrice ??
+										loaderData.transaction.gasPrice ??
+										0,
+								),
+							18,
+						),
+					)
 			const feeDisplay = PriceFormatter.format(fee)
 			search.set('fee', feeDisplay)
 
@@ -415,10 +421,10 @@ function Component() {
 		? Number(Value.format(totalPrice.amount, totalPrice.decimals))
 		: undefined
 
-	const feeAmount = receipt.effectiveGasPrice * receipt.gasUsed
-	// Gas accounting is always in 18-decimal units (wei equivalent), even when the fee token itself
-	// has a different number of decimals. Convert using 18 decimals so we get the actual token amount.
-	const feeRaw = Value.format(feeAmount, 18)
+	const fallbackFeeAmount = receipt.effectiveGasPrice * receipt.gasUsed
+	const feeRaw = feePrice
+		? Value.format(feePrice.amount, feePrice.decimals)
+		: Value.format(fallbackFeeAmount, 18)
 	const fee = Number(feeRaw)
 	const feeTokens = feeBreakdown.filter(hasTokenAmount)
 	const showUsdFeePrefix =

--- a/apps/explorer/test/known-event-totals.node.test.ts
+++ b/apps/explorer/test/known-event-totals.node.test.ts
@@ -11,6 +11,7 @@ function sendEvent(params: {
 	from: `0x${string}`
 	to: `0x${string}`
 	amount: bigint
+	decimals?: number
 }): KnownEvent {
 	return {
 		type: 'send',
@@ -21,8 +22,31 @@ function sendEvent(params: {
 				value: {
 					token: tokenAddress,
 					value: params.amount,
-					decimals: 6,
+					decimals: params.decimals ?? 6,
 					symbol: 'PathUSD',
+				},
+			},
+			{ type: 'text', value: 'to' },
+			{ type: 'account', value: params.to },
+		],
+		meta: { from: params.from, to: params.to },
+	}
+}
+
+function sendEventWithoutMetadata(params: {
+	from: `0x${string}`
+	to: `0x${string}`
+	amount: bigint
+}): KnownEvent {
+	return {
+		type: 'send',
+		parts: [
+			{ type: 'action', value: 'Send' },
+			{
+				type: 'amount',
+				value: {
+					token: tokenAddress,
+					value: params.amount,
 				},
 			},
 			{ type: 'text', value: 'to' },
@@ -68,5 +92,26 @@ describe('calculateKnownEventsTotal', () => {
 		]
 
 		expect(calculateKnownEventsTotal(events)).toBe(100n * 10n ** 18n)
+	})
+
+	it('defaults unknown-decimal transfer amounts to 18 decimals', () => {
+		const oneThousand = 1_000n * 10n ** 18n
+		const fiveHundredPointThree = 500_300_000_000_000_000_000n
+		const events = [
+			sendEventWithoutMetadata({
+				from: senderAddress,
+				to: forwardedAddress,
+				amount: oneThousand,
+			}),
+			sendEventWithoutMetadata({
+				from: senderAddress,
+				to: recipientAddress,
+				amount: fiveHundredPointThree,
+			}),
+		]
+
+		expect(calculateKnownEventsTotal(events)).toBe(
+			1_500_300_000_000_000_000_000n,
+		)
 	})
 })


### PR DESCRIPTION
## Summary
- Default unknown known-event amount decimals to 18 instead of 6 for receipt totals and event side amounts
- Use parsed fee line-item metadata for receipt fee displays before falling back to gas-derived native units
- Add a regression test for unknown-decimal transfer totals

## Validation
- PATH=/tmp/codex-bin:$PATH pnpm --filter explorer check:biome
- PATH=/tmp/codex-bin:$PATH pnpm --filter explorer check:types
- PATH=/tmp/codex-bin:$PATH pnpm --filter explorer exec vitest run --config vitest.node.config.ts test/known-event-totals.node.test.ts

Note: `pnpm --filter explorer test` still fails in the existing wider suite with two `tempo-queries` failures followed by a TanStack `#tanstack-router-entry` package export error.

Prompted by: @Slokh