### PR TITLE
feat(explorer): add network badge switcher

### DIFF
--- a/apps/explorer/src/comps/ConnectWallet.tsx
+++ b/apps/explorer/src/comps/ConnectWallet.tsx
@@ -60,6 +60,7 @@ function ConnectWalletInner({
 	const chains = useChains()
 	const switchChain = useSwitchChain()
 	const isSupported = chains.some((c) => c.id === chain?.id)
+	const blockExplorerUrl = chains[0].blockExplorers?.default.url
 
 	const hasConnectorOptions = injectedConnectors.length > 0
 
@@ -140,7 +141,9 @@ function ConnectWalletInner({
 						switchChain.mutate({
 							chainId: chains[0].id,
 							addEthereumChainParameter: {
-								blockExplorerUrls: ['https://explore.tempo.xyz'],
+								...(blockExplorerUrl
+									? { blockExplorerUrls: [blockExplorerUrl] }
+									: {}),
 								nativeCurrency: { name: 'USD', decimals: 18, symbol: 'USD' },
 							},
 						})

--- a/apps/explorer/src/comps/Header.tsx
+++ b/apps/explorer/src/comps/Header.tsx
@@ -8,19 +8,17 @@ import * as React from 'react'
 import { ExploreInput } from '#comps/ExploreInput'
 import { useAnimatedBlockNumber, useLiveBlockNumber } from '#lib/block-number'
 import { cx } from '#lib/css'
-import { getTempoEnv, isTestnet } from '#lib/env'
+import { type TempoEnv, getTempoEnv, isTestnet } from '#lib/env'
+import {
+	buildExplorerNetworkHref,
+	EXPLORER_NETWORK_OPTIONS,
+	getActiveExplorerNetworkOption,
+} from '#lib/explorer-network'
+import ChevronDownIcon from '~icons/lucide/chevron-down'
 import SquareSquare from '~icons/lucide/square-square'
 
 export function Header(): React.JSX.Element {
 	const tempoEnv = getTempoEnv()
-	const networkBadgeLabel =
-		tempoEnv === 'mainnet'
-			? null
-			: tempoEnv === 'nextfork'
-				? 'Nextfork'
-				: tempoEnv === 'devnet'
-					? 'Devnet'
-					: 'Testnet'
 
 	return (
 		<header className="@container relative z-1">
@@ -31,10 +29,8 @@ export function Header(): React.JSX.Element {
 						className="flex items-center gap-[12px] press-down py-[4px]"
 					>
 						<Header.TempoWordmark />
-						{networkBadgeLabel && (
-							<Header.NetworkBadge label={networkBadgeLabel} />
-						)}
 					</Link>
+					<Header.NetworkBadge tempoEnv={tempoEnv} />
 				</div>
 				<Header.Search />
 				<div className="relative z-1 print:hidden flex items-center gap-[8px]">
@@ -163,6 +159,100 @@ export namespace Header {
 		)
 	}
 
+	export function NetworkBadge(props: NetworkBadge.Props): React.JSX.Element {
+		const { tempoEnv } = props
+		const [isOpen, setIsOpen] = React.useState(false)
+		const menuId = React.useId()
+		const rootRef = React.useRef<HTMLDivElement>(null)
+		const activeOption = getActiveExplorerNetworkOption(tempoEnv)
+		const currentPath = useRouterState({
+			select: (state) => {
+				const location = state.resolvedLocation ?? state.location
+				const hash = location.hash ? `#${location.hash.replace(/^#/, '')}` : ''
+				return `${location.pathname}${location.searchStr}${hash}`
+			},
+		})
+
+		React.useEffect(() => {
+			if (!isOpen) return
+
+			function handlePointerDown(event: PointerEvent) {
+				if (!rootRef.current?.contains(event.target as Node)) setIsOpen(false)
+			}
+
+			function handleKeyDown(event: KeyboardEvent) {
+				if (event.key === 'Escape') setIsOpen(false)
+			}
+
+			window.addEventListener('pointerdown', handlePointerDown)
+			window.addEventListener('keydown', handleKeyDown)
+
+			return () => {
+				window.removeEventListener('pointerdown', handlePointerDown)
+				window.removeEventListener('keydown', handleKeyDown)
+			}
+		}, [isOpen])
+
+		return (
+			<div ref={rootRef} className="relative">
+				<button
+					type="button"
+					aria-controls={isOpen ? menuId : undefined}
+					aria-expanded={isOpen}
+					aria-haspopup="menu"
+					className="flex h-[28px] shrink-0 items-center justify-center gap-[5px] rounded-[8px] border border-[#2C2C2F] bg-[#1A1A1A] px-[8px] py-[4px] text-[14px] font-medium leading-[140%] text-secondary transition-colors hover:border-accent hover:text-primary focus-visible:outline-none press-down"
+					title={`Network: ${activeOption.label}`}
+					onClick={() => setIsOpen((value) => !value)}
+				>
+					<Header.NetworkStatusDot className={activeOption.dotClassName} />
+					<span>{activeOption.label}</span>
+					<ChevronDownIcon
+						className={cx(
+							'size-[12px] text-tertiary transition-transform duration-100',
+							isOpen && 'rotate-180',
+						)}
+					/>
+				</button>
+				{isOpen && (
+					<div
+						id={menuId}
+						role="menu"
+						aria-label="Tempo network"
+						className="absolute left-0 top-[calc(100%+8px)] z-50 w-[156px] overflow-hidden rounded-[10px] border border-base-border bg-base-background/95 p-[4px] shadow-[0_16px_40px_rgba(0,0,0,0.35)] backdrop-blur"
+					>
+						{EXPLORER_NETWORK_OPTIONS.map((option) => {
+							const isActive = option.env === activeOption.env
+
+							return (
+								<a
+									key={option.env}
+									href={buildExplorerNetworkHref(option.host, currentPath)}
+									role="menuitemradio"
+									aria-checked={isActive}
+									aria-current={isActive ? 'page' : undefined}
+									className={cx(
+										'flex items-center gap-[8px] rounded-[7px] px-[10px] py-[9px] text-[13px] font-medium text-secondary transition-colors hover:bg-surface hover:text-primary focus-visible:outline-none',
+										isActive && 'bg-surface text-primary',
+									)}
+									onClick={() => setIsOpen(false)}
+								>
+									<Header.NetworkStatusDot className={option.dotClassName} />
+									<span>{option.label}</span>
+								</a>
+							)
+						})}
+					</div>
+				)}
+			</div>
+		)
+	}
+
+	export namespace NetworkBadge {
+		export interface Props {
+			tempoEnv: TempoEnv
+		}
+	}
+
 	export function BlockNumber(props: BlockNumber.Props) {
 		const { initial, className } = props
 		const resolvedPathname = useRouterState({
@@ -232,20 +322,31 @@ export namespace Header {
 		}
 	}
 
-	export function NetworkBadge(props: NetworkBadge.Props) {
-		const { label } = props
-
+	export function NetworkStatusDot(
+		props: NetworkStatusDot.Props,
+	): React.JSX.Element {
+		const { className } = props
 		return (
-			<span className="flex h-[28px] shrink-0 items-center justify-center gap-[4px] rounded-[8px] border border-[#2C2C2F] bg-[#1A1A1A] px-[8px] py-[4px] text-[14px] font-medium leading-[140%] text-secondary">
-				<span aria-hidden className="size-[6px] rounded-full bg-amber-400" />
-				{label}
+			<span aria-hidden className="relative flex size-[6px] shrink-0">
+				<span
+					className={cx(
+						'absolute inline-flex size-full animate-ping rounded-full opacity-60',
+						className,
+					)}
+				/>
+				<span
+					className={cx(
+						'relative inline-flex size-[6px] rounded-full',
+						className,
+					)}
+				/>
 			</span>
 		)
 	}
 
-	export namespace NetworkBadge {
+	export namespace NetworkStatusDot {
 		export interface Props {
-			label: 'Devnet' | 'Nextfork' | 'Testnet'
+			className: string
 		}
 	}
 }

--- a/apps/explorer/src/lib/explorer-network.ts
+++ b/apps/explorer/src/lib/explorer-network.ts
@@ -1,0 +1,31 @@
+import type { TempoEnv } from './env'
+
+export const EXPLORER_NETWORK_OPTIONS = [
+	{
+		env: 'mainnet',
+		label: 'Mainnet',
+		host: 'https://explore.tempo.xyz',
+		dotClassName: 'bg-positive',
+	},
+	{
+		env: 'testnet',
+		label: 'Testnet',
+		host: 'https://explore.testnet.tempo.xyz',
+		dotClassName: 'bg-amber-400',
+	},
+] as const
+
+export function getActiveExplorerNetworkOption(tempoEnv: TempoEnv) {
+	if (tempoEnv === 'mainnet') return EXPLORER_NETWORK_OPTIONS[0]
+	if (tempoEnv === 'testnet') return EXPLORER_NETWORK_OPTIONS[1]
+
+	return {
+		env: tempoEnv,
+		label: tempoEnv === 'nextfork' ? 'Nextfork' : 'Devnet',
+		dotClassName: 'bg-amber-400',
+	}
+}
+
+export function buildExplorerNetworkHref(host: string, path: string): string {
+	return `${host}${path.startsWith('/') ? path : `/${path}`}`
+}

--- a/apps/explorer/test/explorer-network.test.ts
+++ b/apps/explorer/test/explorer-network.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import {
+	buildExplorerNetworkHref,
+	EXPLORER_NETWORK_OPTIONS,
+} from '#lib/explorer-network.ts'
+
+const MAINNET_HOST = 'https://explore.tempo.xyz'
+const TESTNET_HOST = 'https://explore.testnet.tempo.xyz'
+
+const SAMPLE_HASH =
+	'0x0000000000000000000000000000000000000000000000000000000000000000'
+const SAMPLE_ADDRESS = '0x20c0000000000000000000000000000000000000'
+
+describe('explorer network switcher hrefs', () => {
+	it('uses the canonical mainnet and testnet explorer hosts', () => {
+		expect(EXPLORER_NETWORK_OPTIONS).toEqual([
+			expect.objectContaining({ env: 'mainnet', host: MAINNET_HOST }),
+			expect.objectContaining({ env: 'testnet', host: TESTNET_HOST }),
+		])
+	})
+
+	it.each([
+		['transaction', `/tx/${SAMPLE_HASH}`],
+		['receipt', `/receipt/${SAMPLE_HASH}`],
+		['block', '/block/123456?page=2'],
+		['address', `/address/${SAMPLE_ADDRESS}?tab=tokens&page=3`],
+		['token compatibility route', `/token/${SAMPLE_ADDRESS}?tab=holders`],
+		['fee amm route with hash', '/fee-amm#pools'],
+	])('preserves the %s resource path when switching networks', (_, path) => {
+		expect(buildExplorerNetworkHref(MAINNET_HOST, path)).toBe(
+			`${MAINNET_HOST}${path}`,
+		)
+		expect(buildExplorerNetworkHref(TESTNET_HOST, path)).toBe(
+			`${TESTNET_HOST}${path}`,
+		)
+	})
+
+	it('normalizes a path without a leading slash', () => {
+		expect(buildExplorerNetworkHref(TESTNET_HOST, 'blocks')).toBe(
+			`${TESTNET_HOST}/blocks`,
+		)
+	})
+})


### PR DESCRIPTION
## Summary
- Add the logo-adjacent Mainnet/Testnet badge dropdown.
- Preserve the current resource path, query, and hash when switching both directions.
- Use the active chain's explorer URL in wallet add-chain metadata.
- Add regression coverage for network-switcher resource hrefs.

## Previews
- Mainnet: https://6e5e20ae-explorer-mainnet.porto.workers.dev
- Testnet: https://2158fb86-explorer-testnet.porto.workers.dev

## Screenshots
| Mainnet -> Testnet | Testnet -> Mainnet |
| --- | --- |
| ![Mainnet dropdown](https://raw.githubusercontent.com/tempoxyz/tempo-apps/parv/pr-1055-network-switcher-screenshots/screenshots/pr-1055/tempo-explorer-mainnet-dropdown.png) | ![Testnet dropdown](https://raw.githubusercontent.com/tempoxyz/tempo-apps/parv/pr-1055-network-switcher-screenshots/screenshots/pr-1055/tempo-explorer-testnet-dropdown.png) |

## Validation
- `pnpm exec biome check src/comps/Header.tsx src/comps/ConnectWallet.tsx src/lib/explorer-network.ts test/explorer-network.test.ts`
- `pnpm --filter explorer exec vitest run test/explorer-network.test.ts`
- `pnpm exec tsc --project test/tsconfig.json --noEmit`
- `pnpm --filter explorer check:types`
- `pnpm --filter explorer build`
- Browser verified tx, receipt, block, countdown, address/wallet, token redirect, tokens, and fee AMM routes on both local mainnet and testnet builds; actual click-through passed mainnet -> testnet and testnet -> mainnet.
- GitHub Pull Request workflow passed on `d77c449`, including explorer preview deployments and deployment-table posting.
- Local full-repo `pnpm check` was attempted, but hit unrelated fee-payer Biome warnings and og Env type-generation drift; explorer-focused checks and GitHub Verify / Checks passed.
- Existing issue: `pnpm --filter explorer check:types:test` points to missing `tsconfig.test.json`; direct `test/tsconfig.json` typecheck passes.
