### PR TITLE
fix: remove tokenlist musical network names

### DIFF
--- a/apps/tokenlist/data/4217/tokenlist.json
+++ b/apps/tokenlist/data/4217/tokenlist.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://esm.sh/gh/uniswap/token-lists/src/tokenlist.schema.json",
-	"name": "Tempo Mainnet (Presto)",
+	"name": "Tempo Mainnet",
 	"logoURI": "https://esm.sh/gh/tempoxyz/tokenlist/data/4217/icon.svg",
 	"timestamp": "2026-06-03T20:13:57Z",
 	"version": {

--- a/apps/tokenlist/data/42431/tokenlist.json
+++ b/apps/tokenlist/data/42431/tokenlist.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://esm.sh/gh/uniswap/token-lists/src/tokenlist.schema.json",
-	"name": "Tempo Testnet (Moderato)",
+	"name": "Tempo Testnet",
 	"logoURI": "https://esm.sh/gh/tempoxyz/tokenlist/data/42431/icon.svg",
 	"timestamp": "2026-03-30T16:28:11Z",
 	"version": {

--- a/apps/tokenlist/src/chains.ts
+++ b/apps/tokenlist/src/chains.ts
@@ -1,8 +1,14 @@
-import { tempoDevnet, tempoModerato as tempoTestnet, tempo } from 'viem/chains'
+import { tempoDevnet, tempo } from 'viem/chains'
 
 export const tempoMainnet = tempo.extend({
+	name: 'Tempo Mainnet',
 	feeToken: '0x20c0000000000000000000000000000000000000',
 })
+
+export const tempoTestnet = {
+	id: 42431,
+	name: 'Tempo Testnet',
+} as const
 
 export const CHAIN_IDS = [
 	tempoDevnet.id,


### PR DESCRIPTION
## Summary
- Rename tokenlist mainnet and testnet display names to neutral Tempo names
- Replace tokenlist chain metadata references to musical network wording

## Verification
- pnpm --filter tokenlist check
- pnpm --filter tokenlist check:types
- pnpm --filter tokenlist test
- rg -i "presto|moderato|allegro|andante|largo|adagio" apps/tokenlist

## Notes
- Root pnpm check/check:types are blocked by unrelated workspace issues in fee-payer, contract-verification, and mcp-docs-indexer.