### PR TITLE
feat(contract-verification): schema runtime validations (re-land of #843)

### DIFF
--- a/apps/contract-verification/src/job-runner.ts
+++ b/apps/contract-verification/src/job-runner.ts
@@ -5,27 +5,20 @@ import { formatError } from '#lib/utilities.ts'
 import { runVerificationJob } from '#route.verify.ts'
 import { staticChains } from '#wagmi.config.ts'
 import { ChainRegistry, resolveAuthToken } from '#lib/chain-registry.ts'
+import type { VerificationJob } from '#schema.ts'
 
 const logger = getLogger(['tempo', 'job-runner'])
 
-type StoredJob = {
-	jobId: string
-	chainId: number
-	address: string
-	body: {
-		stdJsonInput: {
-			language: string
-			sources: Record<string, { content: string }>
-			settings: object
-		}
-		compilerVersion: string
-		contractIdentifier: string
-		creationTransactionHash?: string
-	}
+/** Shape of jobs stored by deployments that nested the verification input under `body`. */
+type LegacyStoredJob = Pick<
+	VerificationJob,
+	'jobId' | 'chainId' | 'address'
+> & {
+	body: Omit<VerificationJob, 'jobId' | 'chainId' | 'address'>
 }
 
 export class VerificationJobRunner extends DurableObject<Cloudflare.Env> {
-	async enqueue(job: StoredJob): Promise<void> {
+	async enqueue(job: VerificationJob): Promise<void> {
 		logger.info('job_enqueued', {
 			jobId: job.jobId,
 			chainId: job.chainId,
@@ -37,11 +30,28 @@ export class VerificationJobRunner extends DurableObject<Cloudflare.Env> {
 	}
 
 	override async alarm(): Promise<void> {
-		const job = await this.ctx.storage.get<StoredJob>('job')
-		if (!job) {
+		const storedJob = await this.ctx.storage.get<
+			VerificationJob | LegacyStoredJob
+		>('job')
+		if (!storedJob) {
 			logger.warn('alarm_job_missing')
 			return
 		}
+
+		// Unpack jobs enqueued before the flat VerificationJob shape so
+		// in-flight Durable Object alarms survive a deploy.
+		const job: VerificationJob =
+			'body' in storedJob
+				? {
+						jobId: storedJob.jobId,
+						chainId: storedJob.chainId,
+						address: storedJob.address,
+						stdJsonInput: storedJob.body.stdJsonInput,
+						compilerVersion: storedJob.body.compilerVersion,
+						contractIdentifier: storedJob.body.contractIdentifier,
+						creationTransactionHash: storedJob.body.creationTransactionHash,
+					}
+				: storedJob
 
 		logger.info('job_started', {
 			jobId: job.jobId,
@@ -59,14 +69,7 @@ export class VerificationJobRunner extends DurableObject<Cloudflare.Env> {
 				? await ChainRegistry.fromUrl({ url, authToken, staticChains })
 				: ChainRegistry.fromStatic(staticChains)
 
-			await runVerificationJob(
-				this.env,
-				job.jobId,
-				job.chainId,
-				job.address,
-				job.body,
-				registry,
-			)
+			await runVerificationJob(this.env, job, registry)
 			logger.info('job_finished', { jobId: job.jobId })
 		} catch (error) {
 			logger.error('job_alarm_error', {

--- a/apps/contract-verification/src/lib/bytecode-matching.ts
+++ b/apps/contract-verification/src/lib/bytecode-matching.ts
@@ -2,6 +2,8 @@ import semver from 'semver'
 import * as CBOR from 'cbor-x/decode'
 import { AbiParameters, Hash, Hex } from 'ox'
 
+import type { ImmutableReferences, LinkReferences } from '#schema.ts'
+
 // ============================================================================
 // Types
 // ============================================================================
@@ -28,19 +30,12 @@ export interface TransformationValues {
 	cborAuxdata?: Record<string, string>
 }
 
-export interface LinkReference {
-	start: number
-	length: number
-}
-
-export type LinkReferences = Record<string, Record<string, LinkReference[]>>
-
-export interface ImmutableReference {
-	start: number
-	length: number
-}
-
-export type ImmutableReferences = Record<string, ImmutableReference[]>
+export type {
+	ImmutableReference,
+	ImmutableReferences,
+	LinkReference,
+	LinkReferences,
+} from '#schema.ts'
 
 export interface CborAuxdataPosition {
 	offset: number

--- a/apps/contract-verification/src/route.lookup.ts
+++ b/apps/contract-verification/src/route.lookup.ts
@@ -1160,4 +1160,9 @@ lookupAllChainContractsRoute.get('/:chainId', async (context) => {
 	}
 })
 
-export { lookupRoute, lookupAllChainContractsRoute }
+export {
+	buildSignaturesPayload,
+	formatAbiParameterType,
+	lookupAllChainContractsRoute,
+	lookupRoute,
+}

--- a/apps/contract-verification/src/route.verify.ts
+++ b/apps/contract-verification/src/route.verify.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono'
 import * as z from 'zod/mini'
-import { Address, Hex } from 'ox'
+import { Hex } from 'ox'
 import { and, eq, isNull, or } from 'drizzle-orm'
 import type { BatchItem } from 'drizzle-orm/batch'
 
@@ -31,14 +31,20 @@ import {
 import {
 	AuxdataStyle,
 	matchBytecode,
-	type LinkReferences,
 	getVyperAuxdataStyle,
-	type ImmutableReferences,
 	getVyperImmutableReferences,
 } from '#lib/bytecode-matching.ts'
 import type { AppEnv } from '#index.tsx'
 import type { ChainRegistry } from '#lib/chain-registry.ts'
 import { getLogger } from '#lib/logger.ts'
+import {
+	type CompileOutput,
+	getValidationCustomCode,
+	type StdJsonInput,
+	VerificationJob,
+	zAddress,
+	zChainId,
+} from '#schema.ts'
 
 const logger = getLogger(['tempo'])
 import wranglerJSON from '#wrangler.json' with { type: 'json' }
@@ -73,13 +79,13 @@ function sanitizeJsonValue(value: unknown): unknown {
 	return value
 }
 
-function sanitizeCompilerSettings(settings: object): object {
-	return sanitizeJsonValue(settings) as object
+function sanitizeCompilerSettings<T extends object>(settings: T): T {
+	return sanitizeJsonValue(settings) as T
 }
 
-function sanitizeVerificationInput(
-	input: VerificationInput,
-): VerificationInput {
+function sanitizeVerificationInput<T extends { stdJsonInput: StdJsonInput }>(
+	input: T,
+): T {
 	return {
 		...input,
 		stdJsonInput: {
@@ -150,20 +156,11 @@ verifyRoute
 			}
 
 			const parsedBody = z.safeParse(
-				z.object({
-					stdJsonInput: z.object({
-						language: z.string(),
-						sources: z.record(
-							z.string(),
-							z.object({
-								content: z.string(),
-							}),
-						),
-						settings: z.record(z.string(), z.unknown()),
-					}),
-					compilerVersion: z.string(),
-					contractIdentifier: z.string(),
-					creationTransactionHash: z.optional(z.string()),
+				z.pick(VerificationJob, {
+					stdJsonInput: true,
+					compilerVersion: true,
+					contractIdentifier: true,
+					creationTransactionHash: true,
 				}),
 				body,
 			)
@@ -176,16 +173,17 @@ verifyRoute
 				)
 			}
 
-			if (!/^\d+$/.test(_chainId)) {
+			const parsedChainId = z.safeParse(zChainId(), _chainId)
+			if (!parsedChainId.success) {
 				return sourcifyError(
 					context,
 					400,
-					'invalid_chain_id',
+					getValidationCustomCode(parsedChainId.error) ?? 'invalid_chain_id',
 					`Invalid chainId format: ${_chainId}`,
 				)
 			}
 
-			const chainId = Number(_chainId)
+			const chainId = parsedChainId.data
 			const registry = context.get('chainRegistry')
 			if (!registry.isSupported(chainId)) {
 				return sourcifyError(
@@ -196,14 +194,16 @@ verifyRoute
 				)
 			}
 
-			if (!Address.validate(address, { strict: true })) {
+			const parsedAddress = z.safeParse(zAddress({ strict: true }), address)
+			if (!parsedAddress.success) {
 				return sourcifyError(
 					context,
 					400,
-					'invalid_address',
+					getValidationCustomCode(parsedAddress.error) ?? 'invalid_address',
 					`Invalid address: ${address}`,
 				)
 			}
+			Hex.assert(address)
 
 			const { contractIdentifier } = parsedBody.data
 
@@ -345,9 +345,7 @@ verifyRoute
 				return context.json({ verificationId: firstJob.id }, 202)
 			}
 
-			const verificationInput = sanitizeVerificationInput(
-				parsedBody.data as VerificationInput,
-			)
+			const verificationInput = sanitizeVerificationInput(parsedBody.data)
 
 			// Dispatch verification to a per-job Durable Object for durable background execution
 			const doId = context.env.VERIFICATION_JOB_RUNNER.idFromName(jobId)
@@ -357,7 +355,7 @@ verifyRoute
 					jobId,
 					chainId,
 					address,
-					body: verificationInput,
+					...verificationInput,
 				})
 			} catch (enqueueError) {
 				logger.error('job_enqueue_failed', {
@@ -634,17 +632,6 @@ verifyRoute
 		}
 	})
 
-type VerificationInput = {
-	stdJsonInput: {
-		language: string
-		sources: Record<string, { content: string }>
-		settings: object
-	}
-	compilerVersion: string
-	contractIdentifier: string
-	creationTransactionHash?: string
-}
-
 type PublicClientLike = {
 	getCode: (args: { address: `0x${string}` }) => Promise<`0x${string}`>
 	getTransactionReceipt?: (args: { hash: `0x${string}` }) => Promise<{
@@ -671,59 +658,19 @@ type VerificationDeps = {
 	}) => PublicClientLike
 }
 
-type CompileOutput = {
-	contracts?: Record<
-		string,
-		Record<
-			string,
-			{
-				abi: Array<{
-					type: string
-					name?: string
-					inputs?: Array<{ type: string; name?: string }>
-				}>
-				evm: {
-					bytecode: {
-						object: string
-						linkReferences?: LinkReferences
-						sourceMap?: string
-					}
-					deployedBytecode: {
-						object: string
-						linkReferences?: LinkReferences
-						immutableReferences?: ImmutableReferences
-						sourceMap?: string
-					}
-				}
-				metadata?: string
-				storageLayout?: unknown
-				userdoc?: unknown
-				devdoc?: unknown
-			}
-		>
-	>
-	errors?: Array<{
-		severity: string
-		message: string
-		formattedMessage?: string
-	}>
-}
-
 async function runVerificationJob(
 	env: Cloudflare.Env,
-	jobId: string,
-	chainId: number,
-	address: string,
-	body: VerificationInput,
+	job: VerificationJob,
 	chainRegistry: ChainRegistry,
 	deps?: VerificationDeps,
 ): Promise<void> {
 	const db = getDb(env.CONTRACTS_DB)
+	const { jobId, chainId, address } = job
 	Hex.assert(address)
 	const addressBytes = Hex.toBytes(address)
 	const startTime = Date.now()
 
-	const sanitizedBody = sanitizeVerificationInput(body)
+	const sanitizedBody = sanitizeVerificationInput(job)
 	const { stdJsonInput, compilerVersion, contractIdentifier } = sanitizedBody
 	const language = stdJsonInput.language?.toLowerCase() ?? 'solidity'
 	const isVyper = language === 'vyper'
@@ -831,6 +778,8 @@ async function runVerificationJob(
 			return
 		}
 
+		// Deliberately a cast, not a schema parse: zod objects strip unknown keys,
+		// which would drop ABI fields (stateMutability, outputs, ...) before storage.
 		const compileOutput = (await compileResponse.json()) as CompileOutput
 
 		const errors =

--- a/apps/contract-verification/src/schema.ts
+++ b/apps/contract-verification/src/schema.ts
@@ -1,0 +1,162 @@
+import { Address, Hex } from 'ox'
+import * as z from 'zod/mini'
+
+export const validationCustomCodes = {
+	invalidAddress: 'invalid_address',
+	invalidChainId: 'invalid_chain_id',
+	unsupportedChain: 'unsupported_chain',
+} as const
+
+export function getValidationCustomCode(
+	error: z.core.$ZodError,
+): string | undefined {
+	return error.issues.find((issue) => issue.code === 'custom')?.params
+		?.customCode
+}
+
+export const zAddress = (options: { strict?: boolean } = {}) =>
+	z.string().check((ctx) => {
+		if (!Address.validate(ctx.value, options))
+			ctx.issues.push({
+				code: 'custom',
+				input: ctx.value,
+				message: 'Invalid address',
+				params: { customCode: validationCustomCodes.invalidAddress },
+			})
+	})
+
+export const zHash = (options: { strict?: boolean } = {}) =>
+	z.string().check((ctx) => {
+		if (!Hex.validate(ctx.value, options) || Hex.size(ctx.value) !== 32)
+			ctx.issues.push({
+				code: 'custom',
+				input: ctx.value,
+				message: 'Invalid hash length',
+			})
+	})
+
+/**
+ * Validates chainId format only (string of digits, coerced to number).
+ * Whether the chain is *supported* is a dynamic, per-request concern owned by
+ * the ChainRegistry middleware (`registry.isSupported`), not the schema.
+ */
+export const zChainId = () =>
+	z.pipe(
+		z.string().check((ctx) => {
+			if (!/^\d+$/.test(ctx.value))
+				ctx.issues.push({
+					code: 'custom',
+					input: ctx.value,
+					message: 'Invalid chainId format',
+					params: { customCode: validationCustomCodes.invalidChainId },
+				})
+		}),
+		z.transform((value) => Number(value)),
+	)
+
+export const StdJsonInput = z.object({
+	language: z.string(),
+	settings: z.record(z.string(), z.any()),
+	sources: z.record(z.string(), z.object({ content: z.string() })),
+})
+
+export type StdJsonInput = z.infer<typeof StdJsonInput>
+
+export const VerificationJob = z.object({
+	jobId: z.uuidv4(),
+	chainId: zChainId(),
+	stdJsonInput: StdJsonInput,
+	compilerVersion: z.string(),
+	contractIdentifier: z.string(),
+	address: zAddress({ strict: false }),
+	creationTransactionHash: z.optional(zHash()),
+})
+
+export type VerificationJob = z.infer<typeof VerificationJob>
+
+type AbiParameter = {
+	name?: string | undefined
+	type: string
+	components?: Array<AbiParameter> | undefined
+}
+
+type AbiItem = {
+	type: string
+	name?: string | undefined
+	inputs?: Array<AbiParameter> | undefined
+}
+
+const AbiParameter: z.ZodMiniType<AbiParameter> = z.object({
+	name: z.optional(z.string()),
+	type: z.string(),
+	components: z.optional(
+		z.array(z.lazy((): z.ZodMiniType<AbiParameter> => AbiParameter)),
+	),
+})
+
+const Abi: z.ZodMiniType<AbiItem> = z.object({
+	type: z.string(),
+	name: z.optional(z.string()),
+	inputs: z.optional(z.array(AbiParameter)),
+})
+
+export const LinkReference = z.object({
+	start: z.number(),
+	length: z.number(),
+})
+export const LinkReferences = z.record(
+	z.string(),
+	z.record(z.string(), z.array(LinkReference)),
+)
+export type LinkReference = z.infer<typeof LinkReference>
+export type LinkReferences = z.infer<typeof LinkReferences>
+
+export const ImmutableReference = z.object({
+	start: z.number(),
+	length: z.number(),
+})
+export const ImmutableReferences = z.record(
+	z.string(),
+	z.array(ImmutableReference),
+)
+export type ImmutableReference = z.infer<typeof ImmutableReference>
+export type ImmutableReferences = z.infer<typeof ImmutableReferences>
+
+export const Contract = z.object({
+	abi: z.array(Abi),
+	evm: z.object({
+		bytecode: z.object({
+			object: z.string(),
+			sourceMap: z.optional(z.string()),
+			linkReferences: z.optional(LinkReferences),
+		}),
+		deployedBytecode: z.object({
+			object: z.string(),
+			sourceMap: z.optional(z.string()),
+			linkReferences: z.optional(LinkReferences),
+			immutableReferences: z.optional(ImmutableReferences),
+		}),
+	}),
+	devdoc: z.optional(z.unknown()),
+	userdoc: z.optional(z.unknown()),
+	metadata: z.optional(z.string()),
+	storageLayout: z.optional(z.unknown()),
+})
+
+export type Contract = z.infer<typeof Contract>
+
+export const CompileOutput = z.object({
+	// optional: error-only compiler output has no `contracts` key
+	contracts: z.optional(z.record(z.string(), z.record(z.string(), Contract))),
+	errors: z.optional(
+		z.array(
+			z.object({
+				message: z.string(),
+				severity: z.string(),
+				formattedMessage: z.optional(z.string()),
+			}),
+		),
+	),
+})
+
+export type CompileOutput = z.infer<typeof CompileOutput>

--- a/apps/contract-verification/src/wagmi.config.ts
+++ b/apps/contract-verification/src/wagmi.config.ts
@@ -1,5 +1,3 @@
-import { Address } from 'ox'
-import * as z from 'zod/mini'
 import {
 	tempoDevnet,
 	tempo as tempoMainnet,
@@ -36,23 +34,3 @@ export const chainFeeTokens = {
 	[tempoTestnet.id]: tempoTestnetExtended.feeToken,
 	[tempoMainnet.id]: tempoMainnetExtended.feeToken,
 } as const
-
-export const zAddress = (opts?: { lowercase?: boolean }) =>
-	z.pipe(
-		z.string(),
-		z.transform((x) => {
-			if (opts?.lowercase) x = x.toLowerCase()
-			Address.assert(x)
-			return x
-		}),
-	)
-
-export const zChainId = () =>
-	z.pipe(
-		z.string(),
-		z.transform((x) => {
-			const n = Number.parseInt(x, 10)
-			if (Number.isNaN(n)) throw new Error('Invalid chain ID')
-			return n
-		}),
-	)

--- a/apps/contract-verification/test/e2e/verification.test.ts
+++ b/apps/contract-verification/test/e2e/verification.test.ts
@@ -8,6 +8,7 @@ import * as DB from '#database/schema.ts'
 import { runVerificationJob } from '#route.verify.ts'
 import { staticChains } from '#wagmi.config.ts'
 import { ChainRegistry } from '#lib/chain-registry.ts'
+import type { VerificationJob } from '#schema.ts'
 import { counterFixture, counterSource } from '../fixtures/counter.fixture.ts'
 
 const VerificationIdSchema = z.object({ verificationId: z.string() })
@@ -69,7 +70,10 @@ function solcOutputWithRuntimeBytecode(bytecode: `0x${string}`): unknown {
 }
 
 describe('full verification flow', () => {
-	type VerifyRequestBody = Parameters<typeof runVerificationJob>[4]
+	type VerifyRequestBody = Omit<
+		VerificationJob,
+		'jobId' | 'chainId' | 'address'
+	>
 
 	async function createVerificationJob(
 		body: VerifyRequestBody = verifyRequestBody,
@@ -101,10 +105,12 @@ describe('full verification flow', () => {
 
 		await runVerificationJob(
 			env,
-			verificationId,
-			counterFixture.chainId,
-			counterFixture.address,
-			body,
+			{
+				jobId: verificationId,
+				chainId: counterFixture.chainId,
+				address: counterFixture.address,
+				...body,
+			},
 			ChainRegistry.fromStatic(staticChains),
 			{
 				createPublicClient: () => ({
@@ -154,10 +160,12 @@ describe('full verification flow', () => {
 
 		await runVerificationJob(
 			env,
-			options.jobId ?? globalThis.crypto.randomUUID(),
-			counterFixture.chainId,
-			options.address,
-			body,
+			{
+				jobId: options.jobId ?? globalThis.crypto.randomUUID(),
+				chainId: counterFixture.chainId,
+				address: options.address,
+				...body,
+			},
 			ChainRegistry.fromStatic(staticChains),
 			{
 				createPublicClient: () => ({

--- a/apps/contract-verification/test/fixtures/vyper.fixture.ts
+++ b/apps/contract-verification/test/fixtures/vyper.fixture.ts
@@ -1,0 +1,136 @@
+export const vyperSource = `# @version ^0.3.10
+# Simple Vyper contract for testing
+
+owner: public(address)
+value: public(uint256)
+
+event ValueChanged:
+    sender: indexed(address)
+    newValue: uint256
+
+@deploy
+def __init__():
+    self.owner = msg.sender
+    self.value = 0
+
+@external
+def set_value(_value: uint256):
+    self.value = _value
+    log ValueChanged(msg.sender, _value)
+
+@external
+@view
+def get_value() -> uint256:
+    return self.value
+`
+
+// Realistic Vyper compiler output – bytecodes are shortened but structurally valid
+// hex strings that exercise the Vyper matching branches.
+const VYPER_RUNTIME_BYTECODE =
+	'6003361161000c57610108565b5f3560e01c346101045763b0f2b72a811861002e575f5460405260206040f35b632baeceb78118610068575f5f5460018101818111610104579050815f5560405260016020527f0ef4482aceb854636f33f9cd319f9e1cd6fe3aa2e60523f3583c287b8938244560406020a1005b63d09de08a8118610072575b005b63d14e62b881186100d757602436103417610104576004358060405260015f5460018101818111610104579050815f5560605260016040527f0ef4482aceb854636f33f9cd319f9e1cd6fe3aa2e60523f3583c287b8938244560606040a1005b638da5cb5b81186100f557600154604052602060406100fc565b5f5ffd5b5f5ffd5bf35b5f5ffd'
+const VYPER_CREATION_BYTECODE =
+	'61012461001161000039610124610000f36003361161000c57610108565b5f3560e01c346101045763b0f2b72a811861002e575f5460405260206040f35b632baeceb78118610068575f5f5460018101818111610104579050815f5560405260016020527f0ef4482aceb854636f33f9cd319f9e1cd6fe3aa2e60523f3583c287b8938244560406020a1005b63d09de08a8118610072575b005b63d14e62b881186100d757602436103417610104576004358060405260015f5460018101818111610104579050815f5560605260016040527f0ef4482aceb854636f33f9cd319f9e1cd6fe3aa2e60523f3583c287b8938244560606040a1005b638da5cb5b81186100f557600154604052602060406100fc565b5f5ffd5b5f5ffd5bf35b5f5ffd'
+
+export const vyperFixture = {
+	chainId: 31_318,
+	address: '0x2222222222222222222222222222222222222222' as const,
+	compilerVersion: '0.3.10',
+	contractIdentifier: 'vyper_contract.vy:vyper_contract',
+
+	stdJsonInput: {
+		language: 'Vyper',
+		sources: {
+			'vyper_contract.vy': { content: vyperSource },
+		},
+		settings: {
+			outputSelection: {
+				'*': {
+					'*': ['abi', 'evm.bytecode', 'evm.deployedBytecode'],
+				},
+			},
+			evmVersion: 'cancun',
+		},
+	},
+
+	vyperCompileOutput: {
+		contracts: {
+			'vyper_contract.vy': {
+				vyper_contract: {
+					abi: [
+						{
+							inputs: [],
+							stateMutability: 'nonpayable',
+							type: 'constructor',
+						},
+						{
+							anonymous: false,
+							inputs: [
+								{
+									indexed: true,
+									name: 'sender',
+									type: 'address',
+								},
+								{
+									indexed: false,
+									name: 'newValue',
+									type: 'uint256',
+								},
+							],
+							name: 'ValueChanged',
+							type: 'event',
+						},
+						{
+							inputs: [],
+							name: 'owner',
+							outputs: [{ name: '', type: 'address' }],
+							stateMutability: 'view',
+							type: 'function',
+						},
+						{
+							inputs: [],
+							name: 'value',
+							outputs: [{ name: '', type: 'uint256' }],
+							stateMutability: 'view',
+							type: 'function',
+						},
+						{
+							inputs: [{ name: '_value', type: 'uint256' }],
+							name: 'set_value',
+							outputs: [],
+							stateMutability: 'nonpayable',
+							type: 'function',
+						},
+						{
+							inputs: [],
+							name: 'get_value',
+							outputs: [{ name: '', type: 'uint256' }],
+							stateMutability: 'view',
+							type: 'function',
+						},
+					],
+					evm: {
+						bytecode: {
+							object: VYPER_CREATION_BYTECODE,
+							sourceMap: '',
+						},
+						deployedBytecode: {
+							object: VYPER_RUNTIME_BYTECODE,
+							sourceMap: '',
+						},
+					},
+					metadata: '',
+				},
+			},
+		},
+		sources: {
+			'vyper_contract.vy': { id: 0 },
+		},
+	},
+
+	// On-chain bytecode matches the compiled runtime bytecode exactly (happy path)
+	onchainRuntimeBytecode: `0x${VYPER_RUNTIME_BYTECODE}` as const,
+
+	// A slightly different bytecode to simulate a mismatch
+	mismatchedOnchainBytecode:
+		'0xaabbccdd00000000000000000000000000000000000000000000000000000000000000000000000000000000' as const,
+} as const

--- a/apps/contract-verification/test/integration/route.lookup-verified.test.ts
+++ b/apps/contract-verification/test/integration/route.lookup-verified.test.ts
@@ -1,0 +1,863 @@
+import { Hash, Hex } from 'ox'
+import { eq } from 'drizzle-orm'
+import { env } from 'cloudflare:test'
+import { drizzle } from 'drizzle-orm/d1'
+import { describe, expect, it } from 'vitest'
+
+import { app } from '#index.tsx'
+import * as DB from '#database/schema.ts'
+import { staticChains } from '#wagmi.config.ts'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const chainId = staticChains[0].id
+const address = '0x1111111111111111111111111111111111111111' as const
+
+/** Complex ABI with functions, events, errors, tuples, and nested tuples. */
+const complexAbi = [
+	{
+		type: 'function',
+		name: 'transfer',
+		inputs: [
+			{ name: 'to', type: 'address' },
+			{ name: 'amount', type: 'uint256' },
+		],
+		outputs: [{ name: '', type: 'bool' }],
+		stateMutability: 'nonpayable',
+	},
+	{
+		type: 'function',
+		name: 'balanceOf',
+		inputs: [{ name: 'account', type: 'address' }],
+		outputs: [{ name: '', type: 'uint256' }],
+		stateMutability: 'view',
+	},
+	{
+		type: 'function',
+		name: 'createOrder',
+		inputs: [
+			{
+				name: 'order',
+				type: 'tuple',
+				components: [
+					{ name: 'maker', type: 'address' },
+					{ name: 'amount', type: 'uint256' },
+					{
+						name: 'details',
+						type: 'tuple',
+						components: [
+							{ name: 'expiry', type: 'uint64' },
+							{ name: 'nonce', type: 'uint256' },
+						],
+					},
+				],
+			},
+		],
+		outputs: [{ name: 'orderId', type: 'bytes32' }],
+		stateMutability: 'nonpayable',
+	},
+	{
+		type: 'function',
+		name: 'batchTransfer',
+		inputs: [
+			{
+				name: 'transfers',
+				type: 'tuple[]',
+				components: [
+					{ name: 'to', type: 'address' },
+					{ name: 'amount', type: 'uint256' },
+				],
+			},
+		],
+		outputs: [],
+		stateMutability: 'nonpayable',
+	},
+	{
+		type: 'event',
+		name: 'Transfer',
+		inputs: [
+			{ name: 'from', type: 'address', indexed: true },
+			{ name: 'to', type: 'address', indexed: true },
+			{ name: 'value', type: 'uint256', indexed: false },
+		],
+	},
+	{
+		type: 'event',
+		name: 'Approval',
+		inputs: [
+			{ name: 'owner', type: 'address', indexed: true },
+			{ name: 'spender', type: 'address', indexed: true },
+			{ name: 'value', type: 'uint256', indexed: false },
+		],
+	},
+	{
+		type: 'error',
+		name: 'InsufficientBalance',
+		inputs: [
+			{ name: 'available', type: 'uint256' },
+			{ name: 'required', type: 'uint256' },
+		],
+	},
+	{
+		type: 'error',
+		name: 'Unauthorized',
+		inputs: [{ name: 'caller', type: 'address' }],
+	},
+	// Constructor – should NOT generate a signature
+	{
+		type: 'constructor',
+		inputs: [{ name: 'initialSupply', type: 'uint256' }],
+		stateMutability: 'nonpayable',
+	},
+	// Receive – should NOT generate a signature
+	{ type: 'receive', stateMutability: 'payable' },
+]
+
+const runtimeTransformations = JSON.stringify({
+	cborAuxdata: { offset: 1234, hash: '0xaabb' },
+})
+const creationTransformations = JSON.stringify({
+	constructorArguments:
+		'0x00000000000000000000000000000000000000000000000000000000000003e8',
+})
+const runtimeValues = JSON.stringify({
+	libraries: { MathLib: '0x2222222222222222222222222222222222222222' },
+})
+const creationValues = JSON.stringify({
+	constructorArguments:
+		'0x00000000000000000000000000000000000000000000000000000000000003e8',
+	libraries: { MathLib: '0x2222222222222222222222222222222222222222' },
+})
+
+const compilerSettings = JSON.stringify({
+	optimizer: { enabled: true, runs: 200 },
+	evmVersion: 'cancun',
+})
+
+/** Insert a fully-formed verified contract fixture into the DB.  Returns IDs needed for assertions. */
+async function insertVerifiedContractFixture(opts?: {
+	abi?: unknown[]
+	userdoc?: unknown
+	devdoc?: unknown
+	storageLayout?: unknown
+	metadata?: unknown
+	runtimeMetadataMatch?: boolean
+	creationMetadataMatch?: boolean
+	withTransformations?: boolean
+	withSignatures?: boolean
+	creationSourceMap?: string
+	runtimeSourceMap?: string
+	runtimeImmutableReferences?: unknown
+	runtimeCborAuxdata?: unknown
+	creationCborAuxdata?: unknown
+	creationLinkReferences?: unknown
+	runtimeLinkReferences?: unknown
+	transactionHash?: Uint8Array
+	blockNumber?: number
+	transactionIndex?: number
+	deployer?: Uint8Array
+}): Promise<{
+	compilationId: string
+	deploymentId: string
+	matchId: number
+}> {
+	const db = drizzle(env.CONTRACTS_DB)
+
+	const abi = opts?.abi ?? complexAbi
+	const runtimeHash = new Uint8Array(32).fill(0xa1)
+	const creationHash = new Uint8Array(32).fill(0xa2)
+	const codeHashKeccak = new Uint8Array(32).fill(0xa3)
+
+	await db.insert(DB.codeTable).values([
+		{
+			codeHash: runtimeHash,
+			codeHashKeccak,
+			code: new Uint8Array([0x60, 0x80]),
+		},
+		{
+			codeHash: creationHash,
+			codeHashKeccak,
+			code: new Uint8Array([0x60, 0x80, 0x60, 0x40]),
+		},
+	])
+
+	const contractId = crypto.randomUUID()
+	await db.insert(DB.contractsTable).values({
+		id: contractId,
+		creationCodeHash: creationHash,
+		runtimeCodeHash: runtimeHash,
+	})
+
+	const deploymentId = crypto.randomUUID()
+	await db.insert(DB.contractDeploymentsTable).values({
+		id: deploymentId,
+		chainId,
+		address: Hex.toBytes(address),
+		contractId,
+		transactionHash: opts?.transactionHash ?? null,
+		blockNumber: opts?.blockNumber ?? null,
+		transactionIndex: opts?.transactionIndex ?? null,
+		deployer: opts?.deployer ?? null,
+	})
+
+	const compilationArtifacts = JSON.stringify({
+		abi,
+		userdoc: opts?.userdoc ?? null,
+		devdoc: opts?.devdoc ?? null,
+		storageLayout: opts?.storageLayout ?? null,
+		metadata: opts?.metadata ?? null,
+	})
+
+	const creationCodeArtifacts = JSON.stringify({
+		sourceMap: opts?.creationSourceMap ?? '0:0:0:-:0',
+		linkReferences: opts?.creationLinkReferences ?? {},
+		cborAuxdata: opts?.creationCborAuxdata ?? null,
+	})
+
+	const runtimeCodeArtifacts = JSON.stringify({
+		sourceMap: opts?.runtimeSourceMap ?? '0:0:0:-:0',
+		linkReferences: opts?.runtimeLinkReferences ?? {},
+		immutableReferences: opts?.runtimeImmutableReferences ?? {},
+		cborAuxdata: opts?.runtimeCborAuxdata ?? null,
+	})
+
+	const compilationId = crypto.randomUUID()
+	await db.insert(DB.compiledContractsTable).values({
+		id: compilationId,
+		compiler: 'solc',
+		version: '0.8.30',
+		language: 'Solidity',
+		name: 'Token',
+		fullyQualifiedName: 'contracts/Token.sol:Token',
+		compilerSettings,
+		compilationArtifacts,
+		creationCodeHash: creationHash,
+		creationCodeArtifacts,
+		runtimeCodeHash: runtimeHash,
+		runtimeCodeArtifacts,
+	})
+
+	// Insert sources
+	const sourceContent = 'contract Token { /* ... */ }'
+	const sourceHash = new Uint8Array(32).fill(0xbb)
+	const sourceHashKeccak = new Uint8Array(32).fill(0xcc)
+	await db.insert(DB.sourcesTable).values({
+		sourceHash,
+		sourceHashKeccak,
+		content: sourceContent,
+	})
+	await db.insert(DB.compiledContractsSourcesTable).values({
+		id: crypto.randomUUID(),
+		compilationId,
+		sourceHash,
+		path: 'contracts/Token.sol',
+	})
+
+	// Insert signatures into the DB if requested
+	if (opts?.withSignatures !== false) {
+		const sigItems: Array<{
+			name: string
+			inputs: unknown[]
+			type: 'function' | 'event' | 'error'
+		}> = []
+		for (const item of abi) {
+			if (
+				typeof item === 'object' &&
+				item !== null &&
+				'name' in item &&
+				'type' in item
+			) {
+				const t = (item as Record<string, unknown>).type
+				if (t === 'function' || t === 'event' || t === 'error') {
+					sigItems.push(
+						item as {
+							name: string
+							inputs: unknown[]
+							type: 'function' | 'event' | 'error'
+						},
+					)
+				}
+			}
+		}
+
+		for (const item of sigItems) {
+			const inputTypes = (item.inputs ?? [])
+				.map((inp) => formatType(inp))
+				.join(',')
+			const sig = `${item.name}(${inputTypes})`
+			const hash32 = Hash.keccak256(Hex.fromString(sig))
+			const hash32Bytes = Hex.toBytes(hash32)
+
+			// signatures table (ignore conflicts for duplicate hashes)
+			await db
+				.insert(DB.signaturesTable)
+				.values({ signatureHash32: hash32Bytes, signature: sig })
+				.onConflictDoNothing()
+			await db.insert(DB.compiledContractsSignaturesTable).values({
+				id: crypto.randomUUID(),
+				compilationId,
+				signatureHash32: hash32Bytes,
+				signatureType: item.type,
+			})
+		}
+	}
+
+	await db.insert(DB.verifiedContractsTable).values({
+		deploymentId,
+		compilationId,
+		creationMatch: true,
+		runtimeMatch: true,
+		creationMetadataMatch: opts?.creationMetadataMatch ?? true,
+		runtimeMetadataMatch: opts?.runtimeMetadataMatch ?? true,
+		...(opts?.withTransformations
+			? {
+					runtimeTransformations,
+					creationTransformations,
+					runtimeValues,
+					creationValues,
+				}
+			: {}),
+	})
+
+	const [row] = await db
+		.select({ id: DB.verifiedContractsTable.id })
+		.from(DB.verifiedContractsTable)
+		.where(eq(DB.verifiedContractsTable.deploymentId, deploymentId))
+		.limit(1)
+	if (!row) {
+		throw new Error('expected verified contract row')
+	}
+
+	return {
+		compilationId,
+		deploymentId,
+		matchId: row.id,
+	}
+}
+
+/** Recursively format an ABI input type, handling tuples. */
+function formatType(input: unknown): string {
+	if (typeof input !== 'object' || input === null) return ''
+	const inp = input as Record<string, unknown>
+	const type = inp.type as string
+	if (type === 'tuple' || type?.startsWith('tuple[')) {
+		const components = Array.isArray(inp.components) ? inp.components : []
+		const inner = components.map((c) => formatType(c)).join(',')
+		const suffix = type.slice('tuple'.length)
+		return `(${inner})${suffix}`
+	}
+	return type ?? ''
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('GET /v2/contract/:chainId/:address – verified contract responses', () => {
+	// -----------------------------------------------------------------------
+	// Minimal / default response shape
+	// -----------------------------------------------------------------------
+	it('returns minimal response by default (no fields/omit)', async () => {
+		const { matchId } = await insertVerifiedContractFixture()
+
+		const res = await app.request(`/v2/contract/${chainId}/${address}`, {}, env)
+		expect(res.status).toBe(200)
+
+		const body = (await res.json()) as Record<string, unknown>
+		// Minimal shape: matchId, match, creationMatch, runtimeMatch, chainId, address, verifiedAt
+		expect(body).toHaveProperty('matchId', String(matchId))
+		expect(body).toHaveProperty('match', 'exact_match')
+		expect(body).toHaveProperty('creationMatch', 'exact_match')
+		expect(body).toHaveProperty('runtimeMatch', 'exact_match')
+		expect(body).toHaveProperty('chainId', String(chainId))
+		expect(body).toHaveProperty('address', address)
+		expect(body).toHaveProperty('verifiedAt')
+
+		// Must NOT include extended fields when fields/omit absent
+		expect(body).not.toHaveProperty('abi')
+		expect(body).not.toHaveProperty('name')
+		expect(body).not.toHaveProperty('sources')
+		expect(body).not.toHaveProperty('signatures')
+	})
+
+	// -----------------------------------------------------------------------
+	// fields=all  — full response
+	// -----------------------------------------------------------------------
+	it('returns full response with fields=all', async () => {
+		await insertVerifiedContractFixture()
+
+		const res = await app.request(
+			`/v2/contract/${chainId}/${address}?fields=all`,
+			{},
+			env,
+		)
+		expect(res.status).toBe(200)
+
+		const body = (await res.json()) as Record<string, unknown>
+		// Check extended fields are present
+		expect(body).toHaveProperty('abi')
+		expect(body).toHaveProperty('name', 'Token')
+		expect(body).toHaveProperty(
+			'fullyQualifiedName',
+			'contracts/Token.sol:Token',
+		)
+		expect(body).toHaveProperty('compiler', 'solc')
+		expect(body).toHaveProperty('compilerVersion', '0.8.30')
+		expect(body).toHaveProperty('language', 'Solidity')
+		expect(body).toHaveProperty('sources')
+		expect(body).toHaveProperty('sourceIds')
+		expect(body).toHaveProperty('signatures')
+		expect(body).toHaveProperty('creationBytecode')
+		expect(body).toHaveProperty('runtimeBytecode')
+		expect(body).toHaveProperty('compilation')
+		expect(body).toHaveProperty('deployment')
+		expect(body).toHaveProperty('stdJsonInput')
+		expect(body).toHaveProperty('stdJsonOutput')
+	})
+
+	// -----------------------------------------------------------------------
+	// fields= selective
+	// -----------------------------------------------------------------------
+	it('returns only requested fields plus minimal envelope with fields=abi,name', async () => {
+		await insertVerifiedContractFixture()
+
+		const res = await app.request(
+			`/v2/contract/${chainId}/${address}?fields=abi,name`,
+			{},
+			env,
+		)
+		expect(res.status).toBe(200)
+
+		const body = (await res.json()) as Record<string, unknown>
+		// Minimal fields always present
+		expect(body).toHaveProperty('matchId')
+		expect(body).toHaveProperty('chainId')
+		expect(body).toHaveProperty('address')
+
+		// Requested fields
+		expect(body).toHaveProperty('abi')
+		expect(body).toHaveProperty('name', 'Token')
+
+		// Fields NOT requested should be absent
+		expect(body).not.toHaveProperty('sources')
+		expect(body).not.toHaveProperty('signatures')
+		expect(body).not.toHaveProperty('compilation')
+		expect(body).not.toHaveProperty('stdJsonInput')
+	})
+
+	it('returns only sources and sourceIds with fields=sources,sourceIds', async () => {
+		await insertVerifiedContractFixture()
+
+		const res = await app.request(
+			`/v2/contract/${chainId}/${address}?fields=sources,sourceIds`,
+			{},
+			env,
+		)
+		expect(res.status).toBe(200)
+
+		const body = (await res.json()) as Record<string, unknown>
+		expect(body).toHaveProperty('sources')
+		expect(body).toHaveProperty('sourceIds')
+
+		const sources = body.sources as Record<string, { content: string }>
+		expect(sources).toHaveProperty('contracts/Token.sol')
+		expect(sources['contracts/Token.sol']?.content).toBe(
+			'contract Token { /* ... */ }',
+		)
+
+		// Not requested
+		expect(body).not.toHaveProperty('abi')
+		expect(body).not.toHaveProperty('runtimeBytecode')
+	})
+
+	// -----------------------------------------------------------------------
+	// omit=
+	// -----------------------------------------------------------------------
+	it('omits specified fields from the full response', async () => {
+		await insertVerifiedContractFixture()
+
+		const res = await app.request(
+			`/v2/contract/${chainId}/${address}?omit=abi,sources,stdJsonInput,stdJsonOutput`,
+			{},
+			env,
+		)
+		expect(res.status).toBe(200)
+
+		const body = (await res.json()) as Record<string, unknown>
+		// Omitted fields
+		expect(body).not.toHaveProperty('abi')
+		expect(body).not.toHaveProperty('sources')
+		expect(body).not.toHaveProperty('stdJsonInput')
+		expect(body).not.toHaveProperty('stdJsonOutput')
+
+		// Other extended fields still present because omit exposes full minus omitted
+		expect(body).toHaveProperty('name', 'Token')
+		expect(body).toHaveProperty('compiler', 'solc')
+		expect(body).toHaveProperty('signatures')
+		expect(body).toHaveProperty('compilation')
+	})
+
+	it('returns 400 when both fields and omit are specified', async () => {
+		await insertVerifiedContractFixture()
+
+		const res = await app.request(
+			`/v2/contract/${chainId}/${address}?fields=abi&omit=sources`,
+			{},
+			env,
+		)
+		expect(res.status).toBe(400)
+		const body = (await res.json()) as Record<string, unknown>
+		expect(body).toHaveProperty('customCode', 'invalid_params')
+	})
+
+	// -----------------------------------------------------------------------
+	// Nested field selection
+	// -----------------------------------------------------------------------
+	it('supports nested field selection with dot paths', async () => {
+		await insertVerifiedContractFixture({
+			transactionHash: Hex.toBytes(
+				'0x000000000000000000000000000000000000000000000000000000000000abcd',
+			),
+			blockNumber: 42,
+			transactionIndex: 3,
+			deployer: Hex.toBytes('0x3333333333333333333333333333333333333333'),
+		})
+
+		const res = await app.request(
+			`/v2/contract/${chainId}/${address}?fields=deployment.chainId,deployment.address,deployment.deployer`,
+			{},
+			env,
+		)
+		expect(res.status).toBe(200)
+
+		const body = (await res.json()) as Record<string, unknown>
+		// Should have nested deployment with only requested sub-fields
+		expect(body).toHaveProperty('deployment')
+		const deployment = body.deployment as Record<string, unknown>
+		expect(deployment).toHaveProperty('chainId', String(chainId))
+		expect(deployment).toHaveProperty('address', address)
+		expect(deployment).toHaveProperty(
+			'deployer',
+			'0x3333333333333333333333333333333333333333',
+		)
+
+		// Non-requested fields
+		expect(body).not.toHaveProperty('abi')
+		expect(body).not.toHaveProperty('sources')
+	})
+
+	it('supports nested omit to remove sub-fields', async () => {
+		await insertVerifiedContractFixture()
+
+		const res = await app.request(
+			`/v2/contract/${chainId}/${address}?omit=deployment.deployer,deployment.transactionHash,sources,stdJsonInput,stdJsonOutput`,
+			{},
+			env,
+		)
+		expect(res.status).toBe(200)
+
+		const body = (await res.json()) as Record<string, unknown>
+		expect(body).toHaveProperty('deployment')
+		const deployment = body.deployment as Record<string, unknown>
+		expect(deployment).not.toHaveProperty('deployer')
+		expect(deployment).not.toHaveProperty('transactionHash')
+		// Remaining sub-fields still present
+		expect(deployment).toHaveProperty('chainId')
+		expect(deployment).toHaveProperty('address')
+	})
+
+	it('selecting a non-existent field is silently ignored', async () => {
+		await insertVerifiedContractFixture()
+
+		const res = await app.request(
+			`/v2/contract/${chainId}/${address}?fields=abi,nonExistentField`,
+			{},
+			env,
+		)
+		expect(res.status).toBe(200)
+
+		const body = (await res.json()) as Record<string, unknown>
+		expect(body).toHaveProperty('abi')
+		expect(body).not.toHaveProperty('nonExistentField')
+	})
+
+	// -----------------------------------------------------------------------
+	// Transformation payload exposure
+	// -----------------------------------------------------------------------
+	it('exposes runtimeValues, creationValues, runtimeTransformations, creationTransformations in full response', async () => {
+		await insertVerifiedContractFixture({ withTransformations: true })
+
+		const res = await app.request(
+			`/v2/contract/${chainId}/${address}?fields=all`,
+			{},
+			env,
+		)
+		expect(res.status).toBe(200)
+
+		const body = (await res.json()) as Record<string, unknown>
+		// Note: the current route handler fetches these columns but does NOT
+		// include them in the full response.  This test documents that gap.
+		// If the handler is later fixed to expose them, update the assertions below.
+		//
+		// When exposed they should look like:
+		//   body.runtimeValues → parsed JSON
+		//   body.creationValues → parsed JSON
+		//   body.runtimeTransformations → parsed JSON
+		//   body.creationTransformations → parsed JSON
+		//
+		// For now, assert that the minimal envelope fields are correct even when
+		// transformations are stored in the DB.
+		expect(body).toHaveProperty('matchId')
+		expect(body).toHaveProperty('match', 'exact_match')
+		expect(body).toHaveProperty('runtimeMatch', 'exact_match')
+		expect(body).toHaveProperty('creationMatch', 'exact_match')
+	})
+
+	// -----------------------------------------------------------------------
+	// Metadata match states
+	// -----------------------------------------------------------------------
+	it('reports runtimeMetadataMatch and creationMetadataMatch in full response', async () => {
+		await insertVerifiedContractFixture({
+			runtimeMetadataMatch: false,
+			creationMetadataMatch: true,
+		})
+
+		const res = await app.request(
+			`/v2/contract/${chainId}/${address}?fields=runtimeMetadataMatch,creationMetadataMatch`,
+			{},
+			env,
+		)
+		expect(res.status).toBe(200)
+
+		const body = (await res.json()) as Record<string, unknown>
+		expect(body).toHaveProperty('runtimeMetadataMatch', 'match')
+		expect(body).toHaveProperty('creationMetadataMatch', 'exact_match')
+	})
+
+	// -----------------------------------------------------------------------
+	// Signatures from DB-backed verified contracts
+	// -----------------------------------------------------------------------
+	it('returns DB-backed signatures grouped by type for a complex ABI', async () => {
+		await insertVerifiedContractFixture({ withSignatures: true })
+
+		const res = await app.request(
+			`/v2/contract/${chainId}/${address}?fields=signatures`,
+			{},
+			env,
+		)
+		expect(res.status).toBe(200)
+
+		const body = (await res.json()) as {
+			signatures: {
+				function: Array<{
+					signature: string
+					signatureHash32: string
+					signatureHash4: string
+				}>
+				event: Array<{
+					signature: string
+					signatureHash32: string
+					signatureHash4: string
+				}>
+				error: Array<{
+					signature: string
+					signatureHash32: string
+					signatureHash4: string
+				}>
+			}
+		}
+
+		const sigs = body.signatures
+		expect(sigs).toBeDefined()
+
+		// Functions
+		const fnSigs = sigs.function.map((s) => s.signature).toSorted()
+		expect(fnSigs).toContain('transfer(address,uint256)')
+		expect(fnSigs).toContain('balanceOf(address)')
+		expect(fnSigs).toContain('createOrder((address,uint256,(uint64,uint256)))')
+		expect(fnSigs).toContain('batchTransfer((address,uint256)[])')
+		expect(sigs.function).toHaveLength(4)
+
+		// Events
+		const evSigs = sigs.event.map((s) => s.signature).toSorted()
+		expect(evSigs).toContain('Transfer(address,address,uint256)')
+		expect(evSigs).toContain('Approval(address,address,uint256)')
+		expect(sigs.event).toHaveLength(2)
+
+		// Errors
+		const errSigs = sigs.error.map((s) => s.signature).toSorted()
+		expect(errSigs).toContain('InsufficientBalance(uint256,uint256)')
+		expect(errSigs).toContain('Unauthorized(address)')
+		expect(sigs.error).toHaveLength(2)
+
+		// Each entry should have hash fields
+		for (const group of [sigs.function, sigs.event, sigs.error]) {
+			for (const entry of group) {
+				expect(entry.signatureHash32).toMatch(/^0x[0-9a-f]{64}$/)
+				expect(entry.signatureHash4).toMatch(/^0x[0-9a-f]{8}$/)
+				// hash4 must be a prefix of hash32
+				expect(entry.signatureHash32.startsWith(entry.signatureHash4)).toBe(
+					true,
+				)
+			}
+		}
+	})
+
+	it('returns empty signature groups when no signatures are stored in DB', async () => {
+		await insertVerifiedContractFixture({ withSignatures: false })
+
+		const res = await app.request(
+			`/v2/contract/${chainId}/${address}?fields=signatures`,
+			{},
+			env,
+		)
+		expect(res.status).toBe(200)
+
+		const body = (await res.json()) as {
+			signatures: { function: unknown[]; event: unknown[]; error: unknown[] }
+		}
+		expect(body.signatures.function).toEqual([])
+		expect(body.signatures.event).toEqual([])
+		expect(body.signatures.error).toEqual([])
+	})
+
+	// -----------------------------------------------------------------------
+	// Bytecode fields
+	// -----------------------------------------------------------------------
+	it('returns creation and runtime bytecode with artifact data', async () => {
+		await insertVerifiedContractFixture({
+			creationSourceMap: '1:2:3:-:0',
+			runtimeSourceMap: '4:5:6:-:0',
+			runtimeImmutableReferences: { '5': [{ start: 0, length: 32 }] },
+			runtimeCborAuxdata: { offset: 100 },
+			creationCborAuxdata: { offset: 200 },
+		})
+
+		const res = await app.request(
+			`/v2/contract/${chainId}/${address}?fields=creationBytecode,runtimeBytecode`,
+			{},
+			env,
+		)
+		expect(res.status).toBe(200)
+
+		const body = (await res.json()) as Record<string, unknown>
+		const creation = body.creationBytecode as Record<string, unknown>
+		const runtime = body.runtimeBytecode as Record<string, unknown>
+
+		expect(creation).toBeDefined()
+		expect(creation.bytecode).toMatch(/^0x/)
+		expect(creation.sourceMap).toBe('1:2:3:-:0')
+		expect(creation.cborAuxdata).toEqual({ offset: 200 })
+
+		expect(runtime).toBeDefined()
+		expect(runtime.bytecode).toMatch(/^0x/)
+		expect(runtime.sourceMap).toBe('4:5:6:-:0')
+		expect(runtime.immutableReferences).toEqual({
+			'5': [{ start: 0, length: 32 }],
+		})
+		expect(runtime.cborAuxdata).toEqual({ offset: 100 })
+	})
+
+	// -----------------------------------------------------------------------
+	// Deployment metadata
+	// -----------------------------------------------------------------------
+	it('includes transaction metadata in deployment when available', async () => {
+		const txHash = Hex.toBytes(
+			'0x000000000000000000000000000000000000000000000000000000000000abcd',
+		)
+		const deployerAddr = Hex.toBytes(
+			'0x3333333333333333333333333333333333333333',
+		)
+
+		await insertVerifiedContractFixture({
+			transactionHash: txHash,
+			blockNumber: 999,
+			transactionIndex: 7,
+			deployer: deployerAddr,
+		})
+
+		const res = await app.request(
+			`/v2/contract/${chainId}/${address}?fields=deployment`,
+			{},
+			env,
+		)
+		expect(res.status).toBe(200)
+
+		const body = (await res.json()) as Record<string, unknown>
+		const deployment = body.deployment as Record<string, unknown>
+		expect(deployment.chainId).toBe(String(chainId))
+		expect(deployment.address).toBe(address)
+		expect(deployment.blockNumber).toBe(999)
+		expect(deployment.transactionIndex).toBe(7)
+		expect(deployment.deployer).toBe(
+			'0x3333333333333333333333333333333333333333',
+		)
+		expect(deployment.transactionHash).toMatch(/^0x/)
+	})
+
+	// -----------------------------------------------------------------------
+	// Compilation sub-object
+	// -----------------------------------------------------------------------
+	it('returns compilation sub-object with fields=compilation', async () => {
+		await insertVerifiedContractFixture()
+
+		const res = await app.request(
+			`/v2/contract/${chainId}/${address}?fields=compilation`,
+			{},
+			env,
+		)
+		expect(res.status).toBe(200)
+
+		const body = (await res.json()) as Record<string, unknown>
+		const comp = body.compilation as Record<string, unknown>
+		expect(comp).toBeDefined()
+		expect(comp.compiler).toBe('solc')
+		expect(comp.compilerVersion).toBe('0.8.30')
+		expect(comp.language).toBe('Solidity')
+		expect(comp.name).toBe('Token')
+		expect(comp.fullyQualifiedName).toBe('contracts/Token.sol:Token')
+		expect(comp.compilerSettings).toEqual(JSON.parse(compilerSettings))
+	})
+
+	// -----------------------------------------------------------------------
+	// stdJsonInput / stdJsonOutput
+	// -----------------------------------------------------------------------
+	it('returns stdJsonInput and stdJsonOutput with fields=stdJsonInput,stdJsonOutput', async () => {
+		await insertVerifiedContractFixture()
+
+		const res = await app.request(
+			`/v2/contract/${chainId}/${address}?fields=stdJsonInput,stdJsonOutput`,
+			{},
+			env,
+		)
+		expect(res.status).toBe(200)
+
+		const body = (await res.json()) as Record<string, unknown>
+
+		const input = body.stdJsonInput as Record<string, unknown>
+		expect(input).toBeDefined()
+		expect(input.language).toBe('Solidity')
+		expect(input.sources).toHaveProperty('contracts/Token.sol')
+		expect(input.settings).toEqual(JSON.parse(compilerSettings))
+
+		const output = body.stdJsonOutput as Record<string, unknown>
+		expect(output).toBeDefined()
+		expect(output).toHaveProperty('contracts')
+	})
+
+	// -----------------------------------------------------------------------
+	// 404 for non-existent contract
+	// -----------------------------------------------------------------------
+	it('returns 404 for address with no verified contract', async () => {
+		const res = await app.request(
+			`/v2/contract/${chainId}/0x0000000000000000000000000000000000000099`,
+			{},
+			env,
+		)
+		expect(res.status).toBe(404)
+		const body = (await res.json()) as Record<string, unknown>
+		expect(body).toHaveProperty('customCode', 'contract_not_found')
+	})
+})

--- a/apps/contract-verification/test/integration/route.verify-status.test.ts
+++ b/apps/contract-verification/test/integration/route.verify-status.test.ts
@@ -1,0 +1,338 @@
+import { SELF, env } from 'cloudflare:test'
+import { eq } from 'drizzle-orm'
+import { drizzle } from 'drizzle-orm/d1'
+import { Hex, Hash } from 'ox'
+import { describe, expect, it } from 'vitest'
+
+import {
+	codeTable,
+	compiledContractsTable,
+	contractDeploymentsTable,
+	contractsTable,
+	verifiedContractsTable,
+	verificationJobsTable,
+} from '#database/schema.ts'
+
+function statusUrl(id: string): string {
+	return `https://test.local/v2/verify/${id}`
+}
+
+async function getStatus(id: string): Promise<Response> {
+	return SELF.fetch(statusUrl(id), { method: 'GET' })
+}
+
+const db = () => drizzle(env.CONTRACTS_DB)
+const addressBytes = Hex.toBytes('0x1234567890abcdef1234567890abcdef12345678')
+
+async function insertJob(
+	overrides: Partial<{
+		id: string
+		startedAt: string
+		completedAt: string | null
+		verifiedContractId: number | null
+		errorCode: string | null
+		errorId: string | null
+		errorData: string | null
+		chainId: number
+	}> = {},
+): Promise<string> {
+	const id = overrides.id ?? globalThis.crypto.randomUUID()
+	await db()
+		.insert(verificationJobsTable)
+		.values({
+			id,
+			chainId: overrides.chainId ?? 185,
+			contractAddress: addressBytes,
+			verificationEndpoint: '/v2/verify',
+			startedAt: overrides.startedAt ?? new Date().toISOString(),
+			completedAt: overrides.completedAt ?? null,
+			verifiedContractId: overrides.verifiedContractId ?? null,
+			errorCode: overrides.errorCode ?? null,
+			errorId: overrides.errorId ?? null,
+			errorData: overrides.errorData ?? null,
+		})
+	return id
+}
+
+async function seedVerifiedContract(): Promise<number> {
+	const d = db()
+	const fakeRuntime = '0xdeadbeef'
+	const fakeCreation = '0xcafebabe'
+	const runtimeBytes = Hex.toBytes(fakeRuntime as `0x${string}`)
+	const creationBytes = Hex.toBytes(fakeCreation as `0x${string}`)
+	const runtimeHash = new Uint8Array(
+		await globalThis.crypto.subtle.digest(
+			'SHA-256',
+			new TextEncoder().encode(fakeRuntime),
+		),
+	)
+	const creationHash = new Uint8Array(
+		await globalThis.crypto.subtle.digest(
+			'SHA-256',
+			new TextEncoder().encode(fakeCreation),
+		),
+	)
+	const runtimeKeccak = Hex.toBytes(
+		Hash.keccak256(fakeRuntime as `0x${string}`),
+	)
+	const creationKeccak = Hex.toBytes(
+		Hash.keccak256(fakeCreation as `0x${string}`),
+	)
+
+	await d
+		.insert(codeTable)
+		.values([
+			{
+				codeHash: runtimeHash,
+				codeHashKeccak: runtimeKeccak,
+				code: runtimeBytes,
+			},
+			{
+				codeHash: creationHash,
+				codeHashKeccak: creationKeccak,
+				code: creationBytes,
+			},
+		])
+		.onConflictDoNothing()
+
+	const contractId = globalThis.crypto.randomUUID()
+	await d.insert(contractsTable).values({
+		id: contractId,
+		creationCodeHash: creationHash,
+		runtimeCodeHash: runtimeHash,
+	})
+
+	const deploymentId = globalThis.crypto.randomUUID()
+	await d.insert(contractDeploymentsTable).values({
+		id: deploymentId,
+		chainId: 185,
+		address: addressBytes,
+		contractId,
+	})
+
+	const compilationId = globalThis.crypto.randomUUID()
+	await d.insert(compiledContractsTable).values({
+		id: compilationId,
+		compiler: 'solc',
+		version: '0.8.20',
+		language: 'Solidity',
+		name: 'TestContract',
+		fullyQualifiedName: 'contracts/Test.sol:TestContract',
+		compilerSettings: '{}',
+		compilationArtifacts: '{}',
+		creationCodeHash: creationHash,
+		creationCodeArtifacts: '{}',
+		runtimeCodeHash: runtimeHash,
+		runtimeCodeArtifacts: '{}',
+	})
+
+	await d.insert(verifiedContractsTable).values({
+		deploymentId,
+		compilationId,
+		creationMatch: false,
+		runtimeMatch: true,
+		runtimeMetadataMatch: true,
+	})
+
+	const [row] = await d
+		.select({ id: verifiedContractsTable.id })
+		.from(verifiedContractsTable)
+		.where(eq(verifiedContractsTable.deploymentId, deploymentId))
+		.limit(1)
+
+	if (!row) throw new Error('expected verified contract row')
+	return row.id
+}
+
+describe('GET /v2/verify/:verificationId — status route', () => {
+	it('returns 404 for an unknown UUID', async () => {
+		const res = await getStatus('aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee')
+		expect(res.status).toBe(404)
+
+		const body = (await res.json()) as {
+			customCode: string
+			message: string
+			errorId: string
+		}
+		expect(body.customCode).toBe('not_found')
+		expect(body.message).toContain('aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee')
+		expect(body.errorId).toBeTypeOf('string')
+	})
+
+	it('returns 404 for an unknown numeric id', async () => {
+		const res = await getStatus('99999')
+		expect(res.status).toBe(404)
+
+		const body = (await res.json()) as { customCode: string }
+		expect(body.customCode).toBe('not_found')
+	})
+
+	it('returns 404 for a non-UUID, non-numeric string', async () => {
+		const res = await getStatus('not-a-valid-id!@#')
+		expect(res.status).toBe(404)
+
+		const body = (await res.json()) as { customCode: string }
+		expect(body.customCode).toBe('not_found')
+	})
+
+	it('returns 404 for an empty-ish verificationId', async () => {
+		const res = await getStatus('___')
+		expect(res.status).toBe(404)
+
+		const body = (await res.json()) as { customCode: string }
+		expect(body.customCode).toBe('not_found')
+	})
+
+	it('returns 200 with isJobCompleted=false for a pending job', async () => {
+		const jobId = await insertJob()
+		const res = await getStatus(jobId)
+
+		expect(res.status).toBe(200)
+		const body = (await res.json()) as {
+			isJobCompleted: boolean
+			verificationId: string
+			contract: {
+				match: null
+				creationMatch: null
+				runtimeMatch: null
+				chainId: string
+				address: string
+			}
+		}
+
+		expect(body.isJobCompleted).toBe(false)
+		expect(body.verificationId).toBe(jobId)
+		expect(body.contract.match).toBeNull()
+		expect(body.contract.creationMatch).toBeNull()
+		expect(body.contract.runtimeMatch).toBeNull()
+		expect(body.contract.chainId).toBe('185')
+		expect(body.contract.address).toMatch(/^0x[0-9a-fA-F]{40}$/)
+	})
+
+	it('auto-expires a stale unfinished job on status poll', async () => {
+		const staleDate = new Date(Date.now() - 20 * 60 * 1_000).toISOString()
+		const jobId = await insertJob({ startedAt: staleDate })
+
+		const res = await getStatus(jobId)
+		expect(res.status).toBe(200)
+
+		const body = (await res.json()) as {
+			isJobCompleted: boolean
+			verificationId: string
+			contract: null
+			error: { customCode: string; message: string; errorId: string }
+		}
+
+		expect(body.isJobCompleted).toBe(true)
+		expect(body.verificationId).toBe(jobId)
+		expect(body.contract).toBeNull()
+		expect(body.error.customCode).toBe('timeout')
+		expect(body.error.message).toContain('timed out')
+		expect(body.error.errorId).toBeTypeOf('string')
+
+		const [row] = await db()
+			.select({
+				completedAt: verificationJobsTable.completedAt,
+				errorCode: verificationJobsTable.errorCode,
+			})
+			.from(verificationJobsTable)
+			.where(eq(verificationJobsTable.id, jobId))
+			.limit(1)
+
+		expect(row?.completedAt).not.toBeNull()
+		expect(row?.errorCode).toBe('timeout')
+	})
+
+	it('returns 200 with error details for a failed job', async () => {
+		const errorId = globalThis.crypto.randomUUID()
+		const jobId = await insertJob({
+			completedAt: new Date().toISOString(),
+			errorCode: 'compilation_failed',
+			errorId,
+			errorData: JSON.stringify({ message: 'solc crashed' }),
+		})
+
+		const res = await getStatus(jobId)
+		expect(res.status).toBe(200)
+
+		const body = (await res.json()) as {
+			isJobCompleted: boolean
+			verificationId: string
+			contract: null
+			error: { customCode: string; message: string; errorId: string }
+		}
+
+		expect(body.isJobCompleted).toBe(true)
+		expect(body.verificationId).toBe(jobId)
+		expect(body.contract).toBeNull()
+		expect(body.error.customCode).toBe('compilation_failed')
+		expect(body.error.message).toBe('solc crashed')
+		expect(body.error.errorId).toBe(errorId)
+	})
+
+	it('uses fallback message when errorData has no message field', async () => {
+		const jobId = await insertJob({
+			completedAt: new Date().toISOString(),
+			errorCode: 'internal_error',
+			errorData: JSON.stringify({}),
+		})
+
+		const res = await getStatus(jobId)
+		const body = (await res.json()) as {
+			error: { message: string }
+		}
+		expect(body.error.message).toBe('Verification failed')
+	})
+
+	it('returns full contract details for a completed verification', async () => {
+		const verifiedId = await seedVerifiedContract()
+		const jobId = await insertJob({
+			completedAt: new Date().toISOString(),
+			verifiedContractId: verifiedId,
+		})
+
+		const res = await getStatus(jobId)
+		expect(res.status).toBe(200)
+
+		const body = (await res.json()) as {
+			isJobCompleted: boolean
+			verificationId: string
+			contract: {
+				match: string
+				creationMatch: string
+				runtimeMatch: string
+				matchId: string
+				name: string
+				chainId: string
+				address: string
+				verifiedAt: string
+			}
+		}
+
+		expect(body.isJobCompleted).toBe(true)
+		expect(body.verificationId).toBe(jobId)
+		expect(body.contract.matchId).toBe(String(verifiedId))
+		expect(body.contract.name).toBe('TestContract')
+		expect(body.contract.chainId).toBe('185')
+		expect(body.contract.address).toMatch(/^0x[0-9a-fA-F]{40}$/)
+		expect(body.contract.runtimeMatch).toBe('exact_match')
+		expect(body.contract.match).toBe('exact_match')
+		expect(body.contract.verifiedAt).toBeTypeOf('string')
+	})
+
+	it('resolves a numeric verificationId to a verified contract', async () => {
+		const verifiedId = await seedVerifiedContract()
+
+		const res = await getStatus(String(verifiedId))
+		expect(res.status).toBe(200)
+
+		const body = (await res.json()) as {
+			isJobCompleted: boolean
+			contract: { matchId: string; name: string }
+		}
+
+		expect(body.isJobCompleted).toBe(true)
+		expect(body.contract.matchId).toBe(String(verifiedId))
+		expect(body.contract.name).toBe('TestContract')
+	})
+})

--- a/apps/contract-verification/test/integration/route.verify.test.ts
+++ b/apps/contract-verification/test/integration/route.verify.test.ts
@@ -1,10 +1,27 @@
 import * as z from 'zod/mini'
-import { env } from 'cloudflare:workers'
+import { Hex } from 'ox'
+import { eq } from 'drizzle-orm'
+import { SELF, env } from 'cloudflare:test'
+import { drizzle } from 'drizzle-orm/d1'
 import { describe, it, expect } from 'vitest'
 
+import * as DB from '#database/schema.ts'
 import { app } from '#index.tsx'
+import { staticChains } from '#wagmi.config.ts'
+import { counterFixture } from '../fixtures/counter.fixture.ts'
+import { vyperFixture } from '../fixtures/vyper.fixture.ts'
+
+async function requestFromWorker(
+	path: string,
+	init?: RequestInit,
+): Promise<Response> {
+	return SELF.fetch(`https://test.local${path}`, init)
+}
 
 describe('POST /v2/verify/:chainId/:address', () => {
+	const validChainId = staticChains[0].id
+
+	const validAddress = '0x1234567890123456789012345678901234567890'
 	const validBody = {
 		stdJsonInput: {
 			language: 'Solidity',
@@ -28,51 +45,131 @@ contract Token {
 		contractIdentifier: 'contracts/Token.sol:Token',
 	}
 
-	it('returns 400 for invalid chain ID', async () => {
-		const response = await app.request(
+	it('returns 202 and inserts a verification job row for a fully valid request', async () => {
+		const response = await requestFromWorker(
+			`/v2/verify/${validChainId}/${validAddress}`,
+			{
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify(validBody),
+			},
+		)
+
+		expect(response.status).toBe(202)
+		const body = z.parse(
+			z.object({ verificationId: z.uuidv4() }),
+			await response.json(),
+		)
+		expect(body.verificationId).toBeTruthy()
+
+		const db = drizzle(env.CONTRACTS_DB)
+		const [job] = await db
+			.select()
+			.from(DB.verificationJobsTable)
+			.where(eq(DB.verificationJobsTable.id, body.verificationId))
+			.limit(1)
+
+		expect(job).toBeDefined()
+		if (!job) throw new Error('expected verification job row')
+		expect(job.chainId).toBe(validChainId)
+		expect(new Uint8Array(job.contractAddress as ArrayBuffer)).toEqual(
+			Hex.toBytes(validAddress),
+		)
+		expect(job.verificationEndpoint).toBe('/v2/verify')
+		expect(job.startedAt).not.toBeNull()
+		expect(job.completedAt).toBeNull()
+		expect(job.errorCode).toBeNull()
+		expect(job.verifiedContractId).toBeNull()
+	})
+
+	it('returns 400 with invalid_chain_id for non-numeric chain ID', async () => {
+		const response = await requestFromWorker(
+			'/v2/verify/not-a-chain/0x1234567890123456789012345678901234567890',
+			{
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify(validBody),
+			},
+		)
+
+		expect(response.status).toBe(400)
+		const body = z.parse(
+			z.object({ customCode: z.string() }),
+			await response.json(),
+		)
+		expect(body.customCode).toBe('invalid_chain_id')
+	})
+
+	it('returns 400 with invalid_chain_id for non-decimal chain ID', async () => {
+		const response = await requestFromWorker(
+			`/v2/verify/${validChainId}e0/0x1234567890123456789012345678901234567890`,
+			{
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify(validBody),
+			},
+		)
+
+		expect(response.status).toBe(400)
+		const body = z.parse(
+			z.object({ customCode: z.string() }),
+			await response.json(),
+		)
+		expect(body.customCode).toBe('invalid_chain_id')
+	})
+
+	it('returns 400 with unsupported_chain for unsupported chain ID', async () => {
+		const response = await requestFromWorker(
 			'/v2/verify/999999/0x1234567890123456789012345678901234567890',
 			{
 				method: 'POST',
 				headers: { 'Content-Type': 'application/json' },
 				body: JSON.stringify(validBody),
 			},
-			env,
 		)
 
 		expect(response.status).toBe(400)
+		const body = z.parse(
+			z.object({ customCode: z.string() }),
+			await response.json(),
+		)
+		expect(body.customCode).toBe('unsupported_chain')
 	})
 
-	it('returns 400 for invalid address format', async () => {
-		const response = await app.request(
-			'/v2/verify/1/invalid-address',
+	it('returns 400 with invalid_address for invalid address format', async () => {
+		const response = await requestFromWorker(
+			`/v2/verify/${validChainId}/invalid-address`,
 			{
 				method: 'POST',
 				headers: { 'Content-Type': 'application/json' },
 				body: JSON.stringify(validBody),
 			},
-			env,
 		)
 
 		expect(response.status).toBe(400)
+		const body = z.parse(
+			z.object({ customCode: z.string() }),
+			await response.json(),
+		)
+		expect(body.customCode).toBe('invalid_address')
 	})
 
 	it('returns 400 for invalid JSON body', async () => {
-		const response = await app.request(
-			'/v2/verify/1/0x1234567890123456789012345678901234567890',
+		const response = await requestFromWorker(
+			`/v2/verify/${validChainId}/${validAddress}`,
 			{
 				method: 'POST',
 				headers: { 'Content-Type': 'application/json' },
 				body: 'not valid json',
 			},
-			env,
 		)
 
 		expect(response.status).toBe(400)
 	})
 
 	it('returns 400 for missing required fields', async () => {
-		const response = await app.request(
-			'/v2/verify/1/0x1234567890123456789012345678901234567890',
+		const response = await requestFromWorker(
+			`/v2/verify/${validChainId}/${validAddress}`,
 			{
 				method: 'POST',
 				headers: { 'Content-Type': 'application/json' },
@@ -81,19 +178,386 @@ contract Token {
 					contractIdentifier: 'Token',
 				}),
 			},
-			env,
 		)
+
+		expect(response.status).toBe(400)
+	})
+
+	it('returns 400 with invalid_contract_identifier when contractIdentifier has no colon', async () => {
+		const response = await requestFromWorker(
+			`/v2/verify/${validChainId}/${validAddress}`,
+			{
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({
+					...validBody,
+					contractIdentifier: 'TokenWithoutColon',
+				}),
+			},
+		)
+
+		expect(response.status).toBe(400)
+		const body = z.parse(
+			z.object({ customCode: z.string() }),
+			await response.json(),
+		)
+		expect(body.customCode).toBe('invalid_contract_identifier')
+	})
+
+	it('returns 409 when contract is already verified', async () => {
+		const db = drizzle(env.CONTRACTS_DB)
+		const addressBytes = Hex.toBytes(validAddress)
+		const runtimeHash = new Uint8Array(32).fill(0xaa)
+		const creationHash = new Uint8Array(32).fill(0xbb)
+		const runtimeKeccak = new Uint8Array(32).fill(0xcc)
+		const creationKeccak = new Uint8Array(32).fill(0xdd)
+
+		await db.insert(DB.codeTable).values([
+			{
+				codeHash: runtimeHash,
+				codeHashKeccak: runtimeKeccak,
+				code: new Uint8Array([1]),
+			},
+			{
+				codeHash: creationHash,
+				codeHashKeccak: creationKeccak,
+				code: new Uint8Array([2]),
+			},
+		])
+
+		const contractId = crypto.randomUUID()
+		await db.insert(DB.contractsTable).values({
+			id: contractId,
+			creationCodeHash: creationHash,
+			runtimeCodeHash: runtimeHash,
+		})
+
+		const deploymentId = crypto.randomUUID()
+		await db.insert(DB.contractDeploymentsTable).values({
+			id: deploymentId,
+			chainId: validChainId,
+			address: addressBytes,
+			contractId,
+		})
+
+		const compilationId = crypto.randomUUID()
+		await db.insert(DB.compiledContractsTable).values({
+			id: compilationId,
+			compiler: 'solc',
+			version: validBody.compilerVersion,
+			language: validBody.stdJsonInput.language,
+			name: 'Token',
+			fullyQualifiedName: validBody.contractIdentifier,
+			compilerSettings: '{}',
+			compilationArtifacts: '{}',
+			creationCodeHash: creationHash,
+			creationCodeArtifacts: '{}',
+			runtimeCodeHash: runtimeHash,
+			runtimeCodeArtifacts: '{}',
+		})
+
+		await db.insert(DB.verifiedContractsTable).values({
+			deploymentId,
+			compilationId,
+			creationMatch: false,
+			runtimeMatch: true,
+			runtimeMetadataMatch: true,
+		})
+
+		const response = await requestFromWorker(
+			`/v2/verify/${validChainId}/${validAddress}`,
+			{
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify(validBody),
+			},
+		)
+
+		expect(response.status).toBe(409)
+		const body = z.parse(
+			z.object({ customCode: z.string() }),
+			await response.json(),
+		)
+		expect(body.customCode).toBe('already_verified')
+	})
+
+	it('accepts a new verification request when only a partial match exists', async () => {
+		const db = drizzle(env.CONTRACTS_DB)
+		const addressBytes = Hex.toBytes(validAddress)
+		const runtimeHash = new Uint8Array(32).fill(0x1a)
+		const creationHash = new Uint8Array(32).fill(0x1b)
+		const runtimeKeccak = new Uint8Array(32).fill(0x1c)
+		const creationKeccak = new Uint8Array(32).fill(0x1d)
+
+		await db.insert(DB.codeTable).values([
+			{
+				codeHash: runtimeHash,
+				codeHashKeccak: runtimeKeccak,
+				code: new Uint8Array([1]),
+			},
+			{
+				codeHash: creationHash,
+				codeHashKeccak: creationKeccak,
+				code: new Uint8Array([2]),
+			},
+		])
+
+		const contractId = crypto.randomUUID()
+		await db.insert(DB.contractsTable).values({
+			id: contractId,
+			creationCodeHash: creationHash,
+			runtimeCodeHash: runtimeHash,
+		})
+
+		const deploymentId = crypto.randomUUID()
+		await db.insert(DB.contractDeploymentsTable).values({
+			id: deploymentId,
+			chainId: validChainId,
+			address: addressBytes,
+			contractId,
+		})
+
+		const compilationId = crypto.randomUUID()
+		await db.insert(DB.compiledContractsTable).values({
+			id: compilationId,
+			compiler: 'solc',
+			version: validBody.compilerVersion,
+			language: validBody.stdJsonInput.language,
+			name: 'Token',
+			fullyQualifiedName: validBody.contractIdentifier,
+			compilerSettings: '{}',
+			compilationArtifacts: '{}',
+			creationCodeHash: creationHash,
+			creationCodeArtifacts: '{}',
+			runtimeCodeHash: runtimeHash,
+			runtimeCodeArtifacts: '{}',
+		})
+
+		// Partial match only: no metadata match on either bytecode. Per the
+		// partial-verification-poisoning fix, this must not block re-verification.
+		await db.insert(DB.verifiedContractsTable).values({
+			deploymentId,
+			compilationId,
+			creationMatch: false,
+			runtimeMatch: true,
+			runtimeMetadataMatch: false,
+			creationMetadataMatch: false,
+		})
+
+		const response = await requestFromWorker(
+			`/v2/verify/${validChainId}/${validAddress}`,
+			{
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify(validBody),
+			},
+		)
+
+		expect(response.status).toBe(202)
+	})
+
+	it('returns 429 for a duplicate in-flight request', async () => {
+		const db = drizzle(env.CONTRACTS_DB)
+		await db.insert(DB.verificationJobsTable).values({
+			id: crypto.randomUUID(),
+			chainId: validChainId,
+			contractAddress: Hex.toBytes(validAddress),
+			verificationEndpoint: '/v2/verify',
+		})
+
+		const response = await requestFromWorker(
+			`/v2/verify/${validChainId}/${validAddress}`,
+			{
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify(validBody),
+			},
+		)
+
+		expect(response.status).toBe(429)
+		const body = z.parse(
+			z.object({ customCode: z.string() }),
+			await response.json(),
+		)
+		expect(body.customCode).toBe('duplicate_verification_request')
+	})
+
+	it('expires a stale pending job and replaces it with a new verification request', async () => {
+		const db = drizzle(env.CONTRACTS_DB)
+		const staleJobId = crypto.randomUUID()
+		await db.insert(DB.verificationJobsTable).values({
+			id: staleJobId,
+			chainId: validChainId,
+			contractAddress: Hex.toBytes(validAddress),
+			verificationEndpoint: '/v2/verify',
+			startedAt: new Date(Date.now() - 20 * 60 * 1000).toISOString(),
+		})
+
+		const response = await requestFromWorker(
+			`/v2/verify/${validChainId}/${validAddress}`,
+			{
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify(validBody),
+			},
+		)
+
+		expect(response.status).toBe(202)
+		const body = z.parse(
+			z.object({ verificationId: z.uuidv4() }),
+			await response.json(),
+		)
+		expect(body.verificationId).not.toBe(staleJobId)
+
+		const [staleJob] = await db
+			.select({
+				completedAt: DB.verificationJobsTable.completedAt,
+				errorCode: DB.verificationJobsTable.errorCode,
+			})
+			.from(DB.verificationJobsTable)
+			.where(eq(DB.verificationJobsTable.id, staleJobId))
+			.limit(1)
+
+		expect(staleJob?.completedAt).not.toBeNull()
+		expect(staleJob?.errorCode).toBe('timeout')
+	})
+
+	it('returns 500 and removes the verification_jobs row when DO enqueue throws', async () => {
+		const mockEnv = {
+			...env,
+			VERIFICATION_JOB_RUNNER: {
+				idFromName: (_name: string) => ({ name: _name }),
+				get: (_id: unknown) => ({
+					enqueue: async () => {
+						throw new Error('Simulated DO enqueue failure')
+					},
+				}),
+			},
+		} as unknown as typeof env
+
+		const response = await app.request(
+			`/v2/verify/${counterFixture.chainId}/${counterFixture.address}`,
+			{
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({
+					stdJsonInput: counterFixture.stdJsonInput,
+					compilerVersion: counterFixture.compilerVersion,
+					contractIdentifier: counterFixture.contractIdentifier,
+				}),
+			},
+			mockEnv,
+		)
+
+		expect(response.status).toBe(500)
+		const body = z.parse(
+			z.object({ customCode: z.string() }),
+			await response.json(),
+		)
+		expect(body.customCode).toBe('internal_error')
+
+		const db = drizzle(env.CONTRACTS_DB)
+		const jobs = await db.select().from(DB.verificationJobsTable)
+		expect(jobs).toHaveLength(0)
+	})
+
+	it('accepts a lowercase non-checksummed address and returns 202', async () => {
+		const lowercaseAddress = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd'
+		const response = await requestFromWorker(
+			`/v2/verify/${validChainId}/${lowercaseAddress}`,
+			{
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify(validBody),
+			},
+		)
+
+		expect(response.status).toBe(202)
+	})
+
+	it('returns 400 for a numerically valid but unsupported chain ID', async () => {
+		const response = await requestFromWorker(`/v2/verify/1/${validAddress}`, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify(validBody),
+		})
 
 		expect(response.status).toBe(400)
 	})
 })
 
+describe('POST /v2/verify/:chainId/:address – Vyper payload', () => {
+	const validChainId = staticChains[0].id
+
+	const vyperAddress = '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+	const vyperBody = {
+		stdJsonInput: vyperFixture.stdJsonInput,
+		compilerVersion: vyperFixture.compilerVersion,
+		contractIdentifier: vyperFixture.contractIdentifier,
+	}
+
+	it('returns 202 and inserts a job row for a valid Vyper standard-json request', async () => {
+		const response = await requestFromWorker(
+			`/v2/verify/${validChainId}/${vyperAddress}`,
+			{
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify(vyperBody),
+			},
+		)
+
+		expect(response.status).toBe(202)
+		const body = z.parse(
+			z.object({ verificationId: z.uuidv4() }),
+			await response.json(),
+		)
+		expect(body.verificationId).toBeTruthy()
+
+		const db = drizzle(env.CONTRACTS_DB)
+		const [job] = await db
+			.select()
+			.from(DB.verificationJobsTable)
+			.where(eq(DB.verificationJobsTable.id, body.verificationId))
+			.limit(1)
+
+		expect(job).toBeDefined()
+		if (!job) throw new Error('expected verification job row')
+		expect(job.chainId).toBe(validChainId)
+		expect(new Uint8Array(job.contractAddress as ArrayBuffer)).toEqual(
+			Hex.toBytes(vyperAddress),
+		)
+		expect(job.verificationEndpoint).toBe('/v2/verify')
+		expect(job.startedAt).not.toBeNull()
+		expect(job.completedAt).toBeNull()
+	})
+
+	it('returns 400 for Vyper payload with invalid contractIdentifier (no colon)', async () => {
+		const response = await requestFromWorker(
+			`/v2/verify/${validChainId}/${vyperAddress}`,
+			{
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({
+					...vyperBody,
+					contractIdentifier: 'vyper_contract_no_colon',
+				}),
+			},
+		)
+
+		expect(response.status).toBe(400)
+		const body = z.parse(
+			z.object({ customCode: z.string() }),
+			await response.json(),
+		)
+		expect(body.customCode).toBe('invalid_contract_identifier')
+	})
+})
+
 describe('POST /metadata/:chainId/:address', () => {
 	it('returns 501 not implemented', async () => {
-		const response = await app.request(
+		const response = await requestFromWorker(
 			'/v2/verify/metadata/1/0x1234567890123456789012345678901234567890',
 			{ method: 'POST' },
-			env,
 		)
 
 		expect(response.status).toBe(501)
@@ -108,10 +572,9 @@ describe('POST /metadata/:chainId/:address', () => {
 
 describe('POST /similarity/:chainId/:address', () => {
 	it('returns 501 not implemented', async () => {
-		const response = await app.request(
+		const response = await requestFromWorker(
 			'/v2/verify/similarity/1/0x1234567890123456789012345678901234567890',
 			{ method: 'POST' },
-			env,
 		)
 
 		expect(response.status).toBe(501)

--- a/apps/contract-verification/test/unit/job-runner-do.test.ts
+++ b/apps/contract-verification/test/unit/job-runner-do.test.ts
@@ -1,0 +1,235 @@
+import { eq } from 'drizzle-orm'
+import { drizzle } from 'drizzle-orm/d1'
+import { env } from 'cloudflare:test'
+import { runDurableObjectAlarm, runInDurableObject } from 'cloudflare:test'
+import { Hex } from 'ox'
+import { describe, expect, it } from 'vitest'
+
+import * as DB from '#database/schema.ts'
+import type { VerificationJobRunner } from '#job-runner.ts'
+import type { VerificationJob } from '#schema.ts'
+import { counterFixture } from '../fixtures/counter.fixture.ts'
+
+function makeJob(jobId: string): VerificationJob {
+	return {
+		jobId,
+		chainId: counterFixture.chainId,
+		address: counterFixture.address,
+		stdJsonInput: counterFixture.stdJsonInput,
+		compilerVersion: counterFixture.compilerVersion,
+		contractIdentifier: counterFixture.contractIdentifier,
+	}
+}
+
+async function insertJobRow(jobId: string) {
+	const db = drizzle(env.CONTRACTS_DB)
+	await db.insert(DB.verificationJobsTable).values({
+		id: jobId,
+		chainId: counterFixture.chainId,
+		contractAddress: Hex.toBytes(counterFixture.address),
+		verificationEndpoint: '/v2/verify',
+	})
+}
+
+async function getJobRow(jobId: string) {
+	const db = drizzle(env.CONTRACTS_DB)
+	const rows = await db
+		.select()
+		.from(DB.verificationJobsTable)
+		.where(eq(DB.verificationJobsTable.id, jobId))
+		.limit(1)
+	return rows.at(0) ?? null
+}
+
+function getStub(name: string) {
+	const id = env.VERIFICATION_JOB_RUNNER.idFromName(name)
+	return env.VERIFICATION_JOB_RUNNER.get(
+		id,
+	) as DurableObjectStub<VerificationJobRunner>
+}
+
+describe('VerificationJobRunner Durable Object', () => {
+	describe('alarm – missing job', () => {
+		it('returns early without error when storage has no job', async () => {
+			const stub = getStub('missing-job-test')
+
+			await runInDurableObject(stub, async (_instance, state) => {
+				await state.storage.setAlarm(Date.now() + 60_000)
+			})
+
+			const ran = await runDurableObjectAlarm(stub)
+			expect(ran).toBe(true)
+
+			const hasJob = await runInDurableObject(
+				stub,
+				async (_instance, state) => await state.storage.get('job'),
+			)
+			expect(hasJob).toBeUndefined()
+		})
+	})
+
+	describe('enqueue + alarm – success path', () => {
+		it('stores the job and schedules an alarm via enqueue', async () => {
+			const jobId = globalThis.crypto.randomUUID()
+			await insertJobRow(jobId)
+
+			const stub = getStub(jobId)
+			const job = makeJob(jobId)
+
+			await runInDurableObject(stub, async (_instance, state) => {
+				await state.storage.put('job', job)
+				await state.storage.setAlarm(Date.now() + 60_000)
+			})
+
+			const storedJob = await runInDurableObject(
+				stub,
+				async (_instance, state) =>
+					await state.storage.get<VerificationJob>('job'),
+			)
+			expect(storedJob).toBeDefined()
+			expect(storedJob?.jobId).toBe(jobId)
+
+			const ran = await runDurableObjectAlarm(stub)
+			expect(ran).toBe(true)
+
+			const jobAfterAlarm = await runInDurableObject(
+				stub,
+				async (_instance, state) => await state.storage.get('job'),
+			)
+			expect(jobAfterAlarm).toBeUndefined()
+
+			const row = await getJobRow(jobId)
+			expect(row).not.toBeNull()
+			expect(row?.completedAt).not.toBeNull()
+		})
+
+		it('enqueue() stores job and sets alarm; manually firing alarm completes the job', async () => {
+			const jobId = globalThis.crypto.randomUUID()
+			await insertJobRow(jobId)
+
+			const stub = getStub(jobId)
+			await stub.enqueue(makeJob(jobId))
+
+			const jobInStorage = await runInDurableObject(
+				stub,
+				async (_instance, state) => await state.storage.get('job'),
+			)
+			expect(jobInStorage).toBeDefined()
+
+			await runInDurableObject(stub, async (instance) => {
+				await instance.alarm()
+			})
+
+			const jobAfter = await runInDurableObject(
+				stub,
+				async (_instance, state) => await state.storage.get('job'),
+			)
+			expect(jobAfter).toBeUndefined()
+
+			const row = await getJobRow(jobId)
+			expect(row).not.toBeNull()
+			expect(row?.completedAt).not.toBeNull()
+		})
+	})
+
+	describe('alarm – failure with cleanup', () => {
+		it('deletes the job from DO storage even when runVerificationJob encounters an error', async () => {
+			const jobId = globalThis.crypto.randomUUID()
+			await insertJobRow(jobId)
+
+			const stub = getStub(jobId)
+			const job = makeJob(jobId)
+
+			await runInDurableObject(stub, async (_instance, state) => {
+				await state.storage.put('job', job)
+				await state.storage.setAlarm(Date.now() + 60_000)
+			})
+
+			const before = await runInDurableObject(
+				stub,
+				async (_instance, state) => await state.storage.get('job'),
+			)
+			expect(before).toBeDefined()
+
+			const ran = await runDurableObjectAlarm(stub)
+			expect(ran).toBe(true)
+
+			const after = await runInDurableObject(
+				stub,
+				async (_instance, state) => await state.storage.get('job'),
+			)
+			expect(after).toBeUndefined()
+		})
+
+		it('records an error in the DB row when the job has an invalid chainId', async () => {
+			const jobId = globalThis.crypto.randomUUID()
+			await insertJobRow(jobId)
+
+			const stub = getStub(jobId)
+			await runInDurableObject(stub, async (_instance, state) => {
+				await state.storage.put('job', {
+					...makeJob(jobId),
+					chainId: 999_999,
+				})
+				await state.storage.setAlarm(Date.now() + 60_000)
+			})
+
+			await runDurableObjectAlarm(stub)
+
+			const row = await getJobRow(jobId)
+			expect(row).not.toBeNull()
+			expect(row?.completedAt).not.toBeNull()
+			expect(row?.errorCode).toBe('internal_error')
+		})
+
+		it('handles legacy stored job payloads written before the schema flattening change', async () => {
+			const jobId = globalThis.crypto.randomUUID()
+			await insertJobRow(jobId)
+
+			const stub = getStub(jobId)
+			await runInDurableObject(stub, async (_instance, state) => {
+				const job = makeJob(jobId)
+				await state.storage.put('job', {
+					jobId: job.jobId,
+					chainId: job.chainId,
+					address: job.address,
+					body: {
+						stdJsonInput: job.stdJsonInput,
+						compilerVersion: job.compilerVersion,
+						contractIdentifier: job.contractIdentifier,
+						creationTransactionHash: job.creationTransactionHash,
+					},
+				})
+				await state.storage.setAlarm(Date.now() + 60_000)
+			})
+
+			await runDurableObjectAlarm(stub)
+
+			const row = await getJobRow(jobId)
+			expect(row).not.toBeNull()
+			expect(row?.completedAt).not.toBeNull()
+		})
+
+		it('does not leave a dangling alarm after processing', async () => {
+			const jobId = globalThis.crypto.randomUUID()
+			await insertJobRow(jobId)
+
+			const stub = getStub(jobId)
+			await runInDurableObject(stub, async (_instance, state) => {
+				await state.storage.put('job', makeJob(jobId))
+				await state.storage.setAlarm(Date.now() + 60_000)
+			})
+
+			await runDurableObjectAlarm(stub)
+
+			const alarmAfter = await runInDurableObject(
+				stub,
+				async (_instance, state) => await state.storage.getAlarm(),
+			)
+			expect(alarmAfter).toBeNull()
+
+			const ranAgain = await runDurableObjectAlarm(stub)
+			expect(ranAgain).toBe(false)
+		})
+	})
+})

--- a/apps/contract-verification/test/unit/job-runner-failures.test.ts
+++ b/apps/contract-verification/test/unit/job-runner-failures.test.ts
@@ -1,0 +1,305 @@
+import { eq } from 'drizzle-orm'
+import { drizzle } from 'drizzle-orm/d1'
+import { SELF, env } from 'cloudflare:test'
+import { describe, expect, it } from 'vitest'
+
+import * as DB from '#database/schema.ts'
+import { ChainRegistry } from '#lib/chain-registry.ts'
+import { runVerificationJob as runVerificationJobWithRegistry } from '#route.verify.ts'
+import { staticChains } from '#wagmi.config.ts'
+
+// Tests exercise the job directly against the static chain registry.
+const runVerificationJob = (
+	jobEnv: Parameters<typeof runVerificationJobWithRegistry>[0],
+	job: Parameters<typeof runVerificationJobWithRegistry>[1],
+	deps?: Parameters<typeof runVerificationJobWithRegistry>[3],
+) =>
+	runVerificationJobWithRegistry(
+		jobEnv,
+		job,
+		ChainRegistry.fromStatic(staticChains),
+		deps,
+	)
+import { counterFixture } from '../fixtures/counter.fixture.ts'
+
+const verifyRequestData = {
+	stdJsonInput: counterFixture.stdJsonInput,
+	compilerVersion: counterFixture.compilerVersion,
+	contractIdentifier: counterFixture.contractIdentifier,
+} as const
+
+async function createJob(): Promise<string> {
+	const res = await SELF.fetch(
+		`https://test.local/v2/verify/${counterFixture.chainId}/${counterFixture.address}`,
+		{
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify(verifyRequestData),
+		},
+	)
+	expect(res.status).toBe(202)
+	const body = (await res.json()) as { verificationId: string }
+	return body.verificationId
+}
+
+async function getJob(jobId: string) {
+	const db = drizzle(env.CONTRACTS_DB)
+	const rows = await db
+		.select()
+		.from(DB.verificationJobsTable)
+		.where(eq(DB.verificationJobsTable.id, jobId))
+	expect(rows).toHaveLength(1)
+	const job = rows[0]
+	if (!job) throw new Error('expected verification job row')
+	return job
+}
+
+const validClientDeps = {
+	createPublicClient: () => ({
+		getCode: async () => counterFixture.onchainRuntimeBytecode,
+	}),
+} as const
+
+describe('runVerificationJob failure branches', () => {
+	it('records internal_error for unsupported chain id', async () => {
+		const jobId = await createJob()
+
+		await runVerificationJob(env, {
+			jobId,
+			chainId: 999_999 as never,
+			address: counterFixture.address,
+			stdJsonInput: counterFixture.stdJsonInput,
+			compilerVersion: counterFixture.compilerVersion,
+			contractIdentifier: counterFixture.contractIdentifier,
+		})
+
+		const job = await getJob(jobId)
+		expect(job.completedAt).not.toBeNull()
+		expect(job.errorCode).toBe('internal_error')
+		const data = JSON.parse(job.errorData ?? '{}') as { message?: string }
+		expect(data.message).toMatch(/not supported/i)
+	})
+
+	it('records compilation_failed when container returns non-200', async () => {
+		const jobId = await createJob()
+
+		await runVerificationJob(
+			env,
+			{
+				jobId,
+				...counterFixture,
+			},
+			{
+				...validClientDeps,
+				getContainer: () => ({
+					fetch: async () =>
+						new Response('solc exited with code 1', { status: 500 }),
+				}),
+			},
+		)
+
+		const job = await getJob(jobId)
+		expect(job.completedAt).not.toBeNull()
+		expect(job.errorCode).toBe('compilation_failed')
+		const data = JSON.parse(job.errorData ?? '{}') as { message?: string }
+		expect(data.message).toContain('solc exited with code 1')
+	})
+
+	it('records contract_not_found_in_output when target contract is absent', async () => {
+		const jobId = await createJob()
+
+		const modifiedOutput = structuredClone(counterFixture.solcOutput) as {
+			contracts: Record<string, Record<string, unknown>>
+		}
+		modifiedOutput.contracts = {
+			'Counter.sol': {
+				OtherContract:
+					counterFixture.solcOutput.contracts['Counter.sol'].Counter,
+			},
+		}
+
+		await runVerificationJob(
+			env,
+			{
+				jobId,
+				...counterFixture,
+			},
+			{
+				...validClientDeps,
+				getContainer: () => ({
+					fetch: async () => Response.json(modifiedOutput, { status: 200 }),
+				}),
+			},
+		)
+
+		const job = await getJob(jobId)
+		expect(job.completedAt).not.toBeNull()
+		expect(job.errorCode).toBe('contract_not_found_in_output')
+		const data = JSON.parse(job.errorData ?? '{}') as { message?: string }
+		expect(data.message).toContain('Counter')
+	})
+
+	it('records no_match when compiled bytecode differs from on-chain', async () => {
+		const jobId = await createJob()
+
+		await runVerificationJob(
+			env,
+			{
+				jobId,
+				...counterFixture,
+			},
+			{
+				createPublicClient: () => ({
+					getCode: async () =>
+						'0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef' as `0x${string}`,
+				}),
+				getContainer: () => ({
+					fetch: async () =>
+						Response.json(counterFixture.solcOutput, { status: 200 }),
+				}),
+			},
+		)
+
+		const job = await getJob(jobId)
+		expect(job.completedAt).not.toBeNull()
+		expect(job.errorCode).toBe('no_match')
+		const data = JSON.parse(job.errorData ?? '{}') as { message?: string }
+		expect(data.message).toMatch(/bytecode|match/i)
+	})
+
+	it('persists internal_error with errorId when an unexpected error is thrown', async () => {
+		const jobId = await createJob()
+
+		await runVerificationJob(
+			env,
+			{
+				jobId,
+				...counterFixture,
+			},
+			{
+				createPublicClient: () => ({
+					getCode: async () => {
+						throw new Error('RPC node unreachable')
+					},
+				}),
+			},
+		)
+
+		const job = await getJob(jobId)
+		expect(job.completedAt).not.toBeNull()
+		expect(job.errorCode).toBe('internal_error')
+		expect(job.errorId).toBeTruthy()
+		const data = JSON.parse(job.errorData ?? '{}') as { message?: string }
+		expect(data.message).toContain('RPC node unreachable')
+		expect(job.compilationTime).toBeTypeOf('number')
+	})
+
+	it('records contract_not_found_in_output for empty compile output', async () => {
+		const jobId = await createJob()
+
+		await runVerificationJob(
+			env,
+			{
+				jobId,
+				...counterFixture,
+			},
+			{
+				...validClientDeps,
+				getContainer: () => ({
+					fetch: async () => Response.json({}, { status: 200 }),
+				}),
+			},
+		)
+
+		const job = await getJob(jobId)
+		expect(job.completedAt).not.toBeNull()
+		expect(job.errorCode).toBe('contract_not_found_in_output')
+	})
+
+	it('records internal_error when compile output is not valid JSON', async () => {
+		const jobId = await createJob()
+
+		await runVerificationJob(
+			env,
+			{
+				jobId,
+				...counterFixture,
+			},
+			{
+				...validClientDeps,
+				getContainer: () => ({
+					fetch: async () =>
+						new Response('not json at all', {
+							status: 200,
+							headers: { 'Content-Type': 'application/json' },
+						}),
+				}),
+			},
+		)
+
+		const job = await getJob(jobId)
+		expect(job.completedAt).not.toBeNull()
+		expect(job.errorCode).toBe('internal_error')
+	})
+
+	it('records container_error when container fetch throws', async () => {
+		const jobId = await createJob()
+
+		await runVerificationJob(
+			env,
+			{
+				jobId,
+				...counterFixture,
+			},
+			{
+				...validClientDeps,
+				getContainer: () => ({
+					fetch: async () => {
+						throw new Error('connection refused')
+					},
+				}),
+			},
+		)
+
+		const job = await getJob(jobId)
+		expect(job.completedAt).not.toBeNull()
+		expect(job.errorCode).toBe('container_error')
+		const data = JSON.parse(job.errorData ?? '{}') as { message?: string }
+		expect(data.message).toContain('connection refused')
+	})
+
+	it('records compilation_error when solc output contains severity=error entries', async () => {
+		const jobId = await createJob()
+
+		const errorOutput = {
+			contracts: {},
+			errors: [
+				{
+					severity: 'error',
+					message: 'ParserError: Expected pragma',
+					formattedMessage: 'ParserError: Expected pragma, got EOF',
+				},
+			],
+		}
+
+		await runVerificationJob(
+			env,
+			{
+				jobId,
+				...counterFixture,
+			},
+			{
+				...validClientDeps,
+				getContainer: () => ({
+					fetch: async () => Response.json(errorOutput, { status: 200 }),
+				}),
+			},
+		)
+
+		const job = await getJob(jobId)
+		expect(job.completedAt).not.toBeNull()
+		expect(job.errorCode).toBe('compilation_error')
+		const data = JSON.parse(job.errorData ?? '{}') as { message?: string }
+		expect(data.message).toContain('Expected pragma')
+	})
+})

--- a/apps/contract-verification/test/unit/run-verification-job-persistence.test.ts
+++ b/apps/contract-verification/test/unit/run-verification-job-persistence.test.ts
@@ -1,0 +1,548 @@
+import { eq } from 'drizzle-orm'
+import { drizzle } from 'drizzle-orm/d1'
+import { env } from 'cloudflare:test'
+import { Hex } from 'ox'
+import { describe, expect, it } from 'vitest'
+
+import * as DB from '#database/schema.ts'
+import { ChainRegistry } from '#lib/chain-registry.ts'
+import { runVerificationJob as runVerificationJobWithRegistry } from '#route.verify.ts'
+import { staticChains } from '#wagmi.config.ts'
+
+// Tests exercise the job directly against the static chain registry.
+const runVerificationJob = (
+	jobEnv: Parameters<typeof runVerificationJobWithRegistry>[0],
+	job: Parameters<typeof runVerificationJobWithRegistry>[1],
+	deps?: Parameters<typeof runVerificationJobWithRegistry>[3],
+) =>
+	runVerificationJobWithRegistry(
+		jobEnv,
+		job,
+		ChainRegistry.fromStatic(staticChains),
+		deps,
+	)
+import { counterFixture, counterSource } from '../fixtures/counter.fixture.ts'
+
+const JOB_DEFAULTS = {
+	chainId: counterFixture.chainId,
+	address: counterFixture.address,
+	stdJsonInput: counterFixture.stdJsonInput,
+	compilerVersion: counterFixture.compilerVersion,
+	contractIdentifier: counterFixture.contractIdentifier,
+} as const
+
+async function insertJobRow(jobId: string) {
+	const db = drizzle(env.CONTRACTS_DB)
+	await db.insert(DB.verificationJobsTable).values({
+		id: jobId,
+		chainId: JOB_DEFAULTS.chainId,
+		contractAddress: Hex.toBytes(JOB_DEFAULTS.address),
+		verificationEndpoint: '/v2/verify',
+	})
+}
+
+async function getJobRow(jobId: string) {
+	const db = drizzle(env.CONTRACTS_DB)
+	const rows = await db
+		.select()
+		.from(DB.verificationJobsTable)
+		.where(eq(DB.verificationJobsTable.id, jobId))
+		.limit(1)
+	return rows.at(0) ?? null
+}
+
+function makeContainerStub(solcOutput?: unknown) {
+	return {
+		getContainer: () => ({
+			fetch: async (request: Request) => {
+				const url = new URL(request.url)
+				if (request.method === 'POST' && url.pathname === '/compile') {
+					return Response.json(solcOutput ?? counterFixture.solcOutput, {
+						status: 200,
+					})
+				}
+				throw new Error(
+					`Unexpected container request: ${request.method} ${url.pathname}`,
+				)
+			},
+		}),
+	}
+}
+
+function makeClientStub() {
+	return {
+		createPublicClient: () => ({
+			getCode: async () => counterFixture.onchainRuntimeBytecode,
+		}),
+	}
+}
+
+/**
+ * Compile output whose contract metadata lists `sourcePath` instead of
+ * "Counter.sol" — mirrors real solc output, where metadata.sources uses the
+ * submitted source keys. Sources not listed in the compiler metadata are
+ * excluded from persistence (source-injection hardening).
+ */
+function solcOutputWithMetadataSource(sourcePath: string) {
+	const entry = counterFixture.solcOutput.contracts['Counter.sol']?.Counter
+	if (!entry) throw new Error('fixture contract entry missing')
+	const metadata = JSON.parse(entry.metadata) as {
+		sources: Record<string, unknown>
+	}
+	metadata.sources = { [sourcePath]: metadata.sources['Counter.sol'] }
+	return {
+		...counterFixture.solcOutput,
+		contracts: {
+			'Counter.sol': {
+				Counter: { ...entry, metadata: JSON.stringify(metadata) },
+			},
+		},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 1. Suffix-path contract lookup fallback
+// ---------------------------------------------------------------------------
+describe('runVerificationJob – suffix-path contract lookup fallback', () => {
+	it('finds the contract when the compiler output uses a prefixed path', async () => {
+		const jobId = globalThis.crypto.randomUUID()
+		await insertJobRow(jobId)
+
+		// Build a solcOutput where the contract is stored under a prefixed path
+		// e.g. "project/Counter.sol" instead of "Counter.sol"
+		const originalEntry =
+			counterFixture.solcOutput.contracts['Counter.sol']?.Counter
+		if (!originalEntry) throw new Error('fixture contract entry missing')
+
+		const prefixedOutput = {
+			...counterFixture.solcOutput,
+			contracts: {
+				// Remove the original key; use a prefixed version only
+				'project/Counter.sol': {
+					Counter: originalEntry,
+				},
+			},
+		}
+
+		await runVerificationJob(
+			env,
+			{ ...JOB_DEFAULTS, jobId },
+			{
+				...makeClientStub(),
+				...makeContainerStub(prefixedOutput),
+			},
+		)
+
+		const job = await getJobRow(jobId)
+		expect(job?.completedAt).not.toBeNull()
+		expect(job?.errorCode).toBeNull()
+		expect(job?.verifiedContractId).not.toBeNull()
+	})
+
+	it('finds the contract when the output path ends with /contractPath', async () => {
+		const jobId = globalThis.crypto.randomUUID()
+		await insertJobRow(jobId)
+
+		const originalEntry =
+			counterFixture.solcOutput.contracts['Counter.sol']?.Counter
+		if (!originalEntry) throw new Error('fixture contract entry missing')
+
+		const prefixedOutput = {
+			...counterFixture.solcOutput,
+			contracts: {
+				'/home/user/repo/src/Counter.sol': {
+					Counter: originalEntry,
+				},
+			},
+		}
+
+		await runVerificationJob(
+			env,
+			{ ...JOB_DEFAULTS, jobId },
+			{
+				...makeClientStub(),
+				...makeContainerStub(prefixedOutput),
+			},
+		)
+
+		const job = await getJobRow(jobId)
+		expect(job?.completedAt).not.toBeNull()
+		expect(job?.errorCode).toBeNull()
+		expect(job?.verifiedContractId).not.toBeNull()
+	})
+
+	it('returns contract_not_found_in_output when no suffix match exists', async () => {
+		const jobId = globalThis.crypto.randomUUID()
+		await insertJobRow(jobId)
+
+		const originalEntry =
+			counterFixture.solcOutput.contracts['Counter.sol']?.Counter
+		if (!originalEntry) throw new Error('fixture contract entry missing')
+
+		const unrelatedOutput = {
+			...counterFixture.solcOutput,
+			contracts: {
+				'OtherFile.sol': {
+					Counter: originalEntry,
+				},
+			},
+		}
+
+		await runVerificationJob(
+			env,
+			{ ...JOB_DEFAULTS, jobId },
+			{
+				...makeClientStub(),
+				...makeContainerStub(unrelatedOutput),
+			},
+		)
+
+		const job = await getJobRow(jobId)
+		expect(job?.completedAt).not.toBeNull()
+		expect(job?.errorCode).toBe('contract_not_found_in_output')
+	})
+})
+
+// ---------------------------------------------------------------------------
+// 2. Signature persistence for mixed ABI items (function/event/error)
+// ---------------------------------------------------------------------------
+describe('runVerificationJob – compiled_contracts_signatures persistence', () => {
+	it('persists function, event, and error signatures from ABI', async () => {
+		const jobId = globalThis.crypto.randomUUID()
+		await insertJobRow(jobId)
+
+		// Extend the Counter ABI with a custom error
+		const originalEntry =
+			counterFixture.solcOutput.contracts['Counter.sol']?.Counter
+		if (!originalEntry) throw new Error('fixture contract entry missing')
+
+		const extendedAbi = [
+			...originalEntry.abi,
+			{
+				inputs: [
+					{ internalType: 'uint256', name: 'requested', type: 'uint256' },
+					{ internalType: 'uint256', name: 'available', type: 'uint256' },
+				],
+				name: 'InsufficientBalance',
+				type: 'error',
+			},
+		]
+
+		const solcOutputWithError = {
+			...counterFixture.solcOutput,
+			contracts: {
+				'Counter.sol': {
+					Counter: {
+						...originalEntry,
+						abi: extendedAbi,
+					},
+				},
+			},
+		}
+
+		await runVerificationJob(
+			env,
+			{ ...JOB_DEFAULTS, jobId },
+			{
+				...makeClientStub(),
+				...makeContainerStub(solcOutputWithError),
+			},
+		)
+
+		const job = await getJobRow(jobId)
+		expect(job?.completedAt).not.toBeNull()
+		expect(job?.errorCode).toBeNull()
+
+		const db = drizzle(env.CONTRACTS_DB)
+
+		// Query all signatures linked to this compilation
+		const sigLinks = await db
+			.select({
+				signature: DB.signaturesTable.signature,
+				signatureType: DB.compiledContractsSignaturesTable.signatureType,
+			})
+			.from(DB.compiledContractsSignaturesTable)
+			.innerJoin(
+				DB.signaturesTable,
+				eq(
+					DB.compiledContractsSignaturesTable.signatureHash32,
+					DB.signaturesTable.signatureHash32,
+				),
+			)
+
+		const byType = (t: string) => sigLinks.filter((s) => s.signatureType === t)
+
+		const functions = byType('function')
+		const events = byType('event')
+		const errors = byType('error')
+
+		// The Counter ABI has these named items:
+		// functions: count(), decrement(), increment(), owner(), setCount(uint256)
+		// events:    CountChanged(uint256)
+		// errors:    InsufficientBalance(uint256,uint256) (added above)
+		expect(functions.map((f) => f.signature).sort()).toEqual([
+			'count()',
+			'decrement()',
+			'increment()',
+			'owner()',
+			'setCount(uint256)',
+		])
+
+		expect(events.map((e) => e.signature)).toEqual(['CountChanged(uint256)'])
+
+		expect(errors.map((e) => e.signature)).toEqual([
+			'InsufficientBalance(uint256,uint256)',
+		])
+	})
+})
+
+// ---------------------------------------------------------------------------
+// 3. Source path normalization persistence for odd input paths
+// ---------------------------------------------------------------------------
+describe('runVerificationJob – source path normalization persistence', () => {
+	it('normalizes absolute source paths before persisting to compiled_contracts_sources', async () => {
+		const jobId = globalThis.crypto.randomUUID()
+		await insertJobRow(jobId)
+
+		// Use an absolute path as the source key
+		const oddSourcePath = '/home/user/project/src/Counter.sol'
+		const stdJsonInputWithAbsPath = {
+			...counterFixture.stdJsonInput,
+			sources: {
+				[oddSourcePath]: { content: counterSource },
+			},
+		}
+
+		// The compiler output still references "Counter.sol" in its contracts map
+		await runVerificationJob(
+			env,
+			{
+				...JOB_DEFAULTS,
+				jobId,
+				stdJsonInput: stdJsonInputWithAbsPath,
+			},
+			{
+				...makeClientStub(),
+				...makeContainerStub(solcOutputWithMetadataSource(oddSourcePath)),
+			},
+		)
+
+		const job = await getJobRow(jobId)
+		expect(job?.completedAt).not.toBeNull()
+		expect(job?.errorCode).toBeNull()
+
+		const db = drizzle(env.CONTRACTS_DB)
+		const sources = await db
+			.select({ path: DB.compiledContractsSourcesTable.path })
+			.from(DB.compiledContractsSourcesTable)
+
+		expect(sources).toHaveLength(1)
+		// normalizeSourcePath strips the prefix up to /src/ yielding "src/Counter.sol"
+		expect(sources[0]?.path).toBe('src/Counter.sol')
+	})
+
+	it('preserves relative paths that are already clean', async () => {
+		const jobId = globalThis.crypto.randomUUID()
+		await insertJobRow(jobId)
+
+		await runVerificationJob(
+			env,
+			{ ...JOB_DEFAULTS, jobId },
+			{
+				...makeClientStub(),
+				...makeContainerStub(),
+			},
+		)
+
+		const job = await getJobRow(jobId)
+		expect(job?.errorCode).toBeNull()
+
+		const db = drizzle(env.CONTRACTS_DB)
+		const sources = await db
+			.select({ path: DB.compiledContractsSourcesTable.path })
+			.from(DB.compiledContractsSourcesTable)
+
+		expect(sources).toHaveLength(1)
+		// "Counter.sol" is already relative, should pass through unchanged
+		expect(sources[0]?.path).toBe('Counter.sol')
+	})
+
+	it('normalizes /contracts/ prefix in source paths', async () => {
+		const jobId = globalThis.crypto.randomUUID()
+		await insertJobRow(jobId)
+
+		const oddSourcePath = '/opt/build/contracts/Counter.sol'
+		const stdJsonInputWithAbsPath = {
+			...counterFixture.stdJsonInput,
+			sources: {
+				[oddSourcePath]: { content: counterSource },
+			},
+		}
+
+		await runVerificationJob(
+			env,
+			{
+				...JOB_DEFAULTS,
+				jobId,
+				stdJsonInput: stdJsonInputWithAbsPath,
+			},
+			{
+				...makeClientStub(),
+				...makeContainerStub(solcOutputWithMetadataSource(oddSourcePath)),
+			},
+		)
+
+		const job = await getJobRow(jobId)
+		expect(job?.errorCode).toBeNull()
+
+		const db = drizzle(env.CONTRACTS_DB)
+		const sources = await db
+			.select({ path: DB.compiledContractsSourcesTable.path })
+			.from(DB.compiledContractsSourcesTable)
+
+		expect(sources).toHaveLength(1)
+		expect(sources[0]?.path).toBe('contracts/Counter.sol')
+	})
+
+	it('falls back to filename for unrecognized absolute paths', async () => {
+		const jobId = globalThis.crypto.randomUUID()
+		await insertJobRow(jobId)
+
+		const oddSourcePath = '/weird/deep/nested/Counter.sol'
+		const stdJsonInputWithAbsPath = {
+			...counterFixture.stdJsonInput,
+			sources: {
+				[oddSourcePath]: { content: counterSource },
+			},
+		}
+
+		await runVerificationJob(
+			env,
+			{
+				...JOB_DEFAULTS,
+				jobId,
+				stdJsonInput: stdJsonInputWithAbsPath,
+			},
+			{
+				...makeClientStub(),
+				...makeContainerStub(solcOutputWithMetadataSource(oddSourcePath)),
+			},
+		)
+
+		const job = await getJobRow(jobId)
+		expect(job?.errorCode).toBeNull()
+
+		const db = drizzle(env.CONTRACTS_DB)
+		const sources = await db
+			.select({ path: DB.compiledContractsSourcesTable.path })
+			.from(DB.compiledContractsSourcesTable)
+
+		expect(sources).toHaveLength(1)
+		// No recognized pattern → falls back to filename
+		expect(sources[0]?.path).toBe('Counter.sol')
+	})
+})
+
+// ---------------------------------------------------------------------------
+// 4. ABI with unsupported / malformed items
+// ---------------------------------------------------------------------------
+describe('runVerificationJob – ABI with unsupported/malformed items', () => {
+	it('skips constructor, receive, and fallback ABI items without failing', async () => {
+		const jobId = globalThis.crypto.randomUUID()
+		await insertJobRow(jobId)
+
+		const originalEntry =
+			counterFixture.solcOutput.contracts['Counter.sol']?.Counter
+		if (!originalEntry) throw new Error('fixture contract entry missing')
+
+		// Build an ABI that includes unsupported types alongside real ones
+		const mixedAbi = [
+			// constructor – no name, no signature
+			{
+				inputs: [
+					{ internalType: 'uint256', name: 'initialCount', type: 'uint256' },
+				],
+				stateMutability: 'nonpayable',
+				type: 'constructor',
+			},
+			// receive – no name, no signature
+			{ stateMutability: 'payable', type: 'receive' },
+			// fallback – no name, no signature
+			{ stateMutability: 'nonpayable', type: 'fallback' },
+			// a valid function
+			{
+				inputs: [],
+				name: 'count',
+				outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+				stateMutability: 'view',
+				type: 'function',
+			},
+			// a valid event
+			{
+				anonymous: false,
+				inputs: [
+					{
+						indexed: false,
+						internalType: 'uint256',
+						name: 'newCount',
+						type: 'uint256',
+					},
+				],
+				name: 'CountChanged',
+				type: 'event',
+			},
+			// an item with an unknown type (future-proofing)
+			{
+				inputs: [],
+				name: 'SomeFutureThing',
+				type: 'someFutureType',
+			},
+		]
+
+		const solcOutputMixed = {
+			...counterFixture.solcOutput,
+			contracts: {
+				'Counter.sol': {
+					Counter: {
+						...originalEntry,
+						abi: mixedAbi,
+					},
+				},
+			},
+		}
+
+		await runVerificationJob(
+			env,
+			{ ...JOB_DEFAULTS, jobId },
+			{
+				...makeClientStub(),
+				...makeContainerStub(solcOutputMixed),
+			},
+		)
+
+		const job = await getJobRow(jobId)
+		expect(job?.completedAt).not.toBeNull()
+		expect(job?.errorCode).toBeNull()
+		expect(job?.verifiedContractId).not.toBeNull()
+
+		// Only the function and event should have signatures persisted
+		const db = drizzle(env.CONTRACTS_DB)
+		const sigLinks = await db
+			.select({
+				signature: DB.signaturesTable.signature,
+				signatureType: DB.compiledContractsSignaturesTable.signatureType,
+			})
+			.from(DB.compiledContractsSignaturesTable)
+			.innerJoin(
+				DB.signaturesTable,
+				eq(
+					DB.compiledContractsSignaturesTable.signatureHash32,
+					DB.signaturesTable.signatureHash32,
+				),
+			)
+
+		expect(sigLinks).toHaveLength(2)
+		const signatures = sigLinks.map((s) => s.signature).sort()
+		expect(signatures).toEqual(['CountChanged(uint256)', 'count()'])
+	})
+})

--- a/apps/contract-verification/test/unit/run-verification-job-vyper.test.ts
+++ b/apps/contract-verification/test/unit/run-verification-job-vyper.test.ts
@@ -1,0 +1,263 @@
+import { eq } from 'drizzle-orm'
+import { drizzle } from 'drizzle-orm/d1'
+import { env } from 'cloudflare:test'
+import { Hex } from 'ox'
+import { describe, expect, it } from 'vitest'
+
+import * as DB from '#database/schema.ts'
+import { ChainRegistry } from '#lib/chain-registry.ts'
+import { runVerificationJob as runVerificationJobWithRegistry } from '#route.verify.ts'
+import { staticChains } from '#wagmi.config.ts'
+
+// Tests exercise the job directly against the static chain registry.
+const runVerificationJob = (
+	jobEnv: Parameters<typeof runVerificationJobWithRegistry>[0],
+	job: Parameters<typeof runVerificationJobWithRegistry>[1],
+	deps?: Parameters<typeof runVerificationJobWithRegistry>[3],
+) =>
+	runVerificationJobWithRegistry(
+		jobEnv,
+		job,
+		ChainRegistry.fromStatic(staticChains),
+		deps,
+	)
+import { vyperFixture } from '../fixtures/vyper.fixture.ts'
+
+const JOB_DEFAULTS = {
+	chainId: vyperFixture.chainId,
+	address: vyperFixture.address,
+	stdJsonInput: vyperFixture.stdJsonInput,
+	compilerVersion: vyperFixture.compilerVersion,
+	contractIdentifier: vyperFixture.contractIdentifier,
+} as const
+
+async function insertJobRow(jobId: string) {
+	const db = drizzle(env.CONTRACTS_DB)
+	await db.insert(DB.verificationJobsTable).values({
+		id: jobId,
+		chainId: JOB_DEFAULTS.chainId,
+		contractAddress: Hex.toBytes(JOB_DEFAULTS.address),
+		verificationEndpoint: '/v2/verify',
+	})
+}
+
+async function getJobRow(jobId: string) {
+	const db = drizzle(env.CONTRACTS_DB)
+	const rows = await db
+		.select()
+		.from(DB.verificationJobsTable)
+		.where(eq(DB.verificationJobsTable.id, jobId))
+		.limit(1)
+	return rows.at(0) ?? null
+}
+
+/**
+ * Container stub that responds to /compile/vyper (the Vyper compile endpoint).
+ */
+function makeVyperContainerStub(
+	overrideOutput?: unknown,
+	overrideStatus?: number,
+) {
+	return {
+		getContainer: () => ({
+			fetch: async (request: Request) => {
+				const url = new URL(request.url)
+				if (request.method === 'POST' && url.pathname === '/compile/vyper') {
+					return Response.json(
+						overrideOutput ?? vyperFixture.vyperCompileOutput,
+						{ status: overrideStatus ?? 200 },
+					)
+				}
+				throw new Error(
+					`Unexpected container request: ${request.method} ${url.pathname}`,
+				)
+			},
+		}),
+	}
+}
+
+function makeClientStub(
+	onchainBytecode: `0x${string}` = vyperFixture.onchainRuntimeBytecode,
+) {
+	return {
+		createPublicClient: () => ({
+			getCode: async () => onchainBytecode,
+		}),
+	}
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Happy path
+// ──────────────────────────────────────────────────────────────────────
+
+describe('runVerificationJob – Vyper happy path', () => {
+	it('successfully verifies a Vyper contract via /compile/vyper', async () => {
+		const jobId = globalThis.crypto.randomUUID()
+		await insertJobRow(jobId)
+
+		await runVerificationJob(
+			env,
+			{ ...JOB_DEFAULTS, jobId },
+			{ ...makeClientStub(), ...makeVyperContainerStub() },
+		)
+
+		const job = await getJobRow(jobId)
+		expect(job?.completedAt).not.toBeNull()
+		expect(job?.errorCode).toBeNull()
+		expect(job?.verifiedContractId).not.toBeNull()
+
+		// Verify the compiled_contracts row uses 'vyper' compiler
+		const db = drizzle(env.CONTRACTS_DB)
+		const compilations = await db
+			.select()
+			.from(DB.compiledContractsTable)
+			.limit(1)
+		expect(compilations).toHaveLength(1)
+		const comp = compilations[0]
+		if (!comp) throw new Error('expected compiled_contracts row')
+		expect(comp.compiler).toBe('vyper')
+		expect(comp.language).toBe('Vyper')
+		expect(comp.name).toBe('vyper_contract')
+		expect(comp.fullyQualifiedName).toBe(vyperFixture.contractIdentifier)
+
+		// Vyper compile output carries no compiler metadata, so the
+		// source-injection filter excludes all submitted sources from persistence.
+		const sources = await db
+			.select()
+			.from(DB.compiledContractsSourcesTable)
+			.limit(10)
+		expect(sources).toHaveLength(0)
+	})
+
+	it('persists Vyper ABI signatures correctly', async () => {
+		const jobId = globalThis.crypto.randomUUID()
+		await insertJobRow(jobId)
+
+		await runVerificationJob(
+			env,
+			{ ...JOB_DEFAULTS, jobId },
+			{ ...makeClientStub(), ...makeVyperContainerStub() },
+		)
+
+		const db = drizzle(env.CONTRACTS_DB)
+		const sigLinks = await db
+			.select()
+			.from(DB.compiledContractsSignaturesTable)
+			.limit(50)
+
+		// The fixture ABI has: owner, value, set_value, get_value (functions) + ValueChanged (event)
+		// constructor is excluded from signatures
+		const functionSigs = sigLinks.filter((s) => s.signatureType === 'function')
+		const eventSigs = sigLinks.filter((s) => s.signatureType === 'event')
+
+		expect(functionSigs.length).toBe(4) // owner, value, set_value, get_value
+		expect(eventSigs.length).toBe(1) // ValueChanged
+	})
+})
+
+// ──────────────────────────────────────────────────────────────────────
+// Failure paths
+// ──────────────────────────────────────────────────────────────────────
+
+describe('runVerificationJob – Vyper compilation failure', () => {
+	it('records compilation_failed when /compile/vyper returns non-200', async () => {
+		const jobId = globalThis.crypto.randomUUID()
+		await insertJobRow(jobId)
+
+		await runVerificationJob(
+			env,
+			{ ...JOB_DEFAULTS, jobId },
+			{
+				...makeClientStub(),
+				...makeVyperContainerStub({ error: 'Vyper compiler not found' }, 500),
+			},
+		)
+
+		const job = await getJobRow(jobId)
+		expect(job?.completedAt).not.toBeNull()
+		expect(job?.errorCode).toBe('compilation_failed')
+	})
+
+	it('records compilation_error when Vyper output contains errors', async () => {
+		const jobId = globalThis.crypto.randomUUID()
+		await insertJobRow(jobId)
+
+		const outputWithErrors = {
+			...vyperFixture.vyperCompileOutput,
+			errors: [
+				{
+					severity: 'error',
+					message: 'SyntaxError: invalid syntax',
+					formattedMessage: 'SyntaxError: invalid syntax at line 5',
+				},
+			],
+		}
+
+		await runVerificationJob(
+			env,
+			{ ...JOB_DEFAULTS, jobId },
+			{ ...makeClientStub(), ...makeVyperContainerStub(outputWithErrors) },
+		)
+
+		const job = await getJobRow(jobId)
+		expect(job?.completedAt).not.toBeNull()
+		expect(job?.errorCode).toBe('compilation_error')
+		const errorData = JSON.parse(job?.errorData ?? '{}') as {
+			message?: string
+		}
+		expect(errorData.message).toContain('SyntaxError')
+	})
+})
+
+describe('runVerificationJob – Vyper bytecode mismatch', () => {
+	it('records no_match when on-chain bytecode differs from compiled Vyper output', async () => {
+		const jobId = globalThis.crypto.randomUUID()
+		await insertJobRow(jobId)
+
+		await runVerificationJob(
+			env,
+			{ ...JOB_DEFAULTS, jobId },
+			{
+				...makeClientStub(vyperFixture.mismatchedOnchainBytecode),
+				...makeVyperContainerStub(),
+			},
+		)
+
+		const job = await getJobRow(jobId)
+		expect(job?.completedAt).not.toBeNull()
+		expect(job?.errorCode).toBe('no_match')
+		const errorData = JSON.parse(job?.errorData ?? '{}') as {
+			message?: string
+		}
+		expect(errorData.message).toBeTruthy()
+	})
+})
+
+describe('runVerificationJob – Vyper contract not found in output', () => {
+	it('records contract_not_found_in_output when contract name is absent', async () => {
+		const jobId = globalThis.crypto.randomUUID()
+		await insertJobRow(jobId)
+
+		// Compile output with a different contract name
+		const wrongNameOutput = {
+			contracts: {
+				'vyper_contract.vy': {
+					wrong_name:
+						vyperFixture.vyperCompileOutput.contracts['vyper_contract.vy']
+							?.vyper_contract,
+				},
+			},
+			sources: vyperFixture.vyperCompileOutput.sources,
+		}
+
+		await runVerificationJob(
+			env,
+			{ ...JOB_DEFAULTS, jobId },
+			{ ...makeClientStub(), ...makeVyperContainerStub(wrongNameOutput) },
+		)
+
+		const job = await getJobRow(jobId)
+		expect(job?.completedAt).not.toBeNull()
+		expect(job?.errorCode).toBe('contract_not_found_in_output')
+	})
+})

--- a/apps/contract-verification/test/unit/run-verification-job.test.ts
+++ b/apps/contract-verification/test/unit/run-verification-job.test.ts
@@ -1,0 +1,321 @@
+import { and, eq } from 'drizzle-orm'
+import { drizzle } from 'drizzle-orm/d1'
+import { env } from 'cloudflare:test'
+import { Hex } from 'ox'
+import { describe, expect, it } from 'vitest'
+
+import * as DB from '#database/schema.ts'
+import { ChainRegistry } from '#lib/chain-registry.ts'
+import { runVerificationJob as runVerificationJobWithRegistry } from '#route.verify.ts'
+import { staticChains } from '#wagmi.config.ts'
+
+// Tests exercise the job directly against the static chain registry.
+const runVerificationJob = (
+	jobEnv: Parameters<typeof runVerificationJobWithRegistry>[0],
+	job: Parameters<typeof runVerificationJobWithRegistry>[1],
+	deps?: Parameters<typeof runVerificationJobWithRegistry>[3],
+) =>
+	runVerificationJobWithRegistry(
+		jobEnv,
+		job,
+		ChainRegistry.fromStatic(staticChains),
+		deps,
+	)
+import { counterFixture } from '../fixtures/counter.fixture.ts'
+
+const JOB_DEFAULTS = {
+	chainId: counterFixture.chainId,
+	address: counterFixture.address,
+	stdJsonInput: counterFixture.stdJsonInput,
+	compilerVersion: counterFixture.compilerVersion,
+	contractIdentifier: counterFixture.contractIdentifier,
+} as const
+
+async function insertJobRow(jobId: string) {
+	const db = drizzle(env.CONTRACTS_DB)
+	await db.insert(DB.verificationJobsTable).values({
+		id: jobId,
+		chainId: JOB_DEFAULTS.chainId,
+		contractAddress: Hex.toBytes(JOB_DEFAULTS.address),
+		verificationEndpoint: '/v2/verify',
+	})
+}
+
+async function getJobRow(jobId: string) {
+	const db = drizzle(env.CONTRACTS_DB)
+	const rows = await db
+		.select()
+		.from(DB.verificationJobsTable)
+		.where(eq(DB.verificationJobsTable.id, jobId))
+		.limit(1)
+	return rows.at(0) ?? null
+}
+
+function makeContainerStub() {
+	return {
+		getContainer: () => ({
+			fetch: async (request: Request) => {
+				const url = new URL(request.url)
+				if (request.method === 'POST' && url.pathname === '/compile') {
+					return Response.json(counterFixture.solcOutput, { status: 200 })
+				}
+				throw new Error(
+					`Unexpected container request: ${request.method} ${url.pathname}`,
+				)
+			},
+		}),
+	}
+}
+
+describe('runVerificationJob – creation tx metadata success', () => {
+	it('persists deployer/block/txIndex from a valid creation transaction receipt', async () => {
+		const jobId = globalThis.crypto.randomUUID()
+		await insertJobRow(jobId)
+
+		const fakeTxHash =
+			'0x0000000000000000000000000000000000000000000000000000000000000001' as const
+		const fakeDeployer = '0x00000000000000000000000000000000000000aa' as const
+
+		await runVerificationJob(
+			env,
+			{
+				...JOB_DEFAULTS,
+				jobId,
+				creationTransactionHash: fakeTxHash,
+			},
+			{
+				createPublicClient: () => ({
+					getCode: async () => counterFixture.onchainRuntimeBytecode,
+					getTransactionReceipt: async () => ({
+						transactionHash: fakeTxHash,
+						blockNumber: 42n,
+						transactionIndex: 7,
+						from: fakeDeployer,
+						contractAddress: counterFixture.address,
+					}),
+				}),
+				...makeContainerStub(),
+			},
+		)
+
+		const job = await getJobRow(jobId)
+		expect(job?.completedAt).not.toBeNull()
+		expect(job?.errorCode).toBeNull()
+
+		const db = drizzle(env.CONTRACTS_DB)
+		const deployments = await db
+			.select()
+			.from(DB.contractDeploymentsTable)
+			.where(
+				and(
+					eq(DB.contractDeploymentsTable.chainId, JOB_DEFAULTS.chainId),
+					eq(
+						DB.contractDeploymentsTable.address,
+						Hex.toBytes(JOB_DEFAULTS.address),
+					),
+				),
+			)
+			.limit(1)
+
+		expect(deployments).toHaveLength(1)
+		const dep = deployments[0]
+		if (!dep) throw new Error('expected deployment row')
+		expect(dep.blockNumber).toBe(42)
+		expect(dep.transactionIndex).toBe(7)
+		expect(dep.deployer).not.toBeNull()
+		expect(dep.transactionHash).not.toBeNull()
+	})
+})
+
+describe('runVerificationJob – creation tx metadata failure', () => {
+	it('still verifies when getTransactionReceipt throws', async () => {
+		const jobId = globalThis.crypto.randomUUID()
+		await insertJobRow(jobId)
+
+		const fakeTxHash =
+			'0x0000000000000000000000000000000000000000000000000000000000000002' as const
+
+		await runVerificationJob(
+			env,
+			{
+				...JOB_DEFAULTS,
+				jobId,
+				creationTransactionHash: fakeTxHash,
+			},
+			{
+				createPublicClient: () => ({
+					getCode: async () => counterFixture.onchainRuntimeBytecode,
+					getTransactionReceipt: async () => {
+						throw new Error('RPC receipt error')
+					},
+				}),
+				...makeContainerStub(),
+			},
+		)
+
+		const job = await getJobRow(jobId)
+		expect(job?.completedAt).not.toBeNull()
+		expect(job?.errorCode).toBeNull()
+
+		const db = drizzle(env.CONTRACTS_DB)
+		const deployments = await db
+			.select()
+			.from(DB.contractDeploymentsTable)
+			.where(
+				and(
+					eq(DB.contractDeploymentsTable.chainId, JOB_DEFAULTS.chainId),
+					eq(
+						DB.contractDeploymentsTable.address,
+						Hex.toBytes(JOB_DEFAULTS.address),
+					),
+				),
+			)
+			.limit(1)
+
+		expect(deployments).toHaveLength(1)
+		expect(deployments[0]?.transactionHash).toBeNull()
+		expect(deployments[0]?.deployer).toBeNull()
+	})
+
+	it('still verifies when receipt contractAddress does not match', async () => {
+		const jobId = globalThis.crypto.randomUUID()
+		await insertJobRow(jobId)
+
+		const fakeTxHash =
+			'0x0000000000000000000000000000000000000000000000000000000000000003' as const
+
+		await runVerificationJob(
+			env,
+			{
+				...JOB_DEFAULTS,
+				jobId,
+				creationTransactionHash: fakeTxHash,
+			},
+			{
+				createPublicClient: () => ({
+					getCode: async () => counterFixture.onchainRuntimeBytecode,
+					getTransactionReceipt: async () => ({
+						transactionHash: fakeTxHash,
+						blockNumber: 10n,
+						transactionIndex: 0,
+						from: '0x00000000000000000000000000000000000000bb' as const,
+						contractAddress:
+							'0x0000000000000000000000000000000000099999' as const,
+					}),
+				}),
+				...makeContainerStub(),
+			},
+		)
+
+		const job = await getJobRow(jobId)
+		expect(job?.errorCode).toBeNull()
+
+		const db = drizzle(env.CONTRACTS_DB)
+		const deployments = await db
+			.select()
+			.from(DB.contractDeploymentsTable)
+			.where(
+				and(
+					eq(DB.contractDeploymentsTable.chainId, JOB_DEFAULTS.chainId),
+					eq(
+						DB.contractDeploymentsTable.address,
+						Hex.toBytes(JOB_DEFAULTS.address),
+					),
+				),
+			)
+			.limit(1)
+
+		expect(deployments).toHaveLength(1)
+		expect(deployments[0]?.transactionHash).toBeNull()
+	})
+})
+
+describe('runVerificationJob – getCode returns empty', () => {
+	it('records contract_not_found when getCode returns undefined', async () => {
+		const jobId = globalThis.crypto.randomUUID()
+		await insertJobRow(jobId)
+
+		await runVerificationJob(
+			env,
+			{ ...JOB_DEFAULTS, jobId },
+			{
+				createPublicClient: () => ({
+					getCode: async () => undefined as unknown as `0x${string}`,
+				}),
+				...makeContainerStub(),
+			},
+		)
+
+		const job = await getJobRow(jobId)
+		expect(job?.completedAt).not.toBeNull()
+		expect(job?.errorCode).toBe('contract_not_found')
+		const errorData = JSON.parse(job?.errorData ?? '{}') as { message?: string }
+		expect(errorData.message).toContain('No bytecode found')
+	})
+
+	it('records contract_not_found when getCode returns 0x', async () => {
+		const jobId = globalThis.crypto.randomUUID()
+		await insertJobRow(jobId)
+
+		await runVerificationJob(
+			env,
+			{ ...JOB_DEFAULTS, jobId },
+			{
+				createPublicClient: () => ({
+					getCode: async () => '0x' as `0x${string}`,
+				}),
+				...makeContainerStub(),
+			},
+		)
+
+		const job = await getJobRow(jobId)
+		expect(job?.errorCode).toBe('contract_not_found')
+	})
+})
+
+describe('runVerificationJob – getCode throws', () => {
+	it('records internal_error when getCode rejects', async () => {
+		const jobId = globalThis.crypto.randomUUID()
+		await insertJobRow(jobId)
+
+		await runVerificationJob(
+			env,
+			{ ...JOB_DEFAULTS, jobId },
+			{
+				createPublicClient: () => ({
+					getCode: async () => {
+						throw new Error('RPC transport failure')
+					},
+				}),
+				...makeContainerStub(),
+			},
+		)
+
+		const job = await getJobRow(jobId)
+		expect(job?.completedAt).not.toBeNull()
+		expect(job?.errorCode).toBe('internal_error')
+		const errorData = JSON.parse(job?.errorData ?? '{}') as { message?: string }
+		expect(errorData.message).toContain('RPC transport failure')
+	})
+
+	it('records internal_error when getCode returns non-Error rejection', async () => {
+		const jobId = globalThis.crypto.randomUUID()
+		await insertJobRow(jobId)
+
+		await runVerificationJob(
+			env,
+			{ ...JOB_DEFAULTS, jobId },
+			{
+				createPublicClient: () => ({
+					getCode: async () => {
+						throw 'string rejection'
+					},
+				}),
+				...makeContainerStub(),
+			},
+		)
+
+		const job = await getJobRow(jobId)
+		expect(job?.errorCode).toBe('internal_error')
+	})
+})

--- a/apps/contract-verification/test/unit/signature-reconstruction.test.ts
+++ b/apps/contract-verification/test/unit/signature-reconstruction.test.ts
@@ -1,0 +1,317 @@
+import { describe, expect, it } from 'vitest'
+import { Hash, Hex } from 'ox'
+
+import {
+	buildSignaturesPayload,
+	formatAbiParameterType,
+} from '#route.lookup.ts'
+
+describe('formatAbiParameterType', () => {
+	it('returns primitive types unchanged', () => {
+		expect(formatAbiParameterType({ type: 'uint256' })).toBe('uint256')
+		expect(formatAbiParameterType({ type: 'address' })).toBe('address')
+		expect(formatAbiParameterType({ type: 'bool' })).toBe('bool')
+		expect(formatAbiParameterType({ type: 'bytes32' })).toBe('bytes32')
+		expect(formatAbiParameterType({ type: 'string' })).toBe('string')
+	})
+
+	it('returns array types unchanged', () => {
+		expect(formatAbiParameterType({ type: 'uint256[]' })).toBe('uint256[]')
+		expect(formatAbiParameterType({ type: 'address[3]' })).toBe('address[3]')
+	})
+
+	it('reconstructs a flat tuple', () => {
+		expect(
+			formatAbiParameterType({
+				type: 'tuple',
+				components: [{ type: 'uint256' }, { type: 'address' }],
+			}),
+		).toBe('(uint256,address)')
+	})
+
+	it('reconstructs tuple[]', () => {
+		expect(
+			formatAbiParameterType({
+				type: 'tuple[]',
+				components: [{ type: 'uint256' }, { type: 'bool' }],
+			}),
+		).toBe('(uint256,bool)[]')
+	})
+
+	it('reconstructs tuple with fixed-size array suffix', () => {
+		expect(
+			formatAbiParameterType({
+				type: 'tuple[5]',
+				components: [{ type: 'address' }],
+			}),
+		).toBe('(address)[5]')
+	})
+
+	it('reconstructs nested tuple inside tuple', () => {
+		expect(
+			formatAbiParameterType({
+				type: 'tuple',
+				components: [
+					{ type: 'address' },
+					{
+						type: 'tuple',
+						components: [{ type: 'uint256' }, { type: 'bool' }],
+					},
+				],
+			}),
+		).toBe('(address,(uint256,bool))')
+	})
+
+	it('reconstructs nested tuple[] inside tuple', () => {
+		expect(
+			formatAbiParameterType({
+				type: 'tuple',
+				components: [
+					{ type: 'bytes32' },
+					{
+						type: 'tuple[]',
+						components: [{ type: 'address' }, { type: 'uint256' }],
+					},
+				],
+			}),
+		).toBe('(bytes32,(address,uint256)[])')
+	})
+
+	it('treats tuple with missing components as empty tuple', () => {
+		expect(formatAbiParameterType({ type: 'tuple' })).toBe('()')
+	})
+
+	it('returns null for non-object input', () => {
+		expect(formatAbiParameterType(null)).toBeNull()
+		expect(formatAbiParameterType(undefined)).toBeNull()
+		expect(formatAbiParameterType(42)).toBeNull()
+		expect(formatAbiParameterType('uint256')).toBeNull()
+	})
+
+	it('returns null when type field is missing', () => {
+		expect(formatAbiParameterType({ name: 'x' })).toBeNull()
+	})
+
+	it('filters out invalid components', () => {
+		expect(
+			formatAbiParameterType({
+				type: 'tuple',
+				components: [{ type: 'uint256' }, null, { type: 'bool' }],
+			}),
+		).toBe('(uint256,bool)')
+	})
+})
+
+describe('buildSignaturesPayload', () => {
+	function hash4(signature: string): string {
+		const hash32 = Hash.keccak256(Hex.fromString(signature))
+		return Hex.fromBytes(Hex.toBytes(hash32).slice(0, 4))
+	}
+
+	function hash32(signature: string): string {
+		return Hash.keccak256(Hex.fromString(signature))
+	}
+
+	it('returns empty buckets for non-array input', () => {
+		const result = buildSignaturesPayload(null)
+		expect(result).toStrictEqual({ function: [], event: [], error: [] })
+	})
+
+	it('returns empty buckets for empty array', () => {
+		const result = buildSignaturesPayload([])
+		expect(result).toStrictEqual({ function: [], event: [], error: [] })
+	})
+
+	it('classifies function, event, and error', () => {
+		const abi = [
+			{
+				type: 'function',
+				name: 'transfer',
+				inputs: [{ type: 'address' }, { type: 'uint256' }],
+			},
+			{
+				type: 'event',
+				name: 'Transfer',
+				inputs: [{ type: 'address' }, { type: 'address' }, { type: 'uint256' }],
+			},
+			{
+				type: 'error',
+				name: 'InsufficientBalance',
+				inputs: [{ type: 'uint256' }, { type: 'uint256' }],
+			},
+		]
+
+		const result = buildSignaturesPayload(abi)
+
+		expect(result.function).toHaveLength(1)
+		expect(result.event).toHaveLength(1)
+		expect(result.error).toHaveLength(1)
+		expect(result.function[0]?.signature).toBe('transfer(address,uint256)')
+		expect(result.function[0]?.signatureHash4).toBe(
+			hash4('transfer(address,uint256)'),
+		)
+		expect(result.function[0]?.signatureHash32).toBe(
+			hash32('transfer(address,uint256)'),
+		)
+		expect(result.event[0]?.signature).toBe('Transfer(address,address,uint256)')
+		expect(result.error[0]?.signature).toBe(
+			'InsufficientBalance(uint256,uint256)',
+		)
+	})
+
+	it('skips constructor, fallback, and receive entries', () => {
+		const abi = [
+			{ type: 'constructor', inputs: [{ type: 'uint256' }] },
+			{ type: 'fallback' },
+			{ type: 'receive' },
+		]
+		const result = buildSignaturesPayload(abi)
+		expect(result.function).toHaveLength(0)
+		expect(result.event).toHaveLength(0)
+		expect(result.error).toHaveLength(0)
+	})
+
+	it('skips items without a name', () => {
+		const abi = [{ type: 'function', inputs: [{ type: 'uint256' }] }]
+		const result = buildSignaturesPayload(abi)
+		expect(result.function).toHaveLength(0)
+	})
+
+	it('builds correct signature for tuple input', () => {
+		const abi = [
+			{
+				type: 'function',
+				name: 'doStuff',
+				inputs: [
+					{
+						type: 'tuple',
+						components: [{ type: 'address' }, { type: 'uint256' }],
+					},
+					{ type: 'bool' },
+				],
+			},
+		]
+
+		const result = buildSignaturesPayload(abi)
+		expect(result.function[0]?.signature).toBe(
+			'doStuff((address,uint256),bool)',
+		)
+		expect(result.function[0]?.signatureHash4).toBe(
+			hash4('doStuff((address,uint256),bool)'),
+		)
+	})
+
+	it('builds correct signature for tuple[] input', () => {
+		const abi = [
+			{
+				type: 'function',
+				name: 'batchTransfer',
+				inputs: [
+					{
+						type: 'tuple[]',
+						components: [{ type: 'address' }, { type: 'uint256' }],
+					},
+				],
+			},
+		]
+
+		const result = buildSignaturesPayload(abi)
+		expect(result.function[0]?.signature).toBe(
+			'batchTransfer((address,uint256)[])',
+		)
+	})
+
+	it('builds correct signature for nested tuple[] inside tuple', () => {
+		const abi = [
+			{
+				type: 'function',
+				name: 'complex',
+				inputs: [
+					{
+						type: 'tuple',
+						components: [
+							{ type: 'bytes32' },
+							{
+								type: 'tuple[]',
+								components: [{ type: 'address' }, { type: 'uint256' }],
+							},
+						],
+					},
+				],
+			},
+		]
+
+		const result = buildSignaturesPayload(abi)
+		expect(result.function[0]?.signature).toBe(
+			'complex((bytes32,(address,uint256)[]))',
+		)
+		expect(result.function[0]?.signatureHash4).toBe(
+			hash4('complex((bytes32,(address,uint256)[]))'),
+		)
+	})
+
+	it('builds correct signature for deeply nested tuples', () => {
+		const abi = [
+			{
+				type: 'event',
+				name: 'Deep',
+				inputs: [
+					{
+						type: 'tuple',
+						components: [
+							{
+								type: 'tuple',
+								components: [
+									{
+										type: 'tuple',
+										components: [{ type: 'uint8' }],
+									},
+								],
+							},
+						],
+					},
+				],
+			},
+		]
+
+		const result = buildSignaturesPayload(abi)
+		expect(result.event[0]?.signature).toBe('Deep((((uint8))))')
+	})
+
+	it('builds correct signature for error with tuple input', () => {
+		const abi = [
+			{
+				type: 'error',
+				name: 'BadOrder',
+				inputs: [
+					{
+						type: 'tuple',
+						components: [
+							{ type: 'address' },
+							{ type: 'uint256' },
+							{ type: 'bytes' },
+						],
+					},
+				],
+			},
+		]
+
+		const result = buildSignaturesPayload(abi)
+		expect(result.error[0]?.signature).toBe('BadOrder((address,uint256,bytes))')
+		expect(result.error[0]?.signatureHash32).toBe(
+			hash32('BadOrder((address,uint256,bytes))'),
+		)
+	})
+
+	it('handles function with no inputs', () => {
+		const abi = [{ type: 'function', name: 'pause', inputs: [] }]
+		const result = buildSignaturesPayload(abi)
+		expect(result.function[0]?.signature).toBe('pause()')
+	})
+
+	it('handles function with missing inputs field', () => {
+		const abi = [{ type: 'function', name: 'pause' }]
+		const result = buildSignaturesPayload(abi)
+		expect(result.function[0]?.signature).toBe('pause()')
+	})
+})


### PR DESCRIPTION
## Summary

Re-lands the goal of #843 — centralized Zod (zod/mini) schemas with runtime validation for the contract-verification app — rebuilt on top of current main. The original branch predated the chainregistry middleware (#933) and the three security fixes (#950, #951, #952) and had become unresolvably conflicted.

### What changed
- **New `src/schema.ts`** — single source of truth for `zAddress`, `zHash`, `zChainId`, `StdJsonInput`, `VerificationJob`, `Contract`, `CompileOutput`, link/immutable references, with stable `customCode`s (`invalid_address`, `invalid_chain_id`, `unsupported_chain`) and a `getValidationCustomCode` helper.
- **`route.verify.ts`** — validation layer swapped to schema-based `z.safeParse`; business logic untouched. `creationTransactionHash` is now actually validated as a 32-byte hash (previously any string passed).
- **`job-runner.ts`** — Durable Object payload flattened to `VerificationJob`, with a `LegacyStoredJob` shim in `alarm()` so in-flight jobs enqueued before deploy still process (covered by a dedicated test).
- **`bytecode-matching.ts`** — `LinkReferences`/`ImmutableReferences` types now come from the schema module (re-exported for existing importers).
- **~3,000 lines of ported tests** — DO lifecycle (incl. legacy-payload compat), failure paths, persistence, Vyper, signature reconstruction, verify-status and verified-lookup integration suites, plus a Vyper fixture.

### Deliberate differences from the original #843
- `zChainId` validates **format only**; whether a chain is *supported* stays a dynamic `ChainRegistry` concern (`registry.isSupported`), since #933 made the chain list config-driven.
- Compiler output is **not** runtime-parsed through the schema: zod objects strip unknown keys, which would drop ABI fields (`stateMutability`, `outputs`, …) before storage. The schema provides the type; the cast stays.
- All three security invariants preserved and audited: sanitize-before-enqueue + sanitize-in-job (#950), compiler-metadata source filter (#951), exact-vs-partial verification terminality (#952) — including a new integration test that a partial match does not block re-verification.
- Housekeeping from the original PR (catalog bumps, vite-plugin patch, semver→@std/semver, explorer env rename, CI node bump) is **out of scope** — queued as follow-ups.

### Notes for reviewers
- Post-#951, Vyper verifications persist **zero** sources because the Vyper compile output carries no compiler metadata (`metadata: ''`) for the filter to allowlist against. The ported Vyper test documents this behavior; restoring Vyper source persistence likely needs the compile container to emit metadata and is left as a follow-up.

## Test plan
- `pnpm check:types`, `pnpm check:biome` — clean
- `pnpm test` — 224 tests / 17 files, all passing (7 ported suites + all pre-existing suites)

Closes #843.

🤖 Generated with [Claude Code](https://claude.com/claude-code)