### PR TITLE
perf: optimize docs MCP responses

### DIFF
--- a/apps/mcp-docs-indexer/README.md
+++ b/apps/mcp-docs-indexer/README.md
@@ -2,18 +2,21 @@
 
 Resolver Worker that ingests configured external doc sites into
 the shared **Cloudflare AI Search** instance `tempo-global`. The AI Search
-instance owns the docs.tempo.xyz crawl directly; this Worker handles the
-non-owned sources by uploading their canonical Markdown pages into the
-instance's **built-in storage**, tagged with a `source` metadata field for
-filtering at query time.
+instance may also crawl public websites directly, but this Worker uploads
+canonical Markdown pages for configured sources into the instance's
+**built-in storage**, tagged with a `source` metadata field for filtering at
+query time.
 
-The MCP endpoint is exposed by AI Search itself. This Worker also serves as
-a thin transparent proxy on `mcp.tempo.xyz` → the AI Search MCP upstream, so
-clients connect to a stable branded URL instead of the opaque
-`<instance-id>.search.ai.cloudflare.com` hostname.
+The Worker exposes an optimized MCP endpoint on `mcp.tempo.xyz`. It handles
+`tools/list`, `tools/call` for `search`, and docs source `resources/*` locally
+so it can provide a compact tool schema, source-aware filters, and lower-token
+search responses. Unsupported MCP methods fall through to the AI Search MCP
+upstream, so clients still connect to a stable branded URL instead of the
+opaque `<instance-id>.search.ai.cloudflare.com` hostname.
 
 ```
-MCP clients ──▶ https://mcp.tempo.xyz/ ──▶ AI Search MCP (proxied 1:1)
+MCP clients ──▶ https://mcp.tempo.xyz/ ──▶ optimized search/resources
+                                      └─▶ AI Search MCP fallback
 Cron ──▶ mcp-docs-indexer Worker ──▶ AI Search items.upload() (ingest plane)
 ```
 
