### PR TITLE
fix(explorer): address OG preview data

### DIFF
--- a/apps/explorer/src/lib/address-balances.ts
+++ b/apps/explorer/src/lib/address-balances.ts
@@ -27,7 +27,7 @@ export type AssetData = {
 	balance: bigint | undefined
 }
 
-async function fetchAddressBalances(
+export async function fetchAddressBalances(
 	address: Address.Address,
 ): Promise<BalancesResponse> {
 	const response = await fetch(getApiUrl(`/api/address/balances/${address}`), {

--- a/apps/explorer/src/lib/address-balances.ts
+++ b/apps/explorer/src/lib/address-balances.ts
@@ -27,7 +27,7 @@ export type AssetData = {
 	balance: bigint | undefined
 }
 
-export async function fetchAddressBalances(
+async function fetchAddressBalances(
 	address: Address.Address,
 ): Promise<BalancesResponse> {
 	const response = await fetch(getApiUrl(`/api/address/balances/${address}`), {

--- a/apps/explorer/src/lib/server/address-metadata.ts
+++ b/apps/explorer/src/lib/server/address-metadata.ts
@@ -77,6 +77,8 @@ export function buildAddressTxMetadata(
 					: (creation.hash ?? undefined)
 				: aggregate.oldestTxHash,
 		createdBy:
-			useCreation && creation ? (creation.from ?? undefined) : aggregate.oldestTxFrom,
+			useCreation && creation
+				? (creation.from ?? undefined)
+				: aggregate.oldestTxFrom,
 	}
 }

--- a/apps/explorer/src/routes/_layout/address/$address.tsx
+++ b/apps/explorer/src/routes/_layout/address/$address.tsx
@@ -56,6 +56,7 @@ import {
 	type AssetData,
 	balancesQueryOptions,
 	calculateTotalHoldings,
+	fetchAddressBalances,
 	useBalancesData,
 } from '#lib/address-balances'
 import {
@@ -433,13 +434,16 @@ export const Route = createFileRoute('/_layout/address/$address')({
 		} else {
 			const txCount =
 				ogMeta?.txCount ?? loaderData?.transactionsData?.total ?? 0
+			const balancesData =
+				loaderData?.balancesData ??
+				(await fetchAddressBalances(address).catch(() => undefined))
 			let lastActive: string | undefined
 			let created: string | undefined
 			let holdings = '—'
 
-			if (loaderData?.balancesData?.balances) {
+			if (balancesData?.balances) {
 				const totalValue = calculateTotalHoldings(
-					loaderData.balancesData.balances.map((b) => ({
+					balancesData.balances.map((b) => ({
 						address: b.token,
 						metadata: {
 							decimals: b.decimals,

--- a/apps/explorer/src/routes/_layout/address/$address.tsx
+++ b/apps/explorer/src/routes/_layout/address/$address.tsx
@@ -56,7 +56,6 @@ import {
 	type AssetData,
 	balancesQueryOptions,
 	calculateTotalHoldings,
-	fetchAddressBalances,
 	useBalancesData,
 } from '#lib/address-balances'
 import {
@@ -92,6 +91,15 @@ import {
 import { transfersQueryOptions, holdersQueryOptions } from '#lib/queries/tokens'
 import { getApiUrl } from '#lib/env.ts'
 import { areUsdPricedTokens } from '#lib/pricing'
+import {
+	fetchAddressBalancesData,
+	MAX_TOKENS,
+} from '#lib/server/address-balances'
+import { buildAddressTxMetadata } from '#lib/server/address-metadata'
+import {
+	fetchAddressTxAggregate,
+	fetchContractCreationReceipt,
+} from '#lib/server/tempo-queries'
 import { getFeeTokenForChain } from '#lib/tokenlist'
 import { getTempoChain, getWagmiConfig } from '#wagmi.config.ts'
 import type { EnrichedTransaction } from '#routes/api/address/history/$address.ts'
@@ -104,6 +112,13 @@ import EyeOffIcon from '~icons/lucide/eye-off'
 import XIcon from '~icons/lucide/x'
 
 type TokenMetadata = Actions.token.getMetadata.ReturnValue
+type AddressOgMetadata = {
+	accountType?: AccountType
+	txCount?: number | null
+	holdersCount?: number | null
+	lastActivityTimestamp?: number | null
+	createdTimestamp?: number | null
+}
 
 const TEMPO_CHAIN_ID = getTempoChain().id
 const TEMPO_FEE_TOKEN = getFeeTokenForChain(TEMPO_CHAIN_ID)
@@ -369,7 +384,7 @@ export const Route = createFileRoute('/_layout/address/$address')({
 		const address = params.address as Address.Address
 		const ogMeta =
 			loaderData?.ogMeta ??
-			(await fetchAddressMetadata(address).catch(() => undefined))
+			(await fetchAddressOgMetadata(address).catch(() => undefined))
 		// Fallback to ogMeta.accountType only for contracts (receipts-proven)
 		// since 'empty' is the correct type for regular EOAs
 		let accountType = loaderData?.accountType ?? 'empty'
@@ -436,7 +451,7 @@ export const Route = createFileRoute('/_layout/address/$address')({
 				ogMeta?.txCount ?? loaderData?.transactionsData?.total ?? 0
 			const balancesData =
 				loaderData?.balancesData ??
-				(await fetchAddressBalances(address).catch(() => undefined))
+				(await fetchAddressOgBalances(address).catch(() => undefined))
 			let lastActive: string | undefined
 			let created: string | undefined
 			let holdings = '—'
@@ -722,13 +737,29 @@ async function fetchAddressMetadata(address: Address.Address) {
 		headers: { 'Content-Type': 'application/json' },
 	})
 	if (!response.ok) throw new Error('Failed to fetch address metadata')
-	return response.json() as Promise<{
-		accountType: AccountType
-		txCount: number | null
-		holdersCount?: number | null
-		lastActivityTimestamp: number | null
-		createdTimestamp: number | null
-	}>
+	return response.json() as Promise<AddressOgMetadata>
+}
+
+async function fetchAddressOgMetadata(
+	address: Address.Address,
+): Promise<AddressOgMetadata> {
+	const { id: chainId } = getTempoChain()
+	const result = await fetchAddressTxAggregate(address, chainId)
+	const indexedCreation = await fetchContractCreationReceipt(
+		address,
+		chainId,
+	).catch(() => undefined)
+	return buildAddressTxMetadata(result, indexedCreation)
+}
+
+async function fetchAddressOgBalances(address: Address.Address) {
+	const config = getWagmiConfig()
+	return fetchAddressBalancesData({
+		address,
+		chainId: getTempoChain().id,
+		config,
+		maxTokens: MAX_TOKENS,
+	})
 }
 
 type ContractCreationResponse = {

--- a/apps/explorer/src/routes/_layout/address/$address.tsx
+++ b/apps/explorer/src/routes/_layout/address/$address.tsx
@@ -220,7 +220,6 @@ export const Route = createFileRoute('/_layout/address/$address')({
 
 			// Tab-aware loading: only fetch data needed for the active tab
 			const isTransactionsTab = tab === 'transactions'
-			const isHoldingsTab = tab === 'holdings'
 			const knownContractInfo = getContractInfo(address)
 			const isKnownTokenAddress =
 				Tip20.isTip20Address(address) || knownContractInfo?.category === 'token'
@@ -300,18 +299,18 @@ export const Route = createFileRoute('/_layout/address/$address')({
 					)
 				: Promise.resolve(undefined)
 
-			const balancesPromise =
-				isHoldingsTab && !isKnownTokenAddress
-					? timeout(
-							context.queryClient
-								.ensureQueryData(balancesQueryOptions(address))
-								.catch((error) => {
-									console.error('Fetch balances error:', error)
-									return undefined
-								}),
-							QUERY_TIMEOUT_MS,
-						)
-					: Promise.resolve(undefined)
+			const shouldFetchBalances = !isKnownTokenAddress
+			const balancesPromise = shouldFetchBalances
+				? timeout(
+						context.queryClient
+							.ensureQueryData(balancesQueryOptions(address))
+							.catch((error) => {
+								console.error('Fetch balances error:', error)
+								return undefined
+							}),
+						QUERY_TIMEOUT_MS,
+					)
+				: Promise.resolve(undefined)
 
 			// Fetch address metadata through the API route so TIDX credentials stay
 			// server-side when loaders run in the browser.
@@ -364,7 +363,7 @@ export const Route = createFileRoute('/_layout/address/$address')({
 				balancesData,
 				ogMeta,
 			}
-	}),
+		}),
 	head: async ({ params, loaderData }) => {
 		const address = params.address as Address.Address
 		const ogMeta =
@@ -432,7 +431,8 @@ export const Route = createFileRoute('/_layout/address/$address')({
 				created,
 			})
 		} else {
-			const txCount = ogMeta?.txCount ?? 0
+			const txCount =
+				ogMeta?.txCount ?? loaderData?.transactionsData?.total ?? 0
 			let lastActive: string | undefined
 			let created: string | undefined
 			let holdings = '—'


### PR DESCRIPTION
## Summary
- fetch address balances for SSR/head data even when the default transactions tab is active
- fetch address balances directly in `head` when loader data is unavailable during unfurl/meta generation
- fall back to the loaded transaction total when metadata tx count is unavailable
- fixes address unfurls that rendered holdings as empty and tx count as zero

Prompted by: @shekhirin
Prompted by: @emmajam

## Verification
- pnpm --filter explorer check:types
- pnpm --filter explorer check:biome
- pnpm --filter explorer build

## Notes
- pnpm --filter explorer test previously failed during Vitest startup with: Missing "#tanstack-router-entry" specifier in "@tanstack/start-server-core" package, before tests execute.