### PR TITLE
[codex] add native multisig relay Worker

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ This is a **TypeScript monorepo** for applications on the Tempo blockchain appli
 | `apps/explorer` | Chain explorer UI |
 | `apps/fee-payer` | Transaction fee sponsorship service |
 | `apps/key-manager` | WebAuthn key management service |
+| `apps/native-multisig-relay` | Native multisig approval relay |
 | `apps/tokenlist` | Token registry API |
 | `apps/contract-verification` | Smart contract verification |
 | `apps/og` | OpenGraph image generation |

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Monorepo for Tempo Apps
 | --------- | ----------- | ----------- |
 | [`apps/explorer`](apps/explorer) | Mainnet, Testnet & Devnet Explorer | [`explore.tempo.xyz`](<https://explore.tempo.xyz>) |
 | [`apps/fee-payer`](apps/fee-payer) | Fee payer | [`sponsor.testnet.tempo.xyz`](<https://sponsor.testnet.tempo.xyz>) |
+| [`apps/native-multisig-relay`](apps/native-multisig-relay) | Native multisig approval relay | Cloudflare Workers preview |
 | [`apps/tokenlist`](apps/tokenlist) | Tokenlist Registry & API | [`tokenlist.tempo.xyz`](<https://tokenlist.tempo.xyz>) |
 | [`apps/contract-verification`](apps/contract-verification) | Smart contract verification service | [`contracts.tempo.xyz`](<https://contracts.tempo.xyz>) |
 | [`apps/key-manager`](apps/key-manager) | WebAuthn key management service | [`keys.tempo.xyz`](<https://keys.tempo.xyz>) |

--- a/apps/native-multisig-relay/.env.example
+++ b/apps/native-multisig-relay/.env.example
@@ -1,0 +1,8 @@
+ALLOWED_ORIGINS=*
+TEMPO_ENV=moderato
+TEMPO_RPC_URL=https://rpc.moderato.tempo.xyz
+
+# Optional. When set, finalized multisig transactions can be sponsored by this Worker.
+SPONSOR_PRIVATE_KEY=
+SPONSOR_NAME=Tempo Multisig Relay
+SPONSOR_URL=https://multisig-relay.tempo.xyz

--- a/apps/native-multisig-relay/README.md
+++ b/apps/native-multisig-relay/README.md
@@ -1,0 +1,28 @@
+# Native Multisig Relay
+
+Cloudflare Worker for Tempo native multisig relay flows. This is separate from `apps/fee-payer`: fee-payer sponsors regular wallet transactions, while this Worker stores native multisig approvals and broadcasts once quorum is reached.
+
+If `SPONSOR_PRIVATE_KEY` is configured, the Worker can also sponsor the finalized multisig transaction with the same `feePayer: true` flow as the hosted fee-payer idea. Without it, the multisig account pays its own transaction fee.
+
+## Development
+
+```bash
+pnpm dev
+pnpm test:e2e
+```
+
+The e2e script defaults to:
+
+- `ACCOUNTS_REPO=~/github/tempoxyz/accounts` so it can test the accounts native multisig relay branch before the package is published.
+- `TEMPO_TAG=~/github/tempoxyz/tempo/target/debug/tempo` when that local Tempo binary exists, otherwise Prool starts the Docker image tag.
+- `TEMPO_ENV=localnet`.
+
+Override any of those values when needed:
+
+```bash
+ACCOUNTS_REPO=~/github/tempoxyz/accounts \
+TEMPO_TAG=sha-abc123 \
+pnpm test:e2e
+```
+
+`eth_signTransaction` is intentionally not implemented by this Worker. Owners sign approvals locally; the Worker receives native multisig raw transaction submissions through `eth_sendRawTransaction` or `eth_sendRawTransactionSync`.

--- a/apps/native-multisig-relay/config/accounts-aliases.ts
+++ b/apps/native-multisig-relay/config/accounts-aliases.ts
@@ -1,0 +1,19 @@
+import { resolve } from 'node:path'
+
+export function accountsAliases() {
+	const repo = process.env.ACCOUNTS_REPO
+	if (!repo) return []
+
+	const viem = resolve(repo, 'node_modules/viem')
+	const ox = resolve(repo, 'node_modules/ox')
+	return [
+		{
+			find: 'accounts/server',
+			replacement: resolve(repo, 'src/server/index.ts'),
+		},
+		{ find: /^viem\/(.*)$/, replacement: `${viem}/$1` },
+		{ find: 'viem', replacement: viem },
+		{ find: /^ox\/(.*)$/, replacement: `${ox}/$1` },
+		{ find: 'ox', replacement: ox },
+	]
+}

--- a/apps/native-multisig-relay/env.d.ts
+++ b/apps/native-multisig-relay/env.d.ts
@@ -1,0 +1,8 @@
+interface EnvironmentVariables {
+	readonly TEMPO_ENV: 'testnet' | 'devnet' | 'moderato' | 'localnet' | 'mainnet'
+	readonly TEMPO_RPC_URL?: string
+	readonly ALLOWED_ORIGINS: string
+	readonly SPONSOR_PRIVATE_KEY?: string
+	readonly SPONSOR_NAME?: string
+	readonly SPONSOR_URL?: string
+}

--- a/apps/native-multisig-relay/package.json
+++ b/apps/native-multisig-relay/package.json
@@ -1,0 +1,44 @@
+{
+	"name": "native-multisig-relay",
+	"type": "module",
+	"private": true,
+	"imports": {
+		"#*": "./src/*",
+		"#package.json": "./package.json",
+		"#wrangler.json": "./wrangler.json"
+	},
+	"scripts": {
+		"build": "vite build",
+		"check": "pnpm check:biome && pnpm check:types",
+		"check:biome": "biome check --write .",
+		"check:types": "tsgo --project tsconfig.json --noEmit",
+		"dev": "vite dev",
+		"deploy": "wrangler deploy",
+		"format": "biome format --write .",
+		"gen:types": "CLOUDFLARE_ENV= wrangler types --env-interface='CloudflareBindings' --env-file='.env.example'",
+		"tail": "wrangler tail",
+		"test": "vitest --run",
+		"test:e2e": "./scripts/test-e2e.sh",
+		"test:watch": "vitest",
+		"postinstall": "pnpm gen:types"
+	},
+	"dependencies": {
+		"accounts": "catalog:",
+		"hono": "catalog:",
+		"viem": "catalog:"
+	},
+	"devDependencies": {
+		"@cloudflare/vite-plugin": "catalog:",
+		"@cloudflare/vitest-pool-workers": "catalog:",
+		"@cloudflare/workers-types": "catalog:",
+		"@types/node": "catalog:",
+		"dotenv": "catalog:",
+		"ox": "catalog:",
+		"prool": "catalog:",
+		"testcontainers": "catalog:",
+		"typescript": "catalog:",
+		"vite": "catalog:",
+		"vitest": "catalog:",
+		"wrangler": "catalog:"
+	}
+}

--- a/apps/native-multisig-relay/scripts/test-e2e.sh
+++ b/apps/native-multisig-relay/scripts/test-e2e.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+export ACCOUNTS_REPO="${ACCOUNTS_REPO:-$HOME/github/tempoxyz/accounts}"
+export TEMPO_ENV="${TEMPO_ENV:-localnet}"
+
+if [ ! -f "$ACCOUNTS_REPO/src/server/internal/handlers/multisig.ts" ]; then
+	echo "ACCOUNTS_REPO must point at an accounts checkout with native multisig relay support."
+	echo "Current ACCOUNTS_REPO=$ACCOUNTS_REPO"
+	exit 1
+fi
+
+if [ -z "${TEMPO_TAG:-}" ] && [ -x "$HOME/github/tempoxyz/tempo/target/debug/tempo" ]; then
+	export TEMPO_TAG="$HOME/github/tempoxyz/tempo/target/debug/tempo"
+fi
+
+echo "ACCOUNTS_REPO=$ACCOUNTS_REPO"
+echo "TEMPO_ENV=$TEMPO_ENV"
+echo "TEMPO_TAG=${TEMPO_TAG:-latest}"
+
+if [ -x ./node_modules/.bin/vitest ]; then
+	./node_modules/.bin/vitest --run test/e2e.test.ts
+else
+	pnpm vitest --run test/e2e.test.ts
+fi

--- a/apps/native-multisig-relay/src/index.ts
+++ b/apps/native-multisig-relay/src/index.ts
@@ -1,0 +1,83 @@
+import { env } from 'cloudflare:workers'
+import { Handler } from 'accounts/server'
+import { type Context, Hono } from 'hono'
+import { cors } from 'hono/cors'
+import { HTTPException } from 'hono/http-exception'
+import { http } from 'viem'
+import { privateKeyToAccount } from 'viem/accounts'
+import { tempoChain, tempoFeeToken, tempoTokens } from './lib/chain.js'
+import { createMultisigStore } from './lib/multisig-store.js'
+
+const app = new Hono()
+
+app.onError((error, c) => {
+	if (error instanceof HTTPException) return error.getResponse()
+
+	console.error('Unexpected error:', error)
+	return c.text('Internal Server Error', 500)
+})
+
+app.use(
+	'*',
+	cors({
+		origin: (origin) => {
+			if (env.ALLOWED_ORIGINS === '*') return '*'
+			if (origin && env.ALLOWED_ORIGINS.includes(origin)) return origin
+			return null
+		},
+		allowMethods: ['GET', 'POST', 'OPTIONS'],
+		allowHeaders: ['Content-Type'],
+		maxAge: 86400,
+	}),
+)
+
+app.get('/health', (c) =>
+	c.json({
+		ok: true,
+		chainId: tempoChain.id,
+		sponsored: Boolean(env.SPONSOR_PRIVATE_KEY),
+	}),
+)
+
+app.get('/', (c) =>
+	c.json({
+		ok: true,
+		chainId: tempoChain.id,
+		sponsored: Boolean(env.SPONSOR_PRIVATE_KEY),
+	}),
+)
+
+const sponsor = env.SPONSOR_PRIVATE_KEY
+	? {
+			account: privateKeyToAccount(env.SPONSOR_PRIVATE_KEY as `0x${string}`),
+			feeToken: tempoFeeToken,
+			name: env.SPONSOR_NAME ?? 'Tempo Multisig Relay',
+			url: env.SPONSOR_URL ?? 'https://multisig-relay.tempo.xyz',
+		}
+	: undefined
+
+const relayHandler = Handler.relay({
+	cors: false,
+	chains: [tempoChain],
+	features: 'all',
+	...(sponsor ? { feePayer: sponsor } : {}),
+	multisig: {
+		finalize: 'sync',
+		store: createMultisigStore(env.MultisigOperationStore),
+	},
+	resolveTokens: () => tempoTokens,
+	transports: {
+		[tempoChain.id]: http(
+			env.TEMPO_RPC_URL ?? tempoChain.rpcUrls.default.http[0],
+		),
+	},
+} as never)
+
+async function relay(c: Context) {
+	return relayHandler.fetch(c.req.raw)
+}
+
+app.post('/', relay)
+app.post('/:chainId', relay)
+
+export default app

--- a/apps/native-multisig-relay/src/lib/chain.ts
+++ b/apps/native-multisig-relay/src/lib/chain.ts
@@ -1,0 +1,57 @@
+import { env } from 'cloudflare:workers'
+import { tempo, tempoDevnet, tempoLocalnet, tempoModerato } from 'viem/chains'
+import type { Chain } from 'viem/chains'
+
+type CanonicalTempoEnv = 'devnet' | 'localnet' | 'mainnet' | 'moderato'
+type TempoEnv = CanonicalTempoEnv | 'testnet'
+
+const chains = {
+	devnet: tempoDevnet,
+	localnet: tempoLocalnet,
+	mainnet: tempo,
+	moderato: tempoModerato,
+} as const satisfies Record<CanonicalTempoEnv, Chain>
+
+const feeTokens = {
+	devnet: '0x20c0000000000000000000000000000000000001',
+	localnet: '0x20c0000000000000000000000000000000000000',
+	mainnet: '0x50570a1a3a6e67f87d67737d2e2cc7bd5edb1c9d',
+	moderato: '0x20c0000000000000000000000000000000000001',
+} as const satisfies Record<CanonicalTempoEnv, `0x${string}`>
+
+export const tempoTokens = [
+	{
+		address: '0x20c0000000000000000000000000000000000000',
+		decimals: 6,
+		name: 'pathUSD',
+		symbol: 'pathUSD',
+	},
+	{
+		address: '0x20c0000000000000000000000000000000000001',
+		decimals: 6,
+		name: 'alphaUSD',
+		symbol: 'alphaUSD',
+	},
+	{
+		address: '0x20c0000000000000000000000000000000000002',
+		decimals: 6,
+		name: 'betaUSD',
+		symbol: 'betaUSD',
+	},
+	{
+		address: '0x20c0000000000000000000000000000000000003',
+		decimals: 6,
+		name: 'thetaUSD',
+		symbol: 'thetaUSD',
+	},
+] as const
+
+const rawTempoEnv = (env.TEMPO_ENV as TempoEnv | undefined) ?? 'moderato'
+const tempoEnv: CanonicalTempoEnv =
+	rawTempoEnv === 'testnet' ? 'moderato' : rawTempoEnv
+
+export const tempoFeeToken = feeTokens[tempoEnv]
+
+export const tempoChain = chains[tempoEnv].extend({
+	feeToken: tempoFeeToken,
+})

--- a/apps/native-multisig-relay/src/lib/multisig-store.ts
+++ b/apps/native-multisig-relay/src/lib/multisig-store.ts
@@ -1,0 +1,63 @@
+import type { Address, Hex } from 'viem'
+
+const KV_PREFIX = 'native-multisig-operation:'
+
+type MultisigConfig = {
+	threshold: number
+	owners: readonly {
+		owner: Address
+		weight: number
+	}[]
+}
+
+type MultisigEntry = {
+	account: Address
+	chainId: number
+	config?: MultisigConfig | undefined
+	createdAt: number
+	genesisConfigId: Hex
+	id: Hex
+	payload: Hex
+	signatures: readonly Hex[]
+	submittedHash?: Hex | undefined
+	transaction: Hex
+	updatedAt: number
+}
+
+type MultisigStore = {
+	delete: (id: Hex) => Promise<void>
+	get: (id: Hex) => Promise<MultisigEntry | undefined>
+	listPendingByAddress: (address: Address) => Promise<readonly MultisigEntry[]>
+	set: (entry: MultisigEntry) => Promise<void>
+}
+
+export function createMultisigStore(kv: KVNamespace): MultisigStore {
+	return {
+		async delete(id) {
+			await kv.delete(key(id))
+		},
+		async get(id) {
+			return (await kv.get<MultisigEntry>(key(id), 'json')) ?? undefined
+		},
+		async listPendingByAddress(address) {
+			const list = await kv.list({ prefix: KV_PREFIX })
+			const entries = await Promise.all(
+				list.keys.map((item) => kv.get<MultisigEntry>(item.name, 'json')),
+			)
+			return entries
+				.filter((entry): entry is MultisigEntry => {
+					if (!entry) return false
+					if (entry.submittedHash) return false
+					return entry.account.toLowerCase() === address.toLowerCase()
+				})
+				.sort((a, b) => a.createdAt - b.createdAt)
+		},
+		async set(entry) {
+			await kv.put(key(entry.id), JSON.stringify(entry))
+		},
+	}
+}
+
+function key(id: Hex) {
+	return `${KV_PREFIX}${id.toLowerCase()}`
+}

--- a/apps/native-multisig-relay/test/e2e.test.ts
+++ b/apps/native-multisig-relay/test/e2e.test.ts
@@ -1,0 +1,168 @@
+import { env, exports } from 'cloudflare:workers'
+import { Mnemonic } from 'ox'
+import { createClient, http, parseUnits } from 'viem'
+import {
+	prepareTransactionRequest,
+	sendTransaction,
+	waitForTransactionReceipt,
+} from 'viem/actions'
+import { Account, Actions } from 'viem/tempo'
+import { beforeAll, describe, expect, it } from 'vitest'
+import {
+	feeToken,
+	multisigRelayTransport,
+	recipient,
+	sponsorAddress,
+	tempoChain,
+	testMnemonic,
+} from './helpers.js'
+
+const supportsNativeMultisig =
+	typeof (Account as unknown as { fromMultisig?: unknown }).fromMultisig ===
+	'function'
+const nativeDescribe = supportsNativeMultisig ? describe : describe.skip
+
+describe('native multisig relay Worker', () => {
+	it('proxies eth_chainId', async () => {
+		const response = await exports.default.fetch(
+			new Request('https://native-multisig-relay.test/', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({
+					jsonrpc: '2.0',
+					id: 1,
+					method: 'eth_chainId',
+				}),
+			}),
+		)
+
+		expect(response.status).toBe(200)
+		const data = (await response.json()) as { result?: string }
+		expect(data.result).toBeDefined()
+	})
+
+	it('does not implement eth_signTransaction server-side', async () => {
+		const response = await exports.default.fetch(
+			new Request('https://native-multisig-relay.test/', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({
+					jsonrpc: '2.0',
+					id: 1,
+					method: 'eth_signTransaction',
+					params: [{ to: recipient.address }],
+				}),
+			}),
+		)
+
+		expect(response.status).toBe(200)
+		const data = (await response.json()) as {
+			error?: { code: number; message?: string; name?: string }
+		}
+		expect(data.error).toBeDefined()
+	})
+})
+
+nativeDescribe('native multisig relay e2e', () => {
+	const sponsorAccount = Account.fromSecp256k1(
+		Mnemonic.toPrivateKey(testMnemonic, {
+			as: 'Hex',
+			path: Mnemonic.path({ account: 0 }),
+		}),
+	)
+	const owner_1 = Account.fromSecp256k1(
+		Mnemonic.toPrivateKey(testMnemonic, {
+			as: 'Hex',
+			path: Mnemonic.path({ account: 1 }),
+		}),
+	)
+	const owner_2 = Account.fromSecp256k1(
+		Mnemonic.toPrivateKey(testMnemonic, {
+			as: 'Hex',
+			path: Mnemonic.path({ account: 2 }),
+		}),
+	)
+	const account = (
+		Account as unknown as {
+			fromMultisig: (config: {
+				threshold: number
+				owners: readonly { owner: `0x${string}`; weight: number }[]
+			}) => ReturnType<typeof Account.fromSecp256k1>
+		}
+	).fromMultisig({
+		threshold: 2,
+		owners: [
+			{ owner: owner_1.address, weight: 1 },
+			{ owner: owner_2.address, weight: 1 },
+		],
+	})
+	const rpc = createClient({
+		account: sponsorAccount,
+		chain: tempoChain,
+		transport: http(env.TEMPO_RPC_URL),
+	})
+	const client = createClient({
+		account,
+		chain: tempoChain,
+		transport: multisigRelayTransport('/'),
+	})
+
+	beforeAll(async () => {
+		await Actions.token.transferSync(rpc, {
+			account: sponsorAccount,
+			amount: parseUnits('10', 6),
+			feeToken,
+			nonceKey: 'native-multisig-relay-e2e',
+			to: account.address,
+			token: feeToken,
+		})
+	})
+
+	it('collects approvals in KV and broadcasts at quorum', async () => {
+		const request = {
+			...(await prepareTransactionRequest(client, {
+				account,
+				calls: [
+					{
+						to: recipient.address,
+						value: 0n,
+					},
+				],
+				feeToken,
+			} as never)),
+			gas: 650_000n,
+		}
+		const signature_1 = await owner_1.signTransaction({
+			...request,
+			account: owner_1,
+		} as never)
+		const signature_2 = await owner_2.signTransaction({
+			...request,
+			account: owner_2,
+		} as never)
+		const id = await sendTransaction(client, {
+			...request,
+			signatures: [signature_1],
+		} as never)
+		const pendingReceipt = await client.request({
+			method: 'eth_getTransactionReceipt',
+			params: [id],
+		})
+
+		expect(id).toMatch(/^0x[a-fA-F0-9]{64}$/)
+		expect(pendingReceipt).toBeNull()
+
+		const hash = await sendTransaction(client, {
+			...request,
+			signatures: [signature_2],
+		} as never)
+		const receipt = await waitForTransactionReceipt(rpc, { hash })
+
+		expect(receipt.transactionHash).toBe(hash)
+		expect(receipt.from.toLowerCase()).toBe(account.address.toLowerCase())
+		expect(
+			(receipt as { feePayer?: string | undefined }).feePayer?.toLowerCase(),
+		).toBe(sponsorAddress.toLowerCase())
+		expect(receipt.status).toBe('success')
+	})
+})

--- a/apps/native-multisig-relay/test/helpers.ts
+++ b/apps/native-multisig-relay/test/helpers.ts
@@ -1,0 +1,53 @@
+import { env, exports } from 'cloudflare:workers'
+import { Mnemonic } from 'ox'
+import { custom } from 'viem'
+import { tempo, tempoDevnet, tempoLocalnet, tempoModerato } from 'viem/chains'
+import { Account } from 'viem/tempo'
+
+export const tempoChain = (() => {
+	const e = env.TEMPO_ENV ?? 'localnet'
+	if (e === 'moderato' || e === 'testnet') return tempoModerato
+	if (e === 'mainnet') return tempo
+	if (e === 'devnet') return tempoDevnet
+	return tempoLocalnet
+})()
+
+export const testMnemonic =
+	'test test test test test test test test test test test junk'
+
+export const feeToken = '0x20c0000000000000000000000000000000000000'
+
+export const sponsorAddress = '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266'
+
+export const recipient = Account.fromSecp256k1(
+	Mnemonic.toPrivateKey(testMnemonic, {
+		as: 'Hex',
+		path: Mnemonic.path({ account: 9 }),
+	}),
+)
+
+export function multisigRelayTransport(path: string) {
+	return custom({
+		async request({ method, params }) {
+			const response = await exports.default.fetch(
+				new Request(`https://native-multisig-relay.test${path}`, {
+					method: 'POST',
+					headers: { 'Content-Type': 'application/json' },
+					body: JSON.stringify({ jsonrpc: '2.0', id: 1, method, params }),
+				}),
+			)
+			const data = (await response.json()) as {
+				result?: unknown
+				error?: string | { code?: number; message?: string }
+			}
+			if (data.error) {
+				const message =
+					typeof data.error === 'string'
+						? data.error
+						: (data.error.message ?? JSON.stringify(data.error))
+				throw new Error(message)
+			}
+			return data.result
+		},
+	})
+}

--- a/apps/native-multisig-relay/test/prool.ts
+++ b/apps/native-multisig-relay/test/prool.ts
@@ -1,0 +1,27 @@
+import { Instance, Server } from 'prool'
+import * as TestContainers from 'prool/testcontainers'
+
+export const port = 9655
+
+function isBinaryPath(value: string) {
+	return (
+		value.startsWith('/') || value.startsWith('./') || value.startsWith('../')
+	)
+}
+
+export async function createServer(tag = 'latest') {
+	return Server.create({
+		instance: isBinaryPath(tag)
+			? Instance.tempo({
+					binary: tag,
+					blockTime: '2ms',
+					port,
+				})
+			: TestContainers.Instance.tempo({
+					blockTime: '2ms',
+					port,
+					image: `ghcr.io/tempoxyz/tempo:${tag}`,
+				}),
+		port,
+	})
+}

--- a/apps/native-multisig-relay/test/setup.global.ts
+++ b/apps/native-multisig-relay/test/setup.global.ts
@@ -1,0 +1,52 @@
+import { existsSync } from 'node:fs'
+import { createPublicClient, http } from 'viem'
+import { tempoModerato } from 'viem/chains'
+import { createServer, port } from './prool.js'
+
+async function getCurrentTempoModeratoTag(): Promise<string> {
+	const client = createPublicClient({
+		chain: tempoModerato,
+		transport: http(),
+	})
+	const clientVersion = await client.request({ method: 'web3_clientVersion' })
+	const sha = clientVersion.split('/')[1]?.split('-').pop()
+	if (!sha) throw new Error(`Unexpected web3_clientVersion: ${clientVersion}`)
+	return `sha-${sha}`
+}
+
+async function waitForTempo(maxRetries = 10, delayMs = 500): Promise<void> {
+	const url = `http://localhost:${port}/1`
+	for (let i = 0; i < maxRetries; i++) {
+		try {
+			const response = await fetch(url, {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({
+					jsonrpc: '2.0',
+					id: 1,
+					method: 'web3_clientVersion',
+				}),
+			})
+			if (response.ok) return
+		} catch {
+			// Retry until Prool finishes binding the RPC port.
+		}
+		await new Promise((r) => setTimeout(r, delayMs))
+	}
+	throw new Error(`Tempo not responding at ${url} after ${maxRetries} retries.`)
+}
+
+export default async function globalSetup() {
+	if ((process.env.TEMPO_ENV ?? 'localnet') !== 'localnet') return
+
+	const localBinary = `${process.env.HOME}/github/tempoxyz/tempo/target/debug/tempo`
+	const tag =
+		process.env.TEMPO_TAG ??
+		(existsSync(localBinary) ? localBinary : await getCurrentTempoModeratoTag())
+
+	console.log('[globalSetup] Starting Tempo localnet via Prool...', { tag })
+	const server = await createServer(tag)
+	const teardown = await server.start()
+	await waitForTempo()
+	return teardown
+}

--- a/apps/native-multisig-relay/tsconfig.json
+++ b/apps/native-multisig-relay/tsconfig.json
@@ -1,0 +1,31 @@
+{
+	"compilerOptions": {
+		"target": "ES2024",
+		"module": "ESNext",
+		"lib": ["ES2024"],
+		"types": ["@cloudflare/workers-types", "node", "vite/client"],
+		"moduleResolution": "bundler",
+		"noEmit": true,
+		"strict": true,
+		"skipLibCheck": true,
+		"esModuleInterop": true,
+		"resolveJsonModule": true,
+		"allowSyntheticDefaultImports": true,
+		"forceConsistentCasingInFileNames": true,
+		"allowJs": true,
+		"checkJs": false,
+		"allowImportingTsExtensions": true,
+		"resolvePackageJsonImports": true,
+		"resolvePackageJsonExports": true,
+		"useUnknownInCatchVariables": true,
+		"noUncheckedIndexedAccess": true,
+		"paths": {
+			"#*": ["./src/*"],
+			"#package.json": ["./package.json"],
+			"#wrangler.json": ["./wrangler.json"]
+		}
+	},
+	"files": ["env.d.ts", "worker-configuration.d.ts", "vite.config.ts"],
+	"include": ["src/**/*.ts"],
+	"exclude": ["node_modules", "dist", "**/*.test.ts"]
+}

--- a/apps/native-multisig-relay/vite.config.ts
+++ b/apps/native-multisig-relay/vite.config.ts
@@ -1,0 +1,20 @@
+import { cloudflare } from '@cloudflare/vite-plugin'
+import { defineConfig } from 'vite'
+import { accountsAliases } from './config/accounts-aliases.js'
+
+export default defineConfig({
+	resolve: {
+		alias: accountsAliases(),
+		tsconfigPaths: true,
+	},
+	define: {
+		__BUILD_VERSION__: JSON.stringify(
+			(
+				process.env.CF_PAGES_COMMIT_SHA ??
+				process.env.GITHUB_SHA ??
+				Date.now().toString()
+			).slice(0, 8),
+		),
+	},
+	plugins: [cloudflare()],
+})

--- a/apps/native-multisig-relay/vitest.config.ts
+++ b/apps/native-multisig-relay/vitest.config.ts
@@ -1,0 +1,71 @@
+import 'dotenv/config'
+import { join } from 'node:path'
+import { Mnemonic } from 'ox'
+import { defineConfig } from 'vitest/config'
+import { cloudflareTest } from '@cloudflare/vitest-pool-workers'
+
+import wranglerJSON from '#wrangler.json' with { type: 'json' }
+import { accountsAliases } from './config/accounts-aliases.js'
+
+const tempoEnv = (() => {
+	const raw = process.env.TEMPO_ENV
+	if (raw === 'testnet') return 'moderato'
+	if (raw) return raw
+	if (process.env.TEMPO_RPC_URL) return 'moderato'
+	return 'localnet'
+})()
+
+const testMnemonic =
+	'test test test test test test test test test test test junk'
+const sponsorPrivateKey = Mnemonic.toPrivateKey(testMnemonic, {
+	as: 'Hex',
+	path: Mnemonic.path({ account: 0 }),
+})
+
+const rpcUrl = (() => {
+	if (process.env.TEMPO_RPC_URL) return process.env.TEMPO_RPC_URL
+	if (tempoEnv === 'mainnet') return 'https://rpc.mainnet.tempo.xyz'
+	if (tempoEnv === 'moderato') return 'https://rpc.moderato.tempo.xyz'
+	if (tempoEnv === 'devnet') return 'https://rpc.devnet.tempoxyz.dev'
+	const poolId = Number(process.env.VITEST_POOL_ID ?? 1)
+	return `http://localhost:9655/${poolId}`
+})()
+
+export default defineConfig({
+	resolve: {
+		alias: accountsAliases(),
+		tsconfigPaths: true,
+	},
+	test: {
+		testTimeout: 60_000,
+		include: ['test/**/*.test.ts'],
+		globalSetup: [join(import.meta.dirname, './test/setup.global.ts')],
+	},
+	plugins: [
+		cloudflareTest({
+			wrangler: {
+				configPath: './wrangler.json',
+			},
+			miniflare: {
+				compatibilityFlags: [
+					...wranglerJSON.compatibility_flags,
+					'enable_nodejs_fs_module',
+					'enable_nodejs_v8_module',
+					'enable_nodejs_tty_module',
+					'enable_nodejs_process_v2',
+					'enable_nodejs_http_modules',
+					'enable_nodejs_perf_hooks_module',
+				],
+				bindings: {
+					ALLOWED_ORIGINS: '*',
+					SPONSOR_NAME: 'Tempo Multisig Relay Test',
+					SPONSOR_PRIVATE_KEY: sponsorPrivateKey,
+					SPONSOR_URL: 'https://native-multisig-relay.test',
+					TEMPO_ENV: tempoEnv,
+					TEMPO_RPC_URL: rpcUrl,
+				},
+				kvNamespaces: ['MultisigOperationStore'],
+			},
+		}),
+	],
+})

--- a/apps/native-multisig-relay/wrangler.json
+++ b/apps/native-multisig-relay/wrangler.json
@@ -1,0 +1,32 @@
+{
+	"$schema": "https://esm.sh/wrangler/config-schema.json",
+	"name": "native-multisig-relay",
+	"compatibility_date": "2025-12-17",
+	"compatibility_flags": ["nodejs_compat"],
+	"main": "./src/index.ts",
+	"workers_dev": true,
+	"preview_urls": true,
+	"keep_vars": true,
+	"vars": {
+		"TEMPO_RPC_URL": "https://rpc.moderato.tempo.xyz",
+		"ALLOWED_ORIGINS": "*",
+		"TEMPO_ENV": "moderato",
+		"SPONSOR_NAME": "Tempo Multisig Relay",
+		"SPONSOR_URL": "https://multisig-relay.tempo.xyz"
+	},
+	"kv_namespaces": [
+		{
+			"binding": "MultisigOperationStore",
+			"id": "PLACEHOLDER_KV_NAMESPACE_ID"
+		}
+	],
+	"observability": {
+		"enabled": true,
+		"logs": {
+			"enabled": true,
+			"head_sampling_rate": 1,
+			"invocation_logs": true,
+			"persist": true
+		}
+	}
+}

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
 		"build": "pnpm --recursive --parallel --stream --reporter='append-only' build",
 		"deploy": "pnpm --recursive --parallel --stream --reporter='append-only' deploy",
 		"dev:explorer": "pnpm --filter explorer dev",
+		"dev:multisig-relay": "pnpm --filter native-multisig-relay dev",
 		"dev:sponsor": "pnpm --filter fee-payer dev",
 		"check": "pnpm --recursive --parallel --stream --reporter='append-only' check:biome",
 		"postcheck": "pnpm check:types",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -721,6 +721,55 @@ importers:
         specifier: 'catalog:'
         version: 4.95.0(@cloudflare/workers-types@4.20260531.1)(bufferutil@4.1.0)(utf-8-validate@5.0.10)
 
+  apps/native-multisig-relay:
+    dependencies:
+      accounts:
+        specifier: 'catalog:'
+        version: 0.14.6(@types/react@19.2.14)(@wagmi/core@3.4.8)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.52.0(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6))(wagmi@3.6.9)
+      hono:
+        specifier: 'catalog:'
+        version: 4.12.14
+      viem:
+        specifier: 'catalog:'
+        version: 2.52.0(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6)
+    devDependencies:
+      '@cloudflare/vite-plugin':
+        specifier: 'catalog:'
+        version: 1.30.3(patch_hash=e06eefb6e9635561829ac5e497cea44db1c8cfe738d2336f3f1de75842284333)(bufferutil@4.1.0)(utf-8-validate@5.0.10)(vite@8.0.7(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))(workerd@1.20260526.1)(wrangler@4.95.0(@cloudflare/workers-types@4.20260531.1)(bufferutil@4.1.0)(utf-8-validate@5.0.10))
+      '@cloudflare/vitest-pool-workers':
+        specifier: 'catalog:'
+        version: 0.13.5(@cloudflare/workers-types@4.20260531.1)(@vitest/runner@4.1.0)(@vitest/snapshot@4.1.0)(bufferutil@4.1.0)(utf-8-validate@5.0.10)(vitest@4.1.0)
+      '@cloudflare/workers-types':
+        specifier: 'catalog:'
+        version: 4.20260531.1
+      '@types/node':
+        specifier: 'catalog:'
+        version: 25.5.2
+      dotenv:
+        specifier: 'catalog:'
+        version: 17.3.1
+      ox:
+        specifier: 'catalog:'
+        version: 0.14.20(typescript@6.0.2)(zod@4.3.6)
+      prool:
+        specifier: 'catalog:'
+        version: 0.2.4(testcontainers@11.13.0)
+      testcontainers:
+        specifier: 'catalog:'
+        version: 11.13.0
+      typescript:
+        specifier: 'catalog:'
+        version: 6.0.2
+      vite:
+        specifier: 'catalog:'
+        version: 8.0.7(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(@vitest/ui@4.1.0)(vite@8.0.7(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
+      wrangler:
+        specifier: 'catalog:'
+        version: 4.95.0(@cloudflare/workers-types@4.20260531.1)(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+
   apps/og:
     dependencies:
       '@hono/zod-validator':


### PR DESCRIPTION
## Summary
- adds a standalone `apps/native-multisig-relay` Cloudflare Worker for Tempo native multisig approvals
- backs pending multisig operations with a dedicated KV namespace and optional configured sponsorship
- adds a Prool/Miniflare e2e script that runs against the local accounts checkout and local Tempo binary when available

## Notes
- this is intentionally separate from `apps/fee-payer`
- the e2e path currently depends on tempoxyz/accounts#613 for native multisig relay support and the fee-payer signature normalization fix pushed there

## Validation
- `node_modules/.bin/biome check --write apps/native-multisig-relay/test/helpers.ts apps/native-multisig-relay/test/e2e.test.ts apps/native-multisig-relay/src apps/native-multisig-relay/*.ts apps/native-multisig-relay/scripts/test-e2e.sh`
- `node_modules/.bin/tsgo --project apps/native-multisig-relay/tsconfig.json --noEmit`
- `apps/native-multisig-relay/scripts/test-e2e.sh`
