### PR TITLE
fix: configure mcp docs metadata filtering

### DIFF
--- a/apps/mcp-docs-indexer/.env.example
+++ b/apps/mcp-docs-indexer/.env.example
@@ -2,6 +2,11 @@
 # Bindings are configured in wrangler.jsonc:
 #   - AI_SEARCH  (ai_search_namespaces binding to the "default" namespace)
 #   - ETAG_CACHE (kv namespace for per-source freshness state)
+# Custom AI Search metadata schema is configured via:
+#   pnpm --filter mcp-docs-indexer configure:metadata
+# Required only for configure:metadata:
+#   - CLOUDFLARE_ACCOUNT_ID
+#   - CLOUDFLARE_API_TOKEN     (AI Search:Edit permission)
 # Vars:
 #   - AI_SEARCH_INSTANCE_ID  (default: tempo-global)
 #   - AI_SEARCH_MCP_URL      (AI Search MCP endpoint proxied by this Worker)

--- a/apps/mcp-docs-indexer/README.md
+++ b/apps/mcp-docs-indexer/README.md
@@ -66,6 +66,30 @@ inside Cloudflare Workers.
   `base`, optional `description`, and optional `indexPath` (defaults to
   `/llms.txt`). Adding a docs source should be a config-only change.
 
+## AI Search metadata
+
+Custom metadata fields must be defined on the AI Search instance before MCP
+queries can filter on uploaded metadata. The checked-in schema lives at
+`ai-search-custom-metadata.json` and matches the metadata attached by the
+ingestor:
+
+| Field                | Type   | Purpose                                  |
+| -------------------- | ------ | ---------------------------------------- |
+| `source`             | `text` | Filter results to one configured source  |
+| `url`                | `text` | Return the canonical source page URL     |
+| `source_description` | `text` | Describe the upstream docs source        |
+
+Apply it with:
+
+```bash
+CLOUDFLARE_ACCOUNT_ID=<account-id> \
+CLOUDFLARE_API_TOKEN=<api-token-with-ai-search-edit> \
+pnpm --filter mcp-docs-indexer configure:metadata
+```
+
+Changing AI Search custom metadata triggers a full re-index. Re-run a forced
+sync afterward if existing built-in-storage items need the new schema applied.
+
 `docs.tempo.xyz` is intentionally not listed in `SOURCES` — it's the AI Search
 instance's external website data source and is auto-crawled.
 
@@ -80,6 +104,10 @@ pnpm --filter mcp-docs-indexer exec wrangler kv namespace create ETAG_CACHE
 
 # Generate Worker types
 pnpm --filter mcp-docs-indexer gen:types
+
+# Configure AI Search custom metadata so MCP queries can filter by source.
+# Requires Cloudflare auth with AI Search:Edit permissions.
+pnpm --filter mcp-docs-indexer configure:metadata
 
 # Verify
 pnpm --filter mcp-docs-indexer check

--- a/apps/mcp-docs-indexer/ai-search-custom-metadata.json
+++ b/apps/mcp-docs-indexer/ai-search-custom-metadata.json
@@ -1,0 +1,14 @@
+[
+	{
+		"field_name": "source",
+		"data_type": "text"
+	},
+	{
+		"field_name": "url",
+		"data_type": "text"
+	},
+	{
+		"field_name": "source_description",
+		"data_type": "text"
+	}
+]

