### PR TITLE
fix(explorer): link not-found network switches home

### DIFF
--- a/apps/explorer/src/comps/Header.tsx
+++ b/apps/explorer/src/comps/Header.tsx
@@ -14,6 +14,7 @@ import {
 	EXPLORER_NETWORK_OPTIONS,
 	getActiveExplorerNetworkOption,
 } from '#lib/explorer-network'
+import { useIsNotFoundPage } from '#lib/not-found'
 import ChevronDownIcon from '~icons/lucide/chevron-down'
 import SquareSquare from '~icons/lucide/square-square'
 
@@ -165,6 +166,7 @@ export namespace Header {
 		const menuId = React.useId()
 		const rootRef = React.useRef<HTMLDivElement>(null)
 		const activeOption = getActiveExplorerNetworkOption(tempoEnv)
+		const isNotFoundPage = useIsNotFoundPage()
 		const currentPath = useRouterState({
 			select: (state) => {
 				const location = state.resolvedLocation ?? state.location
@@ -226,7 +228,9 @@ export namespace Header {
 							return (
 								<a
 									key={option.env}
-									href={buildExplorerNetworkHref(option.host, currentPath)}
+									href={buildExplorerNetworkHref(option.host, currentPath, {
+										fallbackToHome: isNotFoundPage,
+									})}
 									role="menuitemradio"
 									aria-checked={isActive}
 									aria-current={isActive ? 'page' : undefined}

--- a/apps/explorer/src/comps/Layout.tsx
+++ b/apps/explorer/src/comps/Layout.tsx
@@ -3,6 +3,7 @@ import { Footer } from '#comps/Footer'
 import { Header } from '#comps/Header'
 import { Sphere } from '#comps/Sphere'
 import { BlockNumberProvider } from '#lib/block-number'
+import { NotFoundProvider } from '#lib/not-found'
 import { useMatchRoute, useRouterState } from '@tanstack/react-router'
 
 export function Layout(props: Layout.Props) {
@@ -14,21 +15,23 @@ export function Layout(props: Layout.Props) {
 			(state.resolvedLocation?.pathname ?? state.location.pathname) === '/',
 	})
 	return (
-		<BlockNumberProvider>
-			<div className="flex min-h-dvh flex-col print:block print:min-h-0">
-				<div className={`relative z-2 ${isReceipt ? 'print:hidden' : ''}`}>
-					<Header />
+		<NotFoundProvider>
+			<BlockNumberProvider>
+				<div className="flex min-h-dvh flex-col print:block print:min-h-0">
+					<div className={`relative z-2 ${isReceipt ? 'print:hidden' : ''}`}>
+						<Header />
+					</div>
+					<main className="flex flex-1 size-full flex-col items-center relative z-1 print:block print:flex-none">
+						<BreadcrumbsPortal />
+						{children}
+					</main>
+					<div className="w-full mt-6 relative z-1 print:hidden">
+						<Footer />
+					</div>
+					{isLanding && <Sphere />}
 				</div>
-				<main className="flex flex-1 size-full flex-col items-center relative z-1 print:block print:flex-none">
-					<BreadcrumbsPortal />
-					{children}
-				</main>
-				<div className="w-full mt-6 relative z-1 print:hidden">
-					<Footer />
-				</div>
-				{isLanding && <Sphere />}
-			</div>
-		</BlockNumberProvider>
+			</BlockNumberProvider>
+		</NotFoundProvider>
 	)
 }
 

--- a/apps/explorer/src/comps/NotFound.tsx
+++ b/apps/explorer/src/comps/NotFound.tsx
@@ -1,12 +1,15 @@
 import { Link } from '@tanstack/react-router'
 import type { Hex } from 'ox'
 import { apostrophe } from '#lib/chars'
+import { useMarkNotFoundPage } from '#lib/not-found'
 
 export function NotFound({
 	title = 'Page Not Found',
 	message = `The page you${apostrophe}re looking for doesn${apostrophe}t exist or has been moved.`,
 	data,
 }: NotFound.Props) {
+	useMarkNotFoundPage()
+
 	return (
 		<section className="flex flex-1 size-full items-center justify-center relative pt-[80px]">
 			<div className="flex flex-col items-center gap-[8px] z-1 px-[16px] w-full max-w-[600px]">

--- a/apps/explorer/src/lib/explorer-network.ts
+++ b/apps/explorer/src/lib/explorer-network.ts
@@ -26,6 +26,17 @@ export function getActiveExplorerNetworkOption(tempoEnv: TempoEnv) {
 	}
 }
 
-export function buildExplorerNetworkHref(host: string, path: string): string {
-	return `${host}${path.startsWith('/') ? path : `/${path}`}`
+export function buildExplorerNetworkHref(
+	host: string,
+	path: string,
+	options?: buildExplorerNetworkHref.Options,
+): string {
+	const targetPath = options?.fallbackToHome ? '/' : path
+	return `${host}${targetPath.startsWith('/') ? targetPath : `/${targetPath}`}`
+}
+
+export namespace buildExplorerNetworkHref {
+	export interface Options {
+		fallbackToHome?: boolean
+	}
 }

--- a/apps/explorer/src/lib/not-found.tsx
+++ b/apps/explorer/src/lib/not-found.tsx
@@ -1,0 +1,51 @@
+import * as React from 'react'
+
+type NotFoundContextValue = {
+	isNotFoundPage: boolean
+	setIsNotFoundPage: React.Dispatch<React.SetStateAction<boolean>>
+}
+
+const NotFoundContext = React.createContext<NotFoundContextValue>({
+	isNotFoundPage: false,
+	setIsNotFoundPage: () => {},
+})
+
+export function NotFoundProvider(
+	props: NotFoundProvider.Props,
+): React.JSX.Element {
+	const { children } = props
+	const [isNotFoundPage, setIsNotFoundPage] = React.useState(false)
+	const value = React.useMemo<NotFoundContextValue>(
+		() => ({
+			isNotFoundPage,
+			setIsNotFoundPage,
+		}),
+		[isNotFoundPage],
+	)
+
+	return (
+		<NotFoundContext.Provider value={value}>
+			{children}
+		</NotFoundContext.Provider>
+	)
+}
+
+export namespace NotFoundProvider {
+	export interface Props {
+		children: React.ReactNode
+	}
+}
+
+export function useIsNotFoundPage(): boolean {
+	return React.useContext(NotFoundContext).isNotFoundPage
+}
+
+export function useMarkNotFoundPage(): void {
+	const { setIsNotFoundPage } = React.useContext(NotFoundContext)
+
+	React.useEffect(() => {
+		setIsNotFoundPage(true)
+
+		return () => setIsNotFoundPage(false)
+	}, [setIsNotFoundPage])
+}

--- a/apps/explorer/test/explorer-network.test.ts
+++ b/apps/explorer/test/explorer-network.test.ts
@@ -40,4 +40,21 @@ describe('explorer network switcher hrefs', () => {
 			`${TESTNET_HOST}/blocks`,
 		)
 	})
+
+	it('links to the target network homepage from not-found pages', () => {
+		expect(
+			buildExplorerNetworkHref(TESTNET_HOST, `/receipt/${SAMPLE_HASH}`, {
+				fallbackToHome: true,
+			}),
+		).toBe(`${TESTNET_HOST}/`)
+		expect(
+			buildExplorerNetworkHref(
+				MAINNET_HOST,
+				`/tx/${SAMPLE_HASH}?tab=logs#top`,
+				{
+					fallbackToHome: true,
+				},
+			),
+		).toBe(`${MAINNET_HOST}/`)
+	})
 })


### PR DESCRIPTION
## Summary
- Route Mainnet/Testnet dropdown links to the target network homepage when the current explorer page is rendering NotFound.
- Preserve the existing path/query/hash behavior for normal explorer pages.
- Add coverage for the not-found homepage fallback.

## Validation
- Live repro: mainnet receipt `0x334d04f62d5e48cee0171396adc95b7f36cef999f95be9e96c5ee42877a057e5` switched to testnet and rendered Page Not Found.
- Browser verified locally: a missing receipt page links Testnet to `https://explore.testnet.tempo.xyz/`.
- Browser verified locally: `/tokens?page=2#top` still links Testnet to `https://explore.testnet.tempo.xyz/tokens?page=2#top`.
- `pnpm exec biome check src/comps/Header.tsx src/comps/Layout.tsx src/comps/NotFound.tsx src/lib/not-found.tsx src/lib/explorer-network.ts test/explorer-network.test.ts`
- `pnpm --filter explorer exec vitest run test/explorer-network.test.ts`
- `pnpm --filter explorer check:types`
- `pnpm --filter explorer build`