@@ -26,16 +29,22 @@ Cron ──▶ mcp-docs-indexer Worker ──▶ AI Search items.upload() (inges
                                 2. parse → page URLs
                                 3. for each page: GET <page>.md, or the listed
                                    .md URL, with If-None-Match (per-page ETag)
-                                4. 304 → skip; 200 → items.upload(),
-                                   record { item id, etag } in KV
-                                5. diff against last sync, delete items
+                                4. strip repeated sitemap/docs chrome noise
+                                5. unchanged content hash → skip upload
+                                6. 304 → skip; 200 → items.upload(),
+                                   record { item id, etag, content hash } in KV
+                                7. diff against last sync, delete items
                                    that fell out of llms.txt
-                                6. save new index + llms.txt ETag to KV
+                                8. save new index + llms.txt ETag to KV
 ```
 
 Once per UTC day (00:00 cron tick) the worker does a **forced deep sync** that
 bypasses every ETag, as a backstop for sources whose `llms.txt` ETag doesn't
 roll over when individual pages change.
+
+Uploaded pages are normalized before indexing: repeated Vocs sitemap comments
+and common docs UI chrome are stripped so AI Search embeds documentation text
+instead of navigation boilerplate.
 
 ### KV layout (per source)
 
@@ -43,15 +52,84 @@ roll over when individual pages change.
 | ------------------- | -------------------------------------------------------- |
 | `etag:<id>`         | last-seen `llms.txt` ETag (only stored on clean syncs)   |
 | `last_sync:<id>`    | ISO timestamp of last sync attempt                       |
-| `index:<id>`        | JSON map: `{ "<key>": { "id": "...", "etag": "..." } }`  |
+| `index:<id>`        | JSON map: `{ "<key>": { "id": "...", "etag": "...", "content_hash": "..." } }` |
 
 `index` is the source of truth for stale-page deletion. We only advance
 `etag` and `index` after a fully clean sync — partial failures don't update
 state, so they retry on the next run instead of permanently desyncing.
 
-The Worker exposes the MCP proxy only. It has **no public sync or ingest
-endpoint**: source ingestion runs exclusively from the scheduled cron handler
-inside Cloudflare Workers.
+The Worker has **no public sync or ingest endpoint**: source ingestion runs
+exclusively from the scheduled cron handler inside Cloudflare Workers.
+
+## MCP search behavior
+
+The local `search` tool accepts Code Mode-friendly top-level controls:
+
+| Field          | Purpose                                                        |
+| -------------- | -------------------------------------------------------------- |
+| `query`        | Natural-language question or code task                         |
+| `source`       | Optional single source filter, e.g. `tempo`, `viem`, `mpp`     |
+| `sources`      | Optional multi-source filter                                   |
+| `max_results`  | Maximum chunks to return; defaults to `5`                      |
+| `max_chars_per_chunk` | Maximum compact text chars per chunk; defaults to `1200` |
+| `max_total_chars` | Maximum total compact chunk text chars; defaults to `2400` |
+| `include_raw`  | Return full AI Search chunks instead of compact chunks         |
+| `response_format` | Use `structured` to return data in MCP `structuredContent` with a short text summary |
+
+When `source` and `sources` are omitted, the server applies a conservative
+source hint for source-specific queries (for example `viem`, `wagmi`,
+`virtual addresses`, `MCP server`, or `Regen button`). Explicit source filters
+always take precedence.
+
+Use `find_pages` when the task names a specific source and you need exact page
+candidates before retrieving content. It searches the source's cached
+`llms.txt` index and returns compact `{ title, url, score }` rows without
+calling AI Search or reading page bodies.
+
+Use `read_page` when a search result points at the exact page you need. It
+fetches one same-origin docs page from a configured source, strips docs chrome,
+and returns bounded cleaned Markdown (`max_chars`, default `12000`). Pass
+`query` with `max_chars` to get a focused excerpt around the relevant section
+instead of the leading page slice. This keeps search cheap while still letting
+clients pull full page context on demand.
+
+By default responses contain compact chunks with only `score`, `source`, `url`
+or `key`, and cleaned query-aware `text` excerpts. This removes AI Search
+internals, common docs chrome, and off-topic page regions before the result
+enters an MCP client's context window. Compact output also returns at most one
+chunk per page, preserving result diversity and avoiding repeated snippets from
+the same URL. Search text is bounded by `max_total_chars` after page
+deduplication, so broad searches cannot accidentally fill the client context
+with five large excerpts. Advanced `ai_search_options` are still accepted and
+normalized into the current AI Search binding shape.
+
+Pass `response_format: "structured"` on `search`, `find_pages`, or `read_page`
+when the client can read MCP `structuredContent`; this keeps the text content to
+a short status line while preserving the same machine-readable result object.
+
+AI Search response caching is enabled by default with the `close_enough`
+threshold. Clients can override this with `ai_search_options.cache`.
+The Worker also keeps a small 60-second in-memory cache of successful search
+results per isolate to skip repeated AI Search round trips for identical
+normalized searches.
+
+If an AI Search metadata filter returns no chunks for a known source, the
+server retries with a wider unfiltered search, filters chunks by source
+metadata/key prefix, and remembers that source briefly so repeated filtered
+queries skip the stale metadata-filter attempt.
+
+The server also exposes MCP resources:
+
+| Resource URI                 | Purpose                                      |
+| ---------------------------- | -------------------------------------------- |
+| `tempo-docs://sources`       | Summary of configured docs sources           |
+| `tempo-docs://source/<id>`   | Per-source filter and indexing information   |
+| `tempo-docs://source/<id>/index` | Compact cached `llms.txt` page index for a source |
+| `tempo-docs://source/<id>/page/<path>` | Exact cleaned page read as Markdown |
+
+The server also advertises matching MCP resource templates, so clients can
+discover page indexes first and then read exact pages without spending search
+tokens.
 
 ## Bindings (wrangler.jsonc)
 
@@ -90,8 +168,8 @@ pnpm --filter mcp-docs-indexer configure:metadata
 Changing AI Search custom metadata triggers a full re-index. Re-run a forced
 sync afterward if existing built-in-storage items need the new schema applied.
 
-`docs.tempo.xyz` is intentionally not listed in `SOURCES` — it's the AI Search
-instance's external website data source and is auto-crawled.
+`docs.tempo.xyz` is listed as the `tempo` source so MCP clients can explicitly
+pull core protocol and integration docs with `source: "tempo"` or `read_page`.
 
 ## Setup
 
@@ -121,6 +199,68 @@ Unit tests use Vitest with mocked `fetch` / AI Search / KV bindings:
 ```bash
 pnpm --filter mcp-docs-indexer test
 ```
+
+## Benchmark
+
+Run the MCP fixture benchmark against production:
+
+```bash
+pnpm --filter mcp-docs-indexer benchmark
+```
+
+Run it against a local Wrangler dev server:
+
+```bash
+pnpm --filter mcp-docs-indexer exec wrangler dev --port 8790
+pnpm --filter mcp-docs-indexer benchmark -- --endpoint http://localhost:8790/
+```
+
+The benchmark records latency, response bytes, returned text chars, chunk
+count, expected source/URL/text hits, common docs chrome noise, and per-tool
+summaries for `search` and `read_page`. Use `--strict` to fail on missing
+expected hits, duplicate pages, docs chrome noise, empty search results, or
+byte/text budget regressions. Use `--json` for machine-readable output.
+
+## Evals
+
+Run deterministic MCP evals against one endpoint:
+
+```bash
+pnpm --filter mcp-docs-indexer eval
+```
+
+Compare production with a local candidate:
+
+```bash
+pnpm --filter mcp-docs-indexer exec wrangler dev --port 8790
+pnpm --filter mcp-docs-indexer eval -- \
+  --baseline https://mcp.tempo.xyz/ \
+  --endpoint http://localhost:8790/
+```
+
+The eval suite checks tool schema quality, configured source/index resources,
+filtered search source/URL hits, exact `read_page` pulls, duplicate returned
+pages, docs chrome noise, bytes, returned text chars, and latency. Add
+`--strict` to exit non-zero unless every candidate eval passes.
+
+Run the same eval cases through Promptfoo:
+
+```bash
+pnpm --filter mcp-docs-indexer eval:promptfoo
+```
+
+Point Promptfoo at a local candidate with `MCP_EVAL_ENDPOINT`:
+
+```bash
+pnpm --filter mcp-docs-indexer exec wrangler dev --port 8790
+MCP_EVAL_ENDPOINT=http://localhost:8790/ pnpm --filter mcp-docs-indexer eval:promptfoo
+```
+
+Promptfoo uses `promptfooconfig.ts` as a thin config shim. The eval cases,
+direct runner, and Promptfoo file provider all live in `scripts/eval-mcp.ts`,
+so direct and Promptfoo evals share the same deterministic byte/text/source/URL
+assertions. One eval case exercises MCP `structuredContent` directly so
+regressions in structured output fail in both runners.
 
 ## Observability
 
@@ -166,9 +306,8 @@ pnpm --filter mcp-docs-indexer tail
 ## Verifying the result
 
 After a sync, open the AI Search dashboard → `tempo-global` → **Items** tab.
-You should see entries keyed by configured source id, such as `viem/...`,
-`wagmi/...`, `vocs/...`, `mpp/...`, and `regen/...`, alongside the
-auto-crawled `docs.tempo.xyz` entries.
+You should see entries keyed by configured source id, such as `tempo/...`,
+`viem/...`, `wagmi/...`, `vocs/...`, `mpp/...`, and `regen/...`.
 
 Query the MCP endpoint to confirm cross-source ranking works:
 

--- a/apps/mcp-docs-indexer/package.json
+++ b/apps/mcp-docs-indexer/package.json
@@ -3,8 +3,11 @@
 	"private": true,
 	"type": "module",
 	"scripts": {
+		"benchmark": "tsx scripts/benchmark-mcp.ts",
 		"build": "echo 'No build step needed for Cloudflare Worker'",
 		"configure:metadata": "tsx scripts/configure-ai-search-metadata.ts",
+		"eval": "tsx scripts/eval-mcp.ts",
+		"eval:promptfoo": "tsx scripts/run-promptfoo.ts",
 		"dev": "wrangler dev",
 		"deploy": "wrangler deploy",
 		"check": "pnpm check:biome && pnpm check:types",

--- a/apps/mcp-docs-indexer/promptfooconfig.ts
+++ b/apps/mcp-docs-indexer/promptfooconfig.ts
@@ -1,0 +1,3 @@
+import { promptfooConfig } from './scripts/eval-mcp.ts'
+
+export default promptfooConfig

--- a/apps/mcp-docs-indexer/scripts/benchmark-mcp.ts
+++ b/apps/mcp-docs-indexer/scripts/benchmark-mcp.ts
@@ -1,0 +1,743 @@
+import { performance } from 'node:perf_hooks'
+
+type Fixture = {
+	name: string
+	query: string
+	expectedSources?: string[]
+	expectedUrlIncludes?: string[]
+	filterSource?: string
+}
+
+type PageFixture = {
+	name: string
+	source: string
+	path: string
+	query?: string
+	expectedUrlIncludes: string[]
+	expectedTextIncludes: string[]
+}
+
+type Variant = {
+	name: string
+	options?: Record<string, unknown>
+}
+
+type Chunk = {
+	text?: string
+	score?: number
+	source?: string
+	url?: string
+	key?: string
+	item?: {
+		key?: string
+		metadata?: Record<string, unknown>
+	}
+}
+
+type PageCandidate = {
+	title?: string
+	url?: string
+	score?: number
+}
+
+type RunResult = {
+	tool: 'search' | 'find_pages' | 'read_page'
+	fixture: string
+	variant: string
+	duration_ms: number
+	bytes: number
+	text_chars: number
+	chunks: number
+	duplicate_pages: number
+	top_score?: number
+	sources: string[]
+	expected_source_hit: boolean | undefined
+	expected_url_hit: boolean | undefined
+	expected_text_hit: boolean | undefined
+	noise_hits: string[]
+	error?: string
+}
+
+type BenchmarkFailure = {
+	fixture: string
+	variant: string
+	reason: string
+}
+
+const ENDPOINT = arg('--endpoint') ?? 'https://mcp.tempo.xyz/'
+const ITERATIONS = Number(arg('--iterations') ?? 1)
+const JSON_OUTPUT = process.argv.includes('--json')
+const STRICT = process.argv.includes('--strict')
+const DEFAULT_SEARCH_MAX_BYTES = 5_000
+const DEFAULT_SEARCH_MAX_TEXT_CHARS = 3_000
+const DEFAULT_READ_PAGE_MAX_BYTES = 6_000
+const DEFAULT_READ_PAGE_MAX_TEXT_CHARS = 5_000
+const BOUNDED_READ_PAGE_MAX_BYTES = 4_000
+const BOUNDED_READ_PAGE_MAX_TEXT_CHARS = 3_200
+const FOCUSED_READ_PAGE_MAX_BYTES = 2_500
+const FOCUSED_READ_PAGE_MAX_TEXT_CHARS = 1_700
+const FIND_PAGES_MAX_BYTES = 1_500
+
+const fixtures: Fixture[] = [
+	{
+		name: 'viem_fee_token',
+		query: 'How do I pay Tempo transaction fees in a stablecoin using viem?',
+		expectedSources: ['viem'],
+		expectedUrlIncludes: ['viem.sh/tempo'],
+		filterSource: 'viem',
+	},
+	{
+		name: 'wagmi_tempo_wallet',
+		query: 'How do I configure the wagmi tempoWallet connector?',
+		expectedSources: ['wagmi'],
+		expectedUrlIncludes: ['wagmi.sh/react/api/connectors/tempoWallet'],
+		filterSource: 'wagmi',
+	},
+	{
+		name: 'mpp_mcp_transport',
+		query: 'How does MPP payment work over MCP JSON-RPC transport?',
+		expectedSources: ['mpp'],
+		expectedUrlIncludes: ['mpp.dev/protocol/transports'],
+		filterSource: 'mpp',
+	},
+	{
+		name: 'regen_button',
+		query: 'What Regen UI Button variants are available?',
+		expectedSources: ['regen'],
+		expectedUrlIncludes: ['regen.tempo.xyz/button'],
+		filterSource: 'regen',
+	},
+	{
+		name: 'vocs_mcp_server',
+		query: 'How do I expose a Vocs docs site as an MCP server?',
+		expectedSources: ['vocs'],
+		expectedUrlIncludes: ['vocs.dev/features/mcp-server'],
+		filterSource: 'vocs',
+	},
+	{
+		name: 'tempo_virtual_addresses',
+		query: 'How do virtual addresses work for TIP-20 deposits on Tempo?',
+		expectedSources: ['tempo'],
+		expectedUrlIncludes: ['docs.tempo.xyz/guide/payments/virtual-addresses'],
+		filterSource: 'tempo',
+	},
+]
+
+const pageFixtures: PageFixture[] = [
+	{
+		name: 'read_tempo_virtual_addresses',
+		source: 'tempo',
+		path: '/guide/payments/virtual-addresses',
+		query: 'virtual addresses deposits',
+		expectedUrlIncludes: ['docs.tempo.xyz/guide/payments/virtual-addresses'],
+		expectedTextIncludes: ['# Use virtual addresses for deposits'],
+	},
+	{
+		name: 'read_vocs_mcp_server',
+		source: 'vocs',
+		path: '/features/mcp-server',
+		query: 'MCP Server McpSource.github',
+		expectedUrlIncludes: ['vocs.dev/features/mcp-server'],
+		expectedTextIncludes: ['# MCP Server', 'McpSource.github'],
+	},
+	{
+		name: 'read_regen_button',
+		source: 'regen',
+		path: '/button',
+		query: 'Button variants',
+		expectedUrlIncludes: ['regen.tempo.xyz/button'],
+		expectedTextIncludes: ['Button'],
+	},
+]
+
+const variants: Variant[] = [
+	{ name: 'default' },
+	{
+		name: 'structured',
+		options: { max_results: 5, response_format: 'structured' },
+	},
+	{
+		name: 'compact',
+		options: {
+			max_results: 5,
+			ai_search_options: {
+				ranking_options: { score_threshold: 0.45 },
+				reranking: { enabled: true },
+			},
+		},
+	},
+]
+
+const noiseTerms = [
+	'Skip to content',
+	'Was this helpful?',
+	'Copy page for AI',
+	'Ask AI...',
+	'Search...',
+]
+
+const results: RunResult[] = []
+for (let i = 0; i < ITERATIONS; i++) {
+	for (const fixture of fixtures) {
+		for (const variant of variantsFor(fixture)) {
+			results.push(await runFixture(fixture, variant))
+		}
+		if (fixture.filterSource) {
+			results.push(await runFindPagesFixture(fixture))
+		}
+	}
+	for (const fixture of pageFixtures) {
+		results.push(await runReadPageFixture(fixture, { name: 'default' }))
+		results.push(
+			await runReadPageFixture(fixture, {
+				name: 'bounded',
+				options: { max_chars: 3000 },
+			}),
+		)
+		results.push(
+			await runReadPageFixture(fixture, {
+				name: 'focused',
+				options: { max_chars: 1500, query: fixture.query },
+			}),
+		)
+		results.push(
+			await runReadPageFixture(fixture, {
+				name: 'focused_structured',
+				options: {
+					max_chars: 1500,
+					query: fixture.query,
+					response_format: 'structured',
+				},
+			}),
+		)
+	}
+}
+
+const failures = benchmarkFailures(results)
+if (JSON_OUTPUT) {
+	console.info(
+		JSON.stringify(
+			{ endpoint: ENDPOINT, iterations: ITERATIONS, results, failures },
+			null,
+			2,
+		),
+	)
+} else {
+	printSummary(results)
+	if (failures.length > 0) {
+		console.info('failures')
+		for (const failure of failures) {
+			console.info(`${failure.fixture}\t${failure.variant}\t${failure.reason}`)
+		}
+	}
+}
+
+if (STRICT && failures.length > 0) {
+	process.exitCode = 1
+}
+
+function variantsFor(fixture: Fixture): Variant[] {
+	if (!fixture.filterSource) return variants
+	return [
+		...variants,
+		{
+			name: 'filtered',
+			options: {
+				max_results: 5,
+				source: fixture.filterSource,
+				ai_search_options: {
+					ranking_options: { score_threshold: 0.35 },
+					reranking: { enabled: true },
+				},
+			},
+		},
+	]
+}
+
+async function runFixture(
+	fixture: Fixture,
+	variant: Variant,
+): Promise<RunResult> {
+	const startedAt = performance.now()
+	try {
+		const response = await fetch(ENDPOINT, {
+			method: 'POST',
+			headers: {
+				Accept: 'application/json, text/event-stream',
+				'Content-Type': 'application/json',
+			},
+			body: JSON.stringify({
+				jsonrpc: '2.0',
+				id: 1,
+				method: 'tools/call',
+				params: {
+					name: 'search',
+					arguments: {
+						query: fixture.query,
+						...variant.options,
+					},
+				},
+			}),
+		})
+		const raw = await response.text()
+		const durationMs = Math.round(performance.now() - startedAt)
+		const parsed = parseMcpResponse(raw)
+		const chunks = parsed.result?.chunks ?? []
+		const text = chunks.map((chunk) => chunk.text ?? '').join('\n')
+		const urls = chunks
+			.map((chunk) => chunk.url ?? chunk.item?.metadata?.url)
+			.filter((url): url is string => typeof url === 'string')
+		const duplicatePages = duplicatePageCount(chunks)
+		const sources = [
+			...new Set(
+				chunks
+					.map(
+						(chunk) =>
+							chunk.source ??
+							chunk.item?.metadata?.source ??
+							sourceFromKey(chunk),
+					)
+					.filter((source): source is string => typeof source === 'string'),
+			),
+		]
+
+		return {
+			tool: 'search',
+			fixture: fixture.name,
+			variant: variant.name,
+			duration_ms: durationMs,
+			bytes: Buffer.byteLength(raw),
+			text_chars: text.length,
+			chunks: chunks.length,
+			duplicate_pages: duplicatePages,
+			...(typeof chunks[0]?.score === 'number'
+				? { top_score: chunks[0].score }
+				: {}),
+			sources,
+			expected_source_hit: fixture.expectedSources
+				? fixture.expectedSources.some((source) => sources.includes(source))
+				: undefined,
+			expected_url_hit: fixture.expectedUrlIncludes
+				? fixture.expectedUrlIncludes.some((needle) =>
+						urls.some((url) => url.includes(needle)),
+					)
+				: undefined,
+			expected_text_hit: undefined,
+			noise_hits: noiseTerms.filter((term) => text.includes(term)),
+			...(parsed.error ? { error: parsed.error } : {}),
+		}
+	} catch (err) {
+		return {
+			tool: 'search',
+			fixture: fixture.name,
+			variant: variant.name,
+			duration_ms: Math.round(performance.now() - startedAt),
+			bytes: 0,
+			text_chars: 0,
+			chunks: 0,
+			duplicate_pages: 0,
+			sources: [],
+			expected_source_hit: fixture.expectedSources ? false : undefined,
+			expected_url_hit: fixture.expectedUrlIncludes ? false : undefined,
+			expected_text_hit: undefined,
+			noise_hits: [],
+			error: err instanceof Error ? err.message : String(err),
+		}
+	}
+}
+
+async function runFindPagesFixture(fixture: Fixture): Promise<RunResult> {
+	const startedAt = performance.now()
+	try {
+		const response = await fetch(ENDPOINT, {
+			method: 'POST',
+			headers: {
+				Accept: 'application/json, text/event-stream',
+				'Content-Type': 'application/json',
+			},
+			body: JSON.stringify({
+				jsonrpc: '2.0',
+				id: 1,
+				method: 'tools/call',
+				params: {
+					name: 'find_pages',
+					arguments: {
+						source: fixture.filterSource,
+						query: fixture.query,
+						max_results: 5,
+						response_format: 'structured',
+					},
+				},
+			}),
+		})
+		const raw = await response.text()
+		const durationMs = Math.round(performance.now() - startedAt)
+		const parsed = parseMcpResponse(raw)
+		const pages = parsed.result?.pages ?? []
+		const urls = pages
+			.map((page) => page.url)
+			.filter((url): url is string => typeof url === 'string')
+
+		return {
+			tool: 'find_pages',
+			fixture: fixture.name,
+			variant: 'index',
+			duration_ms: durationMs,
+			bytes: Buffer.byteLength(raw),
+			text_chars: pages.map((page) => page.title ?? '').join('\n').length,
+			chunks: pages.length,
+			duplicate_pages: 0,
+			...(typeof pages[0]?.score === 'number'
+				? { top_score: pages[0].score }
+				: {}),
+			sources: fixture.filterSource ? [fixture.filterSource] : [],
+			expected_source_hit: fixture.expectedSources
+				? fixture.expectedSources.includes(fixture.filterSource ?? '')
+				: undefined,
+			expected_url_hit: fixture.expectedUrlIncludes
+				? fixture.expectedUrlIncludes.some((needle) =>
+						urls.some((url) => url.includes(needle)),
+					)
+				: undefined,
+			expected_text_hit: undefined,
+			noise_hits: [],
+			...(parsed.error ? { error: parsed.error } : {}),
+		}
+	} catch (err) {
+		return {
+			tool: 'find_pages',
+			fixture: fixture.name,
+			variant: 'index',
+			duration_ms: Math.round(performance.now() - startedAt),
+			bytes: 0,
+			text_chars: 0,
+			chunks: 0,
+			duplicate_pages: 0,
+			sources: fixture.filterSource ? [fixture.filterSource] : [],
+			expected_source_hit: fixture.expectedSources ? false : undefined,
+			expected_url_hit: fixture.expectedUrlIncludes ? false : undefined,
+			expected_text_hit: undefined,
+			noise_hits: [],
+			error: err instanceof Error ? err.message : String(err),
+		}
+	}
+}
+
+async function runReadPageFixture(
+	fixture: PageFixture,
+	variant: Variant,
+): Promise<RunResult> {
+	const startedAt = performance.now()
+	try {
+		const response = await fetch(ENDPOINT, {
+			method: 'POST',
+			headers: {
+				Accept: 'application/json, text/event-stream',
+				'Content-Type': 'application/json',
+			},
+			body: JSON.stringify({
+				jsonrpc: '2.0',
+				id: 1,
+				method: 'tools/call',
+				params: {
+					name: 'read_page',
+					arguments: {
+						source: fixture.source,
+						path: fixture.path,
+						...variant.options,
+					},
+				},
+			}),
+		})
+		const raw = await response.text()
+		const durationMs = Math.round(performance.now() - startedAt)
+		const parsed = parseMcpResponse(raw)
+		const text = parsed.result?.text ?? ''
+		const url = parsed.result?.url
+
+		return {
+			tool: 'read_page',
+			fixture: fixture.name,
+			variant: variant.name,
+			duration_ms: durationMs,
+			bytes: Buffer.byteLength(raw),
+			text_chars: text.length,
+			chunks: 0,
+			duplicate_pages: 0,
+			sources: parsed.result?.source ? [parsed.result.source] : [],
+			expected_source_hit: parsed.result?.source === fixture.source,
+			expected_url_hit: fixture.expectedUrlIncludes.some(
+				(needle) => typeof url === 'string' && url.includes(needle),
+			),
+			expected_text_hit: fixture.expectedTextIncludes.every((needle) =>
+				text.includes(needle),
+			),
+			noise_hits: noiseTerms.filter((term) => text.includes(term)),
+			...(parsed.error ? { error: parsed.error } : {}),
+		}
+	} catch (err) {
+		return {
+			tool: 'read_page',
+			fixture: fixture.name,
+			variant: variant.name,
+			duration_ms: Math.round(performance.now() - startedAt),
+			bytes: 0,
+			text_chars: 0,
+			chunks: 0,
+			duplicate_pages: 0,
+			sources: [],
+			expected_source_hit: false,
+			expected_url_hit: false,
+			expected_text_hit: false,
+			noise_hits: [],
+			error: err instanceof Error ? err.message : String(err),
+		}
+	}
+}
+
+function parseMcpResponse(raw: string): {
+	result?: {
+		chunks?: Chunk[]
+		pages?: PageCandidate[]
+		source?: string
+		url?: string
+		text?: string
+		truncated?: boolean
+	}
+	error?: string
+} {
+	const dataLines = raw
+		.split('\n')
+		.filter((line) => line.startsWith('data: '))
+		.map((line) => line.slice('data: '.length))
+	const payload = JSON.parse(dataLines.at(-1) ?? raw) as {
+		result?: {
+			content?: Array<{ text?: string }>
+			structuredContent?: {
+				success?: boolean
+				result?: {
+					chunks?: Chunk[]
+					pages?: PageCandidate[]
+					source?: string
+					url?: string
+					text?: string
+					truncated?: boolean
+				}
+				error?: string
+			}
+		}
+		error?: { message?: string }
+	}
+	if (payload.error) return { error: payload.error.message ?? 'MCP error' }
+	if (payload.result?.structuredContent) {
+		const decoded = payload.result.structuredContent
+		if (decoded.success === false)
+			return { error: decoded.error ?? 'tool error' }
+		return decoded
+	}
+	const text = payload.result?.content?.find((part) => part.text)?.text
+	if (!text) return {}
+	const decoded = JSON.parse(text) as {
+		success?: boolean
+		result?: {
+			chunks?: Chunk[]
+			pages?: PageCandidate[]
+			source?: string
+			url?: string
+			text?: string
+			truncated?: boolean
+		}
+		error?: string
+	}
+	if (decoded.success === false) return { error: decoded.error ?? 'tool error' }
+	return decoded
+}
+
+function sourceFromKey(chunk: Chunk): string | undefined {
+	const key = chunk.key ?? chunk.item?.key
+	const prefix = key?.split('/')[0]
+	if (!prefix?.startsWith('https:')) return prefix
+	return undefined
+}
+
+function duplicatePageCount(chunks: Chunk[]): number {
+	const pages = chunks
+		.map(pageIdentity)
+		.filter((page): page is string => !!page)
+	return pages.length - new Set(pages).size
+}
+
+function pageIdentity(chunk: Chunk): string | undefined {
+	const url = chunk.url ?? chunk.item?.metadata?.url
+	if (typeof url === 'string') {
+		try {
+			const parsed = new URL(url)
+			parsed.hash = ''
+			parsed.search = ''
+			return parsed.toString().replace(/\/$/, '')
+		} catch {
+			return url
+		}
+	}
+	return chunk.key ?? chunk.item?.key
+}
+
+function printSummary(rows: RunResult[]) {
+	console.info(`MCP benchmark: ${ENDPOINT}`)
+	console.info(
+		[
+			'tool',
+			'fixture',
+			'variant',
+			'ms',
+			'bytes',
+			'chars',
+			'chunks',
+			'dupe_pages',
+			'top_score',
+			'sources',
+			'source_hit',
+			'url_hit',
+			'text_hit',
+			'noise',
+			'error',
+		].join('\t'),
+	)
+	for (const row of rows) {
+		console.info(
+			[
+				row.tool,
+				row.fixture,
+				row.variant,
+				row.duration_ms,
+				row.bytes,
+				row.text_chars,
+				row.chunks,
+				row.duplicate_pages,
+				row.top_score?.toFixed(3) ?? '',
+				row.sources.join(','),
+				formatHit(row.expected_source_hit),
+				formatHit(row.expected_url_hit),
+				formatHit(row.expected_text_hit),
+				row.noise_hits.join('|'),
+				row.error ?? '',
+			].join('\t'),
+		)
+	}
+	const okRows = rows.filter((row) => !row.error)
+	const durations = okRows.map((row) => row.duration_ms).sort((a, b) => a - b)
+	const bytes = sum(okRows.map((row) => row.bytes))
+	const chars = sum(okRows.map((row) => row.text_chars))
+	console.info(
+		`summary\tp50_ms=${percentile(durations, 0.5)}\tp95_ms=${percentile(durations, 0.95)}\ttotal_bytes=${bytes}\ttotal_text_chars=${chars}`,
+	)
+	for (const variant of [...new Set(rows.map((row) => row.variant))]) {
+		const variantRows = okRows.filter((row) => row.variant === variant)
+		const variantDurations = variantRows
+			.map((row) => row.duration_ms)
+			.sort((a, b) => a - b)
+		console.info(
+			`summary:${variant}\tp50_ms=${percentile(variantDurations, 0.5)}\tp95_ms=${percentile(variantDurations, 0.95)}\ttotal_bytes=${sum(variantRows.map((row) => row.bytes))}\ttotal_text_chars=${sum(variantRows.map((row) => row.text_chars))}`,
+		)
+	}
+	for (const tool of [...new Set(rows.map((row) => row.tool))]) {
+		const toolRows = okRows.filter((row) => row.tool === tool)
+		const toolDurations = toolRows
+			.map((row) => row.duration_ms)
+			.sort((a, b) => a - b)
+		console.info(
+			`summary:${tool}\tp50_ms=${percentile(toolDurations, 0.5)}\tp95_ms=${percentile(toolDurations, 0.95)}\ttotal_bytes=${sum(toolRows.map((row) => row.bytes))}\ttotal_text_chars=${sum(toolRows.map((row) => row.text_chars))}`,
+		)
+	}
+}
+
+function benchmarkFailures(rows: RunResult[]): BenchmarkFailure[] {
+	return rows.flatMap((row) =>
+		failuresFor(row).map((reason) => ({
+			fixture: row.fixture,
+			variant: row.variant,
+			reason,
+		})),
+	)
+}
+
+function failuresFor(row: RunResult): string[] {
+	const failures = []
+	if (row.error) failures.push(row.error)
+	if (row.expected_source_hit === false)
+		failures.push('missing expected source')
+	if (row.expected_url_hit === false) failures.push('missing expected url')
+	if (row.expected_text_hit === false) failures.push('missing expected text')
+	if (row.noise_hits.length > 0) {
+		failures.push(`noise terms: ${row.noise_hits.join(', ')}`)
+	}
+	if (row.duplicate_pages > 0) {
+		failures.push(`duplicate pages: ${row.duplicate_pages}`)
+	}
+
+	if (row.tool === 'search') {
+		if (row.chunks < 1) failures.push('no search chunks')
+		if (row.chunks > 5) failures.push(`too many search chunks: ${row.chunks}`)
+		if (row.bytes > DEFAULT_SEARCH_MAX_BYTES) {
+			failures.push(
+				`too many bytes: ${row.bytes} > ${DEFAULT_SEARCH_MAX_BYTES}`,
+			)
+		}
+		if (row.text_chars > DEFAULT_SEARCH_MAX_TEXT_CHARS) {
+			failures.push(
+				`too many text chars: ${row.text_chars} > ${DEFAULT_SEARCH_MAX_TEXT_CHARS}`,
+			)
+		}
+	}
+
+	if (row.tool === 'find_pages') {
+		if (row.chunks < 1) failures.push('no page candidates')
+		if (row.chunks > 5) failures.push(`too many page candidates: ${row.chunks}`)
+		if (row.bytes > FIND_PAGES_MAX_BYTES) {
+			failures.push(`too many bytes: ${row.bytes} > ${FIND_PAGES_MAX_BYTES}`)
+		}
+	}
+
+	if (row.tool === 'read_page') {
+		const maxBytes = readPageMaxBytesFor(row.variant)
+		const maxTextChars = readPageMaxTextCharsFor(row.variant)
+		if (row.bytes > maxBytes) {
+			failures.push(`too many bytes: ${row.bytes} > ${maxBytes}`)
+		}
+		if (row.text_chars > maxTextChars) {
+			failures.push(`too many text chars: ${row.text_chars} > ${maxTextChars}`)
+		}
+	}
+	return failures
+}
+
+function readPageMaxBytesFor(variant: string): number {
+	if (variant.startsWith('focused')) return FOCUSED_READ_PAGE_MAX_BYTES
+	if (variant === 'bounded') return BOUNDED_READ_PAGE_MAX_BYTES
+	return DEFAULT_READ_PAGE_MAX_BYTES
+}
+
+function readPageMaxTextCharsFor(variant: string): number {
+	if (variant.startsWith('focused')) return FOCUSED_READ_PAGE_MAX_TEXT_CHARS
+	if (variant === 'bounded') return BOUNDED_READ_PAGE_MAX_TEXT_CHARS
+	return DEFAULT_READ_PAGE_MAX_TEXT_CHARS
+}
+
+function formatHit(value: boolean | undefined): string {
+	if (value === undefined) return ''
+	return value ? 'yes' : 'no'
+}
+
+function percentile(values: number[], p: number): number {
+	if (values.length === 0) return 0
+	return values[Math.min(values.length - 1, Math.floor(values.length * p))]
+}
+
+function sum(values: number[]): number {
+	return values.reduce((total, value) => total + value, 0)
+}
+
+function arg(name: string): string | undefined {
+	const index = process.argv.indexOf(name)
+	return index === -1 ? undefined : process.argv[index + 1]
+}

--- a/apps/mcp-docs-indexer/scripts/eval-mcp.ts
+++ b/apps/mcp-docs-indexer/scripts/eval-mcp.ts
@@ -1,0 +1,975 @@
+import { performance } from 'node:perf_hooks'
+import { pathToFileURL } from 'node:url'
+
+export type ToolCase = {
+	name: string
+	kind: 'tools'
+	requiredTools: string[]
+	requiredSources: string[]
+	maxBytes: number
+}
+
+export type ResourceCase = {
+	name: string
+	kind: 'resource'
+	uri: string
+	expectedText: string[]
+	maxBytes: number
+	maxTextChars: number
+}
+
+export type SearchCase = {
+	name: string
+	kind: 'search'
+	query: string
+	args?: Record<string, unknown>
+	expectedSources?: string[]
+	expectedUrlIncludes?: string[]
+	expectedTextIncludes?: string[]
+	maxBytes: number
+	maxTextChars: number
+	maxDuplicatePages: number
+	minChunks: number
+	maxChunks: number
+}
+
+export type ReadPageCase = {
+	name: string
+	kind: 'read_page'
+	source: string
+	path: string
+	query?: string
+	maxChars?: number
+	expectedUrlIncludes: string[]
+	expectedTextIncludes: string[]
+	maxBytes: number
+	maxTextChars: number
+}
+
+export type FindPagesCase = {
+	name: string
+	kind: 'find_pages'
+	source: string
+	query: string
+	responseFormat?: 'structured'
+	expectedUrlIncludes: string[]
+	expectedTitleIncludes: string[]
+	maxBytes: number
+	maxPages: number
+}
+
+export type EvalCase =
+	| ToolCase
+	| ResourceCase
+	| SearchCase
+	| ReadPageCase
+	| FindPagesCase
+
+type Chunk = {
+	text?: string
+	score?: number
+	source?: string
+	url?: string
+	key?: string
+	item?: {
+		key?: string
+		metadata?: Record<string, unknown>
+	}
+}
+
+export type EvalResult = {
+	name: string
+	kind: EvalCase['kind']
+	passed: boolean
+	score: number
+	max_score: number
+	duration_ms: number
+	bytes: number
+	text_chars: number
+	chunks: number
+	duplicate_pages: number
+	failures: string[]
+}
+
+export type EndpointResult = {
+	endpoint: string
+	results: EvalResult[]
+	summary: {
+		score: number
+		max_score: number
+		passed: number
+		total: number
+		pass_rate: number
+		bytes: number
+		text_chars: number
+		duplicate_pages: number
+		p50_ms: number
+		p95_ms: number
+	}
+}
+
+const noiseTerms = [
+	'Skip to content',
+	'Was this helpful?',
+	'Copy page for AI',
+	'Ask AI...',
+	'Search...',
+]
+
+export const cases: EvalCase[] = [
+	{
+		name: 'tool_schema',
+		kind: 'tools',
+		requiredTools: ['search', 'find_pages', 'read_page'],
+		requiredSources: ['tempo', 'viem', 'wagmi', 'vocs', 'mpp', 'regen'],
+		maxBytes: 2_800,
+	},
+	{
+		name: 'source_resource',
+		kind: 'resource',
+		uri: 'tempo-docs://sources',
+		expectedText: [
+			'`tempo`',
+			'`viem`',
+			'`wagmi`',
+			'`vocs`',
+			'`mpp`',
+			'`regen`',
+		],
+		maxBytes: 1_000,
+		maxTextChars: 800,
+	},
+	{
+		name: 'tempo_index_resource',
+		kind: 'resource',
+		uri: 'tempo-docs://source/tempo/index',
+		expectedText: [
+			'# tempo docs page index',
+			'Use virtual addresses for deposits',
+			'https://docs.tempo.xyz/guide/payments/virtual-addresses',
+		],
+		maxBytes: 5_200,
+		maxTextChars: 4_800,
+	},
+	{
+		name: 'viem_fee_token_filtered',
+		kind: 'search',
+		query: 'How do I pay Tempo transaction fees in a stablecoin using viem?',
+		args: { source: 'viem', max_results: 5 },
+		expectedSources: ['viem'],
+		expectedUrlIncludes: ['viem.sh/tempo'],
+		expectedTextIncludes: ['fee token'],
+		maxBytes: 2_600,
+		maxTextChars: 1_800,
+		maxDuplicatePages: 0,
+		minChunks: 1,
+		maxChunks: 5,
+	},
+	{
+		name: 'wagmi_wallet_filtered',
+		kind: 'search',
+		query: 'How do I configure the wagmi tempoWallet connector?',
+		args: { source: 'wagmi', max_results: 5 },
+		expectedSources: ['wagmi'],
+		expectedUrlIncludes: ['wagmi.sh/react/api/connectors/tempoWallet'],
+		expectedTextIncludes: ['tempoWallet'],
+		maxBytes: 4_000,
+		maxTextChars: 2_700,
+		maxDuplicatePages: 0,
+		minChunks: 1,
+		maxChunks: 5,
+	},
+	{
+		name: 'mpp_mcp_transport_filtered',
+		kind: 'search',
+		query: 'How does MPP payment work over MCP JSON-RPC transport?',
+		args: { source: 'mpp', max_results: 5 },
+		expectedSources: ['mpp'],
+		expectedUrlIncludes: ['mpp.dev/protocol/transports'],
+		expectedTextIncludes: ['MCP'],
+		maxBytes: 4_000,
+		maxTextChars: 2_700,
+		maxDuplicatePages: 0,
+		minChunks: 1,
+		maxChunks: 5,
+	},
+	{
+		name: 'regen_button_filtered',
+		kind: 'search',
+		query: 'What Regen UI Button variants are available?',
+		args: { source: 'regen', max_results: 5 },
+		expectedSources: ['regen'],
+		expectedUrlIncludes: ['regen.tempo.xyz/button'],
+		expectedTextIncludes: ['Button'],
+		maxBytes: 4_000,
+		maxTextChars: 2_700,
+		maxDuplicatePages: 0,
+		minChunks: 1,
+		maxChunks: 5,
+	},
+	{
+		name: 'vocs_mcp_server_filtered',
+		kind: 'search',
+		query: 'How do I expose a Vocs docs site as an MCP server?',
+		args: { source: 'vocs', max_results: 5 },
+		expectedSources: ['vocs'],
+		expectedUrlIncludes: ['vocs.dev/features/mcp-server'],
+		expectedTextIncludes: ['MCP Server'],
+		maxBytes: 4_000,
+		maxTextChars: 2_700,
+		maxDuplicatePages: 0,
+		minChunks: 1,
+		maxChunks: 5,
+	},
+	{
+		name: 'tempo_virtual_addresses_filtered',
+		kind: 'search',
+		query: 'How do virtual addresses work for TIP-20 deposits on Tempo?',
+		args: { source: 'tempo', max_results: 5 },
+		expectedSources: ['tempo'],
+		expectedUrlIncludes: ['docs.tempo.xyz/guide/payments/virtual-addresses'],
+		expectedTextIncludes: ['virtual addresses'],
+		maxBytes: 4_000,
+		maxTextChars: 2_700,
+		maxDuplicatePages: 0,
+		minChunks: 1,
+		maxChunks: 5,
+	},
+	{
+		name: 'tempo_virtual_addresses_inferred',
+		kind: 'search',
+		query: 'How do virtual addresses work for TIP-20 deposits on Tempo?',
+		expectedSources: ['tempo'],
+		expectedUrlIncludes: ['docs.tempo.xyz/guide/payments/virtual-addresses'],
+		expectedTextIncludes: ['virtual addresses'],
+		maxBytes: 4_000,
+		maxTextChars: 2_700,
+		maxDuplicatePages: 0,
+		minChunks: 1,
+		maxChunks: 5,
+	},
+	{
+		name: 'find_tempo_virtual_addresses',
+		kind: 'find_pages',
+		source: 'tempo',
+		query: 'virtual addresses deposits',
+		expectedUrlIncludes: ['docs.tempo.xyz/guide/payments/virtual-addresses'],
+		expectedTitleIncludes: ['Use virtual addresses for deposits'],
+		maxBytes: 1_500,
+		maxPages: 5,
+	},
+	{
+		name: 'find_tempo_virtual_addresses_structured',
+		kind: 'find_pages',
+		source: 'tempo',
+		query: 'virtual addresses deposits',
+		responseFormat: 'structured',
+		expectedUrlIncludes: ['docs.tempo.xyz/guide/payments/virtual-addresses'],
+		expectedTitleIncludes: ['Use virtual addresses for deposits'],
+		maxBytes: 1_500,
+		maxPages: 5,
+	},
+	{
+		name: 'read_tempo_virtual_addresses',
+		kind: 'read_page',
+		source: 'tempo',
+		path: '/guide/payments/virtual-addresses',
+		query: 'virtual addresses deposits',
+		maxChars: 4_000,
+		expectedUrlIncludes: ['docs.tempo.xyz/guide/payments/virtual-addresses'],
+		expectedTextIncludes: ['# Use virtual addresses for deposits'],
+		maxBytes: 5_000,
+		maxTextChars: 4_100,
+	},
+	{
+		name: 'read_vocs_mcp_server',
+		kind: 'read_page',
+		source: 'vocs',
+		path: '/features/mcp-server',
+		query: 'MCP Server McpSource.github',
+		maxChars: 4_000,
+		expectedUrlIncludes: ['vocs.dev/features/mcp-server'],
+		expectedTextIncludes: ['# MCP Server', 'McpSource.github'],
+		maxBytes: 5_000,
+		maxTextChars: 4_100,
+	},
+]
+
+if (isCli()) await main()
+
+async function main(): Promise<void> {
+	const endpoint = arg('--endpoint') ?? 'https://mcp.tempo.xyz/'
+	const baseline = arg('--baseline')
+	const jsonOutput = process.argv.includes('--json')
+	const strict = process.argv.includes('--strict')
+	const results = baseline
+		? {
+				baseline: await evalEndpoint(baseline),
+				candidate: await evalEndpoint(endpoint),
+			}
+		: { candidate: await evalEndpoint(endpoint) }
+
+	if (jsonOutput) {
+		console.info(JSON.stringify(results, null, 2))
+	} else {
+		if ('baseline' in results) {
+			printEndpoint(results.baseline, 'baseline')
+			console.info('')
+		}
+		printEndpoint(results.candidate, 'candidate')
+		if ('baseline' in results)
+			printComparison(results.baseline, results.candidate)
+	}
+
+	if (
+		strict &&
+		results.candidate.summary.passed !== results.candidate.summary.total
+	) {
+		process.exitCode = 1
+	}
+}
+
+export async function evalEndpoint(endpoint: string): Promise<EndpointResult> {
+	const results = []
+	for (const testCase of cases) {
+		results.push(await runCase(endpoint, testCase))
+	}
+	const durations = results
+		.map((result) => result.duration_ms)
+		.sort((a, b) => a - b)
+	const score = sum(results.map((result) => result.score))
+	const maxScore = sum(results.map((result) => result.max_score))
+	const passed = results.filter((result) => result.passed).length
+	return {
+		endpoint,
+		results,
+		summary: {
+			score,
+			max_score: maxScore,
+			passed,
+			total: results.length,
+			pass_rate: maxScore === 0 ? 0 : score / maxScore,
+			bytes: sum(results.map((result) => result.bytes)),
+			text_chars: sum(results.map((result) => result.text_chars)),
+			duplicate_pages: sum(results.map((result) => result.duplicate_pages)),
+			p50_ms: percentile(durations, 0.5),
+			p95_ms: percentile(durations, 0.95),
+		},
+	}
+}
+
+export async function runCase(
+	endpoint: string,
+	testCase: EvalCase,
+): Promise<EvalResult> {
+	if (testCase.kind === 'tools') return runToolsCase(endpoint, testCase)
+	if (testCase.kind === 'resource') return runResourceCase(endpoint, testCase)
+	if (testCase.kind === 'find_pages')
+		return runFindPagesCase(endpoint, testCase)
+	if (testCase.kind === 'read_page') return runReadPageCase(endpoint, testCase)
+	return runSearchCase(endpoint, testCase)
+}
+
+export class TempoDocsMcpProvider {
+	id(): string {
+		return 'tempo-docs-mcp'
+	}
+
+	async callApi(_prompt: string, context?: { vars?: unknown }) {
+		const endpoint = process.env.MCP_EVAL_ENDPOINT ?? 'https://mcp.tempo.xyz/'
+		const vars = context?.vars as { caseName?: string } | undefined
+		const testCase = cases.find((entry) => entry.name === vars?.caseName)
+		if (!testCase) {
+			return {
+				error: `unknown MCP eval case: ${vars?.caseName ?? 'missing'}`,
+			}
+		}
+		const result = await runCase(endpoint, testCase)
+		return {
+			output: result,
+			metadata: {
+				endpoint,
+				kind: result.kind,
+				score: result.score,
+				max_score: result.max_score,
+				bytes: result.bytes,
+				text_chars: result.text_chars,
+				chunks: result.chunks,
+				duplicate_pages: result.duplicate_pages,
+				duration_ms: result.duration_ms,
+			},
+			tokenUsage: {
+				total: result.bytes,
+				prompt: 0,
+				completion: result.bytes,
+			},
+		}
+	}
+}
+
+export const promptfooConfig = {
+	description: 'Tempo docs MCP server evals',
+	prompts: ['{{caseName}}'],
+	providers: ['file://./scripts/eval-mcp.ts'],
+	tests: cases.map((testCase) => ({
+		description: testCase.name,
+		vars: { caseName: testCase.name },
+		metadata: { kind: testCase.kind },
+		assert: [
+			{
+				type: 'javascript',
+				value: [
+					'const result = typeof output === "string" ? JSON.parse(output) : output;',
+					'if (result.passed) return true;',
+					'return {',
+					'  pass: false,',
+					'  score: result.max_score ? result.score / result.max_score : 0,',
+					'  reason: result.failures.join("; "),',
+					'};',
+				].join('\n'),
+			},
+		],
+	})),
+	evaluateOptions: {
+		cache: false,
+		maxConcurrency: 1,
+		timeoutMs: 30_000,
+	},
+}
+
+export default TempoDocsMcpProvider
+
+async function runToolsCase(
+	endpoint: string,
+	testCase: ToolCase,
+): Promise<EvalResult> {
+	const startedAt = performance.now()
+	const failures = []
+	try {
+		const raw = await mcp(endpoint, {
+			jsonrpc: '2.0',
+			id: 1,
+			method: 'tools/list',
+		})
+		const body = JSON.parse(lastSseData(raw) ?? raw) as {
+			result?: { tools?: Array<{ name?: string; inputSchema?: unknown }> }
+			error?: { message?: string }
+		}
+		if (body.error) failures.push(body.error.message ?? 'tools/list error')
+		const tools = body.result?.tools ?? []
+		const names = tools.map((tool) => tool.name).filter(Boolean)
+		for (const tool of testCase.requiredTools) {
+			if (!names.includes(tool)) failures.push(`missing tool ${tool}`)
+		}
+		const search = tools.find((tool) => tool.name === 'search') as
+			| { inputSchema?: { properties?: { source?: { enum?: string[] } } } }
+			| undefined
+		const sourceEnum = search?.inputSchema?.properties?.source?.enum ?? []
+		for (const source of testCase.requiredSources) {
+			if (!sourceEnum.includes(source))
+				failures.push(`missing source ${source}`)
+		}
+		const bytes = Buffer.byteLength(raw)
+		if (bytes > testCase.maxBytes) {
+			failures.push(`too many bytes ${bytes} > ${testCase.maxBytes}`)
+		}
+		return resultFor({
+			testCase,
+			startedAt,
+			raw,
+			failures,
+			maxScore:
+				testCase.requiredTools.length + testCase.requiredSources.length + 1,
+		})
+	} catch (err) {
+		return resultForError(testCase, startedAt, err)
+	}
+}
+
+async function runResourceCase(
+	endpoint: string,
+	testCase: ResourceCase,
+): Promise<EvalResult> {
+	const startedAt = performance.now()
+	const failures = []
+	try {
+		const raw = await mcp(endpoint, {
+			jsonrpc: '2.0',
+			id: 1,
+			method: 'resources/read',
+			params: { uri: testCase.uri },
+		})
+		const body = JSON.parse(lastSseData(raw) ?? raw) as {
+			result?: { contents?: Array<{ text?: string }> }
+			error?: { message?: string }
+		}
+		if (body.error) failures.push(body.error.message ?? 'resource error')
+		const text =
+			body.result?.contents?.map((content) => content.text ?? '').join('\n') ??
+			''
+		for (const expected of testCase.expectedText) {
+			if (!text.includes(expected)) failures.push(`missing text ${expected}`)
+		}
+		const bytes = Buffer.byteLength(raw)
+		if (bytes > testCase.maxBytes) {
+			failures.push(`too many bytes ${bytes} > ${testCase.maxBytes}`)
+		}
+		if (text.length > testCase.maxTextChars) {
+			failures.push(`too much text ${text.length} > ${testCase.maxTextChars}`)
+		}
+		return resultFor({
+			testCase,
+			startedAt,
+			raw,
+			failures,
+			maxScore: testCase.expectedText.length + 2,
+			textChars: text.length,
+		})
+	} catch (err) {
+		return resultForError(testCase, startedAt, err)
+	}
+}
+
+async function runSearchCase(
+	endpoint: string,
+	testCase: SearchCase,
+): Promise<EvalResult> {
+	const startedAt = performance.now()
+	const failures = []
+	try {
+		const raw = await mcp(endpoint, {
+			jsonrpc: '2.0',
+			id: 1,
+			method: 'tools/call',
+			params: {
+				name: 'search',
+				arguments: {
+					query: testCase.query,
+					...testCase.args,
+				},
+			},
+		})
+		const parsed = parseToolResponse(raw)
+		if (parsed.error) failures.push(parsed.error)
+		const chunks = parsed.result?.chunks ?? []
+		const text = chunks.map((chunk) => chunk.text ?? '').join('\n')
+		const urls = chunks
+			.map((chunk) => chunk.url ?? chunk.item?.metadata?.url)
+			.filter((url): url is string => typeof url === 'string')
+		const sources = [
+			...new Set(
+				chunks
+					.map(
+						(chunk) =>
+							chunk.source ??
+							chunk.item?.metadata?.source ??
+							sourceFromKey(chunk),
+					)
+					.filter((source): source is string => typeof source === 'string'),
+			),
+		]
+		const duplicatePages = duplicatePageCount(chunks)
+		for (const source of testCase.expectedSources ?? []) {
+			if (!sources.includes(source)) failures.push(`missing source ${source}`)
+		}
+		for (const expectedUrl of testCase.expectedUrlIncludes ?? []) {
+			if (!urls.some((url) => url.includes(expectedUrl))) {
+				failures.push(`missing url ${expectedUrl}`)
+			}
+		}
+		for (const expectedText of testCase.expectedTextIncludes ?? []) {
+			if (!text.includes(expectedText))
+				failures.push(`missing text ${expectedText}`)
+		}
+		if (chunks.length < testCase.minChunks) {
+			failures.push(`too few chunks ${chunks.length} < ${testCase.minChunks}`)
+		}
+		if (chunks.length > testCase.maxChunks) {
+			failures.push(`too many chunks ${chunks.length} > ${testCase.maxChunks}`)
+		}
+		if (Buffer.byteLength(raw) > testCase.maxBytes) {
+			failures.push(
+				`too many bytes ${Buffer.byteLength(raw)} > ${testCase.maxBytes}`,
+			)
+		}
+		if (text.length > testCase.maxTextChars) {
+			failures.push(`too much text ${text.length} > ${testCase.maxTextChars}`)
+		}
+		if (duplicatePages > testCase.maxDuplicatePages) {
+			failures.push(
+				`duplicate pages ${duplicatePages} > ${testCase.maxDuplicatePages}`,
+			)
+		}
+		for (const term of noiseTerms) {
+			if (text.includes(term)) failures.push(`noise term ${term}`)
+		}
+		return resultFor({
+			testCase,
+			startedAt,
+			raw,
+			failures,
+			maxScore:
+				(testCase.expectedSources?.length ?? 0) +
+				(testCase.expectedUrlIncludes?.length ?? 0) +
+				(testCase.expectedTextIncludes?.length ?? 0) +
+				6,
+			textChars: text.length,
+			chunks: chunks.length,
+			duplicatePages,
+		})
+	} catch (err) {
+		return resultForError(testCase, startedAt, err)
+	}
+}
+
+async function runFindPagesCase(
+	endpoint: string,
+	testCase: FindPagesCase,
+): Promise<EvalResult> {
+	const startedAt = performance.now()
+	const failures = []
+	try {
+		const raw = await mcp(endpoint, {
+			jsonrpc: '2.0',
+			id: 1,
+			method: 'tools/call',
+			params: {
+				name: 'find_pages',
+				arguments: {
+					source: testCase.source,
+					query: testCase.query,
+					max_results: testCase.maxPages,
+					...(testCase.responseFormat
+						? { response_format: testCase.responseFormat }
+						: {}),
+				},
+			},
+		})
+		const parsed = parseToolResponse(raw)
+		if (parsed.error) failures.push(parsed.error)
+		const pages = parsed.result?.pages ?? []
+		const urls = pages.map((page) => page.url)
+		const titles = pages.map((page) => page.title).join('\n')
+		if (parsed.result?.source !== testCase.source) {
+			failures.push(`wrong source ${parsed.result?.source ?? 'none'}`)
+		}
+		for (const expectedUrl of testCase.expectedUrlIncludes) {
+			if (!urls.some((url) => url.includes(expectedUrl))) {
+				failures.push(`missing url ${expectedUrl}`)
+			}
+		}
+		for (const expectedTitle of testCase.expectedTitleIncludes) {
+			if (!titles.includes(expectedTitle)) {
+				failures.push(`missing title ${expectedTitle}`)
+			}
+		}
+		if (pages.length < 1) failures.push('no page candidates')
+		if (pages.length > testCase.maxPages) {
+			failures.push(`too many pages ${pages.length} > ${testCase.maxPages}`)
+		}
+		if (Buffer.byteLength(raw) > testCase.maxBytes) {
+			failures.push(
+				`too many bytes ${Buffer.byteLength(raw)} > ${testCase.maxBytes}`,
+			)
+		}
+		return resultFor({
+			testCase,
+			startedAt,
+			raw,
+			failures,
+			maxScore:
+				1 +
+				testCase.expectedUrlIncludes.length +
+				testCase.expectedTitleIncludes.length +
+				3,
+		})
+	} catch (err) {
+		return resultForError(testCase, startedAt, err)
+	}
+}
+
+async function runReadPageCase(
+	endpoint: string,
+	testCase: ReadPageCase,
+): Promise<EvalResult> {
+	const startedAt = performance.now()
+	const failures = []
+	try {
+		const raw = await mcp(endpoint, {
+			jsonrpc: '2.0',
+			id: 1,
+			method: 'tools/call',
+			params: {
+				name: 'read_page',
+				arguments: {
+					source: testCase.source,
+					path: testCase.path,
+					...(testCase.query ? { query: testCase.query } : {}),
+					...(testCase.maxChars ? { max_chars: testCase.maxChars } : {}),
+				},
+			},
+		})
+		const parsed = parseToolResponse(raw)
+		if (parsed.error) failures.push(parsed.error)
+		const text = parsed.result?.text ?? ''
+		const url = parsed.result?.url
+		if (parsed.result?.source !== testCase.source) {
+			failures.push(`wrong source ${parsed.result?.source ?? 'none'}`)
+		}
+		for (const expectedUrl of testCase.expectedUrlIncludes) {
+			if (typeof url !== 'string' || !url.includes(expectedUrl)) {
+				failures.push(`missing url ${expectedUrl}`)
+			}
+		}
+		for (const expectedText of testCase.expectedTextIncludes) {
+			if (!text.includes(expectedText))
+				failures.push(`missing text ${expectedText}`)
+		}
+		if (Buffer.byteLength(raw) > testCase.maxBytes) {
+			failures.push(
+				`too many bytes ${Buffer.byteLength(raw)} > ${testCase.maxBytes}`,
+			)
+		}
+		if (text.length > testCase.maxTextChars) {
+			failures.push(`too much text ${text.length} > ${testCase.maxTextChars}`)
+		}
+		for (const term of noiseTerms) {
+			if (text.includes(term)) failures.push(`noise term ${term}`)
+		}
+		return resultFor({
+			testCase,
+			startedAt,
+			raw,
+			failures,
+			maxScore:
+				1 +
+				testCase.expectedUrlIncludes.length +
+				testCase.expectedTextIncludes.length +
+				3,
+			textChars: text.length,
+		})
+	} catch (err) {
+		return resultForError(testCase, startedAt, err)
+	}
+}
+
+async function mcp(endpoint: string, body: unknown): Promise<string> {
+	const response = await fetch(endpoint, {
+		method: 'POST',
+		headers: {
+			Accept: 'application/json, text/event-stream',
+			'Content-Type': 'application/json',
+		},
+		body: JSON.stringify(body),
+	})
+	return response.text()
+}
+
+function resultFor(args: {
+	testCase: EvalCase
+	startedAt: number
+	raw: string
+	failures: string[]
+	maxScore: number
+	textChars?: number
+	chunks?: number
+	duplicatePages?: number
+}): EvalResult {
+	const uniqueFailures = [...new Set(args.failures)]
+	return {
+		name: args.testCase.name,
+		kind: args.testCase.kind,
+		passed: uniqueFailures.length === 0,
+		score: Math.max(0, args.maxScore - uniqueFailures.length),
+		max_score: args.maxScore,
+		duration_ms: Math.round(performance.now() - args.startedAt),
+		bytes: Buffer.byteLength(args.raw),
+		text_chars: args.textChars ?? 0,
+		chunks: args.chunks ?? 0,
+		duplicate_pages: args.duplicatePages ?? 0,
+		failures: uniqueFailures,
+	}
+}
+
+function resultForError(
+	testCase: EvalCase,
+	startedAt: number,
+	err: unknown,
+): EvalResult {
+	return {
+		name: testCase.name,
+		kind: testCase.kind,
+		passed: false,
+		score: 0,
+		max_score: 1,
+		duration_ms: Math.round(performance.now() - startedAt),
+		bytes: 0,
+		text_chars: 0,
+		chunks: 0,
+		duplicate_pages: 0,
+		failures: [err instanceof Error ? err.message : String(err)],
+	}
+}
+
+function parseToolResponse(raw: string): {
+	result?: {
+		chunks?: Chunk[]
+		pages?: Array<{ title: string; url: string; score?: number }>
+		source?: string
+		url?: string
+		text?: string
+		truncated?: boolean
+	}
+	error?: string
+} {
+	const payload = JSON.parse(lastSseData(raw) ?? raw) as {
+		result?: {
+			content?: Array<{ text?: string }>
+			structuredContent?: {
+				success?: boolean
+				result?: {
+					chunks?: Chunk[]
+					pages?: Array<{ title: string; url: string; score?: number }>
+					source?: string
+					url?: string
+					text?: string
+					truncated?: boolean
+				}
+				error?: string
+			}
+		}
+		error?: { message?: string }
+	}
+	if (payload.error) return { error: payload.error.message ?? 'MCP error' }
+	if (payload.result?.structuredContent) {
+		const decoded = payload.result.structuredContent
+		if (decoded.success === false)
+			return { error: decoded.error ?? 'tool error' }
+		return decoded
+	}
+	const text = payload.result?.content?.find((part) => part.text)?.text
+	if (!text) return {}
+	let decoded: {
+		success?: boolean
+		result?: {
+			chunks?: Chunk[]
+			pages?: Array<{ title: string; url: string; score?: number }>
+			source?: string
+			url?: string
+			text?: string
+			truncated?: boolean
+		}
+		error?: string
+	}
+	try {
+		decoded = JSON.parse(text) as typeof decoded
+	} catch {
+		return { error: text }
+	}
+	if (decoded.success === false) return { error: decoded.error ?? 'tool error' }
+	return decoded
+}
+
+function lastSseData(raw: string): string | undefined {
+	return raw
+		.split('\n')
+		.filter((line) => line.startsWith('data: '))
+		.map((line) => line.slice('data: '.length))
+		.at(-1)
+}
+
+function sourceFromKey(chunk: Chunk): string | undefined {
+	const key = chunk.key ?? chunk.item?.key
+	const prefix = key?.split('/')[0]
+	if (!prefix?.startsWith('https:')) return prefix
+	return undefined
+}
+
+function duplicatePageCount(chunks: Chunk[]): number {
+	const pages = chunks
+		.map(pageIdentity)
+		.filter((page): page is string => !!page)
+	return pages.length - new Set(pages).size
+}
+
+function pageIdentity(chunk: Chunk): string | undefined {
+	const url = chunk.url ?? chunk.item?.metadata?.url
+	if (typeof url === 'string') {
+		try {
+			const parsed = new URL(url)
+			parsed.hash = ''
+			parsed.search = ''
+			return parsed.toString().replace(/\/$/, '')
+		} catch {
+			return url
+		}
+	}
+	return chunk.key ?? chunk.item?.key
+}
+
+function printEndpoint(result: EndpointResult, label: string): void {
+	const summary = result.summary
+	console.info(`MCP eval ${label}: ${result.endpoint}`)
+	console.info(
+		`score=${summary.score}/${summary.max_score} pass=${summary.passed}/${summary.total} pass_rate=${summary.pass_rate.toFixed(3)} bytes=${summary.bytes} chars=${summary.text_chars} dupes=${summary.duplicate_pages} p50=${summary.p50_ms}ms p95=${summary.p95_ms}ms`,
+	)
+	console.info(
+		'case\tkind\tpass\tscore\tms\tbytes\tchars\tchunks\tdupes\tfailures',
+	)
+	for (const row of result.results) {
+		console.info(
+			[
+				row.name,
+				row.kind,
+				row.passed ? 'yes' : 'no',
+				`${row.score}/${row.max_score}`,
+				row.duration_ms,
+				row.bytes,
+				row.text_chars,
+				row.chunks,
+				row.duplicate_pages,
+				row.failures.join('|'),
+			].join('\t'),
+		)
+	}
+}
+
+function printComparison(
+	baseline: EndpointResult,
+	candidate: EndpointResult,
+): void {
+	const base = baseline.summary
+	const next = candidate.summary
+	console.info('')
+	console.info('Comparison candidate - baseline')
+	console.info(
+		[
+			`score_delta=${next.score - base.score}`,
+			`pass_delta=${next.passed - base.passed}`,
+			`bytes_delta=${next.bytes - base.bytes}`,
+			`chars_delta=${next.text_chars - base.text_chars}`,
+			`dupes_delta=${next.duplicate_pages - base.duplicate_pages}`,
+			`p95_delta_ms=${next.p95_ms - base.p95_ms}`,
+		].join('\t'),
+	)
+}
+
+function percentile(values: number[], p: number): number {
+	if (values.length === 0) return 0
+	return values[Math.min(values.length - 1, Math.floor(values.length * p))]
+}
+
+function sum(values: number[]): number {
+	return values.reduce((total, value) => total + value, 0)
+}
+
+function arg(name: string): string | undefined {
+	const index = process.argv.indexOf(name)
+	return index === -1 ? undefined : process.argv[index + 1]
+}
+
+function isCli(): boolean {
+	return process.argv[1]
+		? import.meta.url === pathToFileURL(process.argv[1]).href
+		: false
+}

--- a/apps/mcp-docs-indexer/scripts/run-promptfoo.ts
+++ b/apps/mcp-docs-indexer/scripts/run-promptfoo.ts
@@ -1,0 +1,29 @@
+import { spawn } from 'node:child_process'
+
+const env = Object.fromEntries(
+	Object.entries(process.env).filter(([key]) => !key.startsWith('npm_config_')),
+) as NodeJS.ProcessEnv
+
+const child = spawn(
+	'npx',
+	[
+		'--userconfig=/dev/null',
+		'-y',
+		'promptfoo@0.121.15',
+		'eval',
+		'--config',
+		'promptfooconfig.ts',
+		'--no-progress-bar',
+		'--no-cache',
+		...process.argv.slice(2),
+	],
+	{ env, stdio: 'inherit' },
+)
+
+child.on('exit', (code, signal) => {
+	if (signal) {
+		process.kill(process.pid, signal)
+		return
+	}
+	process.exitCode = code ?? 1
+})

--- a/apps/mcp-docs-indexer/src/index.ts
+++ b/apps/mcp-docs-indexer/src/index.ts
@@ -1,12 +1,22 @@
 import { env } from 'cloudflare:workers'
 import { syncSource } from './lib/ingest.js'
 import { log } from './lib/log.js'
+import { handleMcp } from './lib/mcp.js'
 import { proxyMcp } from './lib/proxy.js'
 import { isForcedHour } from './lib/schedule.js'
 import { parseSources } from './lib/sources.js'
+import type { Source } from './lib/sources.js'
+
+let cachedSourcesKey: string | undefined
+let cachedSources: Source[] | undefined
 
 export default {
 	async fetch(req) {
+		const response = await handleMcp(req, {
+			instance: env.AI_SEARCH.get(env.AI_SEARCH_INSTANCE_ID),
+			sources: sourcesFor(env.SOURCES),
+		})
+		if (response) return response
 		return proxyMcp(req, env.AI_SEARCH_MCP_URL)
 	},
 	async scheduled(event) {
@@ -47,3 +57,11 @@ export default {
 		})
 	},
 } satisfies ExportedHandler<Env>
+
+function sourcesFor(config: Env['SOURCES']): Source[] {
+	const key = typeof config === 'string' ? config : JSON.stringify(config)
+	if (cachedSources && cachedSourcesKey === key) return cachedSources
+	cachedSourcesKey = key
+	cachedSources = parseSources(config)
+	return cachedSources
+}

--- a/apps/mcp-docs-indexer/src/lib/ingest.test.ts
+++ b/apps/mcp-docs-indexer/src/lib/ingest.test.ts
@@ -197,6 +197,7 @@ describe('syncSource — page uploads', () => {
 		])
 		expect(idx['viem/docs_bar.md']).toMatchObject({
 			id: 'item-viem/docs_bar.md',
+			content_hash: expect.any(String),
 		})
 	})
 
