### PR TITLE
feat: add receipt support for blocked TIP1028 transfers

### DIFF
--- a/apps/explorer/src/comps/Receipt.tsx
+++ b/apps/explorer/src/comps/Receipt.tsx
@@ -235,6 +235,22 @@ export function Receipt(props: Receipt.Props) {
 															<div className="flex flex-col gap-1 text-secondary text-[13px]">
 																{event.note.map(([label, part], index) => {
 																	const key = `${label}${index}`
+																	if (
+																		(label === 'from' || label === 'to') &&
+																		part.type === 'account'
+																	) {
+																		return (
+																			<div key={key} className="min-w-0">
+																				<TxEventDescription
+																					event={{
+																						type: 'blocked transfer address',
+																						parts: [{ type: 'text', value: label }, part],
+																					}}
+																				/>
+																			</div>
+																		)
+																	}
+
 																	return (
 																		<div
 																			key={key}

--- a/apps/explorer/src/comps/TxEventDescription.tsx
+++ b/apps/explorer/src/comps/TxEventDescription.tsx
@@ -174,13 +174,16 @@ export namespace TxEventDescription {
 			}
 			case 'action': {
 				const isFailed = part.value === 'Failed'
+				const isBlocked = part.value === 'Blocked'
 				return (
 					<span
 						className={cx(
 							'inline-flex h-[24px] items-center rounded-[2px] px-[6px] capitalize',
-							isFailed
-								? 'bg-negative/[0.06] text-primary'
-								: 'bg-distinct/70 text-primary',
+							isBlocked
+								? 'bg-amber-500/10 text-amber-700 dark:text-amber-300'
+								: isFailed
+									? 'bg-negative/[0.06] text-primary'
+									: 'bg-distinct/70 text-primary',
 						)}
 					>
 						{part.value}

--- a/apps/explorer/src/lib/abis.ts
+++ b/apps/explorer/src/lib/abis.ts
@@ -1,3 +1,4 @@
+import { parseAbi } from 'viem'
 import { Abis as ViemTempoAbis, Channel as ViemTempoChannel } from 'viem/tempo'
 
 export const tip20ChannelReserveAbi = ViemTempoAbis.tip20ChannelReserve
@@ -226,8 +227,15 @@ const zoneFactoryAbi = [
 
 export const stablecoinDexAbi = ViemTempoAbis.stablecoinDex
 
+export const receivePolicyGuardAbi = parseAbi([
+	'event TransferBlocked(address indexed token, address indexed receiver, uint64 indexed blockedNonce, uint256 amount, uint8 receiptVersion, bytes receipt)',
+	'event ReceiptClaimed(address indexed token, address indexed receiver, uint8 receiptVersion, uint64 indexed blockedNonce, uint64 blockedAt, address originator, address recipient, address recoveryAuthority, address caller, address to, uint256 amount)',
+	'event ReceiptBurned(address indexed token, address indexed receiver, uint8 receiptVersion, uint64 indexed blockedNonce, uint64 blockedAt, address originator, address recipient, address recoveryAuthority, address caller, uint256 amount)',
+])
+
 export const Abis = {
 	...ViemTempoAbis,
+	receivePolicyGuard: receivePolicyGuardAbi,
 	stablecoinDex: stablecoinDexAbi,
 	streamChannel: streamChannelAbi,
 	zonePortal: zonePortalAbi,

--- a/apps/explorer/src/lib/domain/known-events.ts
+++ b/apps/explorer/src/lib/domain/known-events.ts
@@ -2,7 +2,7 @@ import * as Address from 'ox/Address'
 import { VirtualAddress } from 'ox/tempo'
 import type * as Hex from 'ox/Hex'
 import type { AbiEvent, Log, TransactionReceipt } from 'viem'
-import { decodeFunctionData, parseEventLogs, zeroAddress } from 'viem'
+import { decodeAbiParameters, decodeFunctionData, parseEventLogs, zeroAddress } from 'viem'
 import { Addresses } from 'viem/tempo'
 import { Abis, allAbis } from '#lib/abis'
 import { decodeMemoForDisplay, isMppAttributionMemo } from '#lib/domain/memo'
@@ -10,6 +10,9 @@ import type * as Tip20 from './tip20'
 
 const abi = allAbis
 const FEE_MANAGER = Addresses.feeManager
+const RECEIVE_POLICY_GUARD = Address.from(
+	'0xB10C000000000000000000000000000000000000',
+)
 const STABLECOIN_EXCHANGE = Addresses.stablecoinDex
 export const STREAM_CHANNEL = '0x9d136eEa063eDE5418A6BC7bEafF009bBb6CFa70'
 export const STREAM_CHANNELS = [
@@ -98,6 +101,51 @@ type ParsedEvent = ReturnType<typeof parseEventLogs<typeof abi>>[number]
 
 function checksumAddress(address: string): Address.Address {
 	return Address.from(address, { checksum: true })
+}
+
+function decodeClaimReceiptV1(receipt: Hex.Hex) {
+	try {
+		const [
+			version,
+			token,
+			recoveryAuthority,
+			originator,
+			recipient,
+			blockedAt,
+			blockedNonce,
+			blockedReason,
+			kind,
+			memo,
+		] = decodeAbiParameters(
+			[
+				{ type: 'uint8' },
+				{ type: 'address' },
+				{ type: 'address' },
+				{ type: 'address' },
+				{ type: 'address' },
+				{ type: 'uint64' },
+				{ type: 'uint64' },
+				{ type: 'uint8' },
+				{ type: 'uint8' },
+				{ type: 'bytes32' },
+			],
+			receipt,
+		)
+		return {
+			version,
+			token,
+			recoveryAuthority,
+			originator,
+			recipient,
+			blockedAt,
+			blockedNonce,
+			blockedReason,
+			kind,
+			memo,
+		}
+	} catch {
+		return null
+	}
 }
 
 function createZonePortalMetadata(events: ParsedEvent[]) {
@@ -693,6 +741,75 @@ function createDetectors(
 			return null
 		},
 
+		receivePolicyGuard(event: ParsedEvent) {
+			const { eventName, args } = event
+
+			if (eventName === 'TransferBlocked') {
+				const receipt = decodeClaimReceiptV1(args.receipt)
+				const originator = receipt?.originator ?? args.receiver
+				const recipient = receipt?.recipient ?? args.receiver
+
+				return {
+					type: 'transfer blocked',
+					parts: [
+						{ type: 'action', value: 'Blocked' },
+						{ type: 'action', value: 'Send' },
+						{ type: 'amount', value: createAmount(args.amount, args.token) },
+						{ type: 'text', value: 'to' },
+						{ type: 'account', value: recipient },
+					],
+					meta: { from: originator, to: recipient },
+				}
+			}
+
+			if (eventName === 'ReceiptClaimed')
+				return {
+					type: 'receipt claimed',
+					parts: [
+						{ type: 'action', value: 'Claim Blocked Transfer' },
+						{ type: 'amount', value: createAmount(args.amount, args.token) },
+						{ type: 'text', value: 'to' },
+						{ type: 'account', value: args.to },
+					],
+					note: [
+						['Receiver', { type: 'account', value: args.receiver }],
+						['Originator', { type: 'account', value: args.originator }],
+						['Recipient', { type: 'account', value: args.recipient }],
+						[
+							'Recovery Authority',
+							{ type: 'account', value: args.recoveryAuthority },
+						],
+						['Caller', { type: 'account', value: args.caller }],
+						['Receipt Version', { type: 'number', value: args.receiptVersion }],
+						['Blocked Nonce', { type: 'number', value: args.blockedNonce }],
+					],
+				}
+
+			if (eventName === 'ReceiptBurned')
+				return {
+					type: 'receipt burned',
+					parts: [
+						{ type: 'action', value: 'Burn Blocked Transfer' },
+						{ type: 'amount', value: createAmount(args.amount, args.token) },
+						{ type: 'text', value: 'for' },
+						{ type: 'account', value: args.receiver },
+					],
+					note: [
+						['Originator', { type: 'account', value: args.originator }],
+						['Recipient', { type: 'account', value: args.recipient }],
+						[
+							'Recovery Authority',
+							{ type: 'account', value: args.recoveryAuthority },
+						],
+						['Caller', { type: 'account', value: args.caller }],
+						['Receipt Version', { type: 'number', value: args.receiptVersion }],
+						['Blocked Nonce', { type: 'number', value: args.blockedNonce }],
+					],
+				}
+
+			return null
+		},
+
 		tip403Registry(event: ParsedEvent) {
 			const { eventName, args } = event
 
@@ -1244,6 +1361,7 @@ export function parseKnownEvent(
 		detectors.tip20Factory(event) ||
 		detectors.stablecoinDex(event) ||
 		detectors.tip403Registry(event) ||
+		detectors.receivePolicyGuard(event) ||
 		detectors.feeManager(event) ||
 		detectors.nonce(event) ||
 		detectors.accountKeychain(event) ||
@@ -1366,6 +1484,21 @@ export function parseKnownEvents(
 			if (call.calls) queue.push(...call.calls)
 		}
 	})()
+
+	const blockedTransferKeys = new Set<string>()
+	for (const event of events) {
+		if (event.eventName !== 'TransferBlocked') continue
+		const { token, amount, receipt } = event.args as {
+			token: Address.Address
+			amount: bigint
+			receipt: Hex.Hex
+		}
+		const decodedReceipt = decodeClaimReceiptV1(receipt)
+		if (!decodedReceipt) continue
+		blockedTransferKeys.add(
+			`${Address.from(token)}:${Address.from(decodedReceipt.originator)}:${amount.toString()}`,
+		)
+	}
 
 	const preferenceMap = new Map<string, string>()
 	const feeTransferEvents: Array<{
@@ -1534,6 +1667,14 @@ export function parseKnownEvents(
 					to: Address.Address
 					amount: bigint
 				}
+				if (
+					Address.isEqual(to, RECEIVE_POLICY_GUARD) &&
+					blockedTransferKeys.has(
+						`${Address.from(event.address)}:${Address.from(from)}:${amount.toString()}`,
+					)
+				) {
+					include = false
+				}
 				if (isZonePortalAddress(to)) {
 					const zoneDepositKey = createZoneDepositTransferKey({
 						sender: from,
@@ -1598,6 +1739,15 @@ export function parseKnownEvents(
 					from: Address.Address
 					to: Address.Address
 					amount: bigint
+				}
+
+				if (
+					Address.isEqual(to, RECEIVE_POLICY_GUARD) &&
+					blockedTransferKeys.has(
+						`${Address.from(event.address)}:${Address.from(from)}:${amount.toString()}`,
+					)
+				) {
+					include = false
 				}
 
 				if (isZonePortalAddress(to)) {
@@ -1807,6 +1957,7 @@ export function parseKnownEvents(
 			detectors.tip20Factory(event) ||
 			detectors.stablecoinDex(event) ||
 			detectors.tip403Registry(event) ||
+			detectors.receivePolicyGuard(event) ||
 			detectors.feeManager(event) ||
 			detectors.nonce(event) ||
 			detectors.accountKeychain(event) ||

--- a/apps/explorer/src/routes/_layout/receipt/$hash.tsx
+++ b/apps/explorer/src/routes/_layout/receipt/$hash.tsx
@@ -7,6 +7,7 @@ import {
 	rootRouteId,
 	useNavigate,
 } from '@tanstack/react-router'
+import * as Address from 'ox/Address'
 import * as Hex from 'ox/Hex'
 import * as Json from 'ox/Json'
 import * as Value from 'ox/Value'
@@ -38,6 +39,9 @@ import { getTempoChain, getWagmiConfig } from '#wagmi.config.ts'
 
 const TEMPO_CHAIN_ID = getTempoChain().id
 const TEMPO_FEE_TOKEN = getFeeTokenForChain(TEMPO_CHAIN_ID)
+const RECEIVE_POLICY_GUARD = Address.from(
+	'0xB10C000000000000000000000000000000000000',
+)
 
 function getKnownEventAmounts(
 	events: readonly KnownEvent[],
@@ -410,6 +414,9 @@ function Component() {
 	const { isTokenListed } = useTokenListMembership()
 
 	const { block, feeBreakdown, knownEvents, lineItems, receipt } = data
+	const hasBlockedTransfer = knownEvents.some(
+		(event) => event.type === 'transfer blocked',
+	)
 
 	const feePrice = lineItems.feeTotals?.[0]?.price
 	const previousFee = feePrice
@@ -437,16 +444,29 @@ function Component() {
 		? PriceFormatter.format(fee)
 		: PriceFormatter.formatAmountShort(feeRaw)
 
-	// Inject a streaming payment event when voucher params are present
-	const displayEvents: KnownEvent[] = voucherData
-		? [
-				buildStreamedPaymentEvent(
-					voucherData.packetSize,
-					voucherData.packetCount,
-				),
-				...knownEvents,
-			]
-		: knownEvents
+	// Inject a streaming payment event when voucher params are present.
+	// For TIP-1028 blocked transfers, the TIP-20 receipt also contains the
+	// mechanical Transfer to ReceivePolicyGuard. Hide that implementation detail
+	// from the human receipt so the blocked transfer is not shown or totaled twice.
+	const displayEvents: KnownEvent[] = (
+		voucherData
+			? [
+					buildStreamedPaymentEvent(
+						voucherData.packetSize,
+						voucherData.packetCount,
+					),
+					...knownEvents,
+				]
+			: knownEvents
+	)
+		.filter(
+			(event) =>
+				!hasBlockedTransfer ||
+				event.type !== 'send' ||
+				!event.meta?.to ||
+				!Address.isEqual(event.meta.to, RECEIVE_POLICY_GUARD),
+		)
+
 
 	// When a voucher is present, show the streaming total as the receipt total
 	const streamingTotal = voucherData

--- a/apps/explorer/src/routes/_layout/tx/$hash.tsx
+++ b/apps/explorer/src/routes/_layout/tx/$hash.tsx
@@ -8,6 +8,7 @@ import {
 	useNavigate,
 } from '@tanstack/react-router'
 import type { Address as OxAddress, Hex } from 'ox'
+import * as OxAddressUtil from 'ox/Address'
 import * as Json from 'ox/Json'
 import * as Value from 'ox/Value'
 import * as React from 'react'
@@ -60,6 +61,10 @@ const defaultSearchValues = {
 	tab: 'overview',
 	page: 1,
 } as const
+
+const RECEIVE_POLICY_GUARD = OxAddressUtil.from(
+	'0xB10C000000000000000000000000000000000000',
+)
 
 export const Route = createFileRoute('/_layout/tx/$hash')({
 	component: RouteComponent,
@@ -167,6 +172,16 @@ function RouteComponent() {
 
 	const isMobile = useMediaQuery('(max-width: 799px)')
 	const mode = isMobile ? 'stacked' : 'tabs'
+	const hasBlockedTransfer = knownEvents.some(
+		(event) => event.type === 'transfer blocked',
+	)
+	const displayKnownEvents = knownEvents.filter(
+		(event) =>
+			!hasBlockedTransfer ||
+			event.type !== 'send' ||
+			!event.meta?.to ||
+			!OxAddressUtil.isEqual(event.meta.to, RECEIVE_POLICY_GUARD),
+	)
 
 	useKeyboardShortcut({
 		t: () =>
@@ -207,7 +222,7 @@ function RouteComponent() {
 				receipt={receipt}
 				transaction={transaction}
 				block={block}
-				knownEvents={knownEvents}
+				knownEvents={displayKnownEvents}
 				feeBreakdown={feeBreakdown}
 				balanceChangesData={balanceChangesData}
 			/>


### PR DESCRIPTION
## Summary

- Decode TIP-1028 `ReceivePolicyGuard` blocked transfer events in explorer receipts/tx views.
- Render blocked transfers as `Blocked Send … to …` instead of a successful send to the guard precompile.
- Exclude the mechanical guard transfer from receipt totals so blocked receipts are not double-counted.

## Testing

- `pnpm --filter explorer check:types`
