### PR TITLE
fix(explorer): allow authenticated nextfork RPC override

### DIFF
--- a/apps/explorer/env.d.ts
+++ b/apps/explorer/env.d.ts
@@ -13,6 +13,7 @@ interface EnvironmentVariables {
 	readonly VITE_TEMPO_ENV: 'testnet' | 'devnet' | 'nextfork' | 'mainnet'
 
 	readonly TEMPO_RPC_KEY: string
+	readonly TEMPO_NEXTFORK_RPC_URL: string | undefined
 }
 
 interface ImportMetaEnv extends EnvironmentVariables {}

--- a/apps/explorer/src/lib/server/env.ts
+++ b/apps/explorer/src/lib/server/env.ts
@@ -10,6 +10,7 @@ import * as z from 'zod/mini'
  */
 export const serverEnvSchema = z.object({
 	TEMPO_RPC_KEY: z.optional(z.string()),
+	TEMPO_NEXTFORK_RPC_URL: z.optional(z.url()),
 	TIDX_BASIC_AUTH: z.optional(z.string()),
 	TIDX_BASE_URL: z.prefault(z.url(), 'https://tidx.tempo.xyz'),
 })

--- a/apps/explorer/src/wagmi.config.ts
+++ b/apps/explorer/src/wagmi.config.ts
@@ -69,6 +69,12 @@ const getFallbackUrls = createIsomorphicFn()
 	}))
 	.server(() => {
 		const chain = getTempoChain()
+		if (getTempoEnv() === 'nextfork' && serverEnv.TEMPO_NEXTFORK_RPC_URL) {
+			return {
+				http: [serverEnv.TEMPO_NEXTFORK_RPC_URL],
+			}
+		}
+
 		const key = serverEnv.TEMPO_RPC_KEY
 		return {
 			http: chain.rpcUrls.default.http.map((url) =>
@@ -92,10 +98,13 @@ const getTempoTransport = createIsomorphicFn()
 	.server(() => {
 		const proxy = getRpcProxyUrl()
 		const fallbackUrls = getFallbackUrls()
-		return loadBalance([
-			http(proxy.http),
-			...fallbackUrls.http.map((url) => http(url)),
-		])
+		const useNextforkRpcOverride =
+			getTempoEnv() === 'nextfork' && serverEnv.TEMPO_NEXTFORK_RPC_URL
+		const transports = useNextforkRpcOverride
+			? fallbackUrls.http.map((url) => http(url))
+			: [http(proxy.http), ...fallbackUrls.http.map((url) => http(url))]
+
+		return loadBalance(transports)
 	})
 
 export function getWagmiConfig() {


### PR DESCRIPTION
## Summary
- add a server-only `TEMPO_NEXTFORK_RPC_URL` env var for the nextfork explorer RPC
- for nextfork server-side RPC calls, prefer that authenticated direct RPC URL instead of the proxy returning `null` receipts
- keep browser traffic on the RPC proxy and preserve existing RPC behavior for non-nextfork explorers

## Deployment note
Set `TEMPO_NEXTFORK_RPC_URL` for the nextfork explorer Cloudflare Worker to the authenticated nextfork RPC URL. Do not commit the credential.

## Validation
- `git diff --check`
- `corepack pnpm --filter explorer check:types` could not run because Corepack timed out downloading pinned `pnpm@10.33.0` from npm in this sandbox.

Prompted by: @0xrusowsky