### PR TITLE
feat: configure docs indexer sources

### DIFF
--- a/apps/mcp-docs-indexer/.env.example
+++ b/apps/mcp-docs-indexer/.env.example
@@ -4,4 +4,5 @@
 #   - ETAG_CACHE (kv namespace for per-source freshness state)
 # Vars:
 #   - AI_SEARCH_INSTANCE_ID  (default: tempo-global)
-#   - SOURCES                (default: viem,wagmi,vocs)
+#   - AI_SEARCH_MCP_URL      (AI Search MCP endpoint proxied by this Worker)
+#   - SOURCES                (configured as JSON in wrangler.jsonc)

--- a/apps/mcp-docs-indexer/README.md
+++ b/apps/mcp-docs-indexer/README.md
@@ -1,6 +1,6 @@
 # mcp-docs-indexer
 
-Resolver Worker that ingests external doc sites (viem, wagmi, vocs, mpp) into
+Resolver Worker that ingests configured external doc sites into
 the shared **Cloudflare AI Search** instance `tempo-global`. The AI Search
 instance owns the docs.tempo.xyz crawl directly; this Worker handles the
 non-owned sources by uploading their canonical Markdown pages into the
@@ -22,10 +22,10 @@ Cron ──▶ mcp-docs-indexer Worker ──▶ AI Search items.upload() (inges
 ```
 ┌─────────────────────────┐
 │ Cron (hourly) ──────────┼─▶ for each source in SOURCES:
-└─────────────────────────┘     1. GET <base>/llms.txt with If-None-Match
+└─────────────────────────┘     1. GET <base><indexPath> with If-None-Match
                                 2. parse → page URLs
-                                3. for each page: GET <page>.md with
-                                   If-None-Match (per-page ETag)
+                                3. for each page: GET <page>.md, or the listed
+                                   .md URL, with If-None-Match (per-page ETag)
                                 4. 304 → skip; 200 → items.upload(),
                                    record { item id, etag } in KV
                                 5. diff against last sync, delete items
@@ -49,13 +49,9 @@ roll over when individual pages change.
 `etag` and `index` after a fully clean sync — partial failures don't update
 state, so they retry on the next run instead of permanently desyncing.
 
-The Worker has **no public HTTP surface** beyond a trivial `GET /` health
-string — sync only runs on the scheduled cron. To trigger an out-of-band
-sync, use `wrangler` from an operator's machine:
-
-```bash
-pnpm --filter mcp-docs-indexer exec wrangler triggers cron --once "0 * * * *"
-```
+The Worker exposes the MCP proxy only. It has **no public sync or ingest
+endpoint**: source ingestion runs exclusively from the scheduled cron handler
+inside Cloudflare Workers.
 
 ## Bindings (wrangler.jsonc)
 
@@ -66,9 +62,12 @@ pnpm --filter mcp-docs-indexer exec wrangler triggers cron --once "0 * * * *"
 
 - `AI_SEARCH_INSTANCE_ID` (default `tempo-global`) — instance must exist and
   have been created after 2026-04-16 (when built-in storage shipped).
+- `SOURCES` — JSON array configured in `wrangler.jsonc`. Each entry has `id`,
+  `base`, optional `description`, and optional `indexPath` (defaults to
+  `/llms.txt`). Adding a docs source should be a config-only change.
 
-The set of sources is fixed in `src/lib/sources.ts`. To add a source, edit
-that file.
+`docs.tempo.xyz` is intentionally not listed in `SOURCES` — it's the AI Search
+instance's external website data source and is auto-crawled.
 
 ## Setup
 
@@ -114,7 +113,7 @@ with `invocation_logs: true`). Every cron run emits structured JSON lines via
 | `page.delete_failed` | `items.delete` threw on stale page  | `source`, `key`, `item_id`, `error`                                        |
 | `index.parse_failed` | corrupt JSON in `index:<source>` KV | `key`, `error`                                                             |
 
-Tail logs locally during a manual cron:
+Tail logs to inspect cron runs:
 
 ```bash
 pnpm --filter mcp-docs-indexer tail --format json
@@ -139,8 +138,9 @@ pnpm --filter mcp-docs-indexer tail
 ## Verifying the result
 
 After a sync, open the AI Search dashboard → `tempo-global` → **Items** tab.
-You should see entries keyed `viem/...`, `wagmi/...`, `vocs/...` alongside
-the auto-crawled `docs.tempo.xyz` entries.
+You should see entries keyed by configured source id, such as `viem/...`,
+`wagmi/...`, `vocs/...`, `mpp/...`, and `regen/...`, alongside the
+auto-crawled `docs.tempo.xyz` entries.
 
 Query the MCP endpoint to confirm cross-source ranking works:
 

--- a/apps/mcp-docs-indexer/src/index.ts
+++ b/apps/mcp-docs-indexer/src/index.ts
@@ -3,7 +3,7 @@ import { syncSource } from './lib/ingest.js'
 import { log } from './lib/log.js'
 import { proxyMcp } from './lib/proxy.js'
 import { isForcedHour } from './lib/schedule.js'
-import { SOURCES } from './lib/sources.js'
+import { parseSources } from './lib/sources.js'
 
 export default {
 	async fetch(req) {
@@ -14,17 +14,18 @@ export default {
 		// Once per UTC day, bypass all ETag caches as a backstop for sources
 		// whose llms.txt ETag doesn't track page changes correctly.
 		const force = isForcedHour(event.scheduledTime)
+		const sources = parseSources(env.SOURCES)
 		log.info('cron.start', {
 			cron: event.cron,
 			scheduled_time: new Date(event.scheduledTime).toISOString(),
 			instance: env.AI_SEARCH_INSTANCE_ID,
-			sources: SOURCES.length,
+			sources: sources.length,
 			force,
 		})
 
 		const instance = env.AI_SEARCH.get(env.AI_SEARCH_INSTANCE_ID)
 		const reports = []
-		for (const source of SOURCES) {
+		for (const source of sources) {
 			const report = await syncSource({
 				source,
 				instance,

--- a/apps/mcp-docs-indexer/src/lib/ingest.ts
+++ b/apps/mcp-docs-indexer/src/lib/ingest.ts
@@ -40,10 +40,13 @@ export async function syncSource(args: {
 
 	try {
 		const prevSourceEtag = force ? null : await etagCache.get(etagKey)
-		const res = await fetch(`${source.base}/llms.txt`, {
-			headers: prevSourceEtag ? { 'If-None-Match': prevSourceEtag } : {},
-			cf: { cacheTtl: 60 },
-		})
+		const res = await fetch(
+			new URL(source.indexPath ?? '/llms.txt', source.base).toString(),
+			{
+				headers: prevSourceEtag ? { 'If-None-Match': prevSourceEtag } : {},
+				cf: { cacheTtl: 60 },
+			},
+		)
 		if (res.status === 304) {
 			return { source: source.id, status: 'unchanged', duration_ms: elapsed() }
 		}
@@ -208,7 +211,13 @@ async function syncPage(args: {
 		// serializes with our 8-way concurrency and trips the internal poll
 		// timeout, causing whole batches to fail.
 		const item = await instance.items.upload(key, content, {
-			metadata: { source: source.id, url },
+			metadata: {
+				source: source.id,
+				url,
+				...(source.description
+					? { source_description: source.description }
+					: {}),
+			},
 		})
 		const etag = res.headers.get('etag') ?? undefined
 		return {

--- a/apps/mcp-docs-indexer/src/lib/llms-txt.test.ts
+++ b/apps/mcp-docs-indexer/src/lib/llms-txt.test.ts
@@ -22,6 +22,18 @@ describe('parseLlmsTxt', () => {
 		])
 	})
 
+	it('extracts bare markdown paths from bullet lists', () => {
+		const body = `
+- /index.md: Introduction
+- /installation.md: Installation
+- /agents.txt: non-markdown alias
+`
+		expect(parseLlmsTxt(body, 'https://regen.tempo.xyz')).toEqual([
+			'https://regen.tempo.xyz/index.md',
+			'https://regen.tempo.xyz/installation.md',
+		])
+	})
+
 	it('drops off-origin links', () => {
 		const body = '- [In](/in)\n- [Out](https://other.example.com/out)'
 		expect(parseLlmsTxt(body, 'https://viem.sh')).toEqual([
@@ -74,5 +86,11 @@ describe('toMarkdownUrl', () => {
 
 	it('handles the root path', () => {
 		expect(toMarkdownUrl('https://viem.sh/')).toBe('https://viem.sh/.md')
+	})
+
+	it('does not append .md to a URL that already points at markdown', () => {
+		expect(toMarkdownUrl('https://regen.tempo.xyz/installation.md')).toBe(
+			'https://regen.tempo.xyz/installation.md',
+		)
 	})
 })

--- a/apps/mcp-docs-indexer/src/lib/llms-txt.ts
+++ b/apps/mcp-docs-indexer/src/lib/llms-txt.ts
@@ -2,29 +2,40 @@
  * Parse an `llms.txt` (Vocs or vitepress-plugin-llms) into a list of absolute
  * same-origin page URLs.
  *
- * Links may be absolute (`https://...`) or root-relative (`/path`). Off-origin
- * links and fragments are dropped.
+ * Links may be Markdown links, absolute URLs (`https://...`), or root-relative
+ * Markdown paths (`/path.md`). Off-origin links and fragments are dropped.
  */
 export function parseLlmsTxt(body: string, base: string): string[] {
 	const origin = new URL(base).origin
 	const urls = new Set<string>()
 	for (const m of body.matchAll(/\((https?:\/\/[^)\s]+|\/[^)\s]+)\)/g)) {
-		try {
-			const u = new URL(m[1]!, origin)
-			if (u.origin !== origin) continue
-			u.hash = ''
-			u.search = ''
-			urls.add(u.toString())
-		} catch {
-			// skip invalid URLs
-		}
+		addUrl(urls, m[1], origin)
+	}
+	for (const line of body.split('\n')) {
+		const match = line.match(/^\s*[-*]\s+(https?:\/\/\S+|\/\S+)/)
+		const raw = match?.[1]?.replace(/:$/, '')
+		if (raw?.endsWith('.md')) addUrl(urls, raw, origin)
 	}
 	return [...urls]
+}
+
+function addUrl(urls: Set<string>, raw: string | undefined, origin: string) {
+	if (!raw) return
+	try {
+		const u = new URL(raw, origin)
+		if (u.origin !== origin) return
+		u.hash = ''
+		u.search = ''
+		urls.add(u.toString())
+	} catch {
+		// skip invalid URLs
+	}
 }
 
 /** `https://viem.sh/docs/foo` → `https://viem.sh/docs/foo.md`. */
 export function toMarkdownUrl(pageUrl: string): string {
 	const u = new URL(pageUrl)
+	if (u.pathname.endsWith('.md')) return u.toString()
 	u.pathname = `${u.pathname.replace(/\/$/, '')}.md`
 	return u.toString()
 }

--- a/apps/mcp-docs-indexer/src/lib/sources.ts
+++ b/apps/mcp-docs-indexer/src/lib/sources.ts
@@ -1,21 +1,70 @@
-/**
- * Registry of external doc sites to ingest into AI Search built-in storage.
- *
- * Each source must expose either:
- *   - a Vocs auto-generated `/llms.txt` (viem, vocs, tempo)
- *   - a `vitepress-plugin-llms`-generated `/llms.txt` (wagmi)
- *
- * Pages are then fetched as raw Markdown via `<page>.md`, which both Vocs and
- * vitepress-plugin-llms serve out of the box.
- *
- * `docs.tempo.xyz` is intentionally NOT here — it's the AI Search instance's
- * external website data source and is auto-crawled.
- */
-export type Source = { id: string; base: string }
+export type Source = {
+	id: string
+	base: string
+	indexPath?: string
+	description?: string
+}
 
-export const SOURCES: readonly Source[] = [
-	{ id: 'viem', base: 'https://viem.sh' },
-	{ id: 'wagmi', base: 'https://wagmi.sh' },
-	{ id: 'vocs', base: 'https://vocs.sh' },
-	{ id: 'mpp', base: 'https://mpp.dev' },
-]
+type SourceConfig = {
+	id?: unknown
+	base?: unknown
+	indexPath?: unknown
+	description?: unknown
+}
+
+/**
+ * Parse deploy-time source configuration from `wrangler.jsonc`.
+ *
+ * Adding a docs source should not require changing Worker code unless the new
+ * site exposes a different index or Markdown URL format.
+ */
+export function parseSources(config: unknown): Source[] {
+	const sources = typeof config === 'string' ? JSON.parse(config) : config
+	if (!Array.isArray(sources)) throw new Error('SOURCES must be an array')
+	return sources.map((source, index) => normalizeSource(source, index))
+}
+
+function normalizeSource(source: SourceConfig, index: number): Source {
+	if (!source || typeof source !== 'object') {
+		throw new Error(`SOURCES[${index}] must be an object`)
+	}
+
+	const id = expectString(source.id, `SOURCES[${index}].id`)
+	const base = normalizeBase(
+		expectString(source.base, `SOURCES[${index}].base`),
+		index,
+	)
+	const indexPath =
+		typeof source.indexPath === 'string' ? source.indexPath.trim() : '/llms.txt'
+	const description =
+		typeof source.description === 'string'
+			? source.description.trim()
+			: undefined
+
+	return {
+		id,
+		base,
+		indexPath: indexPath.startsWith('/') ? indexPath : `/${indexPath}`,
+		...(description ? { description } : {}),
+	}
+}
+
+function normalizeBase(value: string, index: number): string {
+	let url: URL
+	try {
+		url = new URL(value)
+	} catch {
+		throw new Error(`SOURCES[${index}].base must be a valid URL`)
+	}
+	if (url.protocol !== 'https:') {
+		throw new Error(`SOURCES[${index}].base must be an https URL`)
+	}
+	return url.origin
+}
+
+function expectString(value: unknown, name: string): string {
+	if (typeof value !== 'string' || value.trim().length === 0) {
+		throw new Error(`${name} must be a non-empty string`)
+	}
+	return value.trim()
+}

--- a/apps/mcp-docs-indexer/wrangler.jsonc
+++ b/apps/mcp-docs-indexer/wrangler.jsonc
@@ -41,7 +41,36 @@
 		// Public MCP endpoint URL for the AI Search instance above. We
 		// transparently proxy mcp.tempo.xyz -> this upstream so clients
 		// connect to a stable branded URL instead of the opaque hostname.
-		"AI_SEARCH_MCP_URL": "https://99c10de8-0264-4978-8212-176265f5de96.search.ai.cloudflare.com/mcp"
+		"AI_SEARCH_MCP_URL": "https://99c10de8-0264-4978-8212-176265f5de96.search.ai.cloudflare.com/mcp",
+		// Docs sources to sync. Add sources here instead of changing Worker code.
+		// `indexPath` defaults to `/llms.txt`.
+		"SOURCES": [
+			{
+				"id": "viem",
+				"base": "https://viem.sh",
+				"description": "TypeScript interface for Ethereum / Tempo"
+			},
+			{
+				"id": "wagmi",
+				"base": "https://wagmi.sh",
+				"description": "React Hooks for Ethereum / Tempo"
+			},
+			{
+				"id": "vocs",
+				"base": "https://vocs.sh",
+				"description": "Documentation framework"
+			},
+			{
+				"id": "mpp",
+				"base": "https://mpp.dev",
+				"description": "Machine Payments Protocol documentation"
+			},
+			{
+				"id": "regen",
+				"base": "https://regen.tempo.xyz",
+				"description": "Tempo Regen UI component documentation"
+			}
+		]
 	},
 	"routes": [
 		{


### PR DESCRIPTION
## Summary
- Move mcp-docs-indexer sources out of code and into wrangler config
- Add regen.tempo.xyz to the indexed docs sources
- Support bare .md entries in llms.txt so Regen pages are fetched directly

## Verification
- pnpm --filter mcp-docs-indexer check
- pnpm --filter mcp-docs-indexer test
- pnpm precommit
- Deployed manually with pnpm --filter mcp-docs-indexer run deploy

## Deploy
- Worker version: fd705c68-4137-4038-b750-3a55f8a3052b