@@ -233,6 +234,45 @@ describe('syncSource — page uploads', () => {
 		expect(Object.keys(JSON.parse(store.get('index:regen') ?? '{}'))).toEqual([
 			'regen/otp.md',
 		])
+	})
+
+	it('strips repeated Vocs sitemap comments and docs chrome before upload', async () => {
+		const source: Source = { id: 'vocs', base: 'https://vocs.dev' }
+		const { instance, uploads } = fakeInstance()
+		const { kv } = fakeKv()
+
+		fetchMock.mockImplementation(async (url: string) => {
+			if (url === 'https://vocs.dev/llms.txt') {
+				return mockResponse({ body: '- [MCP Server](/features/mcp-server)' })
+			}
+			if (url === 'https://vocs.dev/features/mcp-server.md') {
+				return mockResponse({
+					body: `<!--
+Sitemap:
+- [What is Vocs](/introduction/what-is-vocs)
+- [MCP Server](/features/mcp-server)
+-->
+
+[Skip to content](#vocs-content)
+Search...
+
+# MCP Server
+
+Expose your docs and source code to AI assistants.
+
+Was this helpful?
+Copy page for AI`,
+				})
+			}
+			throw new Error(`unexpected: ${url}`)
+		})
+
+		const report = await syncSource({ source, instance, etagCache: kv })
+
+		expect(report).toMatchObject({ status: 'synced', pages: 1, failed: 0 })
+		expect(uploads[0]?.content).toBe(
+			'# MCP Server\n\nExpose your docs and source code to AI assistants.',
+		)
 	})
 })
 
