### PR TITLE
Add MPP Credits tokenlist entries

### DIFF
--- a/apps/tokenlist/data/31318/tokenlist.json
+++ b/apps/tokenlist/data/31318/tokenlist.json
@@ -5,7 +5,7 @@
 	"timestamp": "2026-01-06T00:00:00Z",
 	"version": {
 		"major": 1,
-		"minor": 0,
+		"minor": 1,
 		"patch": 0
 	},
 	"tokens": [
@@ -20,6 +20,18 @@
 				"chain": "tempo",
 				"label": "PathUSD"
 			}
+		},
+		{
+			"name": "MPP Credits",
+			"symbol": "MPPC",
+			"decimals": 6,
+			"chainId": 31318,
+			"address": "0x20c0000000000000000000000000000000000004",
+			"extensions": {
+				"chain": "tempo",
+				"label": "MPP Credits"
+			},
+			"dateAdded": "2026-06-15T00:00:00Z"
 		},
 		{
 			"name": "AlphaUSD",

--- a/apps/tokenlist/data/4217/tokenlist.json
+++ b/apps/tokenlist/data/4217/tokenlist.json
@@ -1,418 +1,430 @@
 {
-  "$schema": "https://esm.sh/gh/uniswap/token-lists/src/tokenlist.schema.json",
-  "name": "Tempo Mainnet",
-  "logoURI": "https://esm.sh/gh/tempoxyz/tokenlist/data/4217/icon.svg",
-  "timestamp": "2026-06-10T16:18:45Z",
-  "version": {
-    "major": 1,
-    "minor": 2,
-    "patch": 25
-  },
-  "tokens": [
-    {
-      "name": "PathUSD",
-      "symbol": "pathUSD",
-      "decimals": 6,
-      "chainId": 4217,
-      "address": "0x20c0000000000000000000000000000000000000",
-      "logoURI": "https://esm.sh/gh/tempoxyz/tempo-apps/apps/tokenlist/data/4217/icons/0x20c0000000000000000000000000000000000000.svg",
-      "extensions": {
-        "chain": "tempo",
-        "label": "PathUSD",
-        "coingeckoId": "pathusd"
-      }
-    },
-    {
-      "name": "Deel USD",
-      "symbol": "DLUSD",
-      "decimals": 6,
-      "chainId": 4217,
-      "address": "0x20c0000000000000000000006fd9a167923ba194",
-      "logoURI": "https://esm.sh/gh/tempoxyz/tempo-apps/apps/tokenlist/data/4217/icons/0x20c0000000000000000000006fd9a167923ba194.png",
-      "extensions": {
-        "chain": "tempo",
-        "label": "DLUSD"
-      },
-      "dateAdded": "2026-06-03T20:13:57Z"
-    },
-    {
-      "name": "Bridged USDC (Stargate)",
-      "symbol": "USDC.e",
-      "decimals": 6,
-      "chainId": 4217,
-      "address": "0x20c000000000000000000000b9537d11c60e8b50",
-      "logoURI": "https://esm.sh/gh/tempoxyz/tempo-apps/apps/tokenlist/data/4217/icons/0x20c000000000000000000000b9537d11c60e8b50.svg",
-      "extensions": {
-        "chain": "tempo",
-        "label": "USDC.e",
-        "coingeckoId": "usd-coin",
-        "bridgeInfo": {
-          "sourceChainId": 1,
-          "sourceAddress": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
-        }
-      }
-    },
-    {
-      "name": "Bridged EURC (Stargate)",
-      "symbol": "EURC.e",
-      "decimals": 6,
-      "chainId": 4217,
-      "address": "0x20c0000000000000000000001621e21f71cf12fb",
-      "logoURI": "https://esm.sh/gh/tempoxyz/tempo-apps/apps/tokenlist/data/4217/icons/0x20c0000000000000000000001621e21f71cf12fb.svg",
-      "extensions": {
-        "chain": "tempo",
-        "label": "EURC",
-        "coingeckoId": "euro-coin",
-        "bridgeInfo": {
-          "sourceChainId": 1,
-          "sourceAddress": "0x1abaea1f7c830bd89acc67ec4af516284b1bc33c"
-        }
-      }
-    },
-    {
-      "name": "USDT0",
-      "symbol": "USDT0",
-      "decimals": 6,
-      "chainId": 4217,
-      "address": "0x20c00000000000000000000014f22ca97301eb73",
-      "logoURI": "https://esm.sh/gh/tempoxyz/tempo-apps/apps/tokenlist/data/4217/icons/0x20c00000000000000000000014f22ca97301eb73.svg",
-      "extensions": {
-        "chain": "tempo",
-        "coingeckoId": "usdt0",
-        "bridgeInfo": {
-          "sourceChainId": 1,
-          "sourceAddress": "0xdac17f958d2ee523a2206206994597c13d831ec7"
-        }
-      }
-    },
-    {
-      "name": "Frax USD",
-      "symbol": "frxUSD",
-      "decimals": 6,
-      "chainId": 4217,
-      "address": "0x20c0000000000000000000003554d28269e0f3c2",
-      "logoURI": "https://esm.sh/gh/tempoxyz/tempo-apps/apps/tokenlist/data/4217/icons/0x20c0000000000000000000003554d28269e0f3c2.svg",
-      "extensions": {
-        "chain": "tempo",
-        "coingeckoId": "frax-usd",
-        "bridgeInfo": {
-          "sourceChainId": 1,
-          "sourceAddress": "0xcacd6fd266af91b8aed52accc382b4e165586e29"
-        }
-      }
-    },
-    {
-      "name": "Cap USD",
-      "symbol": "cUSD",
-      "decimals": 6,
-      "chainId": 4217,
-      "address": "0x20c0000000000000000000000520792dcccccccc",
-      "logoURI": "https://esm.sh/gh/tempoxyz/tempo-apps/apps/tokenlist/data/4217/icons/0x20c0000000000000000000000520792dcccccccc.svg",
-      "extensions": {
-        "chain": "tempo",
-        "label": "cUSD",
-        "coingeckoId": "cap-usd",
-        "bridgeInfo": {
-          "sourceChainId": 1,
-          "sourceAddress": "0xcccc62962d17b8914c62d74ffb843d73b2a3cccc"
-        }
-      },
-      "dateAdded": "2026-03-11T04:44:38Z"
-    },
-    {
-      "name": "Staked Cap USD",
-      "symbol": "stcUSD",
-      "decimals": 6,
-      "chainId": 4217,
-      "address": "0x20c0000000000000000000008ee4fcff88888888",
-      "logoURI": "https://esm.sh/gh/tempoxyz/tempo-apps/apps/tokenlist/data/4217/icons/0x20c0000000000000000000008ee4fcff88888888.svg",
-      "extensions": {
-        "chain": "tempo",
-        "label": "stcUSD",
-        "coingeckoId": "staked-cap-usd",
-        "bridgeInfo": {
-          "sourceChainId": 1,
-          "sourceAddress": "0x88887be419578051ff9f4eb6c858a951921d8888"
-        }
-      },
-      "dateAdded": "2026-03-16T02:56:16Z"
-    },
-    {
-      "name": "Generic USD",
-      "symbol": "GUSD",
-      "address": "0x20c0000000000000000000005c0bac7cef389a11",
-      "decimals": 6,
-      "chainId": 4217,
-      "logoURI": "https://esm.sh/gh/tempoxyz/tempo-apps/apps/tokenlist/data/4217/icons/0x20c0000000000000000000005c0bac7cef389a11.svg",
-      "extensions": {
-        "chain": "tempo",
-        "label": "GUSD",
-        "coingeckoId": "generic-usd",
-        "bridgeInfo": {
-          "sourceChainId": 1,
-          "sourceAddress": "0xece811d35f79c4868a2b911e55d9aa0821399edf"
-        }
-      },
-      "dateAdded": "2026-03-21T05:24:26Z"
-    },
-    {
-      "name": "Reservoir Stablecoin",
-      "symbol": "rUSD",
-      "decimals": 6,
-      "chainId": 4217,
-      "address": "0x20c0000000000000000000007f7ba549dd0251b9",
-      "logoURI": "https://esm.sh/gh/tempoxyz/tempo-apps/apps/tokenlist/data/4217/icons/0x20c0000000000000000000007f7ba549dd0251b9.svg",
-      "extensions": {
-        "chain": "tempo",
-        "label": "rUSD",
-        "coingeckoId": "reservoir-rusd",
-        "bridgeInfo": {
-          "sourceChainId": 1,
-          "sourceAddress": "0x09d4214c03d01f49544c0448dbe3a27f768f2b34"
-        }
-      },
-      "dateAdded": "2026-04-02T18:36:11Z"
-    },
-    {
-      "name": "Wrapped Savings rUSD",
-      "symbol": "wsrUSD",
-      "decimals": 6,
-      "chainId": 4217,
-      "address": "0x20c000000000000000000000aeed2ec36a54d0e5",
-      "logoURI": "https://esm.sh/gh/tempoxyz/tempo-apps/apps/tokenlist/data/4217/icons/0x20c000000000000000000000aeed2ec36a54d0e5.svg",
-      "extensions": {
-        "chain": "tempo",
-        "label": "wsrUSD",
-        "bridgeInfo": {
-          "sourceChainId": 1,
-          "sourceAddress": "0xd3fd63209fa2d55b07a0f6db36c2f43900be3094"
-        }
-      },
-      "dateAdded": "2026-04-02T18:36:11Z"
-    },
-    {
-      "name": "AllUnity EUR",
-      "symbol": "EURAU",
-      "decimals": 6,
-      "chainId": 4217,
-      "address": "0x20c0000000000000000000009a4a4b17e0dc6651",
-      "logoURI": "https://esm.sh/gh/tempoxyz/tempo-apps/apps/tokenlist/data/4217/icons/0x20c0000000000000000000009a4a4b17e0dc6651.svg",
-      "extensions": {
-        "chain": "tempo",
-        "label": "EURAU",
-        "coingeckoId": "allunity-eur"
-      },
-      "dateAdded": "2026-04-02T18:36:11Z"
-    },
-    {
-      "name": "AllUnity CHF",
-      "symbol": "CHFAU",
-      "decimals": 6,
-      "chainId": 4217,
-      "address": "0x20c00000000000000000000042109aef2f8b28e1",
-      "logoURI": "https://esm.sh/gh/tempoxyz/tempo-apps/apps/tokenlist/data/4217/icons/0x20c00000000000000000000042109aef2f8b28e1.png",
-      "extensions": {
-        "chain": "tempo",
-        "label": "CHFAU",
-        "currency": "CHF",
-        "coingeckoId": "allunity-chf"
-      },
-      "dateAdded": "2026-06-09T14:44:13Z"
-    },
-    {
-      "name": "Re Protocol reUSD",
-      "symbol": "reUSD",
-      "decimals": 6,
-      "chainId": 4217,
-      "address": "0x20c000000000000000000000383a23bacb546ab9",
-      "logoURI": "https://esm.sh/gh/tempoxyz/tempo-apps/apps/tokenlist/data/4217/icons/0x20c000000000000000000000383a23bacb546ab9.svg",
-      "extensions": {
-        "chain": "tempo",
-        "label": "reUSD",
-        "coingeckoId": "re-protocol-reusd",
-        "bridgeInfo": {
-          "sourceChainId": 1,
-          "sourceAddress": "0x5086bf358635b81d8c47c66d1c8b9e567db70c72"
-        }
-      },
-      "dateAdded": "2026-04-06T23:13:41Z"
-    },
-    {
-      "name": "InfiniFi USD",
-      "symbol": "iUSD",
-      "decimals": 6,
-      "chainId": 4217,
-      "address": "0x20c000000000000000000000ab02d39df30bd17e",
-      "logoURI": "https://esm.sh/gh/tempoxyz/tempo-apps/apps/tokenlist/data/4217/icons/0x20c000000000000000000000ab02d39df30bd17e.svg",
-      "extensions": {
-        "chain": "tempo",
-        "label": "iUSD",
-        "coingeckoId": "infinifi-usd",
-        "bridgeInfo": {
-          "sourceChainId": 1,
-          "sourceAddress": "0x48f9e38f3070ad8945dfeae3fa70987722e3d89c"
-        }
-      },
-      "dateAdded": "2026-04-14T04:51:53Z"
-    },
-    {
-      "name": "InfiniFi Staked USD",
-      "symbol": "siUSD",
-      "decimals": 6,
-      "chainId": 4217,
-      "address": "0x20c000000000000000000000048c8f36df1c9a4a",
-      "logoURI": "https://esm.sh/gh/tempoxyz/tempo-apps/apps/tokenlist/data/4217/icons/0x20c000000000000000000000048c8f36df1c9a4a.svg",
-      "extensions": {
-        "chain": "tempo",
-        "label": "siUSD",
-        "coingeckoId": "infinifi-staked-iusd",
-        "bridgeInfo": {
-          "sourceChainId": 1,
-          "sourceAddress": "0xdbdc1ef57537e34680b898e1febd3d68c7389bcb"
-        }
-      },
-      "dateAdded": "2026-04-14T04:51:53Z"
-    },
-    {
-      "name": "USDe",
-      "symbol": "USDe",
-      "decimals": 6,
-      "chainId": 4217,
-      "address": "0x20c0000000000000000000002f52d5cc21a3207b",
-      "logoURI": "https://esm.sh/gh/tempoxyz/tempo-apps/apps/tokenlist/data/4217/icons/0x20c0000000000000000000002f52d5cc21a3207b.svg",
-      "extensions": {
-        "chain": "tempo",
-        "label": "USDe",
-        "coingeckoId": "ethena-usde",
-        "bridgeInfo": {
-          "sourceChainId": 1,
-          "sourceAddress": "0x4c9edd5852cd905f086c759e8383e09bff1e68b3"
-        }
-      },
-      "dateAdded": "2026-04-14T04:51:53Z"
-    },
-    {
-      "name": "Staked USDe",
-      "symbol": "sUSDe",
-      "decimals": 6,
-      "chainId": 4217,
-      "address": "0x20c000000000000000000000bd95bfb69fbe6ce3",
-      "logoURI": "https://esm.sh/gh/tempoxyz/tempo-apps/apps/tokenlist/data/4217/icons/0x20c000000000000000000000bd95bfb69fbe6ce3.svg",
-      "extensions": {
-        "chain": "tempo",
-        "coingeckoId": "ethena-staked-usde",
-        "bridgeInfo": {
-          "sourceChainId": 1,
-          "sourceAddress": "0x9d39a5de30e57443bff2a8307a4256c8797a3497"
-        }
-      },
-      "dateAdded": "2026-04-14T04:51:53Z"
-    },
-    {
-      "name": "Stable Coin",
-      "symbol": "SBC",
-      "decimals": 6,
-      "chainId": 4217,
-      "address": "0x20c000000000000000000000ae247a1130450f09",
-      "logoURI": "https://esm.sh/gh/tempoxyz/tempo-apps/apps/tokenlist/data/4217/icons/0x20c000000000000000000000ae247a1130450f09.svg",
-      "extensions": {
-        "chain": "tempo",
-        "label": "SBC",
-        "coingeckoId": "stable-coin-2"
-      },
-      "dateAdded": "2026-04-14T17:12:36Z"
-    },
-    {
-      "name": "Syrup USDC",
-      "symbol": "syrupUSDC",
-      "decimals": 6,
-      "chainId": 4217,
-      "address": "0x20c0000000000000000000008191667423f70e67",
-      "logoURI": "https://esm.sh/gh/tempoxyz/tempo-apps/apps/tokenlist/data/4217/icons/0x20c0000000000000000000008191667423f70e67.svg",
-      "extensions": {
-        "chain": "tempo",
-        "label": "syrupUSDC",
-        "coingeckoId": "syrup-USDC",
-        "bridgeInfo": {
-          "sourceChainId": 1,
-          "sourceAddress": "0x80ac24aa929eaf5013f6436cda2a7ba190f5cc0b"
-        }
-      },
-      "dateAdded": "2026-05-06T19:33:19Z"
-    },
-    {
-      "name": "Coinbase Wrapped BTC",
-      "symbol": "cbBTC",
-      "decimals": 6,
-      "chainId": 4217,
-      "address": "0x20c000000000000000000000c412ec89d0c08be5",
-      "logoURI": "https://static-assets.coinbase.com/marketing/wrapped-assets/cbbtc.svg",
-      "extensions": {
-        "chain": "tempo",
-        "label": "cbBTC",
-        "coingeckoId": "coinbase-wrapped-btc",
-        "bridgeInfo": {
-          "sourceChainId": 8453,
-          "sourceAddress": "0xcbb7c0000ab88b473b1f5afd9ef808440eed33bf"
-        }
-      },
-      "dateAdded": "2026-05-08T18:42:44Z"
-    },
-    {
-      "name": "USDBridge",
-      "symbol": "USDB",
-      "address": "0x20c0000000000000000000003158081efd85bfc2",
-      "decimals": 6,
-      "chainId": 4217,
-      "logoURI": "https://esm.sh/gh/tempoxyz/tempo-apps/apps/tokenlist/data/4217/icons/0x20c0000000000000000000003158081efd85bfc2.svg",
-      "extensions": {
-        "chain": "tempo",
-        "label": "USDB"
-      },
-      "dateAdded": "2026-05-12T02:30:31Z"
-    },
-    {
-      "name": "USD1",
-      "symbol": "USD1",
-      "decimals": 6,
-      "chainId": 4217,
-      "address": "0x20c000000000000000000000111111111e910f0f",
-      "logoURI": "https://static.worldlibertyfinancial.com/assets/brand/usd1.svg",
-      "extensions": {
-        "chain": "tempo",
-        "coingeckoId": "usd1-wlfi"
-      },
-      "dateAdded": "2026-05-12T15:17:32Z"
-    },
-    {
-      "name": "BRLA Token",
-      "symbol": "BRLA",
-      "decimals": 6,
-      "chainId": 4217,
-      "address": "0x20c000000000000000000000f047dd7018e50367",
-      "logoURI": "https://esm.sh/gh/tempoxyz/tempo-apps/apps/tokenlist/data/4217/icons/0x20c000000000000000000000f047dd7018e50367.png",
-      "extensions": {
-        "chain": "tempo",
-        "label": "BRLA",
-        "currency": "BRL",
-        "coingeckoId": "brla-digital-brla"
-      },
-      "dateAdded": "2026-06-10T15:22:01Z"
-    },
-    {
-      "name": "Agant GBP",
-      "symbol": "GBPA",
-      "decimals": 6,
-      "chainId": 4217,
-      "address": "0x20c0000000000000000000000a6da882d075a4c3",
-      "logoURI": "https://esm.sh/gh/tempoxyz/tempo-apps/apps/tokenlist/data/4217/icons/0x20c0000000000000000000000a6da882d075a4c3.svg",
-      "extensions": {
-        "chain": "tempo",
-        "label": "GBPA",
-        "currency": "GBP",
-        "coingeckoId": "agant-gbp"
-      },
-      "dateAdded": "2026-06-10T16:18:45Z"
-    }
-  ]
+	"$schema": "https://esm.sh/gh/uniswap/token-lists/src/tokenlist.schema.json",
+	"name": "Tempo Mainnet",
+	"logoURI": "https://esm.sh/gh/tempoxyz/tokenlist/data/4217/icon.svg",
+	"timestamp": "2026-06-10T16:18:45Z",
+	"version": {
+		"major": 1,
+		"minor": 3,
+		"patch": 0
+	},
+	"tokens": [
+		{
+			"name": "PathUSD",
+			"symbol": "pathUSD",
+			"decimals": 6,
+			"chainId": 4217,
+			"address": "0x20c0000000000000000000000000000000000000",
+			"logoURI": "https://esm.sh/gh/tempoxyz/tempo-apps/apps/tokenlist/data/4217/icons/0x20c0000000000000000000000000000000000000.svg",
+			"extensions": {
+				"chain": "tempo",
+				"label": "PathUSD",
+				"coingeckoId": "pathusd"
+			}
+		},
+		{
+			"name": "MPP Credits",
+			"symbol": "MPPC",
+			"decimals": 6,
+			"chainId": 4217,
+			"address": "0x20c0000000000000000000000000000000000004",
+			"extensions": {
+				"chain": "tempo",
+				"label": "MPP Credits"
+			},
+			"dateAdded": "2026-06-15T00:00:00Z"
+		},
+		{
+			"name": "Deel USD",
+			"symbol": "DLUSD",
+			"decimals": 6,
+			"chainId": 4217,
+			"address": "0x20c0000000000000000000006fd9a167923ba194",
+			"logoURI": "https://esm.sh/gh/tempoxyz/tempo-apps/apps/tokenlist/data/4217/icons/0x20c0000000000000000000006fd9a167923ba194.png",
+			"extensions": {
+				"chain": "tempo",
+				"label": "DLUSD"
+			},
+			"dateAdded": "2026-06-03T20:13:57Z"
+		},
+		{
+			"name": "Bridged USDC (Stargate)",
+			"symbol": "USDC.e",
+			"decimals": 6,
+			"chainId": 4217,
+			"address": "0x20c000000000000000000000b9537d11c60e8b50",
+			"logoURI": "https://esm.sh/gh/tempoxyz/tempo-apps/apps/tokenlist/data/4217/icons/0x20c000000000000000000000b9537d11c60e8b50.svg",
+			"extensions": {
+				"chain": "tempo",
+				"label": "USDC.e",
+				"coingeckoId": "usd-coin",
+				"bridgeInfo": {
+					"sourceChainId": 1,
+					"sourceAddress": "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48"
+				}
+			}
+		},
+		{
+			"name": "Bridged EURC (Stargate)",
+			"symbol": "EURC.e",
+			"decimals": 6,
+			"chainId": 4217,
+			"address": "0x20c0000000000000000000001621e21f71cf12fb",
+			"logoURI": "https://esm.sh/gh/tempoxyz/tempo-apps/apps/tokenlist/data/4217/icons/0x20c0000000000000000000001621e21f71cf12fb.svg",
+			"extensions": {
+				"chain": "tempo",
+				"label": "EURC",
+				"coingeckoId": "euro-coin",
+				"bridgeInfo": {
+					"sourceChainId": 1,
+					"sourceAddress": "0x1abaea1f7c830bd89acc67ec4af516284b1bc33c"
+				}
+			}
+		},
+		{
+			"name": "USDT0",
+			"symbol": "USDT0",
+			"decimals": 6,
+			"chainId": 4217,
+			"address": "0x20c00000000000000000000014f22ca97301eb73",
+			"logoURI": "https://esm.sh/gh/tempoxyz/tempo-apps/apps/tokenlist/data/4217/icons/0x20c00000000000000000000014f22ca97301eb73.svg",
+			"extensions": {
+				"chain": "tempo",
+				"coingeckoId": "usdt0",
+				"bridgeInfo": {
+					"sourceChainId": 1,
+					"sourceAddress": "0xdac17f958d2ee523a2206206994597c13d831ec7"
+				}
+			}
+		},
+		{
+			"name": "Frax USD",
+			"symbol": "frxUSD",
+			"decimals": 6,
+			"chainId": 4217,
+			"address": "0x20c0000000000000000000003554d28269e0f3c2",
+			"logoURI": "https://esm.sh/gh/tempoxyz/tempo-apps/apps/tokenlist/data/4217/icons/0x20c0000000000000000000003554d28269e0f3c2.svg",
+			"extensions": {
+				"chain": "tempo",
+				"coingeckoId": "frax-usd",
+				"bridgeInfo": {
+					"sourceChainId": 1,
+					"sourceAddress": "0xcacd6fd266af91b8aed52accc382b4e165586e29"
+				}
+			}
+		},
+		{
+			"name": "Cap USD",
+			"symbol": "cUSD",
+			"decimals": 6,
+			"chainId": 4217,
+			"address": "0x20c0000000000000000000000520792dcccccccc",
+			"logoURI": "https://esm.sh/gh/tempoxyz/tempo-apps/apps/tokenlist/data/4217/icons/0x20c0000000000000000000000520792dcccccccc.svg",
+			"extensions": {
+				"chain": "tempo",
+				"label": "cUSD",
+				"coingeckoId": "cap-usd",
+				"bridgeInfo": {
+					"sourceChainId": 1,
+					"sourceAddress": "0xcccc62962d17b8914c62d74ffb843d73b2a3cccc"
+				}
+			},
+			"dateAdded": "2026-03-11T04:44:38Z"
+		},
+		{
+			"name": "Staked Cap USD",
+			"symbol": "stcUSD",
+			"decimals": 6,
+			"chainId": 4217,
+			"address": "0x20c0000000000000000000008ee4fcff88888888",
+			"logoURI": "https://esm.sh/gh/tempoxyz/tempo-apps/apps/tokenlist/data/4217/icons/0x20c0000000000000000000008ee4fcff88888888.svg",
+			"extensions": {
+				"chain": "tempo",
+				"label": "stcUSD",
+				"coingeckoId": "staked-cap-usd",
+				"bridgeInfo": {
+					"sourceChainId": 1,
+					"sourceAddress": "0x88887be419578051ff9f4eb6c858a951921d8888"
+				}
+			},
+			"dateAdded": "2026-03-16T02:56:16Z"
+		},
+		{
+			"name": "Generic USD",
+			"symbol": "GUSD",
+			"address": "0x20c0000000000000000000005c0bac7cef389a11",
+			"decimals": 6,
+			"chainId": 4217,
+			"logoURI": "https://esm.sh/gh/tempoxyz/tempo-apps/apps/tokenlist/data/4217/icons/0x20c0000000000000000000005c0bac7cef389a11.svg",
+			"extensions": {
+				"chain": "tempo",
+				"label": "GUSD",
+				"coingeckoId": "generic-usd",
+				"bridgeInfo": {
+					"sourceChainId": 1,
+					"sourceAddress": "0xece811d35f79c4868a2b911e55d9aa0821399edf"
+				}
+			},
+			"dateAdded": "2026-03-21T05:24:26Z"
+		},
+		{
+			"name": "Reservoir Stablecoin",
+			"symbol": "rUSD",
+			"decimals": 6,
+			"chainId": 4217,
+			"address": "0x20c0000000000000000000007f7ba549dd0251b9",
+			"logoURI": "https://esm.sh/gh/tempoxyz/tempo-apps/apps/tokenlist/data/4217/icons/0x20c0000000000000000000007f7ba549dd0251b9.svg",
+			"extensions": {
+				"chain": "tempo",
+				"label": "rUSD",
+				"coingeckoId": "reservoir-rusd",
+				"bridgeInfo": {
+					"sourceChainId": 1,
+					"sourceAddress": "0x09d4214c03d01f49544c0448dbe3a27f768f2b34"
+				}
+			},
+			"dateAdded": "2026-04-02T18:36:11Z"
+		},
+		{
+			"name": "Wrapped Savings rUSD",
+			"symbol": "wsrUSD",
+			"decimals": 6,
+			"chainId": 4217,
+			"address": "0x20c000000000000000000000aeed2ec36a54d0e5",
+			"logoURI": "https://esm.sh/gh/tempoxyz/tempo-apps/apps/tokenlist/data/4217/icons/0x20c000000000000000000000aeed2ec36a54d0e5.svg",
+			"extensions": {
+				"chain": "tempo",
+				"label": "wsrUSD",
+				"bridgeInfo": {
+					"sourceChainId": 1,
+					"sourceAddress": "0xd3fd63209fa2d55b07a0f6db36c2f43900be3094"
+				}
+			},
+			"dateAdded": "2026-04-02T18:36:11Z"
+		},
+		{
+			"name": "AllUnity EUR",
+			"symbol": "EURAU",
+			"decimals": 6,
+			"chainId": 4217,
+			"address": "0x20c0000000000000000000009a4a4b17e0dc6651",
+			"logoURI": "https://esm.sh/gh/tempoxyz/tempo-apps/apps/tokenlist/data/4217/icons/0x20c0000000000000000000009a4a4b17e0dc6651.svg",
+			"extensions": {
+				"chain": "tempo",
+				"label": "EURAU",
+				"coingeckoId": "allunity-eur"
+			},
+			"dateAdded": "2026-04-02T18:36:11Z"
+		},
+		{
+			"name": "AllUnity CHF",
+			"symbol": "CHFAU",
+			"decimals": 6,
+			"chainId": 4217,
+			"address": "0x20c00000000000000000000042109aef2f8b28e1",
+			"logoURI": "https://esm.sh/gh/tempoxyz/tempo-apps/apps/tokenlist/data/4217/icons/0x20c00000000000000000000042109aef2f8b28e1.png",
+			"extensions": {
+				"chain": "tempo",
+				"label": "CHFAU",
+				"currency": "CHF",
+				"coingeckoId": "allunity-chf"
+			},
+			"dateAdded": "2026-06-09T14:44:13Z"
+		},
+		{
+			"name": "Re Protocol reUSD",
+			"symbol": "reUSD",
+			"decimals": 6,
+			"chainId": 4217,
+			"address": "0x20c000000000000000000000383a23bacb546ab9",
+			"logoURI": "https://esm.sh/gh/tempoxyz/tempo-apps/apps/tokenlist/data/4217/icons/0x20c000000000000000000000383a23bacb546ab9.svg",
+			"extensions": {
+				"chain": "tempo",
+				"label": "reUSD",
+				"coingeckoId": "re-protocol-reusd",
+				"bridgeInfo": {
+					"sourceChainId": 1,
+					"sourceAddress": "0x5086bf358635b81d8c47c66d1c8b9e567db70c72"
+				}
+			},
+			"dateAdded": "2026-04-06T23:13:41Z"
+		},
+		{
+			"name": "InfiniFi USD",
+			"symbol": "iUSD",
+			"decimals": 6,
+			"chainId": 4217,
+			"address": "0x20c000000000000000000000ab02d39df30bd17e",
+			"logoURI": "https://esm.sh/gh/tempoxyz/tempo-apps/apps/tokenlist/data/4217/icons/0x20c000000000000000000000ab02d39df30bd17e.svg",
+			"extensions": {
+				"chain": "tempo",
+				"label": "iUSD",
+				"coingeckoId": "infinifi-usd",
+				"bridgeInfo": {
+					"sourceChainId": 1,
+					"sourceAddress": "0x48f9e38f3070ad8945dfeae3fa70987722e3d89c"
+				}
+			},
+			"dateAdded": "2026-04-14T04:51:53Z"
+		},
+		{
+			"name": "InfiniFi Staked USD",
+			"symbol": "siUSD",
+			"decimals": 6,
+			"chainId": 4217,
+			"address": "0x20c000000000000000000000048c8f36df1c9a4a",
+			"logoURI": "https://esm.sh/gh/tempoxyz/tempo-apps/apps/tokenlist/data/4217/icons/0x20c000000000000000000000048c8f36df1c9a4a.svg",
+			"extensions": {
+				"chain": "tempo",
+				"label": "siUSD",
+				"coingeckoId": "infinifi-staked-iusd",
+				"bridgeInfo": {
+					"sourceChainId": 1,
+					"sourceAddress": "0xdbdc1ef57537e34680b898e1febd3d68c7389bcb"
+				}
+			},
+			"dateAdded": "2026-04-14T04:51:53Z"
+		},
+		{
+			"name": "USDe",
+			"symbol": "USDe",
+			"decimals": 6,
+			"chainId": 4217,
+			"address": "0x20c0000000000000000000002f52d5cc21a3207b",
+			"logoURI": "https://esm.sh/gh/tempoxyz/tempo-apps/apps/tokenlist/data/4217/icons/0x20c0000000000000000000002f52d5cc21a3207b.svg",
+			"extensions": {
+				"chain": "tempo",
+				"label": "USDe",
+				"coingeckoId": "ethena-usde",
+				"bridgeInfo": {
+					"sourceChainId": 1,
+					"sourceAddress": "0x4c9edd5852cd905f086c759e8383e09bff1e68b3"
+				}
+			},
+			"dateAdded": "2026-04-14T04:51:53Z"
+		},
+		{
+			"name": "Staked USDe",
+			"symbol": "sUSDe",
+			"decimals": 6,
+			"chainId": 4217,
+			"address": "0x20c000000000000000000000bd95bfb69fbe6ce3",
+			"logoURI": "https://esm.sh/gh/tempoxyz/tempo-apps/apps/tokenlist/data/4217/icons/0x20c000000000000000000000bd95bfb69fbe6ce3.svg",
+			"extensions": {
+				"chain": "tempo",
+				"coingeckoId": "ethena-staked-usde",
+				"bridgeInfo": {
+					"sourceChainId": 1,
+					"sourceAddress": "0x9d39a5de30e57443bff2a8307a4256c8797a3497"
+				}
+			},
+			"dateAdded": "2026-04-14T04:51:53Z"
+		},
+		{
+			"name": "Stable Coin",
+			"symbol": "SBC",
+			"decimals": 6,
+			"chainId": 4217,
+			"address": "0x20c000000000000000000000ae247a1130450f09",
+			"logoURI": "https://esm.sh/gh/tempoxyz/tempo-apps/apps/tokenlist/data/4217/icons/0x20c000000000000000000000ae247a1130450f09.svg",
+			"extensions": {
+				"chain": "tempo",
+				"label": "SBC",
+				"coingeckoId": "stable-coin-2"
+			},
+			"dateAdded": "2026-04-14T17:12:36Z"
+		},
+		{
+			"name": "Syrup USDC",
+			"symbol": "syrupUSDC",
+			"decimals": 6,
+			"chainId": 4217,
+			"address": "0x20c0000000000000000000008191667423f70e67",
+			"logoURI": "https://esm.sh/gh/tempoxyz/tempo-apps/apps/tokenlist/data/4217/icons/0x20c0000000000000000000008191667423f70e67.svg",
+			"extensions": {
+				"chain": "tempo",
+				"label": "syrupUSDC",
+				"coingeckoId": "syrup-USDC",
+				"bridgeInfo": {
+					"sourceChainId": 1,
+					"sourceAddress": "0x80ac24aa929eaf5013f6436cda2a7ba190f5cc0b"
+				}
+			},
+			"dateAdded": "2026-05-06T19:33:19Z"
+		},
+		{
+			"name": "Coinbase Wrapped BTC",
+			"symbol": "cbBTC",
+			"decimals": 6,
+			"chainId": 4217,
+			"address": "0x20c000000000000000000000c412ec89d0c08be5",
+			"logoURI": "https://static-assets.coinbase.com/marketing/wrapped-assets/cbbtc.svg",
+			"extensions": {
+				"chain": "tempo",
+				"label": "cbBTC",
+				"coingeckoId": "coinbase-wrapped-btc",
+				"bridgeInfo": {
+					"sourceChainId": 8453,
+					"sourceAddress": "0xcbb7c0000ab88b473b1f5afd9ef808440eed33bf"
+				}
+			},
+			"dateAdded": "2026-05-08T18:42:44Z"
+		},
+		{
+			"name": "USDBridge",
+			"symbol": "USDB",
+			"address": "0x20c0000000000000000000003158081efd85bfc2",
+			"decimals": 6,
+			"chainId": 4217,
+			"logoURI": "https://esm.sh/gh/tempoxyz/tempo-apps/apps/tokenlist/data/4217/icons/0x20c0000000000000000000003158081efd85bfc2.svg",
+			"extensions": {
+				"chain": "tempo",
+				"label": "USDB"
+			},
+			"dateAdded": "2026-05-12T02:30:31Z"
+		},
+		{
+			"name": "USD1",
+			"symbol": "USD1",
+			"decimals": 6,
+			"chainId": 4217,
+			"address": "0x20c000000000000000000000111111111e910f0f",
+			"logoURI": "https://static.worldlibertyfinancial.com/assets/brand/usd1.svg",
+			"extensions": {
+				"chain": "tempo",
+				"coingeckoId": "usd1-wlfi"
+			},
+			"dateAdded": "2026-05-12T15:17:32Z"
+		},
+		{
+			"name": "BRLA Token",
+			"symbol": "BRLA",
+			"decimals": 6,
+			"chainId": 4217,
+			"address": "0x20c000000000000000000000f047dd7018e50367",
+			"logoURI": "https://esm.sh/gh/tempoxyz/tempo-apps/apps/tokenlist/data/4217/icons/0x20c000000000000000000000f047dd7018e50367.png",
+			"extensions": {
+				"chain": "tempo",
+				"label": "BRLA",
+				"currency": "BRL",
+				"coingeckoId": "brla-digital-brla"
+			},
+			"dateAdded": "2026-06-10T15:22:01Z"
+		},
+		{
+			"name": "Agant GBP",
+			"symbol": "GBPA",
+			"decimals": 6,
+			"chainId": 4217,
+			"address": "0x20c0000000000000000000000a6da882d075a4c3",
+			"logoURI": "https://esm.sh/gh/tempoxyz/tempo-apps/apps/tokenlist/data/4217/icons/0x20c0000000000000000000000a6da882d075a4c3.svg",
+			"extensions": {
+				"chain": "tempo",
+				"label": "GBPA",
+				"currency": "GBP",
+				"coingeckoId": "agant-gbp"
+			},
+			"dateAdded": "2026-06-10T16:18:45Z"
+		}
+	]
 }

--- a/apps/tokenlist/data/42431/tokenlist.json
+++ b/apps/tokenlist/data/42431/tokenlist.json
@@ -5,8 +5,8 @@
 	"timestamp": "2026-03-30T16:28:11Z",
 	"version": {
 		"major": 1,
-		"minor": 1,
-		"patch": 2
+		"minor": 2,
+		"patch": 0
 	},
 	"tokens": [
 		{
@@ -20,6 +20,18 @@
 				"chain": "tempo",
 				"label": "PathUSD"
 			}
+		},
+		{
+			"name": "MPP Credits",
+			"symbol": "MPPC",
+			"decimals": 6,
+			"chainId": 42431,
+			"address": "0x20c0000000000000000000000000000000000004",
+			"extensions": {
+				"chain": "tempo",
+				"label": "MPP Credits"
+			},
+			"dateAdded": "2026-06-15T00:00:00Z"
 		},
 		{
 			"name": "AlphaUSD",


### PR DESCRIPTION
## Summary
- Add MPP Credits (`MPPC`) entries to the Tempo devnet, testnet, and mainnet token lists.
- Bump each token list version for the added token.

## TODO
- Confirm or replace the provisional reserved TIP-20 address (`0x20c0000000000000000000000000000000000004`) once the MPP Credits TIP-20 is created.
- Add a token logo asset after the final TIP-20 address is confirmed.

## Validation
- `pnpm --filter tokenlist check`
- `pnpm --filter tokenlist test --run`

Prompted by: @alexrisch