### PR TITLE
fix: serve tokenlist icons and index listed tokens

### DIFF
--- a/apps/explorer/src/lib/server/tokens.ts
+++ b/apps/explorer/src/lib/server/tokens.ts
@@ -38,7 +38,7 @@ export type TokensApiResponse = {
 	total: number
 }
 
-type TokenListEntry = {
+export type TokenListEntry = {
 	address: string
 	name: string
 	symbol: string
@@ -97,6 +97,12 @@ export async function getTokenListAddresses(
 	chainId: number,
 ): Promise<Set<string>> {
 	return (await getTokenList(chainId)).addresses
+}
+
+export async function getTokenListEntries(
+	chainId: number,
+): Promise<TokenListEntry[]> {
+	return (await getTokenList(chainId)).entries
 }
 
 function getAddressKey(address: string): string {

--- a/apps/explorer/src/routes/api/search.ts
+++ b/apps/explorer/src/routes/api/search.ts
@@ -15,7 +15,7 @@ import {
 	fetchLatestBlockNumber,
 	fetchTransactionTimestamp,
 } from '#lib/server/tempo-queries'
-import { getTokenListAddresses } from '#lib/server/tokens'
+import { getTokenListEntries, type TokenListEntry } from '#lib/server/tokens'
 import { getWagmiConfig } from '#wagmi.config.ts'
 
 export type SearchResult =
@@ -72,26 +72,49 @@ function indexTokens(tokens: Token[]): IndexedToken[] {
 	}))
 }
 
+function indexTokenListEntries(tokens: TokenListEntry[]): IndexedToken[] {
+	return tokens.map((token) => ({
+		address: token.address.toLowerCase() as Address.Address,
+		symbol: token.symbol,
+		name: token.name,
+		searchKey: `${token.symbol.toLowerCase()}|${token.name.toLowerCase()}|${token.address.toLowerCase()}`,
+	}))
+}
+
+function mergeIndexedTokens(tokens: IndexedToken[]): IndexedToken[] {
+	const tokensByAddress = new Map<string, IndexedToken>()
+	for (const token of tokens) {
+		tokensByAddress.set(token.address.toLowerCase(), token)
+	}
+	return [...tokensByAddress.values()]
+}
+
 const INDEXED_TOKENS: Record<number, IndexedToken[]> = {
 	31318: indexTokens(tokensIndex31318 as Token[]),
 	42431: indexTokens(tokensIndex42431 as Token[]),
 	4217: indexTokens(tokensIndex4217 as Token[]),
 }
 
