### PR TITLE
fix(explorer): keep network menu above mobile search

### DIFF
--- a/apps/explorer/src/comps/Header.tsx
+++ b/apps/explorer/src/comps/Header.tsx
@@ -22,7 +22,7 @@ export function Header(): React.JSX.Element {
 
 	return (
 		<header className="@container relative z-1">
-			<div className="px-[24px] @min-[1240px]:pt-[48px] @min-[1240px]:px-[84px] flex items-center justify-between min-h-16 @min-[800px]:@max-[1239px]:h-[88px] pt-[36px] select-none relative z-1 print:justify-center">
+			<div className="px-[24px] @min-[1240px]:pt-[48px] @min-[1240px]:px-[84px] flex items-center justify-between min-h-16 @min-[800px]:@max-[1239px]:h-[88px] pt-[36px] select-none relative z-20 print:justify-center">
 				<div className="flex items-center gap-[12px] relative z-1 h-[28px]">
 					<Link
 						to="/"


### PR DESCRIPTION
## Summary
- Raise the explorer header row above the compact mobile search bar.
- Keep the network dropdown clickable when it overlaps the sticky mobile search input.

## Validation
- `pnpm exec biome check apps/explorer/src/comps/Header.tsx`
- `pnpm --filter explorer check:types`
- `pnpm --filter explorer build`