@@ -285,6 +325,48 @@ describe('syncSource — per-page conditional fetch', () => {
 		expect(idx['viem/b.md']).toMatchObject({
 			id: 'item-viem/b.md',
 			etag: 'W/"b2"',
+			content_hash: expect.any(String),
+		})
+	})
+
+	it('skips upload when cleaned content hash is unchanged despite a new ETag', async () => {
+		const { instance, uploads } = fakeInstance()
+		const contentHash =
+			'b2e77fbb5f564e2145071c75ac6a7d56478cf3ef696e5100f53378a7bb185750'
+		const { kv, store } = fakeKv({
+			'index:viem': JSON.stringify({
+				'viem/a.md': {
+					id: 'item-viem/a.md',
+					etag: 'W/"a1"',
+					content_hash: contentHash,
+				},
+			}),
+		})
+
+		fetchMock.mockImplementation(async (url: string) => {
+			if (url === 'https://viem.sh/llms.txt') {
+				return mockResponse({ body: '- [A](/a)' })
+			}
+			if (url === 'https://viem.sh/a.md') {
+				return mockResponse({ body: '# a', etag: 'W/"a2"' })
+			}
+			throw new Error(`unexpected: ${url}`)
+		})
+
+		const report = await syncSource({ source: SOURCE, instance, etagCache: kv })
+
+		expect(report).toMatchObject({
+			status: 'synced',
+			pages: 0,
+			unchanged: 1,
+			failed: 0,
+		})
+		expect(uploads).toHaveLength(0)
+		const idx = JSON.parse(store.get('index:viem') ?? '{}')
+		expect(idx['viem/a.md']).toEqual({
+			id: 'item-viem/a.md',
+			etag: 'W/"a2"',
+			content_hash: contentHash,
 		})
 	})
 

--- a/apps/mcp-docs-indexer/src/lib/ingest.ts
+++ b/apps/mcp-docs-indexer/src/lib/ingest.ts
@@ -3,7 +3,7 @@ import { parseLlmsTxt, toMarkdownUrl } from './llms-txt.js'
 import type { Source } from './sources.js'
 
 /** Recorded state for one AI Search item, persisted to KV per source. */
-type IndexEntry = { id: string; etag?: string }
+type IndexEntry = { id: string; etag?: string; content_hash?: string }
 /** Per-source map of AI Search item key → {item id, last-seen ETag}. */
 type SourceIndex = Record<string, IndexEntry>
 
