### PR TITLE
Fix receipt totals for mixed priced events

### DIFF
--- a/apps/explorer/src/lib/domain/known-event-totals.ts
+++ b/apps/explorer/src/lib/domain/known-event-totals.ts
@@ -30,6 +30,15 @@ export function calculateKnownEventsTotal(
 ): bigint {
 	let fallbackTotal = 0n
 	const flowsByToken = new Map<string, Map<string, Flow>>()
+	const countPricedOnly = events.some((event) => {
+		if (event.type === 'approval') return false
+		const amounts = event.totalAmount
+			? [event.totalAmount]
+			: event.parts
+					.filter((part): part is AmountPart => part.type === 'amount')
+					.map((part) => part.value)
+		return amounts.some((amount) => Boolean(amount.currency))
+	})
 
 	for (const event of events) {
 		// Approvals grant spending permission rather than moving value, and
@@ -44,18 +53,23 @@ export function calculateKnownEventsTotal(
 					.map((part) => part.value)
 		if (amounts.length === 0) continue
 
+		const totalableAmounts = countPricedOnly
+			? amounts.filter((amount) => Boolean(amount.currency))
+			: amounts
+		if (totalableAmounts.length === 0) continue
+
 		const from = event.meta?.from?.toLowerCase()
 		const to = event.meta?.to?.toLowerCase()
 
 		if (!from || !to) {
-			fallbackTotal += amounts.reduce((max, amountValue) => {
+			fallbackTotal += totalableAmounts.reduce((max, amountValue) => {
 				const amount = normalizeAmount(amountValue)
 				return amount > max ? amount : max
 			}, 0n)
 			continue
 		}
 
-		for (const amountValue of amounts) {
+		for (const amountValue of totalableAmounts) {
 			const token = amountValue.token.toLowerCase()
 			const amount = normalizeAmount(amountValue)
 			let flows = flowsByToken.get(token)

--- a/apps/explorer/src/routes/_layout/receipt/$hash.tsx
+++ b/apps/explorer/src/routes/_layout/receipt/$hash.tsx
@@ -42,7 +42,7 @@ const TEMPO_FEE_TOKEN = getFeeTokenForChain(TEMPO_CHAIN_ID)
 function getKnownEventAmounts(
 	events: readonly KnownEvent[],
 ): NonNullable<KnownEvent['totalAmount']>[] {
-	return events.flatMap((event) => {
+	const amounts = events.flatMap((event) => {
 		if (event.type === 'approval') return []
 		if (event.totalAmount) return [event.totalAmount]
 
@@ -50,6 +50,8 @@ function getKnownEventAmounts(
 			.filter((part) => part.type === 'amount')
 			.map((part) => part.value)
 	})
+	const pricedAmounts = amounts.filter((amount) => Boolean(amount.currency))
+	return pricedAmounts.length > 0 ? pricedAmounts : amounts
 }
 
 function receiptDetailQueryOptions(params: { hash: Hex.Hex; rpcUrl?: string }) {

--- a/apps/explorer/test/known-event-totals.node.test.ts
+++ b/apps/explorer/test/known-event-totals.node.test.ts
@@ -12,6 +12,8 @@ function sendEvent(params: {
 	to: `0x${string}`
 	amount: bigint
 	decimals?: number
+	currency?: string
+	token?: `0x${string}`
 }): KnownEvent {
 	return {
 		type: 'send',
@@ -20,10 +22,11 @@ function sendEvent(params: {
 			{
 				type: 'amount',
 				value: {
-					token: tokenAddress,
+					token: params.token ?? tokenAddress,
 					value: params.amount,
 					decimals: params.decimals ?? 6,
 					symbol: 'PathUSD',
+					...(params.currency ? { currency: params.currency } : {}),
 				},
 			},
 			{ type: 'text', value: 'to' },
@@ -113,5 +116,44 @@ describe('calculateKnownEventsTotal', () => {
 		expect(calculateKnownEventsTotal(events)).toBe(
 			1_500_300_000_000_000_000_000n,
 		)
+	})
+
+	it('uses only priced events when priced and unpriced amounts are mixed', () => {
+		const pricedAmount = 500_000_000n
+		const unpricedAmount = 250_000_000n
+		const unpricedTokenAddress = `0x${'e'.repeat(40)}` as const
+		const events = [
+			sendEvent({
+				from: senderAddress,
+				to: recipientAddress,
+				amount: pricedAmount,
+				currency: 'USD',
+			}),
+			sendEvent({
+				from: senderAddress,
+				to: recipientAddress,
+				amount: unpricedAmount,
+				token: unpricedTokenAddress,
+			}),
+		]
+
+		expect(calculateKnownEventsTotal(events)).toBe(500n * 10n ** 18n)
+	})
+
+	it('keeps the existing raw total fallback when no events are priced', () => {
+		const amount = 500_000_000n
+		const otherAmount = 250_000_000n
+		const otherTokenAddress = `0x${'e'.repeat(40)}` as const
+		const events = [
+			sendEvent({ from: senderAddress, to: recipientAddress, amount }),
+			sendEvent({
+				from: senderAddress,
+				to: recipientAddress,
+				amount: otherAmount,
+				token: otherTokenAddress,
+			}),
+		]
+
+		expect(calculateKnownEventsTotal(events)).toBe(750n * 10n ** 18n)
 	})
 })


### PR DESCRIPTION
## Summary
- use priced known-event amounts only when a receipt has any priced events
- preserve the existing raw total fallback when no event has pricing
- keep the currency prefix decision aligned with the priced-only total inputs
- add regression coverage for mixed priced/unpriced totals

## Tests
- corepack pnpm --dir apps/explorer exec vitest run --config vitest.node.config.ts test/known-event-totals.node.test.ts
- corepack pnpm --dir apps/explorer exec biome check src/routes/_layout/receipt/\$hash.tsx src/lib/domain/known-event-totals.ts test/known-event-totals.node.test.ts

Prompted by: @Slokh