### PR TITLE
Fix tx-only address history period filter

### DIFF
--- a/apps/explorer/src/lib/server/address-history.ts
+++ b/apps/explorer/src/lib/server/address-history.ts
@@ -294,7 +294,10 @@ export async function fetchAddressHistoryData(params: {
 			limit,
 			countCap: HISTORY_COUNT_MAX,
 			statusFilter,
-			after,
+			// TIDX rejects the optimized joined tx-only query when the timestamp
+			// predicate is pushed into the paged subquery. Filter after enrichment
+			// below, matching the mixed-source history path.
+			after: undefined,
 		})
 
 		hasMore = txOnlyPageResult.hasMore
@@ -475,13 +478,15 @@ export async function fetchAddressHistoryData(params: {
 		const finalTransactions = after
 			? transactions.filter((transaction) => transaction.timestamp >= after)
 			: transactions
+		const hasFilteredTransactions =
+			finalTransactions.length < transactions.length
 
 		return {
 			transactions: finalTransactions,
 			total: after ? finalTransactions.length : totalCount,
 			offset,
 			limit,
-			hasMore: after ? false : hasMore,
+			hasMore: after ? hasMore && !hasFilteredTransactions : hasMore,
 			countCapped: after ? false : countCapped,
 			error: null,
 		}
@@ -500,13 +505,19 @@ export async function fetchAddressHistoryData(params: {
 			logRows: txOnlyPageResult.logRows,
 		})
 
+		const finalTransactions = after
+			? transactions.filter((transaction) => transaction.timestamp >= after)
+			: transactions
+		const hasFilteredTransactions =
+			finalTransactions.length < transactions.length
+
 		return {
-			transactions,
-			total: totalCount,
+			transactions: finalTransactions,
+			total: after ? finalTransactions.length : totalCount,
 			offset,
 			limit,
-			hasMore,
-			countCapped,
+			hasMore: after ? hasMore && !hasFilteredTransactions : hasMore,
+			countCapped: after ? false : countCapped,
 			error: null,
 		}
 	}

--- a/apps/explorer/test/address-history.test.ts
+++ b/apps/explorer/test/address-history.test.ts
@@ -1,0 +1,220 @@
+import type { Address, Hex } from 'ox'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockFetchAddressTxOnlyHistoryPageWithJoins = vi.hoisted(() => vi.fn())
+
+vi.mock('#wagmi.config', () => ({
+	getWagmiConfig: () => ({}),
+}))
+
+vi.mock('#lib/server/tempo-queries', () => ({
+	fetchAddressDirectTxHistoryRows: vi.fn(),
+	fetchAddressHistoryTxDetailsByHashes: vi.fn(),
+	fetchAddressLogRowsByTxHashes: vi.fn(),
+	fetchAddressReceiptRowsByHashes: vi.fn(),
+	fetchAddressTransferRowsByTxHashes: vi.fn(),
+	fetchAddressTransferEmittedHashes: vi.fn(),
+	fetchAddressTransferHashes: vi.fn(),
+	fetchAddressTxOnlyHistoryPageWithJoins:
+		mockFetchAddressTxOnlyHistoryPageWithJoins,
+}))
+
+import { fetchAddressHistoryData } from '#lib/server/address-history'
+
+describe('fetchAddressHistoryData', () => {
+	beforeEach(() => {
+		mockFetchAddressTxOnlyHistoryPageWithJoins.mockReset()
+	})
+
+	it('filters tx-only history by timestamp without pushing after into the TIDX joined query', async () => {
+		const address =
+			'0x20C0000000000000000000000000000000000000' as Address.Address
+		const recentHash = `0x${'a'.repeat(64)}` as Hex.Hex
+		const oldHash = `0x${'b'.repeat(64)}` as Hex.Hex
+
+		mockFetchAddressTxOnlyHistoryPageWithJoins.mockResolvedValue({
+			hashes: [
+				{
+					hash: recentHash,
+					block_num: 2n,
+					from: '0x1111111111111111111111111111111111111111',
+					to: address,
+					value: 0n,
+				},
+				{
+					hash: oldHash,
+					block_num: 1n,
+					from: '0x2222222222222222222222222222222222222222',
+					to: address,
+					value: 0n,
+				},
+			],
+			txRows: [
+				{
+					hash: recentHash,
+					block_num: 2n,
+					block_timestamp: 200,
+					from: '0x1111111111111111111111111111111111111111',
+					to: address,
+					value: 0n,
+					input: '0x',
+					calls: null,
+				},
+				{
+					hash: oldHash,
+					block_num: 1n,
+					block_timestamp: 100,
+					from: '0x2222222222222222222222222222222222222222',
+					to: address,
+					value: 0n,
+					input: '0x',
+					calls: null,
+				},
+			],
+			receiptRows: [
+				{
+					tx_hash: recentHash,
+					block_num: 2n,
+					block_timestamp: 200,
+					from: '0x1111111111111111111111111111111111111111',
+					to: address,
+					status: 1,
+					gas_used: 21_000n,
+					effective_gas_price: 2n,
+				},
+				{
+					tx_hash: oldHash,
+					block_num: 1n,
+					block_timestamp: 100,
+					from: '0x2222222222222222222222222222222222222222',
+					to: address,
+					status: 1,
+					gas_used: 21_000n,
+					effective_gas_price: 2n,
+				},
+			],
+			logRows: [],
+			total: 2,
+			countCapped: false,
+			hasMore: true,
+		})
+
+		const result = await fetchAddressHistoryData({
+			address,
+			chainId: 1,
+			searchParams: {
+				offset: 0,
+				limit: 10,
+				sort: 'desc',
+				include: 'all',
+				sources: 'txs',
+				after: 150,
+			},
+			includeKnownEvents: false,
+		})
+
+		expect(mockFetchAddressTxOnlyHistoryPageWithJoins).toHaveBeenCalledWith(
+			expect.objectContaining({ after: undefined }),
+		)
+		expect(result.transactions.map((transaction) => transaction.hash)).toEqual([
+			recentHash,
+		])
+		expect(result.total).toBe(1)
+		expect(result.hasMore).toBe(false)
+		expect(result.countCapped).toBe(false)
+	})
+
+	it('preserves tx-only pagination when the full page is inside the timestamp window', async () => {
+		const address =
+			'0x20C0000000000000000000000000000000000000' as Address.Address
+		const firstHash = `0x${'c'.repeat(64)}` as Hex.Hex
+		const secondHash = `0x${'d'.repeat(64)}` as Hex.Hex
+
+		mockFetchAddressTxOnlyHistoryPageWithJoins.mockResolvedValue({
+			hashes: [
+				{
+					hash: firstHash,
+					block_num: 2n,
+					from: '0x1111111111111111111111111111111111111111',
+					to: address,
+					value: 0n,
+				},
+				{
+					hash: secondHash,
+					block_num: 1n,
+					from: '0x2222222222222222222222222222222222222222',
+					to: address,
+					value: 0n,
+				},
+			],
+			txRows: [
+				{
+					hash: firstHash,
+					block_num: 2n,
+					block_timestamp: 200,
+					from: '0x1111111111111111111111111111111111111111',
+					to: address,
+					value: 0n,
+					input: '0x',
+					calls: null,
+				},
+				{
+					hash: secondHash,
+					block_num: 1n,
+					block_timestamp: 190,
+					from: '0x2222222222222222222222222222222222222222',
+					to: address,
+					value: 0n,
+					input: '0x',
+					calls: null,
+				},
+			],
+			receiptRows: [
+				{
+					tx_hash: firstHash,
+					block_num: 2n,
+					block_timestamp: 200,
+					from: '0x1111111111111111111111111111111111111111',
+					to: address,
+					status: 1,
+					gas_used: 21_000n,
+					effective_gas_price: 2n,
+				},
+				{
+					tx_hash: secondHash,
+					block_num: 1n,
+					block_timestamp: 190,
+					from: '0x2222222222222222222222222222222222222222',
+					to: address,
+					status: 1,
+					gas_used: 21_000n,
+					effective_gas_price: 2n,
+				},
+			],
+			logRows: [],
+			total: 3,
+			countCapped: false,
+			hasMore: true,
+		})
+
+		const result = await fetchAddressHistoryData({
+			address,
+			chainId: 1,
+			searchParams: {
+				offset: 0,
+				limit: 2,
+				sort: 'desc',
+				include: 'all',
+				sources: 'txs',
+				after: 150,
+			},
+			includeKnownEvents: false,
+		})
+
+		expect(result.transactions.map((transaction) => transaction.hash)).toEqual([
+			firstHash,
+			secondHash,
+		])
+		expect(result.hasMore).toBe(true)
+	})
+})


### PR DESCRIPTION
Root cause:
- TIP-20 addresses use the tx-only optimized address history query.
- TIDX rejects that joined tx-only query when `after` is pushed into the paged subquery, returning 422.
- Mixed-source history already works because it filters by timestamp after enrichment.

Fix:
- Keep the tx-only optimized query, but do not pass `after` into that TIDX query shape.
- Filter tx-only results after receipt/transaction enrichment.
- Preserve pagination when the full page remains inside the timestamp window; stop pagination when rows older than the cutoff appear.
- Add regression tests proving `after` is not sent to the joined tx-only helper and pagination is preserved for dense pages.

Verification:
- `PATH=/tmp/corepack-bin:$PATH pnpm --filter explorer check:types`
- `PATH=/tmp/corepack-bin:$PATH pnpm exec biome check --write src/lib/server/address-history.ts test/address-history.test.ts`
- `PATH=/tmp/corepack-bin:$PATH pnpm --filter explorer exec vitest run test/address-history.test.ts` (2 tests passed)
- Browser screenshot attempt: local explorer rendered the address Transactions tab, but the sandbox lost upstream TIDX network connectivity (`Network connection lost`) before rows loaded, so I could not honestly attach a loaded-history screenshot from this environment. This is a different failure from the original 422.

Prompted by: @snario