@@ -192,7 +192,7 @@ async function syncPage(args: {
 			return { key, outcome: 'failed', entry: prev }
 		}
 
-		const content = await res.text()
+		const content = preparePageContent(await res.text())
 		if (!content) {
 			log.warn('page.empty', { source: source.id, url })
 			return { key, outcome: 'failed', entry: prev }
@@ -204,6 +204,19 @@ async function syncPage(args: {
 				bytes: content.length,
 			})
 			return { key, outcome: 'failed', entry: prev }
+		}
+		const contentHash = await sha256(content)
+		if (prev?.content_hash === contentHash && !force) {
+			const etag = res.headers.get('etag') ?? prev.etag
+			return {
+				key,
+				outcome: 'unchanged',
+				entry: {
+					...prev,
+					...(etag ? { etag } : {}),
+					content_hash: contentHash,
+				},
+			}
 		}
 
 		// Use upload() not uploadAndPoll(): we don't need to block on indexing
@@ -223,7 +236,7 @@ async function syncPage(args: {
 		return {
 			key,
 			outcome: 'uploaded',
-			entry: { id: item.id, etag },
+			entry: { id: item.id, etag, content_hash: contentHash },
 		}
 	} catch (err) {
 		log.error('page.upload_failed', {
@@ -233,6 +246,46 @@ async function syncPage(args: {
 		})
 		return { key, outcome: 'failed', entry: prev }
 	}
+}
+
+async function sha256(content: string): Promise<string> {
+	const bytes = new TextEncoder().encode(content)
+	const digest = await crypto.subtle.digest('SHA-256', bytes)
+	return [...new Uint8Array(digest)]
+		.map((byte) => byte.toString(16).padStart(2, '0'))
+		.join('')
+}
+
+function preparePageContent(content: string): string {
+	return stripSitemapComment(content)
+		.split('\n')
+		.map((line) => line.trimEnd())
+		.filter((line) => !isDocsChromeLine(line))
+		.join('\n')
+		.replace(/\n{3,}/g, '\n\n')
+		.trim()
+}
+
+function stripSitemapComment(content: string): string {
+	return content
+		.replace(/\r\n/g, '\n')
+		.replace(/^<!--\nSitemap:\n[\s\S]*?\n-->\n*/, '')
+}
+
+function isDocsChromeLine(line: string): boolean {
+	return [
+		/^skip to content$/i,
+		/^\[skip to content\]\(/i,
+		/^search\.\.\.$/i,
+		/^\[\]\(\/\)$/i,
+		/^⌘$/i,
+		/^k$/i,
+		/^i$/i,
+		/^was this helpful\?$/i,
+		/^copy page for ai$/i,
+		/^ask ai\.\.\.$/i,
+		/^suggest changes to this page$/i,
+	].some((pattern) => pattern.test(line.trim()))
 }
 
 /** Derive a stable AI Search item key from a page URL and source id. */

--- a/apps/mcp-docs-indexer/src/lib/mcp.test.ts
+++ b/apps/mcp-docs-indexer/src/lib/mcp.test.ts
@@ -1,0 +1,1504 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { handleMcp } from './mcp.js'
+import type { Source } from './sources.js'
+
+function instance(
+	search: (params: AiSearchSearchRequest) => Promise<AiSearchSearchResponse>,
+) {
+	return { search } as unknown as AiSearchInstance
+}
+
+const sources: Source[] = [
+	{
+		id: 'viem',
+		base: 'https://viem.sh',
+		description: 'TypeScript interface for Ethereum / Tempo',
+	},
+	{
+		id: 'wagmi',
+		base: 'https://wagmi.sh',
+		description: 'React Hooks for Ethereum / Tempo',
+	},
+]
+
+afterEach(() => {
+	vi.unstubAllGlobals()
+})
+
+describe('handleMcp', () => {
+	it('serves compact search and page read tool schemas', async () => {
+		const res = await handleMcp(
+			new Request('https://mcp.tempo.xyz/', {
+				method: 'POST',
+				body: JSON.stringify({
+					jsonrpc: '2.0',
+					id: 1,
+					method: 'tools/list',
+				}),
+			}),
+			{
+				instance: instance(async () => ({ search_query: '', chunks: [] })),
+				sources,
+			},
+		)
+
+		expect(res).toBeDefined()
+		const body = await res?.json()
+		expect(body.result.tools).toHaveLength(3)
+		expect(body.result.tools[0].name).toBe('search')
+		expect(body.result.tools[0].inputSchema.properties.source.enum).toEqual([
+			'viem',
+			'wagmi',
+		])
+		expect(body.result.tools[0].inputSchema.properties.max_results.type).toBe(
+			'number',
+		)
+		expect(
+			body.result.tools[0].inputSchema.properties.max_chars_per_chunk.type,
+		).toBe('number')
+		expect(body.result.tools[1].name).toBe('find_pages')
+		expect(body.result.tools[1].inputSchema.properties.source.enum).toEqual([
+			'viem',
+			'wagmi',
+		])
+		expect(body.result.tools[2].name).toBe('read_page')
+		expect(body.result.tools[2].inputSchema.properties.source.enum).toEqual([
+			'viem',
+			'wagmi',
+		])
+	})
+
+	it('normalizes simple source and result controls into retrieval options', async () => {
+		let seen: AiSearchSearchRequest | undefined
+		const res = await handleMcp(
+			new Request('https://mcp.tempo.xyz/', {
+				method: 'POST',
+				headers: { accept: 'application/json, text/event-stream' },
+				body: JSON.stringify({
+					jsonrpc: '2.0',
+					id: 2,
+					method: 'tools/call',
+					params: {
+						name: 'search',
+						arguments: {
+							query: 'tempo wallet connector',
+							source: 'wagmi',
+							max_results: 3,
+							ai_search_options: {
+								ranking_options: { score_threshold: 0.6 },
+							},
+						},
+					},
+				}),
+			}),
+			{
+				instance: instance(async (params) => {
+					seen = params
+					return {
+						search_query: 'tempo wallet connector',
+						chunks: [
+							{
+								id: '1',
+								type: 'text',
+								score: 1,
+								text: 'wagmi docs',
+								item: { key: 'wagmi/docs_wallet' },
+							},
+						],
+					}
+				}),
+				sources,
+			},
+		)
+
+		expect(res).toBeDefined()
+		expect(seen?.ai_search_options?.retrieval).toMatchObject({
+			retrieval_type: 'hybrid',
+			keyword_match_mode: 'or',
+			max_num_results: 3,
+			match_threshold: 0.6,
+			context_expansion: 0,
+			filters: { source: 'wagmi' },
+		})
+		expect(seen?.ai_search_options?.cache).toEqual({
+			enabled: true,
+			cache_threshold: 'close_enough',
+		})
+	})
+
+	it('infers a source filter for unfiltered source-specific queries', async () => {
+		let seen: AiSearchSearchRequest | undefined
+		await handleMcp(
+			new Request('https://mcp.tempo.xyz/', {
+				method: 'POST',
+				body: JSON.stringify({
+					jsonrpc: '2.0',
+					id: 21,
+					method: 'tools/call',
+					params: {
+						name: 'search',
+						arguments: {
+							query: 'unique virtual addresses TIP-20 deposit question',
+							max_results: 4,
+						},
+					},
+				}),
+			}),
+			{
+				instance: instance(async (params) => {
+					seen = params
+					return {
+						search_query: 'unique virtual addresses TIP-20 deposit question',
+						chunks: [
+							{
+								id: '1',
+								type: 'text',
+								score: 1,
+								text: 'tempo virtual address docs',
+								item: { key: 'tempo/guide_payments_virtual-addresses' },
+							},
+						],
+					}
+				}),
+				sources: [
+					...sources,
+					{
+						id: 'tempo',
+						base: 'https://docs.tempo.xyz',
+						description: 'Tempo protocol docs',
+					},
+				],
+			},
+		)
+
+		expect(seen?.ai_search_options?.retrieval?.filters).toEqual({
+			source: 'tempo',
+		})
+	})
+
+	it('preserves explicit AI Search cache overrides', async () => {
+		let seen: AiSearchSearchRequest | undefined
+		await handleMcp(
+			new Request('https://mcp.tempo.xyz/', {
+				method: 'POST',
+				body: JSON.stringify({
+					jsonrpc: '2.0',
+					id: 3,
+					method: 'tools/call',
+					params: {
+						name: 'search',
+						arguments: {
+							query: 'explicit cache override query',
+							ai_search_options: {
+								cache: { enabled: false },
+							},
+						},
+					},
+				}),
+			}),
+			{
+				instance: instance(async (params) => {
+					seen = params
+					return { search_query: 'explicit cache override query', chunks: [] }
+				}),
+			},
+		)
+
+		expect(seen?.ai_search_options?.cache).toEqual({
+			enabled: false,
+			cache_threshold: 'close_enough',
+		})
+	})
+
+	it('caches successful search results in the worker isolate', async () => {
+		let calls = 0
+		const searchInstance = instance(async () => {
+			calls++
+			return {
+				search_query: 'unique cache query',
+				chunks: [
+					{
+						id: '1',
+						type: 'text',
+						score: 1,
+						text: 'cached docs',
+						item: { key: 'viem/cached' },
+					},
+				],
+			}
+		})
+		const reqBody = {
+			jsonrpc: '2.0',
+			id: 4,
+			method: 'tools/call',
+			params: {
+				name: 'search',
+				arguments: {
+					query: 'unique cache query',
+				},
+			},
+		}
+
+		await handleMcp(
+			new Request('https://mcp.tempo.xyz/', {
+				method: 'POST',
+				body: JSON.stringify(reqBody),
+			}),
+			{ instance: searchInstance },
+		)
+		const second = await handleMcp(
+			new Request('https://mcp.tempo.xyz/', {
+				method: 'POST',
+				body: JSON.stringify({ ...reqBody, id: 5 }),
+			}),
+			{ instance: searchInstance },
+		)
+
+		expect(calls).toBe(1)
+		const text = await textContent(second)
+		expect(text.result.chunks[0].text).toBe('cached docs')
+	})
+
+	it('coalesces identical concurrent search requests', async () => {
+		let calls = 0
+		let release: (() => void) | undefined
+		const wait = new Promise<void>((resolve) => {
+			release = resolve
+		})
+		const searchInstance = instance(async () => {
+			calls++
+			await wait
+			return {
+				search_query: 'concurrent cache query',
+				chunks: [
+					{
+						id: '1',
+						type: 'text',
+						score: 1,
+						text: 'shared docs',
+						item: { key: 'viem/shared' },
+					},
+				],
+			}
+		})
+		const reqBody = {
+			jsonrpc: '2.0',
+			method: 'tools/call',
+			params: {
+				name: 'search',
+				arguments: {
+					query: 'concurrent cache query',
+				},
+			},
+		}
+		const first = handleMcp(
+			new Request('https://mcp.tempo.xyz/', {
+				method: 'POST',
+				body: JSON.stringify({ ...reqBody, id: 41 }),
+			}),
+			{ instance: searchInstance },
+		)
+		const second = handleMcp(
+			new Request('https://mcp.tempo.xyz/', {
+				method: 'POST',
+				body: JSON.stringify({ ...reqBody, id: 42 }),
+			}),
+			{ instance: searchInstance },
+		)
+		await Promise.resolve()
+		release?.()
+
+		const [firstRes, secondRes] = await Promise.all([first, second])
+		expect(calls).toBe(1)
+		expect((await textContent(firstRes)).result.chunks[0].text).toBe(
+			'shared docs',
+		)
+		expect((await textContent(secondRes)).result.chunks[0].text).toBe(
+			'shared docs',
+		)
+	})
+
+	it('returns compact cleaned chunks by default', async () => {
+		const res = await handleMcp(
+			new Request('https://mcp.tempo.xyz/', {
+				method: 'POST',
+				headers: { accept: 'text/event-stream' },
+				body: JSON.stringify({
+					jsonrpc: '2.0',
+					id: 6,
+					method: 'tools/call',
+					params: {
+						name: 'search',
+						arguments: { query: 'pay fees' },
+					},
+				}),
+			}),
+			{
+				instance: instance(async () => ({
+					search_query: 'pay fees',
+					chunks: [
+						{
+							id: '1',
+							type: 'text',
+							score: 0.987654321,
+							text: '[Skip to content](#vocs-content)\nSearch...\n# Pay Fees\nUseful docs\nWas this helpful?',
+							item: {
+								key: 'viem/docs_pay-fees',
+								metadata: {
+									source: 'viem',
+									url: 'https://viem.sh/tempo/pay-fees',
+								},
+							},
+							scoring_details: { keyword_score: 1 },
+						},
+					],
+				})),
+			},
+		)
+
+		expect(res).toBeDefined()
+		const text = await textContent(res)
+		expect(text.result.chunks[0]).toEqual({
+			score: 0.9877,
+			source: 'viem',
+			url: 'https://viem.sh/tempo/pay-fees',
+			text: '# Pay Fees\nUseful docs',
+		})
+	})
+
+	it('reconstructs compact result URLs from source item keys', async () => {
+		const res = await handleMcp(
+			new Request('https://mcp.tempo.xyz/', {
+				method: 'POST',
+				body: JSON.stringify({
+					jsonrpc: '2.0',
+					id: 61,
+					method: 'tools/call',
+					params: {
+						name: 'search',
+						arguments: {
+							query: 'tempo wallet connector',
+							source: 'wagmi',
+						},
+					},
+				}),
+			}),
+			{
+				instance: instance(async () => ({
+					search_query: 'tempo wallet connector',
+					chunks: [
+						{
+							id: '1',
+							type: 'text',
+							score: 1,
+							text: 'tempoWallet connector docs',
+							item: { key: 'wagmi/tempo_connectors_tempoWallet.md' },
+						},
+					],
+				})),
+				sources,
+			},
+		)
+
+		const text = await textContent(res)
+		expect(text.result.chunks[0]).toEqual({
+			score: 1,
+			source: 'wagmi',
+			url: 'https://wagmi.sh/tempo/connectors/tempoWallet',
+			text: 'tempoWallet connector docs',
+		})
+	})
+
+	it('can return the raw AI Search chunk shape when requested', async () => {
+		let seen: AiSearchSearchRequest | undefined
+		const res = await handleMcp(
+			new Request('https://mcp.tempo.xyz/', {
+				method: 'POST',
+				body: JSON.stringify({
+					jsonrpc: '2.0',
+					id: 7,
+					method: 'tools/call',
+					params: {
+						name: 'search',
+						arguments: {
+							query: 'pay fees raw',
+							include_raw: true,
+						},
+					},
+				}),
+			}),
+			{
+				instance: instance(async (params) => {
+					seen = params
+					return {
+						search_query: 'pay fees raw',
+						chunks: [
+							{
+								id: '1',
+								type: 'text',
+								score: 1,
+								text: 'Copy page for AI\n# Pay Fees',
+								item: { key: 'viem/docs_pay-fees' },
+								scoring_details: { keyword_score: 1 },
+							},
+							{
+								id: '2',
+								type: 'text',
+								score: 0.9,
+								text: 'same page duplicate',
+								item: { key: 'viem/docs_pay-fees' },
+							},
+						],
+					}
+				}),
+			},
+		)
+
+		expect(seen?.ai_search_options?.retrieval?.max_num_results).toBe(5)
+		const text = await textContent(res)
+		expect(text.result.chunks).toHaveLength(2)
+		expect(text.result.chunks[0]).toMatchObject({
+			id: '1',
+			type: 'text',
+			score: 1,
+			text: '# Pay Fees',
+			scoring_details: { keyword_score: 1 },
+		})
+	})
+
+	it('deduplicates compact chunks by page', async () => {
+		let seen: AiSearchSearchRequest | undefined
+		const res = await handleMcp(
+			new Request('https://mcp.tempo.xyz/', {
+				method: 'POST',
+				body: JSON.stringify({
+					jsonrpc: '2.0',
+					id: 71,
+					method: 'tools/call',
+					params: {
+						name: 'search',
+						arguments: {
+							query: 'distinct pages query',
+							max_results: 2,
+						},
+					},
+				}),
+			}),
+			{
+				instance: instance(async (params) => {
+					seen = params
+					return {
+						search_query: 'distinct pages query',
+						chunks: [
+							{
+								id: '1',
+								type: 'text',
+								score: 1,
+								text: 'first page',
+								item: {
+									key: 'viem/a.md#one',
+									metadata: {
+										source: 'viem',
+										url: 'https://viem.sh/a?x=1#one',
+									},
+								},
+							},
+							{
+								id: '2',
+								type: 'text',
+								score: 0.9,
+								text: 'duplicate page',
+								item: {
+									key: 'viem/a.md#two',
+									metadata: { source: 'viem', url: 'https://viem.sh/a#two' },
+								},
+							},
+							{
+								id: '3',
+								type: 'text',
+								score: 0.8,
+								text: 'second page',
+								item: {
+									key: 'viem/b.md',
+									metadata: { source: 'viem', url: 'https://viem.sh/b' },
+								},
+							},
+						],
+					}
+				}),
+			},
+		)
+
+		expect(seen?.ai_search_options?.retrieval?.max_num_results).toBe(2)
+		const text = await textContent(res)
+		expect(text.result.chunks).toEqual([
+			{
+				score: 1,
+				source: 'viem',
+				url: 'https://viem.sh/a',
+				text: 'first page',
+			},
+			{
+				score: 0.8,
+				source: 'viem',
+				url: 'https://viem.sh/b',
+				text: 'second page',
+			},
+		])
+	})
+
+	it('centers compact excerpts around query terms', async () => {
+		const res = await handleMcp(
+			new Request('https://mcp.tempo.xyz/', {
+				method: 'POST',
+				body: JSON.stringify({
+					jsonrpc: '2.0',
+					id: 8,
+					method: 'tools/call',
+					params: {
+						name: 'search',
+						arguments: {
+							query: 'wallet connector',
+							source: 'wagmi',
+							max_chars_per_chunk: 300,
+						},
+					},
+				}),
+			}),
+			{
+				instance: instance(async () => ({
+					search_query: 'wallet connector',
+					chunks: [
+						{
+							id: '1',
+							type: 'text',
+							score: 1,
+							text: `${'intro '.repeat(120)}\nThe wallet connector setup uses createConfig.\n${'tail '.repeat(120)}`,
+							item: { key: 'wagmi/docs_wallet' },
+						},
+					],
+				})),
+			},
+		)
+
+		const text = await textContent(res)
+		const chunkText = text.result.chunks[0].text
+		expect(chunkText.length).toBeLessThanOrEqual(310)
+		expect(chunkText).toContain('wallet connector')
+		expect(chunkText.startsWith('... ')).toBe(true)
+		expect(chunkText.endsWith(' ...')).toBe(true)
+	})
+
+	it('bounds compact search output by total text chars', async () => {
+		const res = await handleMcp(
+			new Request('https://mcp.tempo.xyz/', {
+				method: 'POST',
+				body: JSON.stringify({
+					jsonrpc: '2.0',
+					id: 81,
+					method: 'tools/call',
+					params: {
+						name: 'search',
+						arguments: {
+							query: 'wallet connector',
+							max_results: 5,
+							max_total_chars: 700,
+						},
+					},
+				}),
+			}),
+			{
+				instance: instance(async () => ({
+					search_query: 'wallet connector',
+					chunks: [1, 2, 3, 4, 5].map((index) => ({
+						id: String(index),
+						type: 'text',
+						score: 1 - index / 10,
+						text: `wallet connector ${index} ${'docs '.repeat(60)}`,
+						item: { key: `wagmi/page-${index}` },
+					})),
+				})),
+				sources,
+			},
+		)
+
+		const text = await textContent(res)
+		const returnedTextChars = text.result.chunks
+			.map((chunk: { text: string }) => chunk.text.length)
+			.reduce((total: number, value: number) => total + value, 0)
+		expect(text.result.chunks).toHaveLength(2)
+		expect(returnedTextChars).toBeLessThanOrEqual(710)
+	})
+
+	it('rejects unknown source filters before querying AI Search', async () => {
+		let called = false
+		const res = await handleMcp(
+			new Request('https://mcp.tempo.xyz/', {
+				method: 'POST',
+				body: JSON.stringify({
+					jsonrpc: '2.0',
+					id: 9,
+					method: 'tools/call',
+					params: {
+						name: 'search',
+						arguments: {
+							query: 'wallet connector',
+							source: 'unknown',
+						},
+					},
+				}),
+			}),
+			{
+				instance: instance(async () => {
+					called = true
+					return { search_query: '', chunks: [] }
+				}),
+				sources,
+			},
+		)
+
+		expect(called).toBe(false)
+		const body = await res?.json()
+		expect(body.error.message).toBe('unknown source: unknown')
+	})
+
+	it('falls back to unfiltered search when metadata filters are stale', async () => {
+		const calls: AiSearchSearchRequest[] = []
+		const res = await handleMcp(
+			new Request('https://mcp.tempo.xyz/', {
+				method: 'POST',
+				body: JSON.stringify({
+					jsonrpc: '2.0',
+					id: 10,
+					method: 'tools/call',
+					params: {
+						name: 'search',
+						arguments: {
+							query: 'wallet connector',
+							source: 'wagmi',
+							max_results: 1,
+						},
+					},
+				}),
+			}),
+			{
+				instance: instance(async (params) => {
+					calls.push(params)
+					if (calls.length === 1)
+						return { search_query: 'wallet connector', chunks: [] }
+					return {
+						search_query: 'wallet connector',
+						chunks: [
+							{
+								id: '1',
+								type: 'text',
+								score: 0.5,
+								text: 'viem docs',
+								item: { key: 'viem/docs_wallet' },
+							},
+							{
+								id: '2',
+								type: 'text',
+								score: 0.4,
+								text: 'wagmi docs',
+								item: { key: 'wagmi/docs_wallet' },
+							},
+						],
+					}
+				}),
+				sources,
+			},
+		)
+
+		expect(calls).toHaveLength(2)
+		expect(calls[0]?.ai_search_options?.retrieval?.filters).toEqual({
+			source: 'wagmi',
+		})
+		expect(calls[1]?.ai_search_options?.retrieval?.filters).toBeUndefined()
+		expect(calls[1]?.ai_search_options?.retrieval?.max_num_results).toBe(20)
+
+		const text = await textContent(res)
+		expect(text.result.chunks).toEqual([
+			{
+				score: 0.4,
+				source: 'wagmi',
+				url: 'https://wagmi.sh/docs/wallet',
+				text: 'wagmi docs',
+			},
+		])
+
+		calls.length = 0
+		await handleMcp(
+			new Request('https://mcp.tempo.xyz/', {
+				method: 'POST',
+				body: JSON.stringify({
+					jsonrpc: '2.0',
+					id: 11,
+					method: 'tools/call',
+					params: {
+						name: 'search',
+						arguments: {
+							query: 'wallet connector',
+							source: 'wagmi',
+							max_results: 1,
+						},
+					},
+				}),
+			}),
+			{
+				instance: instance(async (params) => {
+					calls.push(params)
+					return { search_query: 'wallet connector', chunks: [] }
+				}),
+				sources,
+			},
+		)
+
+		expect(calls).toHaveLength(0)
+
+		await handleMcp(
+			new Request('https://mcp.tempo.xyz/', {
+				method: 'POST',
+				body: JSON.stringify({
+					jsonrpc: '2.0',
+					id: 12,
+					method: 'tools/call',
+					params: {
+						name: 'search',
+						arguments: {
+							query: 'wallet connector setup',
+							source: 'wagmi',
+							max_results: 1,
+						},
+					},
+				}),
+			}),
+			{
+				instance: instance(async (params) => {
+					calls.push(params)
+					return {
+						search_query: 'wallet connector setup',
+						chunks: [
+							{
+								id: '1',
+								type: 'text',
+								score: 0.4,
+								text: 'wagmi docs',
+								item: { key: 'wagmi/docs_wallet' },
+							},
+						],
+					}
+				}),
+				sources,
+			},
+		)
+
+		expect(calls).toHaveLength(1)
+		expect(calls[0]?.ai_search_options?.retrieval?.filters).toBeUndefined()
+		expect(calls[0]?.ai_search_options?.retrieval?.max_num_results).toBe(20)
+	})
+
+	it('falls back to source llms.txt when filtered search returns no chunks', async () => {
+		const tempoSource: Source = {
+			id: 'tempo',
+			base: 'https://docs.tempo.xyz',
+			description: 'Tempo docs',
+		}
+		const fetches: string[] = []
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(async (url: string) => {
+				fetches.push(url)
+				if (url === 'https://docs.tempo.xyz/llms.txt') {
+					return new Response(
+						'- [Use virtual addresses for deposits](/guide/payments/virtual-addresses): Register a virtual-address master and derive deposit addresses.',
+					)
+				}
+				if (
+					url === 'https://docs.tempo.xyz/guide/payments/virtual-addresses.md'
+				) {
+					return new Response(
+						'# Use virtual addresses for deposits\n\nRegister a virtual-address master and watch deposits.',
+					)
+				}
+				return new Response('not found', { status: 404 })
+			}),
+		)
+
+		const res = await handleMcp(
+			new Request('https://mcp.tempo.xyz/', {
+				method: 'POST',
+				body: JSON.stringify({
+					jsonrpc: '2.0',
+					id: 111,
+					method: 'tools/call',
+					params: {
+						name: 'search',
+						arguments: {
+							query: 'How do virtual addresses work for deposits?',
+							source: 'tempo',
+							max_results: 3,
+						},
+					},
+				}),
+			}),
+			{
+				instance: instance(async () => ({
+					search_query: 'virtual',
+					chunks: [],
+				})),
+				sources: [tempoSource],
+			},
+		)
+
+		expect(fetches).toEqual([
+			'https://docs.tempo.xyz/llms.txt',
+			'https://docs.tempo.xyz/guide/payments/virtual-addresses.md',
+		])
+		const text = await textContent(res)
+		expect(text.result.chunks).toEqual([
+			{
+				score: 0.85,
+				source: 'tempo',
+				url: 'https://docs.tempo.xyz/guide/payments/virtual-addresses',
+				text: '# Use virtual addresses for deposits\n\nRegister a virtual-address master and watch deposits.',
+			},
+		])
+	})
+
+	it('reads local source fallback pages in parallel while preserving score order', async () => {
+		const tempoSource: Source = {
+			id: 'tempo-parallel',
+			base: 'https://parallel.tempo.xyz',
+		}
+		let activePageFetches = 0
+		let maxActivePageFetches = 0
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(async (url: string) => {
+				if (url === 'https://parallel.tempo.xyz/llms.txt') {
+					return new Response(
+						[
+							'- [Virtual addresses](/guide/payments/virtual-addresses): virtual deposits',
+							'- [Deposit funds](/guide/payments/deposits): deposit funds',
+						].join('\n'),
+					)
+				}
+				activePageFetches++
+				maxActivePageFetches = Math.max(maxActivePageFetches, activePageFetches)
+				await new Promise((resolve) => setTimeout(resolve, 5))
+				activePageFetches--
+				if (
+					url ===
+					'https://parallel.tempo.xyz/guide/payments/virtual-addresses.md'
+				) {
+					return new Response('# Virtual addresses\n\nvirtual deposits')
+				}
+				if (url === 'https://parallel.tempo.xyz/guide/payments/deposits.md') {
+					return new Response('# Deposit funds\n\ndeposit funds')
+				}
+				return new Response('not found', { status: 404 })
+			}),
+		)
+
+		const res = await handleMcp(
+			new Request('https://mcp.tempo.xyz/', {
+				method: 'POST',
+				body: JSON.stringify({
+					jsonrpc: '2.0',
+					id: 112,
+					method: 'tools/call',
+					params: {
+						name: 'search',
+						arguments: {
+							query: 'virtual deposits',
+							source: 'tempo-parallel',
+							max_results: 3,
+						},
+					},
+				}),
+			}),
+			{
+				instance: instance(async () => ({
+					search_query: 'virtual deposits',
+					chunks: [],
+				})),
+				sources: [tempoSource],
+			},
+		)
+
+		const text = await textContent(res)
+		expect(maxActivePageFetches).toBe(2)
+		expect(
+			text.result.chunks.map((chunk: { url: string }) => chunk.url),
+		).toEqual([
+			'https://parallel.tempo.xyz/guide/payments/virtual-addresses',
+			'https://parallel.tempo.xyz/guide/payments/deposits',
+		])
+	})
+
+	it('coalesces concurrent source index fallback fetches', async () => {
+		const source: Source = {
+			id: 'tempo-index-coalesce',
+			base: 'https://index-coalesce.tempo.xyz',
+		}
+		let indexFetches = 0
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(async (url: string) => {
+				if (url === 'https://index-coalesce.tempo.xyz/llms.txt') {
+					indexFetches++
+					await new Promise((resolve) => setTimeout(resolve, 5))
+					return new Response(
+						[
+							'- [Virtual addresses](/virtual): virtual addresses',
+							'- [Deposits](/deposits): stablecoin deposits',
+						].join('\n'),
+					)
+				}
+				if (url === 'https://index-coalesce.tempo.xyz/virtual.md') {
+					return new Response('# Virtual addresses')
+				}
+				if (url === 'https://index-coalesce.tempo.xyz/deposits.md') {
+					return new Response('# Deposits')
+				}
+				return new Response('not found', { status: 404 })
+			}),
+		)
+		const searchInstance = instance(async () => ({
+			search_query: '',
+			chunks: [],
+		}))
+
+		const [virtual, deposits] = await Promise.all([
+			handleMcp(
+				new Request('https://mcp.tempo.xyz/', {
+					method: 'POST',
+					body: JSON.stringify({
+						jsonrpc: '2.0',
+						id: 211,
+						method: 'tools/call',
+						params: {
+							name: 'search',
+							arguments: {
+								query: 'virtual addresses',
+								source: 'tempo-index-coalesce',
+							},
+						},
+					}),
+				}),
+				{ instance: searchInstance, sources: [source] },
+			),
+			handleMcp(
+				new Request('https://mcp.tempo.xyz/', {
+					method: 'POST',
+					body: JSON.stringify({
+						jsonrpc: '2.0',
+						id: 212,
+						method: 'tools/call',
+						params: {
+							name: 'search',
+							arguments: {
+								query: 'stablecoin deposits',
+								source: 'tempo-index-coalesce',
+							},
+						},
+					}),
+				}),
+				{ instance: searchInstance, sources: [source] },
+			),
+		])
+
+		expect(indexFetches).toBe(1)
+		expect((await textContent(virtual)).result.chunks[0].url).toBe(
+			'https://index-coalesce.tempo.xyz/virtual',
+		)
+		expect((await textContent(deposits)).result.chunks[0].url).toBe(
+			'https://index-coalesce.tempo.xyz/deposits',
+		)
+	})
+
+	it('finds compact page candidates from a source index', async () => {
+		const source: Source = {
+			id: 'page-finder',
+			base: 'https://page-finder.tempo.xyz',
+		}
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(async (url: string) => {
+				expect(url).toBe('https://page-finder.tempo.xyz/llms.txt')
+				return new Response(
+					[
+						'- /virtual-addresses.md: stablecoin deposits',
+						'- [Stablecoin fees](/fees): fee token setup',
+						'- [Wallets](/wallets): account setup',
+					].join('\n'),
+				)
+			}),
+		)
+
+		const res = await handleMcp(
+			new Request('https://mcp.tempo.xyz/', {
+				method: 'POST',
+				body: JSON.stringify({
+					jsonrpc: '2.0',
+					id: 301,
+					method: 'tools/call',
+					params: {
+						name: 'find_pages',
+						arguments: {
+							source: 'page-finder',
+							query: 'virtual addresses deposits',
+							max_results: 2,
+						},
+					},
+				}),
+			}),
+			{
+				instance: instance(async () => ({ search_query: '', chunks: [] })),
+				sources: [source],
+			},
+		)
+
+		const body = await textContent(res)
+		expect(body.result).toMatchObject({
+			source: 'page-finder',
+			query: 'virtual addresses deposits',
+		})
+		expect(body.result.pages).toEqual([
+			{
+				title: 'Virtual addresses',
+				url: 'https://page-finder.tempo.xyz/virtual-addresses',
+				score: 0.35,
+			},
+		])
+	})
+
+	it('can return tool data as MCP structuredContent', async () => {
+		const source: Source = {
+			id: 'structured-pages',
+			base: 'https://structured-pages.tempo.xyz',
+		}
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(
+				async () =>
+					new Response('- [Virtual addresses](/virtual): stablecoin deposits'),
+			),
+		)
+
+		const res = await handleMcp(
+			new Request('https://mcp.tempo.xyz/', {
+				method: 'POST',
+				body: JSON.stringify({
+					jsonrpc: '2.0',
+					id: 302,
+					method: 'tools/call',
+					params: {
+						name: 'find_pages',
+						arguments: {
+							source: 'structured-pages',
+							query: 'virtual addresses',
+							response_format: 'structured',
+						},
+					},
+				}),
+			}),
+			{
+				instance: instance(async () => ({ search_query: '', chunks: [] })),
+				sources: [source],
+			},
+		)
+
+		const body = await res?.json()
+		expect(body.result.content[0].text).toBe('page candidates found')
+		expect(body.result.structuredContent.result.pages[0]).toMatchObject({
+			title: 'Virtual addresses',
+			url: 'https://structured-pages.tempo.xyz/virtual',
+		})
+	})
+
+	it('exposes source resources for MCP clients', async () => {
+		const list = await handleMcp(
+			new Request('https://mcp.tempo.xyz/', {
+				method: 'POST',
+				body: JSON.stringify({
+					jsonrpc: '2.0',
+					id: 12,
+					method: 'resources/list',
+				}),
+			}),
+			{
+				instance: instance(async () => ({ search_query: '', chunks: [] })),
+				sources,
+			},
+		)
+
+		const listBody = await list?.json()
+		expect(listBody.result.resources).toContainEqual(
+			expect.objectContaining({
+				uri: 'tempo-docs://source/viem',
+				name: 'viem docs source',
+			}),
+		)
+
+		const read = await handleMcp(
+			new Request('https://mcp.tempo.xyz/', {
+				method: 'POST',
+				body: JSON.stringify({
+					jsonrpc: '2.0',
+					id: 13,
+					method: 'resources/read',
+					params: { uri: 'tempo-docs://sources' },
+				}),
+			}),
+			{
+				instance: instance(async () => ({ search_query: '', chunks: [] })),
+				sources,
+			},
+		)
+		const readBody = await read?.json()
+		expect(readBody.result.contents[0].text).toContain('`viem`')
+		expect(readBody.result.contents[0].text).toContain('source')
+	})
+
+	it('exposes source indexes and exact pages as MCP resources', async () => {
+		const source: Source = {
+			id: 'resource-source',
+			base: 'https://resource-source.tempo.xyz',
+			description: 'Resource source docs',
+		}
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(async (url: string) => {
+				if (url === 'https://resource-source.tempo.xyz/llms.txt') {
+					return new Response(
+						[
+							'- [Virtual addresses](/virtual-addresses): Deposit guide',
+							'- [Stablecoin fees](/fees): Fee guide',
+						].join('\n'),
+					)
+				}
+				if (url === 'https://resource-source.tempo.xyz/virtual-addresses.md') {
+					return new Response(
+						[
+							'[Skip to content](#vocs-content)',
+							'# Virtual addresses',
+							'Use virtual addresses for deposits.',
+							'Was this helpful?',
+						].join('\n'),
+					)
+				}
+				return new Response('not found', { status: 404 })
+			}),
+		)
+
+		const templates = await handleMcp(
+			new Request('https://mcp.tempo.xyz/', {
+				method: 'POST',
+				body: JSON.stringify({
+					jsonrpc: '2.0',
+					id: 121,
+					method: 'resources/templates/list',
+				}),
+			}),
+			{
+				instance: instance(async () => ({ search_query: '', chunks: [] })),
+				sources: [source],
+			},
+		)
+		const templatesBody = await templates?.json()
+		expect(templatesBody.result.resourceTemplates).toContainEqual(
+			expect.objectContaining({
+				uriTemplate: 'tempo-docs://source/{source}/index',
+			}),
+		)
+
+		const index = await handleMcp(
+			new Request('https://mcp.tempo.xyz/', {
+				method: 'POST',
+				body: JSON.stringify({
+					jsonrpc: '2.0',
+					id: 122,
+					method: 'resources/read',
+					params: { uri: 'tempo-docs://source/resource-source/index' },
+				}),
+			}),
+			{
+				instance: instance(async () => ({ search_query: '', chunks: [] })),
+				sources: [source],
+			},
+		)
+		const indexBody = await index?.json()
+		expect(indexBody.result.contents[0].text).toContain(
+			'[Virtual addresses](https://resource-source.tempo.xyz/virtual-addresses)',
+		)
+
+		const page = await handleMcp(
+			new Request('https://mcp.tempo.xyz/', {
+				method: 'POST',
+				body: JSON.stringify({
+					jsonrpc: '2.0',
+					id: 123,
+					method: 'resources/read',
+					params: {
+						uri: 'tempo-docs://source/resource-source/page/virtual-addresses',
+					},
+				}),
+			}),
+			{
+				instance: instance(async () => ({ search_query: '', chunks: [] })),
+				sources: [source],
+			},
+		)
+		const pageBody = await page?.json()
+		expect(pageBody.result.contents[0].text).toContain('# Virtual addresses')
+		expect(pageBody.result.contents[0].text).not.toContain('Skip to content')
+		expect(pageBody.result.contents[0].text).not.toContain('Was this helpful?')
+	})
+
+	it('reads an exact source page as bounded cleaned Markdown', async () => {
+		let fetches = 0
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(async (url: string) => {
+				fetches++
+				expect(url).toBe('https://viem.sh/docs/cache.md')
+				return new Response(
+					`<!--
+Sitemap:
+- [Cached](/docs/cache)
+-->
+
+[Skip to content](#vocs-content)
+Search...
+
+# Cached Page
+
+${'important '.repeat(80)}
+
+Was this helpful?`,
+				)
+			}),
+		)
+
+		const first = await handleMcp(
+			new Request('https://mcp.tempo.xyz/', {
+				method: 'POST',
+				body: JSON.stringify({
+					jsonrpc: '2.0',
+					id: 14,
+					method: 'tools/call',
+					params: {
+						name: 'read_page',
+						arguments: {
+							source: 'viem',
+							path: '/docs/cache',
+							max_chars: 300,
+						},
+					},
+				}),
+			}),
+			{
+				instance: instance(async () => ({ search_query: '', chunks: [] })),
+				sources,
+			},
+		)
+		const second = await handleMcp(
+			new Request('https://mcp.tempo.xyz/', {
+				method: 'POST',
+				body: JSON.stringify({
+					jsonrpc: '2.0',
+					id: 15,
+					method: 'tools/call',
+					params: {
+						name: 'read_page',
+						arguments: {
+							source: 'viem',
+							url: 'https://viem.sh/docs/cache',
+							max_chars: 300,
+						},
+					},
+				}),
+			}),
+			{
+				instance: instance(async () => ({ search_query: '', chunks: [] })),
+				sources,
+			},
+		)
+
+		expect(fetches).toBe(1)
+		const firstText = await textContent(first)
+		const secondText = await textContent(second)
+		expect(firstText.result).toMatchObject({
+			source: 'viem',
+			url: 'https://viem.sh/docs/cache',
+			truncated: true,
+		})
+		expect(firstText.result.text).toContain('# Cached Page')
+		expect(firstText.result.text).not.toContain('Sitemap:')
+		expect(firstText.result.text).not.toContain('Search...')
+		expect(secondText.result.text).toBe(firstText.result.text)
+	})
+
+	it('returns query-focused read_page excerpts when truncating', async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(
+				async () =>
+					new Response(
+						[
+							'# Long Page',
+							'Intro section',
+							'alpha '.repeat(120),
+							'## Stablecoin fee tokens',
+							'Configure users to pay transaction fees in supported stablecoins.',
+							'beta '.repeat(120),
+						].join('\n'),
+					),
+			),
+		)
+
+		const res = await handleMcp(
+			new Request('https://mcp.tempo.xyz/', {
+				method: 'POST',
+				body: JSON.stringify({
+					jsonrpc: '2.0',
+					id: 151,
+					method: 'tools/call',
+					params: {
+						name: 'read_page',
+						arguments: {
+							source: 'viem',
+							path: '/docs/long',
+							query: 'stablecoin fee tokens',
+							max_chars: 300,
+						},
+					},
+				}),
+			}),
+			{
+				instance: instance(async () => ({ search_query: '', chunks: [] })),
+				sources,
+			},
+		)
+
+		const body = await textContent(res)
+		expect(body.result.truncated).toBe(true)
+		expect(body.result.text).toContain('# Long Page')
+		expect(body.result.text).toContain('## Stablecoin fee tokens')
+		expect(body.result.text).not.toContain('Intro section')
+	})
+
+	it('coalesces identical concurrent read_page fetches', async () => {
+		const source: Source = {
+			id: 'parallel-page',
+			base: 'https://parallel-page.tempo.xyz',
+		}
+		let fetches = 0
+		let release: (() => void) | undefined
+		const wait = new Promise<void>((resolve) => {
+			release = resolve
+		})
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(async () => {
+				fetches++
+				await wait
+				return new Response('# Parallel Page\n\nsame content')
+			}),
+		)
+		const reqBody = {
+			jsonrpc: '2.0',
+			method: 'tools/call',
+			params: {
+				name: 'read_page',
+				arguments: {
+					source: 'parallel-page',
+					path: '/docs/page',
+				},
+			},
+		}
+
+		const first = handleMcp(
+			new Request('https://mcp.tempo.xyz/', {
+				method: 'POST',
+				body: JSON.stringify({ ...reqBody, id: 181 }),
+			}),
+			{
+				instance: instance(async () => ({ search_query: '', chunks: [] })),
+				sources: [source],
+			},
+		)
+		const second = handleMcp(
+			new Request('https://mcp.tempo.xyz/', {
+				method: 'POST',
+				body: JSON.stringify({ ...reqBody, id: 182 }),
+			}),
+			{
+				instance: instance(async () => ({ search_query: '', chunks: [] })),
+				sources: [source],
+			},
+		)
+		await Promise.resolve()
+		release?.()
+
+		const [firstText, secondText] = await Promise.all([
+			textContent(await first),
+			textContent(await second),
+		])
+		expect(fetches).toBe(1)
+		expect(firstText.result.text).toBe('# Parallel Page\n\nsame content')
+		expect(secondText.result.text).toBe(firstText.result.text)
+	})
+
+	it('rejects read_page URLs outside the selected source origin', async () => {
+		const res = await handleMcp(
+			new Request('https://mcp.tempo.xyz/', {
+				method: 'POST',
+				body: JSON.stringify({
+					jsonrpc: '2.0',
+					id: 16,
+					method: 'tools/call',
+					params: {
+						name: 'read_page',
+						arguments: {
+							source: 'viem',
+							url: 'https://example.com/docs/cache',
+						},
+					},
+				}),
+			}),
+			{
+				instance: instance(async () => ({ search_query: '', chunks: [] })),
+				sources,
+			},
+		)
+
+		const body = await res?.json()
+		expect(body.error.message).toBe('path or url must be provided')
+	})
+
+	it('falls back to the upstream proxy for unsupported MCP methods', async () => {
+		const res = await handleMcp(
+			new Request('https://mcp.tempo.xyz/', {
+				method: 'POST',
+				body: JSON.stringify({ jsonrpc: '2.0', id: 17, method: 'initialize' }),
+			}),
+			{ instance: instance(async () => ({ search_query: '', chunks: [] })) },
+		)
+
+		expect(res).toBeUndefined()
+	})
+})
+
+async function textContent(res: Response | undefined) {
+	const raw = await res?.text()
+	const data =
+		raw
+			?.split('\n')
+			.find((line) => line.startsWith('data: '))
+			?.slice('data: '.length) ?? raw
+	const payload = JSON.parse(data ?? '{}')
+	return JSON.parse(payload.result.content[0].text)
+}