-function searchTokens(
+export function searchTokens(
 	query: string,
 	chainId: number,
-	verifiedAddresses: Set<string>,
+	tokenListEntries: TokenListEntry[],
 ): TokenSearchResult[] {
 	query = query.toLowerCase()
-	const indexedTokens = INDEXED_TOKENS[chainId] ?? []
+	const tokenListAddresses = new Set(
+		tokenListEntries.map((token) => token.address.toLowerCase()),
+	)
+	const indexedTokens = mergeIndexedTokens([
+		...(INDEXED_TOKENS[chainId] ?? []),
+		...indexTokenListEntries(tokenListEntries),
+	])
 	const isAddressQuery = query.startsWith('0x')
 
 	// filter using search keys
 	const matches = indexedTokens.filter((token) => {
 		if (isAddressQuery) return token.address.startsWith(query)
 		// for name/symbol queries, only match verified tokenlist tokens
-		if (verifiedAddresses.size > 0 && !verifiedAddresses.has(token.address))
+		if (tokenListAddresses.size > 0 && !tokenListAddresses.has(token.address))
 			return false
 		return token.searchKey.includes(query)
 	})
@@ -145,7 +168,7 @@ export const Route = createFileRoute('/api/search')({
 					} satisfies SearchApiResponse)
 
 				const chainId = getChainId(getWagmiConfig())
-				const verifiedAddresses = await getTokenListAddresses(chainId)
+				const tokenListEntries = await getTokenListEntries(chainId)
 				const results: SearchResult[] = []
 
 				// block number (plain digits or #-prefixed)
@@ -196,7 +219,7 @@ export const Route = createFileRoute('/api/search')({
 					}
 				} else {
 					// search for token matches (even if an address was found)
-					results.push(...searchTokens(query, chainId, verifiedAddresses))
+					results.push(...searchTokens(query, chainId, tokenListEntries))
 				}
 
 				return Response.json(

--- a/apps/explorer/test/search-tokens.node.test.ts
+++ b/apps/explorer/test/search-tokens.node.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import { searchTokens } from '../src/routes/api/search.ts'
+
+describe('searchTokens', () => {
+	it('finds tokenlist-only entries by symbol', () => {
+		expect(
+			searchTokens('BRLA', 4217, [
+				{
+					address: '0x20c000000000000000000000f047dd7018e50367',
+					name: 'BRLA Token',
+					symbol: 'BRLA',
+				},
+			]),
+		).toEqual([
+			{
+				type: 'token',
+				address: '0x20c000000000000000000000f047dd7018e50367',
+				symbol: 'BRLA',
+				name: 'BRLA Token',
+				isTip20: true,
+			},
+		])
+	})
+})

--- a/apps/tokenlist/package.json
+++ b/apps/tokenlist/package.json
@@ -20,6 +20,7 @@
 		"check": "pnpm check:biome && pnpm check:types",
 		"check:biome": "biome check --write --unsafe",
 		"check:types": "tsgo --project tsconfig.json --noEmit",
+		"test": "vitest",
 		"process-icons": "node ./scripts/svg2g.ts",
 		"tail": "wrangler tail",
 		"gen:types": "wrangler types --env-interface='CloudflareBindings' --env-file='.env.example'",
@@ -38,6 +39,7 @@
 		"@types/node": "catalog:",
 		"typescript": "catalog:",
 		"vite": "catalog:",
+		"vitest": "catalog:",
 		"wrangler": "catalog:"
 	},
 	"license": "MIT"

--- a/apps/tokenlist/src/index.tsx
+++ b/apps/tokenlist/src/index.tsx
@@ -13,6 +13,21 @@ app.use('*', cors())
 const staticAssetBindingError =
 	'Static assets binding "ASSETS" is not configured.'
 
+const tokenIconExtensions = ['svg', 'png'] as const
+const tokenIconContentTypes = {
+	svg: 'image/svg+xml',
+	png: 'image/png',
+} satisfies Record<(typeof tokenIconExtensions)[number], string>
+
+function getTokenIconBaseName(address: string): string {
+	const lowercased = address.toLowerCase()
+	for (const extension of tokenIconExtensions) {
+		const suffix = `.${extension}`
+		if (lowercased.endsWith(suffix)) return lowercased.slice(0, -suffix.length)
+	}
+	return lowercased
+}
+
 app
 	.get('/', (context) => context.redirect('/docs'))
 	.get('/health', (_context) => new Response('ok'))
@@ -66,20 +81,30 @@ app.get('/icon/:chain_id/:address', async (context) => {
 	const assets = context.env.ASSETS
 	if (!assets) return new Response(staticAssetBindingError, { status: 500 })
 
-	const assetUrl = new URL(
-		`/${chainId}/icons/${address.toLowerCase().replace('.svg', '')}.svg`,
-		'http://assets',
-	)
-	let assetResponse = await assets.fetch(assetUrl)
+	const iconBaseName = getTokenIconBaseName(address)
+	let assetResponse: Response | undefined
+	let contentType = 'image/svg+xml'
+	for (const extension of tokenIconExtensions) {
+		const assetUrl = new URL(
+			`/${chainId}/icons/${iconBaseName}.${extension}`,
+			'http://assets',
+		)
+		const response = await assets.fetch(assetUrl)
+		if (response.status === 200) {
+			assetResponse = response
+			contentType = tokenIconContentTypes[extension]
+			break
+		}
+	}
 
-	if (assetResponse.status !== 200)
+	if (!assetResponse)
 		assetResponse = await assets.fetch(
 			new URL(`/${chainId}/icons/fallback.svg`, 'http://assets'),
 		)
 
 	// Let CF set correct headers; override only when missing
 	const headers = new Headers(assetResponse.headers)
-	if (!headers.has('Content-Type')) headers.set('Content-Type', 'image/svg+xml')
+	if (!headers.has('Content-Type')) headers.set('Content-Type', contentType)
 
 	return new Response(assetResponse.body, {
 		status: assetResponse.status,

--- a/apps/tokenlist/test/icon.test.ts
+++ b/apps/tokenlist/test/icon.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+import app from '../src/index.tsx'
+
+type Asset = {
+	body: string
+	contentType?: string | undefined
+}
+
+function createAssets(files: Record<string, Asset>): Fetcher {
+	return {
+		fetch: async (input) => {
+			const url = new URL(input.toString())
+			const asset = files[url.pathname]
+			if (!asset) return new Response('not found', { status: 404 })
+
+			const headers = new Headers()
+			if (asset.contentType) headers.set('Content-Type', asset.contentType)
+
+			return new Response(asset.body, { headers })
+		},
+	} satisfies Fetcher
+}
+
+describe('token icon route', () => {
+	it('serves a PNG icon when the token has no SVG asset', async () => {
+		const response = await app.request(
+			'/icon/4217/0x20c000000000000000000000f047dd7018e50367',
+			{},
+			{
+				ASSETS: createAssets({
+					'/4217/icons/0x20c000000000000000000000f047dd7018e50367.png': {
+						body: 'png icon',
+						contentType: 'image/png',
+					},
+					'/4217/icons/fallback.svg': {
+						body: 'fallback icon',
+						contentType: 'image/svg+xml',
+					},
+				}),
+			},
+		)
+
+		await expect(response.text()).resolves.toBe('png icon')
+		expect(response.headers.get('Content-Type')).toBe('image/png')
+	})
+
+	it('falls back to the default SVG when no token icon exists', async () => {
+		const response = await app.request(
+			'/icon/4217/0x20c000000000000000000000000000000000dead',
+			{},
+			{
+				ASSETS: createAssets({
+					'/4217/icons/fallback.svg': {
+						body: 'fallback icon',
+						contentType: 'image/svg+xml',
+					},
+				}),
+			},
+		)
+
+		await expect(response.text()).resolves.toBe('fallback icon')
+		expect(response.headers.get('Content-Type')).toBe('image/svg+xml')
+	})
+})

--- a/apps/tokenlist/vitest.config.ts
+++ b/apps/tokenlist/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+	resolve: {
+		tsconfigPaths: true,
+	},
+	test: {
+		include: ['test/**/*.test.ts'],
+	},
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -802,6 +802,9 @@ importers:
       vite:
         specifier: 'catalog:'
         version: 8.0.7(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(@vitest/ui@4.1.0)(vite@8.0.7(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
       wrangler:
         specifier: 'catalog:'
         version: 4.95.0(@cloudflare/workers-types@4.20260531.1)(bufferutil@4.1.0)(utf-8-validate@5.0.10)


### PR DESCRIPTION
## Summary
- Serve token icons from `.svg` or `.png`, so PNG-backed tokenlist icons like BRLA resolve through `/icon/:chain_id/:address`.
- Use the live tokenlist entries that Explorer already fetches as token search candidates, so tokenlist-only tokens like BRLA and GBPA are searchable without waiting for the generated TIDX/native index to include them.

## Root cause
Explorer treated tokenlist membership as the verification filter, but its search candidates came only from the generated TIDX/native index. Tokenlist-only assets were verified but absent from the candidate index. Separately, tokenlist's icon route always requested `.svg`, so PNG token icons fell through to fallback.

## Validation
- `pnpm --filter explorer check:env`
- `pnpm --filter explorer check:types`
- `pnpm --filter tokenlist exec vitest run`
- `pnpm --filter tokenlist check:types`
- `pnpm exec biome check --write apps/explorer/src/lib/server/tokens.ts apps/explorer/src/routes/api/search.ts apps/explorer/test/search-tokens.node.test.ts apps/tokenlist/src/index.tsx apps/tokenlist/test/icon.test.ts apps/tokenlist/vitest.config.ts apps/tokenlist/package.json pnpm-lock.yaml`
- `pnpm install --lockfile-only --frozen-lockfile --ignore-scripts`