### PR TITLE
fix: avoid double markdown suffix in docs indexer

### DIFF
--- a/apps/mcp-docs-indexer/src/lib/ingest.test.ts
+++ b/apps/mcp-docs-indexer/src/lib/ingest.test.ts
@@ -196,6 +196,41 @@ describe('syncSource — page uploads', () => {
 			id: 'item-viem/docs_bar.md',
 		})
 	})
+
+	it('fetches existing bare .md pages without double-suffixing item keys', async () => {
+		const source: Source = { id: 'regen', base: 'https://regen.tempo.xyz' }
+		const { instance, uploads } = fakeInstance()
+		const { kv, store } = fakeKv()
+
+		fetchMock.mockImplementation(async (url: string) => {
+			if (url === 'https://regen.tempo.xyz/llms.txt') {
+				return mockResponse({
+					body: '- /otp.md: One-time passcode fields\n- /agents.txt: alias',
+				})
+			}
+			if (url === 'https://regen.tempo.xyz/otp.md') {
+				return mockResponse({ body: '# OTP' })
+			}
+			throw new Error(`unexpected: ${url}`)
+		})
+
+		const report = await syncSource({ source, instance, etagCache: kv })
+
+		expect(report).toMatchObject({
+			source: 'regen',
+			status: 'synced',
+			pages: 1,
+			failed: 0,
+		})
+		expect(uploads.map((u) => u.key)).toEqual(['regen/otp.md'])
+		expect(fetchMock).toHaveBeenCalledWith(
+			'https://regen.tempo.xyz/otp.md',
+			expect.any(Object),
+		)
+		expect(Object.keys(JSON.parse(store.get('index:regen') ?? '{}'))).toEqual([
+			'regen/otp.md',
+		])
+	})
 })
 
 describe('syncSource — per-page conditional fetch', () => {

--- a/apps/mcp-docs-indexer/src/lib/ingest.ts
+++ b/apps/mcp-docs-indexer/src/lib/ingest.ts
@@ -237,6 +237,6 @@ async function syncPage(args: {
 
 /** Derive a stable AI Search item key from a page URL and source id. */
 function pageKey(url: string, sourceId: string): string {
-	const path = new URL(url).pathname.replace(/^\/+|\/+$/g, '') || 'index'
-	return `${sourceId}/${path.replace(/\//g, '_')}.md`
+	const path = new URL(toMarkdownUrl(url)).pathname.replace(/^\/+|\/+$/g, '')
+	return `${sourceId}/${path.replace(/\//g, '_')}`
 }

--- a/apps/mcp-docs-indexer/src/lib/llms-txt.test.ts
+++ b/apps/mcp-docs-indexer/src/lib/llms-txt.test.ts
@@ -25,8 +25,9 @@ describe('parseLlmsTxt', () => {
 	it('extracts bare markdown paths from bullet lists', () => {
 		const body = `
 - /index.md: Introduction
-- /installation.md: Installation
+- /installation.md?ref=llms#setup: Installation
 - /agents.txt: non-markdown alias
+- /sitemap.xml: sitemap
 `
 		expect(parseLlmsTxt(body, 'https://regen.tempo.xyz')).toEqual([
 			'https://regen.tempo.xyz/index.md',
@@ -59,6 +60,14 @@ describe('parseLlmsTxt', () => {
 		])
 	})
 
+	it('drops linked non-page file aliases', () => {
+		const body =
+			'- [Agent text](/agents.txt)\n- [Sitemap](/sitemap.xml)\n- [Page](/page)'
+		expect(parseLlmsTxt(body, 'https://regen.tempo.xyz')).toEqual([
+			'https://regen.tempo.xyz/page',
+		])
+	})
+
 	it('ignores malformed parenthesized strings without crashing', () => {
 		const body = '- [Bad](not a url)\n- [Good](/good)'
 		expect(parseLlmsTxt(body, 'https://viem.sh')).toEqual([
@@ -84,13 +93,13 @@ describe('toMarkdownUrl', () => {
 		)
 	})
 
-	it('handles the root path', () => {
-		expect(toMarkdownUrl('https://viem.sh/')).toBe('https://viem.sh/.md')
+	it('maps the root path to index.md', () => {
+		expect(toMarkdownUrl('https://viem.sh/')).toBe('https://viem.sh/index.md')
 	})
 
 	it('does not append .md to a URL that already points at markdown', () => {
-		expect(toMarkdownUrl('https://regen.tempo.xyz/installation.md')).toBe(
-			'https://regen.tempo.xyz/installation.md',
-		)
+		expect(
+			toMarkdownUrl('https://regen.tempo.xyz/installation.md?x=1#setup'),
+		).toBe('https://regen.tempo.xyz/installation.md')
 	})
 })

--- a/apps/mcp-docs-indexer/src/lib/llms-txt.ts
+++ b/apps/mcp-docs-indexer/src/lib/llms-txt.ts
@@ -14,7 +14,7 @@ export function parseLlmsTxt(body: string, base: string): string[] {
 	for (const line of body.split('\n')) {
 		const match = line.match(/^\s*[-*]\s+(https?:\/\/\S+|\/\S+)/)
 		const raw = match?.[1]?.replace(/:$/, '')
-		if (raw?.endsWith('.md')) addUrl(urls, raw, origin)
+		addUrl(urls, raw, origin)
 	}
 	return [...urls]
 }
@@ -22,20 +22,35 @@ export function parseLlmsTxt(body: string, base: string): string[] {
 function addUrl(urls: Set<string>, raw: string | undefined, origin: string) {
 	if (!raw) return
 	try {
-		const u = new URL(raw, origin)
+		const u = new URL(cleanRawUrl(raw), origin)
 		if (u.origin !== origin) return
 		u.hash = ''
 		u.search = ''
+		if (!isLikelyDocsPage(u)) return
 		urls.add(u.toString())
 	} catch {
 		// skip invalid URLs
 	}
 }
 
+function cleanRawUrl(raw: string): string {
+	return raw.trim().replace(/[),.;:]+$/, '')
+}
+
+function isLikelyDocsPage(url: URL): boolean {
+	const segment = url.pathname.split('/').pop() ?? ''
+	const extension = segment.includes('.') ? segment.split('.').pop() : undefined
+	return extension === undefined || extension === 'md'
+}
+
 /** `https://viem.sh/docs/foo` → `https://viem.sh/docs/foo.md`. */
 export function toMarkdownUrl(pageUrl: string): string {
 	const u = new URL(pageUrl)
-	if (u.pathname.endsWith('.md')) return u.toString()
-	u.pathname = `${u.pathname.replace(/\/$/, '')}.md`
+	u.hash = ''
+	u.search = ''
+	const path = u.pathname.replace(/\/+$/, '')
+	if (path === '') u.pathname = '/index.md'
+	else if (path.endsWith('.md')) u.pathname = path
+	else u.pathname = `${path}.md`
 	return u.toString()
 }


### PR DESCRIPTION
## Summary
- Avoid appending .md to AI Search item keys that already come from .md page URLs
- Add regression coverage for Regen-style bare .md paths
- Verified Regen llms.txt markdown pages resolve successfully

## Verification
- pnpm --filter mcp-docs-indexer check
- pnpm --filter mcp-docs-indexer test
- pnpm precommit
- Checked 26 unique https://regen.tempo.xyz/*.md pages from llms.txt returned 200
