### PR TITLE
Fix explorer receipt amount truncation

### DIFF
--- a/apps/explorer/src/comps/Receipt.tsx
+++ b/apps/explorer/src/comps/Receipt.tsx
@@ -199,12 +199,12 @@ export function Receipt(props: Receipt.Props) {
 										className="[counter-increment:event]"
 									>
 										<div className="flex flex-col gap-[8px]">
-											<div className="grid grid-cols-[1fr_minmax(0,30%)] gap-[10px]">
+											<div className="grid grid-cols-[minmax(0,1fr)_auto] gap-[10px]">
 												<div className="flex flex-row items-start gap-[4px] grow min-w-0 text-tertiary">
 													<div className="flex items-center text-tertiary before:content-[counter(event)_'.'] shrink-0 leading-[24px] min-w-[20px]"></div>
 													<TxEventDescription event={event} />
 												</div>
-												<div className="flex items-start justify-end shrink leading-[24px]">
+												<div className="flex items-start justify-end min-w-0 leading-[24px]">
 													{sideAmount && sideAmount.value > 0n ? (
 														<Amount
 															{...sideAmount}


### PR DESCRIPTION
## Summary
- Let receipt event amount cells size to their content instead of capping them at 30% of the receipt width.
- Keep event descriptions shrinkable so longer amount values remain visible on receipt cards.

## Screenshots

Screenshot capture was not available in this sandbox: Playwright/Chromium are not installed. Local demo SSR was verified at `/demo/tx?plain`; the linked live receipt route reached the loader but `https://rpc.tempo.xyz/` timed out from the sandbox.

## Verification
- `PATH="/tmp/codex-bin:$PATH" pnpm --filter explorer check:biome`
- `PATH="/tmp/codex-bin:$PATH" pnpm --filter explorer check:types`
- `PATH="/tmp/codex-bin:$PATH" pnpm --filter explorer build`
- `PATH="/tmp/codex-bin:$PATH" pnpm --filter explorer test` fails before completion with Vite/TanStack resolution: `Missing "#tanstack-router-entry" specifier in "@tanstack/start-server-core" package`

Prompted by: @Slokh