--- a/apps/mcp-docs-indexer/package.json
+++ b/apps/mcp-docs-indexer/package.json
@@ -4,6 +4,7 @@
 	"type": "module",
 	"scripts": {
 		"build": "echo 'No build step needed for Cloudflare Worker'",
+		"configure:metadata": "tsx scripts/configure-ai-search-metadata.ts",
 		"dev": "wrangler dev",
 		"deploy": "wrangler deploy",
 		"check": "pnpm check:biome && pnpm check:types",

--- a/apps/mcp-docs-indexer/scripts/configure-ai-search-metadata.ts
+++ b/apps/mcp-docs-indexer/scripts/configure-ai-search-metadata.ts
@@ -1,0 +1,86 @@
+import { readFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+
+type MetadataField = {
+	field_name: string
+	data_type: 'text' | 'number' | 'boolean' | 'datetime'
+}
+
+const schemaPath = resolve('ai-search-custom-metadata.json')
+const accountId = expectEnv('CLOUDFLARE_ACCOUNT_ID')
+const apiToken = expectEnv('CLOUDFLARE_API_TOKEN')
+const namespace = process.env.AI_SEARCH_NAMESPACE ?? 'default'
+const instanceId = process.env.AI_SEARCH_INSTANCE_ID ?? 'tempo-global'
+
+const schema = validateSchema(
+	JSON.parse(await readFile(schemaPath, 'utf8')) as unknown,
+)
+const endpoint = new URL(
+	`/client/v4/accounts/${accountId}/ai-search/namespaces/${namespace}/instances/${instanceId}`,
+	'https://api.cloudflare.com',
+)
+
+const response = await fetch(endpoint, {
+	method: 'PUT',
+	headers: {
+		Authorization: `Bearer ${apiToken}`,
+		'Content-Type': 'application/json',
+	},
+	body: JSON.stringify({ custom_metadata: schema }),
+})
+
+const body = (await response.json().catch(() => null)) as {
+	success?: boolean
+	errors?: Array<{ message?: string }>
+} | null
+
+if (!response.ok || body?.success === false) {
+	const message =
+		body?.errors
+			?.map((error) => error.message)
+			.filter(Boolean)
+			.join('; ') || `HTTP ${response.status}`
+	throw new Error(`Failed to configure AI Search metadata: ${message}`)
+}
+
+console.info(
+	`Configured ${schema.length} AI Search metadata fields on ${namespace}/${instanceId}`,
+)
+
+function expectEnv(name: string): string {
+	const value = process.env[name]
+	if (!value) throw new Error(`${name} is required`)
+	return value
+}
+
+function validateSchema(value: unknown): MetadataField[] {
+	if (!Array.isArray(value)) throw new Error('metadata schema must be an array')
+	if (value.length > 5)
+		throw new Error('metadata schema cannot exceed 5 fields')
+
+	return value.map((field, index) => {
+		if (!field || typeof field !== 'object') {
+			throw new Error(`metadata schema field ${index} must be an object`)
+		}
+
+		const entry = field as Record<string, unknown>
+		const fieldName = entry.field_name
+		const dataType = entry.data_type
+		if (typeof fieldName !== 'string' || fieldName.trim().length === 0) {
+			throw new Error(`metadata schema field ${index} has invalid field_name`)
+		}
+		if (
+			dataType !== 'text' &&
+			dataType !== 'number' &&
+			dataType !== 'boolean' &&
+			dataType !== 'datetime'
+		) {
+			throw new Error(`metadata schema field ${index} has invalid data_type`)
+		}
+		if (['timestamp', 'folder', 'filename'].includes(fieldName.toLowerCase())) {
+			throw new Error(`metadata schema field ${index} uses a reserved name`)
+		}
+
+		return { field_name: fieldName, data_type: dataType }
+	})
+}

--- a/apps/mcp-docs-indexer/src/lib/ingest.test.ts
+++ b/apps/mcp-docs-indexer/src/lib/ingest.test.ts
@@ -182,7 +182,10 @@ describe('syncSource — page uploads', () => {
 			'viem/docs_foo.md',
 		])
 		for (const u of uploads) {
-			expect(u.metadata).toMatchObject({ source: 'viem' })
+			expect(u.metadata).toEqual({
+				source: 'viem',
+				url: expect.any(String),
+			})
 		}
 		expect(store.get('etag:viem')).toBe('W/"new"')
 		expect(store.get('last_sync:viem')).toBeTruthy()

--- a/apps/mcp-docs-indexer/wrangler.jsonc
+++ b/apps/mcp-docs-indexer/wrangler.jsonc
@@ -57,7 +57,7 @@
 			},
 			{
 				"id": "vocs",
-				"base": "https://vocs.sh",
+				"base": "https://vocs.dev",
 				"description": "Documentation framework"
 			},
 			{


### PR DESCRIPTION
## Summary

- Fix Vocs docs ingestion source to use vocs.dev
- Add AI Search custom metadata schema and configuration script for source filtering
- Document metadata setup requirements for the MCP docs indexer