### PR TITLE
fix(contract-verification): remove unprovisioned Secrets Store binding

### DIFF
--- a/apps/contract-verification/src/index.tsx
+++ b/apps/contract-verification/src/index.tsx
@@ -81,9 +81,7 @@ app.use(
 	chainRegistry({
 		staticChains,
 		url: env.CHAINS_CONFIG_URL || undefined,
-		authToken: await resolveAuthToken(
-			env.CHAINS_CONFIG_AUTH_TOKEN_SECRET || env.CHAINS_CONFIG_AUTH_TOKEN,
-		),
+		authToken: await resolveAuthToken(env.CHAINS_CONFIG_AUTH_TOKEN),
 	}),
 )
 

--- a/apps/contract-verification/src/job-runner.ts
+++ b/apps/contract-verification/src/job-runner.ts
@@ -61,8 +61,7 @@ export class VerificationJobRunner extends DurableObject<Cloudflare.Env> {
 
 		try {
 			const authToken = await resolveAuthToken(
-				this.env.CHAINS_CONFIG_AUTH_TOKEN_SECRET ||
-					this.env.CHAINS_CONFIG_AUTH_TOKEN,
+				this.env.CHAINS_CONFIG_AUTH_TOKEN,
 			)
 			const url = this.env.CHAINS_CONFIG_URL || undefined
 			const registry = url

--- a/apps/contract-verification/wrangler.json
+++ b/apps/contract-verification/wrangler.json
@@ -13,13 +13,6 @@
 		"CHAINS_CONFIG_URL": "",
 		"CHAINS_CONFIG_AUTH_TOKEN": ""
 	},
-	"secrets_store_secrets": [
-		{
-			"binding": "CHAINS_CONFIG_AUTH_TOKEN_SECRET",
-			"store_id": "",
-			"secret_name": "CHAINS_CONFIG_AUTH_TOKEN"
-		}
-	],
 	"ratelimits": [
 		{
 			"name": "RATE_LIMITER",


### PR DESCRIPTION
## Summary

Every "Deploy Contract Verification" run on main has failed since #933 landed with:

```
Secrets Store binding 'CHAINS_CONFIG_AUTH_TOKEN_SECRET' references store '' and secret 'CHAINS_CONFIG_AUTH_TOKEN' which were not found. [code: 10182]
```

`wrangler.json` committed the binding with an empty `store_id`, and no Secrets Store secret exists in the account. Confirmed failing on #1069, #1076, and #1071's deploys; the in-between green runs only skipped the deploy via the relevant-changes check. Local tests never caught it because miniflare doesn't validate store IDs (it just logged `Secret "CHAINS_CONFIG_AUTH_TOKEN" not found` warnings — also gone with this change).

## Changes
- Remove the `secrets_store_secrets` block from `wrangler.json`
- Drop the two `env.CHAINS_CONFIG_AUTH_TOKEN_SECRET ||` fallbacks (`index.tsx`, `job-runner.ts`) — `resolveAuthToken` takes the plain var directly

## Runtime impact

None. `CHAINS_CONFIG_URL` is `""` so the chain registry uses static chains, and `resolveAuthToken` already returned `undefined` for the broken binding. Re-add the binding with the real `store_id` once the store and `CHAINS_CONFIG_AUTH_TOKEN` secret are provisioned in the Cloudflare account.

## Test plan
- `pnpm check:types`, `pnpm check:biome`, `pnpm gen:types` — clean
- `pnpm test` — 224 tests / 17 files passing
- Real validation is the main deploy after merge (the failure was API-side)

🤖 Generated with [Claude Code](https://claude.com/claude-code)