--- a/apps/mcp-docs-indexer/src/lib/mcp.ts
+++ b/apps/mcp-docs-indexer/src/lib/mcp.ts
@@ -1,0 +1,1514 @@
+import { toMarkdownUrl } from './llms-txt.js'
+import type { Source } from './sources.js'
+
+type JsonRpcRequest = {
+	jsonrpc?: string
+	id?: string | number | null
+	method?: string
+	params?: {
+		name?: string
+		arguments?: ToolArguments
+	}
+}
+
+type ToolArguments = SearchArguments & ReadPageArguments & FindPagesArguments
+
+type SearchArguments = {
+	query?: unknown
+	source?: unknown
+	sources?: unknown
+	max_results?: unknown
+	max_chars_per_chunk?: unknown
+	max_total_chars?: unknown
+	include_raw?: unknown
+	response_format?: unknown
+	ai_search_options?: LegacySearchOptions
+}
+
+type ReadPageArguments = {
+	source?: unknown
+	path?: unknown
+	url?: unknown
+	query?: unknown
+	max_chars?: unknown
+	response_format?: unknown
+}
+
+type FindPagesArguments = {
+	source?: unknown
+	query?: unknown
+	max_results?: unknown
+	response_format?: unknown
+}
+
+type SourceIndexEntry = {
+	title: string
+	url: string
+	description?: string
+}
+
+type LegacySearchOptions = {
+	max_num_results?: unknown
+	ranking_options?: {
+		score_threshold?: unknown
+	}
+	reranking?: AiSearchOptions['reranking']
+	filters?: VectorizeVectorMetadataFilter
+	retrieval?: AiSearchOptions['retrieval']
+	query_rewrite?: AiSearchOptions['query_rewrite']
+	cache?: AiSearchOptions['cache']
+}
+
+type McpContext = {
+	instance: AiSearchInstance
+	sources?: Source[]
+}
+
+const DEFAULT_MAX_RESULTS = 5
+const DEFAULT_MATCH_THRESHOLD = 0.45
+const DEFAULT_MAX_CHARS_PER_CHUNK = 1200
+const DEFAULT_MAX_TOTAL_CHARS = 2400
+const FILTER_FALLBACK_TTL_MS = 10 * 60_000
+const SEARCH_RESULT_CACHE_TTL_MS = 60_000
+const SEARCH_RESULT_CACHE_MAX_ENTRIES = 128
+const PAGE_CACHE_TTL_MS = 60_000
+const PAGE_CACHE_MAX_ENTRIES = 128
+const SOURCE_INDEX_CACHE_TTL_MS = 10 * 60_000
+const SOURCE_INDEX_CACHE_MAX_ENTRIES = 64
+const DEFAULT_MAX_PAGE_CHARS = 12_000
+const RESOURCE_INDEX_MAX_ENTRIES = 50
+const SOURCES_RESOURCE_URI = 'tempo-docs://sources'
+
+type SearchResultChunk = AiSearchSearchResponse['chunks'][number]
+const sourceFilterFallbackUntil = new Map<string, number>()
+const searchResultCache = new Map<
+	string,
+	{ expiresAt: number; result: AiSearchSearchResponse }
+>()
+const searchInFlight = new Map<string, Promise<AiSearchSearchResponse>>()
+const pageCache = new Map<string, { expiresAt: number; text: string }>()
+const pageInFlight = new Map<string, Promise<string>>()
+const sourceIndexCache = new Map<
+	string,
+	{ expiresAt: number; entries: SourceIndexEntry[] }
+>()
+const sourceIndexInFlight = new Map<string, Promise<SourceIndexEntry[]>>()
+
+const NOISE_LINE_PATTERNS = [
+	/^skip to content$/i,
+	/^\[skip to content\]\(/i,
+	/^search\.\.\.$/i,
+	/^\[\]\(\/\)$/i,
+	/^⌘$/i,
+	/^k$/i,
+	/^i$/i,
+	/^was this helpful\?$/i,
+	/^copy page for ai$/i,
+	/^ask ai\.\.\.$/i,
+	/^suggest changes to this page$/i,
+]
+
+const SOURCE_QUERY_HINTS: Record<
+	string,
+	{ pattern: RegExp; weight: number }[]
+> = {
+	mpp: [
+		{ pattern: /\bmpp\b/, weight: 5 },
+		{ pattern: /\bmachine payments?\b/, weight: 4 },
+		{ pattern: /\bpayment protocol\b/, weight: 4 },
+		{ pattern: /\bjson rpc\b/, weight: 2 },
+		{ pattern: /\bx402\b/, weight: 2 },
+	],
+	regen: [
+		{ pattern: /\bregen\b/, weight: 5 },
+		{ pattern: /\bbutton\b/, weight: 3 },
+		{ pattern: /\bvariants?\b/, weight: 2 },
+		{ pattern: /\bcomponents?\b/, weight: 2 },
+	],
+	tempo: [
+		{ pattern: /\bvirtual addresses?\b/, weight: 5 },
+		{ pattern: /\btip 20\b/, weight: 4 },
+		{ pattern: /\bdeposits?\b/, weight: 2 },
+	],
+	viem: [
+		{ pattern: /\bviem\b/, weight: 5 },
+		{ pattern: /\bwallet client\b/, weight: 3 },
+		{ pattern: /\bpublic client\b/, weight: 3 },
+		{ pattern: /\btypescript\b/, weight: 2 },
+		{ pattern: /\bfee token\b/, weight: 2 },
+	],
+	vocs: [
+		{ pattern: /\bvocs\b/, weight: 5 },
+		{ pattern: /\bmcp server\b/, weight: 4 },
+		{ pattern: /\bdocs site\b/, weight: 3 },
+		{ pattern: /\bdocumentation framework\b/, weight: 3 },
+	],
+	wagmi: [
+		{ pattern: /\bwagmi\b/, weight: 5 },
+		{ pattern: /\btempowallet\b/, weight: 4 },
+		{ pattern: /\bconnector\b/, weight: 3 },
+		{ pattern: /\breact hooks?\b/, weight: 3 },
+	],
+}
+
+export async function handleMcp(
+	req: Request,
+	context: McpContext,
+): Promise<Response | undefined> {
+	if (req.method !== 'POST') return undefined
+
+	let body: JsonRpcRequest
+	try {
+		body = (await req.clone().json()) as JsonRpcRequest
+	} catch {
+		return undefined
+	}
+
+	if (body.method === 'tools/list') {
+		return jsonRpc(req, body.id, { tools: toolSchemas(context.sources ?? []) })
+	}
+
+	if (body.method === 'resources/list') {
+		return jsonRpc(req, body.id, {
+			resources: resourcesFor(context.sources ?? []),
+		})
+	}
+
+	if (body.method === 'resources/templates/list') {
+		return jsonRpc(req, body.id, {
+			resourceTemplates: resourceTemplatesFor(context.sources ?? []),
+		})
+	}
+
+	if (body.method === 'resources/read') {
+		const uri = (body.params as { uri?: unknown } | undefined)?.uri
+		if (typeof uri !== 'string') {
+			return jsonRpcError(req, body.id, -32602, 'uri must be a string')
+		}
+		const contents = await readResource(uri, context.sources ?? [])
+		if (!contents) {
+			return jsonRpcError(req, body.id, -32002, `resource not found: ${uri}`)
+		}
+		return jsonRpc(req, body.id, { contents })
+	}
+
+	if (body.method !== 'tools/call') {
+		return undefined
+	}
+	if (body.params?.name === 'read_page') {
+		return handleReadPage(req, body, context.sources ?? [])
+	}
+	if (body.params?.name === 'find_pages') {
+		return handleFindPages(req, body, context.sources ?? [])
+	}
+	if (body.params?.name !== 'search') return undefined
+
+	const query = body.params.arguments?.query
+	if (typeof query !== 'string' || query.trim().length === 0) {
+		return jsonRpcError(
+			req,
+			body.id,
+			-32602,
+			'query must be a non-empty string',
+		)
+	}
+
+	const sourceError = validateSources(
+		body.params.arguments,
+		context.sources ?? [],
+	)
+	if (sourceError) {
+		return jsonRpcError(req, body.id, -32602, sourceError)
+	}
+
+	try {
+		const args = body.params.arguments
+		const effectiveArgs = argsWithInferredSource(
+			query.trim(),
+			args,
+			context.sources ?? [],
+		)
+		const result = await cachedSearch(
+			query.trim(),
+			effectiveArgs,
+			context.instance,
+			context.sources ?? [],
+		)
+		const formatted = formatResult(result, effectiveArgs, context.sources ?? [])
+
+		return toolResult(req, body.id, effectiveArgs, formatted, 'search complete')
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err)
+		return jsonRpc(req, body.id, {
+			content: [
+				{
+					type: 'text',
+					text: JSON.stringify({ success: false, error: message }),
+				},
+			],
+			isError: true,
+		})
+	}
+}
+
+async function handleFindPages(
+	req: Request,
+	body: JsonRpcRequest,
+	sources: Source[],
+): Promise<Response> {
+	const args = body.params?.arguments
+	const sourceId = typeof args?.source === 'string' ? args.source.trim() : ''
+	const source = sources.find((entry) => entry.id === sourceId)
+	if (!source) {
+		return jsonRpcError(req, body.id, -32602, `unknown source: ${sourceId}`)
+	}
+	const query = typeof args?.query === 'string' ? args.query.trim() : ''
+	if (!query) {
+		return jsonRpcError(
+			req,
+			body.id,
+			-32602,
+			'query must be a non-empty string',
+		)
+	}
+
+	try {
+		const entries = await readSourceIndex(source)
+		const tokens = queryTokens(query)
+		const pages = entries
+			.map((entry) => ({ entry, score: sourceEntryScore(entry, tokens) }))
+			.filter(({ score }) => score > 0)
+			.sort((a, b) => b.score - a.score)
+			.slice(0, findPagesMaxResultsFor(args))
+			.map(({ entry, score }) => ({
+				title: entry.title,
+				url: entry.url,
+				score: Number(Math.min(0.99, score / 20).toFixed(4)),
+			}))
+		return toolResult(
+			req,
+			body.id,
+			args,
+			{ source: source.id, query, pages },
+			'page candidates found',
+		)
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err)
+		return jsonRpc(req, body.id, {
+			content: [
+				{
+					type: 'text',
+					text: JSON.stringify({ success: false, error: message }),
+				},
+			],
+			isError: true,
+		})
+	}
+}
+
+async function handleReadPage(
+	req: Request,
+	body: JsonRpcRequest,
+	sources: Source[],
+): Promise<Response> {
+	const args = body.params?.arguments
+	const sourceId = typeof args?.source === 'string' ? args.source.trim() : ''
+	const source = sources.find((entry) => entry.id === sourceId)
+	if (!source) {
+		return jsonRpcError(req, body.id, -32602, `unknown source: ${sourceId}`)
+	}
+
+	const pageUrl = resolvePageUrl(args, source)
+	if (!pageUrl) {
+		return jsonRpcError(req, body.id, -32602, 'path or url must be provided')
+	}
+
+	try {
+		const text = await readCleanPage(pageUrl)
+		const maxChars = maxPageCharsFor(args)
+		const truncated = text.length > maxChars
+		const resultText = pageTextFor(text, args, maxChars)
+		return toolResult(
+			req,
+			body.id,
+			args,
+			{
+				source: source.id,
+				url: pageUrl,
+				text: resultText,
+				truncated,
+			},
+			'page read complete',
+		)
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err)
+		return jsonRpc(req, body.id, {
+			content: [
+				{
+					type: 'text',
+					text: JSON.stringify({ success: false, error: message }),
+				},
+			],
+			isError: true,
+		})
+	}
+}
+
+function resolvePageUrl(
+	args: ReadPageArguments | undefined,
+	source: Source,
+): string | undefined {
+	const raw =
+		typeof args?.url === 'string'
+			? args.url.trim()
+			: typeof args?.path === 'string'
+				? args.path.trim()
+				: ''
+	if (!raw) return undefined
+
+	try {
+		const url = new URL(raw, source.base)
+		if (url.origin !== new URL(source.base).origin) return undefined
+		url.hash = ''
+		url.search = ''
+		return url.toString()
+	} catch {
+		return undefined
+	}
+}
+
+async function readCleanPage(pageUrl: string): Promise<string> {
+	const markdownUrl = toMarkdownUrl(pageUrl)
+	const cached = pageCache.get(markdownUrl)
+	if (cached && cached.expiresAt > Date.now()) return cached.text
+	if (cached) pageCache.delete(markdownUrl)
+
+	const inFlight = pageInFlight.get(markdownUrl)
+	if (inFlight) return inFlight
+
+	const pending = fetchCleanPage(markdownUrl)
+	pageInFlight.set(markdownUrl, pending)
+	try {
+		return await pending
+	} finally {
+		pageInFlight.delete(markdownUrl)
+	}
+}
+
+async function fetchCleanPage(markdownUrl: string): Promise<string> {
+	const res = await fetch(markdownUrl, { cf: { cacheTtl: 60 } })
+	if (!res.ok) throw new Error(`page fetch ${res.status}`)
+	const text = normalizeMarkdown(await res.text())
+	if (!text) throw new Error('page is empty')
+	cachePage(markdownUrl, text)
+	return text
+}
+
+function cachePage(key: string, text: string): void {
+	pageCache.set(key, { expiresAt: Date.now() + PAGE_CACHE_TTL_MS, text })
+	if (pageCache.size <= PAGE_CACHE_MAX_ENTRIES) return
+	const oldestKey = pageCache.keys().next().value
+	if (oldestKey) pageCache.delete(oldestKey)
+}
+
+async function cachedSearch(
+	query: string,
+	args: SearchArguments | undefined,
+	instance: AiSearchInstance,
+	sources: Source[],
+): Promise<AiSearchSearchResponse> {
+	const key = searchCacheKey(query, args)
+	const cached = searchResultCache.get(key)
+	if (cached && cached.expiresAt > Date.now()) return cached.result
+	if (cached) searchResultCache.delete(key)
+
+	const inFlight = searchInFlight.get(key)
+	if (inFlight) return inFlight
+
+	const pending = runAndCacheSearch(key, query, args, instance, sources)
+	searchInFlight.set(key, pending)
+	try {
+		return await pending
+	} finally {
+		searchInFlight.delete(key)
+	}
+}
+
+async function runAndCacheSearch(
+	key: string,
+	query: string,
+	args: SearchArguments | undefined,
+	instance: AiSearchInstance,
+	sources: Source[],
+): Promise<AiSearchSearchResponse> {
+	const result = await runSearch(query, args, instance, sources)
+	cacheSearchResult(key, result)
+	const postFallbackKey = searchCacheKey(query, args)
+	if (postFallbackKey !== key) cacheSearchResult(postFallbackKey, result)
+	return result
+}
+
+async function runSearch(
+	query: string,
+	args: SearchArguments | undefined,
+	instance: AiSearchInstance,
+	sources: Source[],
+): Promise<AiSearchSearchResponse> {
+	const wantedSources = selectedSources(args)
+	const skipSourceFilter = shouldSkipSourceFilter(wantedSources)
+	let result = await instance.search({
+		query,
+		ai_search_options: normalizeOptions(args, {
+			includeSourceFilter: !skipSourceFilter,
+			maxResults: upstreamMaxResultsFor(args),
+			...(skipSourceFilter ? { maxResults: fallbackMaxResultsFor(args) } : {}),
+		}),
+	})
+	if (skipSourceFilter) {
+		result = filterSourceChunks(
+			result,
+			wantedSources,
+			upstreamMaxResultsFor(args),
+		)
+	} else if (result.chunks.length === 0 && wantedSources.length > 0) {
+		rememberStaleSourceFilters(wantedSources)
+		const fallback = await instance.search({
+			query,
+			ai_search_options: normalizeOptions(args, {
+				includeSourceFilter: false,
+				maxResults: fallbackMaxResultsFor(args),
+			}),
+		})
+		const filtered = filterSourceChunks(
+			fallback,
+			wantedSources,
+			upstreamMaxResultsFor(args),
+		)
+		if (filtered.chunks.length > 0) result = filtered
+	}
+	if (result.chunks.length === 0) {
+		result = await localSourceSearch(
+			query,
+			args,
+			wantedSources,
+			sources,
+			result,
+		)
+	}
+	return result
+}
+
+function searchCacheKey(
+	query: string,
+	args: SearchArguments | undefined,
+): string {
+	const wantedSources = selectedSources(args)
+	const skipSourceFilter = shouldSkipSourceFilter(wantedSources)
+	return stableStringify({
+		query,
+		sources: wantedSources,
+		options: normalizeOptions(args, {
+			includeSourceFilter: !skipSourceFilter,
+			maxResults: upstreamMaxResultsFor(args),
+			...(skipSourceFilter ? { maxResults: fallbackMaxResultsFor(args) } : {}),
+		}),
+	})
+}
+
+function cacheSearchResult(key: string, result: AiSearchSearchResponse): void {
+	searchResultCache.set(key, {
+		expiresAt: Date.now() + SEARCH_RESULT_CACHE_TTL_MS,
+		result,
+	})
+	if (searchResultCache.size <= SEARCH_RESULT_CACHE_MAX_ENTRIES) return
+	const oldestKey = searchResultCache.keys().next().value
+	if (oldestKey) searchResultCache.delete(oldestKey)
+}
+
+function shouldSkipSourceFilter(sources: string[]): boolean {
+	if (sources.length === 0) return false
+	const now = Date.now()
+	return sources.every(
+		(source) => (sourceFilterFallbackUntil.get(source) ?? 0) > now,
+	)
+}
+
+function rememberStaleSourceFilters(sources: string[]): void {
+	const until = Date.now() + FILTER_FALLBACK_TTL_MS
+	for (const source of sources) sourceFilterFallbackUntil.set(source, until)
+}
+
+function filterSourceChunks(
+	result: AiSearchSearchResponse,
+	sources: string[],
+	maxResults: number,
+): AiSearchSearchResponse {
+	if (sources.length === 0) return result
+	return {
+		...result,
+		chunks: result.chunks
+			.filter((chunk) => {
+				const source = sourceForChunk(chunk)
+				return source ? sources.includes(source) : false
+			})
+			.slice(0, maxResults),
+	}
+}
+
+async function localSourceSearch(
+	query: string,
+	args: SearchArguments | undefined,
+	sourceIds: string[],
+	sources: Source[],
+	emptyResult: AiSearchSearchResponse,
+): Promise<AiSearchSearchResponse> {
+	if (sourceIds.length !== 1) return emptyResult
+	if (args?.include_raw === true) return emptyResult
+
+	const source = sources.find((entry) => entry.id === sourceIds[0])
+	if (!source) return emptyResult
+
+	const entries = await readSourceIndex(source)
+	const tokens = queryTokens(query)
+	const scored = entries
+		.map((entry) => ({ entry, score: sourceEntryScore(entry, tokens) }))
+		.filter((entry) => entry.score > 0)
+		.sort((a, b) => b.score - a.score)
+		.slice(0, localSourceMaxResultsFor(args))
+
+	const chunks = (
+		await Promise.allSettled(
+			scored.map(async ({ entry, score }) =>
+				sourceIndexChunk(source, entry, await readCleanPage(entry.url), score),
+			),
+		)
+	)
+		.filter(
+			(result): result is PromiseFulfilledResult<SearchResultChunk> =>
+				result.status === 'fulfilled',
+		)
+		.map((result) => result.value)
+	if (chunks.length === 0) return emptyResult
+	return { ...emptyResult, chunks }
+}
+
+async function readSourceIndex(source: Source): Promise<SourceIndexEntry[]> {
+	const key = `${source.id}:${source.indexPath ?? '/llms.txt'}`
+	const cached = sourceIndexCache.get(key)
+	if (cached && cached.expiresAt > Date.now()) return cached.entries
+	if (cached) sourceIndexCache.delete(key)
+
+	const inFlight = sourceIndexInFlight.get(key)
+	if (inFlight) return inFlight
+
+	const pending = fetchSourceIndex(source)
+	sourceIndexInFlight.set(key, pending)
+	try {
+		return await pending
+	} finally {
+		sourceIndexInFlight.delete(key)
+	}
+}
+
+async function fetchSourceIndex(source: Source): Promise<SourceIndexEntry[]> {
+	const res = await fetch(
+		new URL(source.indexPath ?? '/llms.txt', source.base).toString(),
+		{
+			cf: { cacheTtl: 60 },
+		},
+	)
+	if (!res.ok) return []
+	const entries = parseSourceIndex(await res.text(), source.base)
+	cacheSourceIndex(`${source.id}:${source.indexPath ?? '/llms.txt'}`, entries)
+	return entries
+}
+
+function cacheSourceIndex(key: string, entries: SourceIndexEntry[]): void {
+	sourceIndexCache.set(key, {
+		expiresAt: Date.now() + SOURCE_INDEX_CACHE_TTL_MS,
+		entries,
+	})
+	if (sourceIndexCache.size <= SOURCE_INDEX_CACHE_MAX_ENTRIES) return
+	const oldestKey = sourceIndexCache.keys().next().value
+	if (oldestKey) sourceIndexCache.delete(oldestKey)
+}
+
+function parseSourceIndex(body: string, base: string): SourceIndexEntry[] {
+	const origin = new URL(base).origin
+	const entries = []
+	for (const line of body.split('\n')) {
+		const match =
+			line.match(/^\s*[-*]\s+\[([^\]]+)\]\(([^)]+)\)(?::\s*(.*))?/) ??
+			plainPathSourceIndexMatch(line)
+		if (!match) continue
+		const [, title, rawUrl, description] = match
+		try {
+			const url = new URL(rawUrl, origin)
+			if (url.origin !== origin) continue
+			url.hash = ''
+			url.search = ''
+			entries.push({
+				title: title.trim(),
+				url: publicDocsUrl(url.toString()),
+				...(description?.trim() ? { description: description.trim() } : {}),
+			})
+		} catch {
+			// Ignore invalid index entries.
+		}
+	}
+	return entries
+}
+
+function plainPathSourceIndexMatch(
+	line: string,
+): [string, string, string, string | undefined] | undefined {
+	const match = line.match(/^\s*[-*]\s+((?:\/|\.\/)[^:\s]+)(?::\s*(.*))?/)
+	if (!match) return undefined
+	const [, rawUrl, description] = match
+	return [match[0], titleFromPath(rawUrl), rawUrl, description]
+}
+
+function titleFromPath(path: string): string {
+	const last = path
+		.split('/')
+		.filter(Boolean)
+		.at(-1)
+		?.replace(/\.md$/i, '')
+		.replace(/[-_]+/g, ' ')
+		.trim()
+	if (!last) return path
+	return last.charAt(0).toUpperCase() + last.slice(1)
+}
+
+function sourceEntryScore(entry: SourceIndexEntry, tokens: string[]): number {
+	if (tokens.length === 0) return 0
+	const haystack = `${entry.title} ${entry.description ?? ''} ${entry.url}`
+		.toLowerCase()
+		.replace(/[-_/]+/g, ' ')
+	let score = 0
+	for (const token of tokens) {
+		if (!haystack.includes(token)) continue
+		score += entry.title.toLowerCase().includes(token) ? 3 : 1
+	}
+	return score
+}
+
+function sourceIndexChunk(
+	source: Source,
+	entry: SourceIndexEntry,
+	text: string,
+	score: number,
+): SearchResultChunk {
+	return {
+		id: `${source.id}:${entry.url}`,
+		type: 'text',
+		score: Math.min(0.9, 0.4 + score / 20),
+		text,
+		item: {
+			key: keyForSourceUrl(source, entry.url),
+			metadata: {
+				source: source.id,
+				url: entry.url,
+				...(source.description
+					? { source_description: source.description }
+					: {}),
+			},
+		},
+	}
+}
+
+function keyForSourceUrl(source: Source, url: string): string {
+	const path = new URL(toMarkdownUrl(url)).pathname.replace(/^\/+|\/+$/g, '')
+	return `${source.id}/${path.replace(/\//g, '_')}`
+}
+
+function normalizeOptions(
+	args: SearchArguments | undefined,
+	options: { includeSourceFilter?: boolean; maxResults?: number } = {},
+): AiSearchOptions {
+	const input = args?.ai_search_options
+	const {
+		max_num_results: legacyMaxResults,
+		ranking_options: rankingOptions,
+		filters,
+		retrieval = {},
+		...rest
+	} = input ?? {}
+	const maxResults = options.maxResults ?? maxResultsFor(args)
+	const threshold = numberInRange(rankingOptions?.score_threshold, 0, 1)
+	const sourceFilter =
+		options.includeSourceFilter === false ? undefined : sourceFilterFor(args)
+
+	return {
+		...rest,
+		retrieval: {
+			...retrieval,
+			retrieval_type: retrieval.retrieval_type ?? 'hybrid',
+			keyword_match_mode: retrieval.keyword_match_mode ?? 'or',
+			max_num_results:
+				retrieval.max_num_results ?? maxResults ?? DEFAULT_MAX_RESULTS,
+			match_threshold:
+				retrieval.match_threshold ?? threshold ?? DEFAULT_MATCH_THRESHOLD,
+			context_expansion: retrieval.context_expansion ?? 0,
+			...(filters || sourceFilter
+				? { filters: { ...filters, ...sourceFilter } }
+				: {}),
+		},
+		reranking: {
+			enabled: true,
+			...input?.reranking,
+		},
+		cache: {
+			enabled: true,
+			cache_threshold: 'close_enough',
+			...input?.cache,
+		},
+	}
+}
+
+function formatResult(
+	result: AiSearchSearchResponse,
+	args: SearchArguments | undefined,
+	sources: Source[],
+): AiSearchSearchResponse | { search_query: string; chunks: unknown[] } {
+	if (args?.include_raw === true) {
+		return {
+			...result,
+			chunks: result.chunks.map((chunk) => ({
+				...chunk,
+				text: cleanChunkText(chunk.text),
+			})),
+		}
+	}
+
+	return {
+		search_query: result.search_query,
+		chunks: compactChunks(
+			distinctPageChunks(result.chunks, sources).slice(0, maxResultsFor(args)),
+			args,
+			sources,
+		),
+	}
+}
+
+function compactChunks(
+	chunks: SearchResultChunk[],
+	args: SearchArguments | undefined,
+	sources: Source[],
+) {
+	const maxTotalChars = maxTotalCharsFor(args)
+	const maxChunks = Math.max(
+		1,
+		Math.min(chunks.length, Math.floor(maxTotalChars / 300)),
+	)
+	const selected = chunks.slice(0, maxChunks)
+	const maxChars = Math.min(
+		maxCharsPerChunkFor(args),
+		Math.floor(maxTotalChars / selected.length),
+	)
+	return selected.map((chunk) => compactChunk(chunk, args, sources, maxChars))
+}
+
+function distinctPageChunks(
+	chunks: SearchResultChunk[],
+	sources: Source[],
+): SearchResultChunk[] {
+	const seen = new Set<string>()
+	const distinct = []
+	for (const chunk of chunks) {
+		const key = pageIdentityForChunk(chunk, sources)
+		if (seen.has(key)) continue
+		seen.add(key)
+		distinct.push(chunk)
+	}
+	return distinct
+}
+
+function pageIdentityForChunk(
+	chunk: SearchResultChunk,
+	sources: Source[],
+): string {
+	const url = urlForChunk(chunk, sources)
+	if (!url) return chunk.item.key
+	try {
+		const parsed = new URL(url)
+		parsed.hash = ''
+		parsed.search = ''
+		return parsed.toString().replace(/\/$/, '')
+	} catch {
+		return url
+	}
+}
+
+function compactChunk(
+	chunk: SearchResultChunk,
+	args: SearchArguments | undefined,
+	sources: Source[],
+	maxChars = maxCharsPerChunkFor(args),
+) {
+	const source = sourceForChunk(chunk)
+	const url = urlForChunk(chunk, sources)
+	const text = compactText(chunk.text, args, maxChars)
+
+	return {
+		score: Number(chunk.score.toFixed(4)),
+		...(source ? { source } : {}),
+		...(url ? { url } : { key: chunk.item.key }),
+		text,
+	}
+}
+
+function urlForChunk(
+	chunk: SearchResultChunk,
+	sources: Source[],
+): string | undefined {
+	const metadata = chunk.item.metadata ?? {}
+	if (typeof metadata.url === 'string') return publicDocsUrl(metadata.url)
+	return urlFromKey(chunk.item.key, sources)
+}
+
+function urlFromKey(key: string, sources: Source[]): string | undefined {
+	const slash = key.indexOf('/')
+	if (slash === -1 || key.startsWith('http')) return undefined
+	const sourceId = key.slice(0, slash)
+	const source = sources.find((entry) => entry.id === sourceId)
+	if (!source) return undefined
+
+	const path = key
+		.slice(slash + 1)
+		.replace(/\.md$/i, '')
+		.replace(/_/g, '/')
+	if (!path) return source.base
+	try {
+		return publicDocsUrl(new URL(`/${path}`, source.base).toString())
+	} catch {
+		return undefined
+	}
+}
+
+function publicDocsUrl(url: string): string {
+	try {
+		const parsed = new URL(url)
+		if (parsed.pathname.endsWith('.md')) {
+			parsed.pathname = parsed.pathname.slice(0, -'.md'.length)
+		}
+		parsed.hash = ''
+		parsed.search = ''
+		return parsed.toString().replace(/\/$/, '')
+	} catch {
+		return url
+	}
+}
+
+function compactText(
+	text: string,
+	args: SearchArguments | undefined,
+	maxChars = maxCharsPerChunkFor(args),
+): string {
+	const cleaned = cleanChunkText(text)
+	if (cleaned.length <= maxChars) return cleaned
+	return excerptText(cleaned, queryFor(args), maxChars)
+}
+
+function maxCharsPerChunkFor(args: SearchArguments | undefined): number {
+	return (
+		numberInRange(args?.max_chars_per_chunk, 300, 12_000) ??
+		DEFAULT_MAX_CHARS_PER_CHUNK
+	)
+}
+
+function maxTotalCharsFor(args: SearchArguments | undefined): number {
+	return (
+		numberInRange(args?.max_total_chars, 300, 50_000) ??
+		Math.max(maxResultsFor(args) * 300, DEFAULT_MAX_TOTAL_CHARS)
+	)
+}
+
+function queryFor(args: SearchArguments | undefined): string {
+	return typeof args?.query === 'string' ? args.query : ''
+}
+
+function excerptText(text: string, query: string, maxChars: number): string {
+	const index = bestMatchIndex(text, query) ?? 0
+	const halfWindow = Math.floor(maxChars / 2)
+	let start = Math.max(0, index - halfWindow)
+	let end = Math.min(text.length, start + maxChars)
+	start = Math.max(0, end - maxChars)
+	end = Math.min(text.length, start + maxChars)
+
+	const excerpt = text.slice(start, end).trim()
+	const prefix = start > 0 ? '... ' : ''
+	const suffix = end < text.length ? ' ...' : ''
+	return `${prefix}${excerpt}${suffix}`
+}
+
+function bestMatchIndex(text: string, query: string): number | undefined {
+	const lowerText = text.toLowerCase()
+	for (const token of queryTokens(query)) {
+		const index = lowerText.indexOf(token)
+		if (index !== -1) return index
+	}
+	return undefined
+}
+
+function queryTokens(query: string): string[] {
+	const stopwords = new Set([
+		'about',
+		'available',
+		'configure',
+		'does',
+		'have',
+		'into',
+		'over',
+		'tempo',
+		'that',
+		'this',
+		'using',
+		'what',
+		'when',
+		'with',
+		'work',
+		'works',
+	])
+	return [
+		...new Set(
+			query
+				.toLowerCase()
+				.split(/[^a-z0-9]+/)
+				.filter((token) => token.length >= 4 && !stopwords.has(token)),
+		),
+	].sort((a, b) => b.length - a.length)
+}
+
+function maxResultsFor(args: SearchArguments | undefined): number {
+	const input = args?.ai_search_options
+	return (
+		numberInRange(input?.retrieval?.max_num_results, 1, 50) ??
+		numberInRange(args?.max_results, 1, 50) ??
+		numberInRange(input?.max_num_results, 1, 50) ??
+		DEFAULT_MAX_RESULTS
+	)
+}
+
+function upstreamMaxResultsFor(args: SearchArguments | undefined): number {
+	return maxResultsFor(args)
+}
+
+function fallbackMaxResultsFor(args: SearchArguments | undefined): number {
+	return Math.max(upstreamMaxResultsFor(args), 20)
+}
+
+function localSourceMaxResultsFor(args: SearchArguments | undefined): number {
+	return Math.min(maxResultsFor(args), 3)
+}
+
+function findPagesMaxResultsFor(args: FindPagesArguments | undefined): number {
+	return (
+		numberInRange(args?.max_results, 1, 25) ?? Math.min(DEFAULT_MAX_RESULTS, 5)
+	)
+}
+
+function cleanChunkText(text: string): string {
+	return normalizeMarkdown(text)
+}
+
+function normalizeMarkdown(text: string): string {
+	return stripSitemapComment(text)
+		.split('\n')
+		.map((line) => line.trimEnd())
+		.filter(
+			(line) => !NOISE_LINE_PATTERNS.some((pattern) => pattern.test(line)),
+		)
+		.join('\n')
+		.replace(/\n{3,}/g, '\n\n')
+		.trim()
+}
+
+function stripSitemapComment(content: string): string {
+	return content
+		.replace(/\r\n/g, '\n')
+		.replace(/^<!--\nSitemap:\n[\s\S]*?\n-->\n*/, '')
+}
+
+function maxPageCharsFor(args: ReadPageArguments | undefined): number {
+	return numberInRange(args?.max_chars, 300, 50_000) ?? DEFAULT_MAX_PAGE_CHARS
+}
+
+function sourceFilterFor(
+	args: SearchArguments | undefined,
+): VectorizeVectorMetadataFilter | undefined {
+	const sources = selectedSources(args)
+	if (sources.length === 0) return undefined
+	if (sources.length === 1) return { source: sources[0] }
+	return { source: { $in: sources } }
+}
+
+function selectedSources(args: SearchArguments | undefined): string[] {
+	const sources = [
+		typeof args?.source === 'string' ? args.source : undefined,
+		...(Array.isArray(args?.sources) ? args.sources : []),
+	]
+		.filter((source): source is string => typeof source === 'string')
+		.map((source) => source.trim())
+		.filter(Boolean)
+	return [...new Set(sources)]
+}
+
+function argsWithInferredSource(
+	query: string,
+	args: SearchArguments | undefined,
+	sources: Source[],
+): SearchArguments | undefined {
+	if (selectedSources(args).length > 0) return args
+
+	const inferred = inferSourceForQuery(query, sources)
+	if (!inferred) return args
+	return { ...args, sources: [inferred] }
+}
+
+function inferSourceForQuery(
+	query: string,
+	sources: Source[],
+): string | undefined {
+	const knownSources = new Set(sources.map((source) => source.id))
+	if (knownSources.size === 0) return undefined
+
+	const normalized = query.toLowerCase().replace(/[^a-z0-9]+/g, ' ')
+	const scores = [...knownSources]
+		.map((source) => ({
+			source,
+			score: (SOURCE_QUERY_HINTS[source] ?? []).reduce(
+				(total, hint) =>
+					total + (hint.pattern.test(normalized) ? hint.weight : 0),
+				0,
+			),
+		}))
+		.filter(({ score }) => score > 0)
+		.sort((a, b) => b.score - a.score)
+
+	const [best, second] = scores
+	if (!best || best.score < 4) return undefined
+	if (second && second.score >= best.score) return undefined
+	return best.source
+}
+
+function validateSources(
+	args: SearchArguments | undefined,
+	sources: Source[],
+): string | undefined {
+	const known = new Set(sources.map((source) => source.id))
+	if (known.size === 0) return undefined
+
+	const unknown = selectedSources(args).filter((source) => !known.has(source))
+	if (unknown.length === 0) return undefined
+	return `unknown source: ${unknown.join(', ')}`
+}
+
+function sourceFromKey(chunk: SearchResultChunk): string | undefined {
+	const prefix = chunk.item.key.split('/')[0]
+	if (!prefix || prefix.startsWith('https:')) return undefined
+	return prefix
+}
+
+function sourceForChunk(chunk: SearchResultChunk): string | undefined {
+	const metadata = chunk.item.metadata ?? {}
+	return typeof metadata.source === 'string'
+		? metadata.source
+		: sourceFromKey(chunk)
+}
+
+function numberInRange(
+	value: unknown,
+	min: number,
+	max: number,
+): number | undefined {
+	if (typeof value !== 'number' || !Number.isFinite(value)) return undefined
+	return Math.min(max, Math.max(min, value))
+}
+
+function stableStringify(value: unknown): string {
+	return JSON.stringify(sortJson(value))
+}
+
+function sortJson(value: unknown): unknown {
+	if (Array.isArray(value)) return value.map(sortJson)
+	if (!value || typeof value !== 'object') return value
+	return Object.fromEntries(
+		Object.entries(value as Record<string, unknown>)
+			.filter(([, entry]) => entry !== undefined)
+			.sort(([a], [b]) => a.localeCompare(b))
+			.map(([key, entry]) => [key, sortJson(entry)]),
+	)
+}
+
+function jsonRpc(
+	req: Request,
+	id: JsonRpcRequest['id'],
+	result: unknown,
+): Response {
+	const payload = JSON.stringify({ result, jsonrpc: '2.0', id: id ?? null })
+	return mcpResponse(req, payload)
+}
+
+function toolResult(
+	req: Request,
+	id: JsonRpcRequest['id'],
+	args: { response_format?: unknown } | undefined,
+	result: unknown,
+	textSummary: string,
+): Response {
+	if (args?.response_format === 'structured') {
+		return jsonRpc(req, id, {
+			content: [{ type: 'text', text: textSummary }],
+			structuredContent: { success: true, result },
+		})
+	}
+	return jsonRpc(req, id, {
+		content: [
+			{
+				type: 'text',
+				text: JSON.stringify({ success: true, result }),
+			},
+		],
+	})
+}
+
+function jsonRpcError(
+	req: Request,
+	id: JsonRpcRequest['id'],
+	code: number,
+	message: string,
+): Response {
+	const payload = JSON.stringify({
+		jsonrpc: '2.0',
+		id: id ?? null,
+		error: { code, message },
+	})
+	return mcpResponse(req, payload)
+}
+
+function mcpResponse(req: Request, payload: string): Response {
+	if (req.headers.get('accept')?.includes('text/event-stream')) {
+		return new Response(`event: message\ndata: ${payload}\n\n`, {
+			headers: { 'content-type': 'text/event-stream' },
+		})
+	}
+	return new Response(payload, {
+		headers: { 'content-type': 'application/json' },
+	})
+}
+
+function toolSchemas(sources: Source[]) {
+	const sourceIds = sources.map((source) => source.id)
+	return [
+		{
+			name: 'search',
+			description: 'Search Tempo, viem, wagmi, MPP, Vocs, and Regen docs.',
+			inputSchema: {
+				type: 'object',
+				properties: {
+					query: {
+						type: 'string',
+						description: 'Question or task.',
+					},
+					source: {
+						type: 'string',
+						description: 'One source.',
+						...(sourceIds.length > 0 ? { enum: sourceIds } : {}),
+					},
+					sources: {
+						type: 'array',
+						description: 'Source filters.',
+						items: {
+							type: 'string',
+							...(sourceIds.length > 0 ? { enum: sourceIds } : {}),
+						},
+					},
+					max_results: {
+						type: 'number',
+						description: 'Chunks. Default 5.',
+						minimum: 1,
+						maximum: 50,
+					},
+					max_chars_per_chunk: {
+						type: 'number',
+						description: 'Chars/chunk. Default 1200.',
+						minimum: 300,
+						maximum: 12000,
+					},
+					max_total_chars: {
+						type: 'number',
+						description: 'Total text chars. Default 2400.',
+						minimum: 300,
+						maximum: 50000,
+					},
+					include_raw: {
+						type: 'boolean',
+						description: 'Return raw AI Search chunks.',
+					},
+					ai_search_options: {
+						type: 'object',
+						description: 'Advanced AI Search options.',
+						additionalProperties: true,
+					},
+					response_format: {
+						type: 'string',
+						enum: ['text', 'structured'],
+						description: 'structured returns structuredContent.',
+					},
+				},
+				required: ['query'],
+			},
+			execution: { taskSupport: 'forbidden' },
+		},
+		{
+			name: 'find_pages',
+			description: 'Find page URLs from a source index.',
+			inputSchema: {
+				type: 'object',
+				properties: {
+					source: {
+						type: 'string',
+						description: 'Source id.',
+						...(sourceIds.length > 0 ? { enum: sourceIds } : {}),
+					},
+					query: {
+						type: 'string',
+						description: 'Page topic.',
+					},
+					max_results: {
+						type: 'number',
+						description: 'Pages. Default 5.',
+						minimum: 1,
+						maximum: 25,
+					},
+					response_format: {
+						type: 'string',
+						enum: ['text', 'structured'],
+						description: 'structured returns structuredContent.',
+					},
+				},
+				required: ['source', 'query'],
+			},
+			execution: { taskSupport: 'forbidden' },
+		},
+		{
+			name: 'read_page',
+			description: 'Read one cleaned docs page.',
+			inputSchema: {
+				type: 'object',
+				properties: {
+					source: {
+						type: 'string',
+						description: 'Source id.',
+						...(sourceIds.length > 0 ? { enum: sourceIds } : {}),
+					},
+					path: {
+						type: 'string',
+						description: 'Page path.',
+					},
+					url: {
+						type: 'string',
+						description: 'Same-origin page URL.',
+					},
+					max_chars: {
+						type: 'number',
+						description: 'Chars. Default 12000.',
+						minimum: 300,
+						maximum: 50000,
+					},
+					query: {
+						type: 'string',
+						description: 'Focus excerpt when truncating.',
+					},
+					response_format: {
+						type: 'string',
+						enum: ['text', 'structured'],
+						description: 'structured returns structuredContent.',
+					},
+				},
+				required: ['source'],
+			},
+			execution: { taskSupport: 'forbidden' },
+		},
+	] as const
+}
+
+function pageTextFor(
+	text: string,
+	args: ReadPageArguments | undefined,
+	maxChars: number,
+): string {
+	if (text.length <= maxChars) return text
+	const query = typeof args?.query === 'string' ? args.query.trim() : ''
+	if (query) return pageExcerptText(text, query, maxChars)
+	return `${text.slice(0, maxChars).trimEnd()} ...`
+}
+
+function pageExcerptText(
+	text: string,
+	query: string,
+	maxChars: number,
+): string {
+	const heading = text
+		.split('\n')
+		.find((line) => /^#\s+\S/.test(line) || /^##\s+\S/.test(line))
+	const excerpt = excerptText(
+		text,
+		query,
+		heading ? Math.max(300, maxChars - heading.length - 2) : maxChars,
+	)
+	if (!heading || excerpt.includes(heading)) return excerpt
+	return `${heading}\n\n${excerpt}`
+}
+
+function resourcesFor(sources: Source[]) {
+	return [
+		{
+			uri: SOURCES_RESOURCE_URI,
+			name: 'Tempo docs MCP sources',
+			description: 'Configured docs sources.',
+			mimeType: 'text/markdown',
+		},
+		...sources.map((source) => ({
+			uri: `tempo-docs://source/${source.id}`,
+			name: `${source.id} docs source`,
+			description: source.description ?? source.base,
+			mimeType: 'text/markdown',
+		})),
+		...sources.map((source) => ({
+			uri: `tempo-docs://source/${source.id}/index`,
+			name: `${source.id} docs page index`,
+			description: `${source.id} page index.`,
+			mimeType: 'text/markdown',
+		})),
+	]
+}
+
+function resourceTemplatesFor(sources: Source[]) {
+	const sourceNames =
+		sources.length > 0
+			? sources.map((source) => source.id).join(', ')
+			: 'source'
+	return [
+		{
+			uriTemplate: 'tempo-docs://source/{source}',
+			name: 'Docs source metadata',
+			description: `Source metadata: ${sourceNames}.`,
+			mimeType: 'text/markdown',
+		},
+		{
+			uriTemplate: 'tempo-docs://source/{source}/index',
+			name: 'Docs source page index',
+			description: 'Read one source page index.',
+			mimeType: 'text/markdown',
+		},
+		{
+			uriTemplate: 'tempo-docs://source/{source}/page/{path}',
+			name: 'Docs source page',
+			description: 'Read one cleaned page.',
+			mimeType: 'text/markdown',
+		},
+	]
+}
+
+async function readResource(uri: string, sources: Source[]) {
+	if (uri === SOURCES_RESOURCE_URI) {
+		return [
+			{
+				uri,
+				mimeType: 'text/markdown',
+				text: [
+					'# Tempo docs MCP sources',
+					'Use the `search` tool with `source` to narrow retrieval when the task names a specific library.',
+					'Use `source: "tempo"` for core Tempo protocol and integration docs from docs.tempo.xyz.',
+					'',
+					...sources.map(
+						(source) =>
+							`- \`${source.id}\`: ${source.description ?? source.base} (${source.base})`,
+					),
+				].join('\n'),
+			},
+		]
+	}
+
+	const prefix = 'tempo-docs://source/'
+	if (!uri.startsWith(prefix)) return undefined
+	const rest = uri.slice(prefix.length)
+	const [sourceId, ...segments] = rest.split('/')
+	const source = sources.find((entry) => entry.id === sourceId)
+	if (!source) return undefined
+	if (segments[0] === 'index' && segments.length === 1) {
+		const entries = await readSourceIndex(source)
+		return [
+			{
+				uri,
+				mimeType: 'text/markdown',
+				text: sourceIndexResourceText(source, entries),
+			},
+		]
+	}
+	if (segments[0] === 'page' && segments.length > 1) {
+		const pageUrl = resolvePageUrl(
+			{ path: `/${segments.slice(1).join('/')}` },
+			source,
+		)
+		if (!pageUrl) return undefined
+		const text = await readCleanPage(pageUrl)
+		return [
+			{
+				uri,
+				mimeType: 'text/markdown',
+				text:
+					text.length > DEFAULT_MAX_PAGE_CHARS
+						? `${text.slice(0, DEFAULT_MAX_PAGE_CHARS).trimEnd()} ...`
+						: text,
+			},
+		]
+	}
+	if (segments.length > 0) return undefined
+	return [
+		{
+			uri,
+			mimeType: 'text/markdown',
+			text: [
+				`# ${source.id} docs source`,
+				`Base URL: ${source.base}`,
+				`Index path: ${source.indexPath ?? '/llms.txt'}`,
+				source.description ? `Description: ${source.description}` : undefined,
+				'',
+				'Search example:',
+				'```json',
+				JSON.stringify(
+					{
+						query: `${source.id} Tempo integration`,
+						source: source.id,
+						max_results: DEFAULT_MAX_RESULTS,
+					},
+					null,
+					2,
+				),
+				'```',
+			]
+				.filter((line): line is string => typeof line === 'string')
+				.join('\n'),
+		},
+	]
+}
+
+function sourceIndexResourceText(
+	source: Source,
+	entries: SourceIndexEntry[],
+): string {
+	return [
+		`# ${source.id} docs page index`,
+		entries.length === 0
+			? 'No pages found in this source index.'
+			: entries
+					.slice(0, RESOURCE_INDEX_MAX_ENTRIES)
+					.map((entry) => `- [${entry.title}](${entry.url})`)
+					.join('\n'),
+	]
+		.filter(Boolean)
+		.join('\n')
+}

--- a/apps/mcp-docs-indexer/wrangler.jsonc
+++ b/apps/mcp-docs-indexer/wrangler.jsonc
@@ -46,6 +46,11 @@
 		// `indexPath` defaults to `/llms.txt`.
 		"SOURCES": [
 			{
+				"id": "tempo",
+				"base": "https://docs.tempo.xyz",
+				"description": "Tempo network, protocol, and integration documentation"
+			},
+			{
 				"id": "viem",
 				"base": "https://viem.sh",
 				"description": "TypeScript interface for Ethereum / Tempo"


### PR DESCRIPTION
## Summary

- add first-party docs MCP search, page lookup, page read, and resource handling
- compact search/page outputs with source filters, dedupe, focused excerpts, and bounded text budgets
- clean indexed docs content and skip unchanged uploads with content hashes
- add benchmark, direct eval, and Promptfoo eval harnesses with stricter quality and byte budgets
- benchmark raw AI Search MCP upstream vs optimized `mcp.tempo.xyz` endpoint

| Metric | Before | After | Delta |
| --- | ---: | ---: | ---: |
| Eval score | 30/111 | 111/111 | +81 |
| Eval passes | 0/14 | 14/14 | +14 |
| Eval bytes | 160,770 | 39,159 | -121,611 |
| Eval text chars | 113,966 | 28,363 | -85,603 |
| Eval duplicate pages | 13 | 0 | -13 |
| Benchmark bytes | 514,588 | 110,435 | -404,153 |
| Benchmark text chars | 372,940 | 83,778 | -289,162 |
| Benchmark duplicate pages | 40 | 0 | -40 |
