### PR TITLE
Fix explorer address OG creation metadata

### DIFF
--- a/apps/explorer/src/lib/server/address-metadata.ts
+++ b/apps/explorer/src/lib/server/address-metadata.ts
@@ -1,5 +1,6 @@
 import type { ContractCreationReceiptRow } from '#lib/server/tempo-queries'
 import { parseTimestamp } from '#lib/timestamp'
+import type { ContractCreationData } from '#lib/server/contract-creation'
 
 type AddressTxAggregate = {
 	count?: number
@@ -44,7 +45,7 @@ export function pickTip20CreatedTimestamp(params: {
 
 export function buildAddressTxMetadata(
 	aggregate: AddressTxAggregate,
-	creation: ContractCreationReceiptRow | undefined,
+	creation: ContractCreationReceiptRow | ContractCreationData | undefined,
 ): {
 	txCount: number
 	lastActivityTimestamp?: number
@@ -53,7 +54,11 @@ export function buildAddressTxMetadata(
 	createdBy?: string
 } {
 	const oldestTimestamp = parseTimestamp(aggregate.oldestTxsBlockTimestamp)
-	const creationTimestamp = parseTimestamp(creation?.block_timestamp)
+	const creationTimestamp = parseTimestamp(
+		creation && 'block_timestamp' in creation
+			? creation.block_timestamp
+			: creation?.timestamp,
+	)
 	const useCreation =
 		creationTimestamp != null &&
 		(oldestTimestamp == null || creationTimestamp <= oldestTimestamp)
@@ -66,7 +71,12 @@ export function buildAddressTxMetadata(
 				? creationTimestamp
 				: oldestTimestamp,
 		createdTxHash:
-			useCreation && creation ? creation.tx_hash : aggregate.oldestTxHash,
-		createdBy: useCreation && creation ? creation.from : aggregate.oldestTxFrom,
+			useCreation && creation
+				? 'tx_hash' in creation
+					? creation.tx_hash
+					: (creation.hash ?? undefined)
+				: aggregate.oldestTxHash,
+		createdBy:
+			useCreation && creation ? (creation.from ?? undefined) : aggregate.oldestTxFrom,
 	}
 }

--- a/apps/explorer/src/lib/server/tempo-queries.ts
+++ b/apps/explorer/src/lib/server/tempo-queries.ts
@@ -20,6 +20,14 @@ type QueryWithWhere<TQuery> = TQuery & {
 	where: (...args: unknown[]) => TQuery
 }
 
+function indexedAddress(address: Address.Address): Address.Address {
+	return address.toLowerCase() as Address.Address
+}
+
+function indexedAddresses(addresses: Address.Address[]): Address.Address[] {
+	return addresses.map(indexedAddress)
+}
+
 export type TokenHolderBalance = { address: string; balance: bigint }
 
 type TokenHolderAggregationRow = {
@@ -65,6 +73,7 @@ export async function fetchTokenHolderBalances(
 	address: Address.Address,
 	chainId: number,
 ): Promise<TokenHolderBalance[]> {
+	const tokenAddress = indexedAddress(address)
 	const qb = QB(chainId).withSignatures([TRANSFER_SIGNATURE])
 	const transfers = (await qb
 		.selectFrom('transfer')
@@ -73,7 +82,7 @@ export async function fetchTokenHolderBalances(
 			eb.ref('to').as('to'),
 			eb.fn.sum('tokens').as('tokens'),
 		])
-		.where('address', '=', address)
+		.where('address', '=', tokenAddress)
 		.groupBy(['from', 'to'])
 		.execute()) as TokenHolderAggregationRow[]
 
@@ -87,6 +96,7 @@ export async function fetchTokenHoldersCountRows(
 ): Promise<TokenHoldersCountRow[]> {
 	if (addresses.length === 0) return []
 
+	const tokenAddresses = indexedAddresses(addresses)
 	const qb = QB(chainId).withSignatures([TRANSFER_SIGNATURE])
 	const transfers = (await qb
 		.selectFrom('transfer')
@@ -96,7 +106,7 @@ export async function fetchTokenHoldersCountRows(
 			eb.ref('to').as('to'),
 			eb.fn.sum('tokens').as('tokens'),
 		])
-		.where('address', 'in', addresses)
+		.where('address', 'in', tokenAddresses)
 		.groupBy(['address', 'from', 'to'])
 		.execute()) as Array<{
 		address: string
@@ -126,7 +136,7 @@ export async function fetchTokenHoldersCountRows(
 		}
 	}
 
-	return addresses.map((address) => {
+	return tokenAddresses.map((address) => {
 		const token = address.toLowerCase()
 		const tokenBalances = balancesByToken.get(token)
 		const rawCount = tokenBalances
@@ -191,6 +201,7 @@ export async function fetchTokenHoldersCount(
 	countCap: number,
 ): Promise<{ count: number; capped: boolean }> {
 	try {
+		const tokenAddress = indexedAddress(address)
 		const qb = QB(chainId).withSignatures([TRANSFER_SIGNATURE])
 		const transfers = (await qb
 			.selectFrom('transfer')
@@ -199,7 +210,7 @@ export async function fetchTokenHoldersCount(
 				eb.ref('to').as('to'),
 				eb.fn.sum('tokens').as('tokens'),
 			])
-			.where('address', '=', address)
+			.where('address', '=', tokenAddress)
 			.groupBy(['from', 'to'])
 			.execute()) as TokenHolderAggregationRow[]
 
@@ -236,12 +247,13 @@ export async function fetchTokenFirstTransferTimestamp(
 	address: Address.Address,
 	chainId: number,
 ): Promise<number | null> {
+	const tokenAddress = indexedAddress(address)
 	const qb = QB(chainId).withSignatures([TRANSFER_SIGNATURE])
 
 	const firstTransfer = await qb
 		.selectFrom('transfer')
 		.select(['block_timestamp'])
-		.where('address', '=', address)
+		.where('address', '=', tokenAddress)
 		.orderBy('block_num', 'asc')
 		.limit(1)
 		.executeTakeFirst()
@@ -268,6 +280,8 @@ export async function fetchTokenTransfers(
 	offset: number,
 	account?: Address.Address,
 ): Promise<TokenTransferRow[]> {
+	const tokenAddress = indexedAddress(address)
+	const accountAddress = account ? indexedAddress(account) : undefined
 	let query = QB(chainId)
 		.withSignatures([TRANSFER_SIGNATURE])
 		.selectFrom('transfer')
@@ -280,11 +294,11 @@ export async function fetchTokenTransfers(
 			'log_idx',
 			'block_timestamp',
 		])
-		.where('address', '=', address)
+		.where('address', '=', tokenAddress)
 
-	if (account) {
+	if (accountAddress) {
 		query = query.where((eb) =>
-			eb.or([eb('from', '=', account), eb('to', '=', account)]),
+			eb.or([eb('from', '=', accountAddress), eb('to', '=', accountAddress)]),
 		)
 	}
 
@@ -312,16 +326,18 @@ export async function fetchTokenTransferCount(
 	countCap: number,
 	account?: Address.Address,
 ): Promise<{ count: number; capped: boolean }> {
+	const tokenAddress = indexedAddress(address)
+	const accountAddress = account ? indexedAddress(account) : undefined
 	const qb = QB(chainId)
 	let subquery = qb
 		.withSignatures([TRANSFER_SIGNATURE])
 		.selectFrom('transfer')
 		.select((eb) => eb.lit(1).as('x'))
-		.where('address', '=', address)
+		.where('address', '=', tokenAddress)
 
-	if (account) {
+	if (accountAddress) {
 		subquery = subquery.where((eb) =>
-			eb.or([eb('from', '=', account), eb('to', '=', account)]),
+			eb.or([eb('from', '=', accountAddress), eb('to', '=', accountAddress)]),
 		)
 	}
 
@@ -508,7 +524,8 @@ function applyAddressDirectionFilter<TQuery>(
 	query: QueryWithWhere<TQuery>,
 	params: AddressDirectionParams,
 ): TQuery {
-	const { address, includeSent, includeReceived } = params
+	const { includeSent, includeReceived } = params
+	const address = indexedAddress(params.address)
 	if (includeSent && includeReceived) {
 		return query.where(
 			// @ts-expect-error
@@ -600,12 +617,13 @@ export async function fetchAddressTransferEmittedHashes(params: {
 	sortDirection: SortDirection
 	limit: number
 }): Promise<TransferHashRow[]> {
+	const address = indexedAddress(params.address)
 	return QB(params.chainId)
 		.withSignatures([TRANSFER_SIGNATURE])
 		.selectFrom('transfer')
 		.select(['tx_hash', 'block_num'])
 		.distinct()
-		.where('address', '=', params.address)
+		.where('address', '=', address)
 		.orderBy('block_num', params.sortDirection)
 		.orderBy('tx_hash', params.sortDirection)
 		.limit(params.limit)
@@ -619,6 +637,7 @@ export async function fetchAddressDirectTxCount(
 		after?: number
 	},
 ): Promise<number> {
+	const address = indexedAddress(params.address)
 	const statusJoin = params.statusFilter
 		? 'INNER JOIN receipts status_receipts ON status_receipts.tx_hash = txs.hash'
 		: ''
@@ -631,7 +650,7 @@ export async function fetchAddressDirectTxCount(
 		filters.push(`txs.block_timestamp >= '${toSqlTimestamp(params.after)}'`)
 
 	const whereForSide = (side: 'from' | 'to') =>
-		[`txs."${side}" = '${params.address}'`, ...filters].join(' AND ')
+		[`txs."${side}" = '${address}'`, ...filters].join(' AND ')
 	const sideQuery = (side: 'from' | 'to') =>
 		`(SELECT txs.hash FROM txs ${statusJoin} WHERE ${whereForSide(side)} LIMIT ${params.countCap})`
 	const matchesQuery =
@@ -681,13 +700,14 @@ export async function fetchAddressTransferEmittedDistinctCount(params: {
 	chainId: number
 	countCap: number
 }): Promise<number> {
+	const address = indexedAddress(params.address)
 	const qb = QB(params.chainId)
 	const subquery = qb
 		.withSignatures([TRANSFER_SIGNATURE])
 		.selectFrom('transfer')
 		.select('tx_hash')
 		.distinct()
-		.where('address', '=', params.address)
+		.where('address', '=', address)
 
 	const result = await qb
 		.selectFrom(subquery.limit(params.countCap).as('subquery'))
@@ -1273,6 +1293,7 @@ export async function fetchAddressTransferBalances(
 ): Promise<
 	Array<{ token: string; received: string | number; sent: string | number }>
 > {
+	const accountAddress = indexedAddress(address)
 	const [incoming, outgoing] = await Promise.all([
 		QB(chainId)
 			.withSignatures([TRANSFER_SIGNATURE])
@@ -1281,7 +1302,7 @@ export async function fetchAddressTransferBalances(
 				eb.ref('address').as('token'),
 				eb.fn.sum('tokens').as('received'),
 			])
-			.where('to', '=', address)
+			.where('to', '=', accountAddress)
 			.groupBy('address')
 			.execute()
 			.catch((e) => {
@@ -1295,7 +1316,7 @@ export async function fetchAddressTransferBalances(
 				eb.ref('address').as('token'),
 				eb.fn.sum('tokens').as('sent'),
 			])
-			.where('from', '=', address)
+			.where('from', '=', accountAddress)
 			.groupBy('address')
 			.execute()
 			.catch((e) => {
@@ -1346,11 +1367,14 @@ export async function fetchAddressTransfersForValue(
 ): Promise<
 	Array<{ address: string; from: string; to: string; tokens: string | number }>
 > {
+	const accountAddress = indexedAddress(address)
 	const result = await QB(chainId)
 		.withSignatures([TRANSFER_SIGNATURE])
 		.selectFrom('transfer')
 		.select(['address', 'from', 'to', 'tokens'])
-		.where((eb) => eb.or([eb('from', '=', address), eb('to', '=', address)]))
+		.where((eb) =>
+			eb.or([eb('from', '=', accountAddress), eb('to', '=', accountAddress)]),
+		)
 		.limit(limit)
 		.execute()
 
@@ -1444,6 +1468,7 @@ export async function fetchTokenTransferAggregate(
 	oldestTimestamp?: unknown
 	latestTimestamp?: unknown
 }> {
+	const tokenAddress = indexedAddress(address)
 	// Use raw logs instead of the Transfer CTE here. Production tidx currently
 	// errors on aggregate queries over event CTEs, while the raw logs aggregate
 	// is fast and keeps TIDX credentials server-side.
@@ -1453,7 +1478,7 @@ export async function fetchTokenTransferAggregate(
 			sb.fn.min('block_timestamp').as('oldestTimestamp'),
 			sb.fn.max('block_timestamp').as('latestTimestamp'),
 		])
-		.where('address', '=', address)
+		.where('address', '=', tokenAddress)
 		.where('topic0', '=', TRANSFER_TOPIC0)
 		.executeTakeFirst()
 
@@ -1473,6 +1498,7 @@ export async function fetchAddressTxAggregate(
 	oldestTxHash?: string
 	oldestTxFrom?: string
 }> {
+	const accountAddress = indexedAddress(address)
 	type AddressTxBoundaryRow = {
 		hash: Hex.Hex
 		from: string
@@ -1487,7 +1513,7 @@ export async function fetchAddressTxAggregate(
 		const result = (await QB(chainId)
 			.selectFrom('txs')
 			.select((eb) => eb.fn.count('hash').as('count'))
-			.where(field, '=', address)
+			.where(field, '=', accountAddress)
 			.executeTakeFirst()) as AddressTxCountRow | undefined
 
 		return Number(result?.count ?? 0)
@@ -1500,7 +1526,7 @@ export async function fetchAddressTxAggregate(
 		(await QB(chainId)
 			.selectFrom('txs')
 			.select(['hash', 'from', 'block_timestamp'])
-			.where(field, '=', address)
+			.where(field, '=', accountAddress)
 			.orderBy('block_timestamp', sortDirection)
 			.orderBy('hash', sortDirection)
 			.limit(1)
@@ -1549,8 +1575,8 @@ export async function fetchAddressTxAggregate(
 		QB(chainId)
 			.selectFrom('txs')
 			.select((eb) => eb.fn.count('hash').as('count'))
-			.where('from', '=', address)
-			.where('to', '=', address)
+			.where('from', '=', accountAddress)
+			.where('to', '=', accountAddress)
 			.executeTakeFirst()
 			.then((result) =>
 				Number((result as AddressTxCountRow | undefined)?.count ?? 0),
@@ -1583,10 +1609,11 @@ export async function fetchContractCreationReceipt(
 	address: Address.Address,
 	chainId: number,
 ): Promise<ContractCreationReceiptRow | undefined> {
+	const contractAddress = indexedAddress(address)
 	return (await QB(chainId)
 		.selectFrom('receipts')
 		.select(['tx_hash', 'from', 'block_timestamp'])
-		.where('contract_address', '=', address)
+		.where('contract_address', '=', contractAddress)
 		.orderBy('block_num', 'asc')
 		.limit(1)
 		.executeTakeFirst()) as ContractCreationReceiptRow | undefined
@@ -1596,17 +1623,18 @@ export async function fetchAddressTxCounts(
 	address: Address.Address,
 	chainId: number,
 ): Promise<{ sent: number; received: number }> {
+	const accountAddress = indexedAddress(address)
 	const qb = QB(chainId)
 	const [txSentResult, txReceivedResult] = await Promise.all([
 		qb
 			.selectFrom('txs')
 			.select((eb) => eb.fn.count('hash').as('cnt'))
-			.where('from', '=', address)
+			.where('from', '=', accountAddress)
 			.executeTakeFirst(),
 		qb
 			.selectFrom('txs')
 			.select((eb) => eb.fn.count('hash').as('cnt'))
-			.where('to', '=', address)
+			.where('to', '=', accountAddress)
 			.executeTakeFirst(),
 	])
 
@@ -1631,19 +1659,20 @@ export async function fetchAddressTransferActivity(
 		block_timestamp: string | number
 	}>
 }> {
+	const accountAddress = indexedAddress(address)
 	const qb = QB(chainId).withSignatures([TRANSFER_SIGNATURE])
 
 	const [incoming, outgoing] = await Promise.all([
 		qb
 			.selectFrom('transfer')
 			.select(['tokens', 'address', 'block_timestamp'])
-			.where('to', '=', address)
+			.where('to', '=', accountAddress)
 			.orderBy('block_timestamp', 'desc')
 			.execute(),
 		qb
 			.selectFrom('transfer')
 			.select(['tokens', 'address', 'block_timestamp'])
-			.where('from', '=', address)
+			.where('from', '=', accountAddress)
 			.orderBy('block_timestamp', 'desc')
 			.execute(),
 	])

--- a/apps/explorer/src/routes/_layout/address/$address.tsx
+++ b/apps/explorer/src/routes/_layout/address/$address.tsx
@@ -364,15 +364,16 @@ export const Route = createFileRoute('/_layout/address/$address')({
 				balancesData,
 				ogMeta,
 			}
-		}),
+	}),
 	head: async ({ params, loaderData }) => {
+		const address = params.address as Address.Address
+		const ogMeta =
+			loaderData?.ogMeta ??
+			(await fetchAddressMetadata(address).catch(() => undefined))
 		// Fallback to ogMeta.accountType only for contracts (receipts-proven)
 		// since 'empty' is the correct type for regular EOAs
 		let accountType = loaderData?.accountType ?? 'empty'
-		if (
-			accountType === 'empty' &&
-			loaderData?.ogMeta?.accountType === 'contract'
-		) {
+		if (accountType === 'empty' && ogMeta?.accountType === 'contract') {
 			accountType = 'contract'
 		}
 		const isToken = loaderData?.isToken ?? false
@@ -408,9 +409,9 @@ export const Route = createFileRoute('/_layout/address/$address')({
 			const chainId = getTempoChain().id
 
 			let created: string | undefined
-			if (loaderData?.ogMeta?.createdTimestamp) {
+			if (ogMeta?.createdTimestamp) {
 				created = DateFormatter.formatTimestampForOg(
-					BigInt(loaderData.ogMeta.createdTimestamp),
+					BigInt(ogMeta.createdTimestamp),
 				).date
 			}
 
@@ -427,11 +428,11 @@ export const Route = createFileRoute('/_layout/address/$address')({
 				symbol: tokenMeta.symbol,
 				supply,
 				currency: tokenMeta.currency ?? undefined,
-				holders: loaderData?.ogMeta?.holdersCount ?? undefined,
+				holders: ogMeta?.holdersCount ?? undefined,
 				created,
 			})
 		} else {
-			const txCount = loaderData?.ogMeta?.txCount ?? 0
+			const txCount = ogMeta?.txCount ?? 0
 			let lastActive: string | undefined
 			let created: string | undefined
 			let holdings = '—'
@@ -452,15 +453,15 @@ export const Route = createFileRoute('/_layout/address/$address')({
 				}
 			}
 
-			if (loaderData?.ogMeta?.lastActivityTimestamp) {
+			if (ogMeta?.lastActivityTimestamp) {
 				lastActive = DateFormatter.formatTimestampForOg(
-					BigInt(loaderData.ogMeta.lastActivityTimestamp),
+					BigInt(ogMeta.lastActivityTimestamp),
 				).date
 			}
 
-			if (loaderData?.ogMeta?.createdTimestamp) {
+			if (ogMeta?.createdTimestamp) {
 				created = DateFormatter.formatTimestampForOg(
-					BigInt(loaderData.ogMeta.createdTimestamp),
+					BigInt(ogMeta.createdTimestamp),
 				).date
 			}
 

--- a/apps/explorer/src/routes/api/address/metadata/$address.ts
+++ b/apps/explorer/src/routes/api/address/metadata/$address.ts
@@ -46,7 +46,7 @@ export const Route = createFileRoute('/api/address/metadata/$address')({
 				}
 
 				try {
-					const address = zAddress().parse(params.address)
+					const address = zAddress({ lowercase: true }).parse(params.address)
 					Address.assert(address)
 
 					const client = getBatchedClient()
@@ -111,19 +111,26 @@ export const Route = createFileRoute('/api/address/metadata/$address')({
 							}),
 						}
 					} else {
-						const [bytecode, result, creation] = await Promise.all([
+						const [bytecode, result, indexedCreation] = await Promise.all([
 							bytecodePromise,
 							fetchAddressTxAggregate(address, chainId),
 							fetchContractCreationReceipt(address, chainId).catch(
 								() => undefined,
 							),
 						])
+						const accountType = getAccountType(bytecode)
+						const creation =
+							indexedCreation ??
+							(accountType === 'contract'
+								? await fetchContractCreationData(address).catch(() => null)
+								: undefined) ??
+							undefined
 						const metadata = buildAddressTxMetadata(result, creation)
 
 						response = {
 							address,
 							chainId,
-							accountType: getAccountType(bytecode),
+							accountType,
 							...metadata,
 						}
 					}

--- a/apps/explorer/src/routes/api/tip20-roles.ts
+++ b/apps/explorer/src/routes/api/tip20-roles.ts
@@ -65,7 +65,9 @@ export const Route = createFileRoute('/api/tip20-roles')({
 			GET: async ({ request }) => {
 				try {
 					const url = new URL(request.url)
-					const address = zAddress().parse(url.searchParams.get('address'))
+					const address = zAddress({ lowercase: true }).parse(
+						url.searchParams.get('address'),
+					)
 					const chainIdParam = url.searchParams.get('chainId')
 					const config = getWagmiConfig()
 					const chainId = chainIdParam

--- a/apps/explorer/test/address-metadata.node.test.ts
+++ b/apps/explorer/test/address-metadata.node.test.ts
@@ -1,0 +1,70 @@
+import type { Address, Hex } from 'ox'
+import { describe, expect, it } from 'vitest'
+import { buildAddressTxMetadata } from '#lib/server/address-metadata'
+import type { ContractCreationData } from '#lib/server/contract-creation'
+
+describe('address metadata', () => {
+	it('uses RPC contract creation fallback when indexed receipts miss creation', () => {
+		const creation = {
+			blockNumber: 10n,
+			timestamp: 100n,
+			hash: '0xcreate' as Hex.Hex,
+			from: '0xdeployer' as Address.Address,
+			to: null,
+			value: 0n,
+			status: 'success',
+			gasUsed: 21_000n,
+			effectiveGasPrice: 1n,
+		} satisfies ContractCreationData
+
+		expect(
+			buildAddressTxMetadata(
+				{
+					count: 0,
+					latestTxsBlockTimestamp: undefined,
+					oldestTxsBlockTimestamp: undefined,
+				},
+				creation,
+			),
+		).toEqual({
+			txCount: 1,
+			lastActivityTimestamp: undefined,
+			createdTimestamp: 100,
+			createdTxHash: '0xcreate',
+			createdBy: '0xdeployer',
+		})
+	})
+
+	it('keeps older direct address activity as the created timestamp', () => {
+		const creation = {
+			blockNumber: 20n,
+			timestamp: 200n,
+			hash: '0xcreate' as Hex.Hex,
+			from: '0xdeployer' as Address.Address,
+			to: null,
+			value: 0n,
+			status: 'success',
+			gasUsed: 21_000n,
+			effectiveGasPrice: 1n,
+		} satisfies ContractCreationData
+
+		expect(
+			buildAddressTxMetadata(
+				{
+					count: 3,
+					latestTxsBlockTimestamp: 300,
+					oldestTxsBlockTimestamp: 100,
+					oldestTxHash: '0xold',
+					oldestTxFrom: '0xsender',
+				},
+				creation,
+			),
+		).toEqual({
+			txCount: 4,
+			lastActivityTimestamp: 300,
+			createdTimestamp: 100,
+			createdTxHash: '0xold',
+			createdBy: '0xsender',
+		})
+	})
+})

--- a/apps/explorer/test/tempo-queries.test.ts
+++ b/apps/explorer/test/tempo-queries.test.ts
@@ -14,6 +14,7 @@ const mockQueryBuilder = vi.hoisted(() => {
 	class MockQueryBuilder {
 		private responses: unknown[] = []
 		private executeCallCount = 0
+		private whereCalls: unknown[][] = []
 
 		setResponses(responses: unknown[]): void {
 			this.responses = [...responses]
@@ -22,10 +23,15 @@ const mockQueryBuilder = vi.hoisted(() => {
 		reset(): void {
 			this.responses = []
 			this.executeCallCount = 0
+			this.whereCalls = []
 		}
 
 		getExecuteCallCount(): number {
 			return this.executeCallCount
+		}
+
+		getWhereCalls(): unknown[][] {
+			return this.whereCalls
 		}
 
 		withSignatures(): this {
@@ -52,7 +58,8 @@ const mockQueryBuilder = vi.hoisted(() => {
 			return this
 		}
 
-		where(): this {
+		where(...args: unknown[]): this {
+			this.whereCalls.push(args)
 			return this
 		}
 
@@ -1691,6 +1698,34 @@ describe('tempo-queries', () => {
 		})
 	})
 
+	it('fetchAddressTxAggregate lowercases checksum addresses before indexed comparisons', async () => {
+		mockQueryBuilder.setResponses([
+			{ count: '0' },
+			{ count: '0' },
+			{ count: '0' },
+			undefined,
+			undefined,
+			undefined,
+			undefined,
+		])
+
+		await fetchAddressTxAggregate(
+			'0x73b5d86dEae56497f852FD79dd6fe68C7270FB6B' as Address.Address,
+			1,
+		)
+
+		expect(mockQueryBuilder.getWhereCalls()).toContainEqual([
+			'from',
+			'=',
+			'0x73b5d86deae56497f852fd79dd6fe68c7270fb6b',
+		])
+		expect(mockQueryBuilder.getWhereCalls()).toContainEqual([
+			'to',
+			'=',
+			'0x73b5d86deae56497f852fd79dd6fe68c7270fb6b',
+		])
+	})
+
 	it('fetchContractCreationReceipt returns the creation receipt row', async () => {
 		mockQueryBuilder.setResponses([
 			{
@@ -1707,6 +1742,21 @@ describe('tempo-queries', () => {
 			from: '0xCreator',
 			block_timestamp: '123',
 		})
+	})
+
+	it('fetchContractCreationReceipt lowercases checksum addresses before indexed comparisons', async () => {
+		mockQueryBuilder.setResponses([undefined])
+
+		await fetchContractCreationReceipt(
+			'0x73b5d86dEae56497f852FD79dd6fe68C7270FB6B' as Address.Address,
+			1,
+		)
+
+		expect(mockQueryBuilder.getWhereCalls()).toContainEqual([
+			'contract_address',
+			'=',
+			'0x73b5d86deae56497f852fd79dd6fe68c7270fb6b',
+		])
 	})
 
 	it('fetchContractCreationReceipt returns undefined when missing', async () => {


### PR DESCRIPTION
## Summary
- normalize indexed address comparisons in explorer server TIDX query helpers so checksum/mixed-case inputs compare against lowercase indexed address columns consistently
- make address page `head()` fetch metadata directly when loader metadata is missing, preventing OG URLs from falling back to `txCount=0` / missing `created`
- keep the RPC contract-creation fallback as a secondary safety net when indexed creation data is unavailable
- add focused tests for checksum-address normalization and the missing-created/zero-count regression

## Testing
- Live production API check: `/api/address/metadata/0x73b5d86dEae56497f852FD79dd6fe68C7270FB6B` and lowercase `/api/address/metadata/0x73b5d86deae56497f852fd79dd6fe68c7270fb6b` both returned `txCount: 44`, `createdTimestamp: 1777407009`, and the same creation tx.
- Live production count check: checksum and lowercase `/api/address/txs-count/...` both returned `44`.
- Live production page-head check still emits stale OG params (`txCount=0`, no `created`), confirming the remaining issue is the page `head()` fallback path fixed in this PR.
- Not run locally: `corepack pnpm --filter explorer test -- test/tempo-queries.test.ts test/address-metadata.node.test.ts` could not download pnpm 10.33.0 from npm due network timeout in the sandbox.

Prompted by: @snario