### PR TITLE
Add PostHog analytics to Tempo MCP server

### DIFF
--- a/apps/mcp-docs-indexer/.env.example
+++ b/apps/mcp-docs-indexer/.env.example
@@ -10,4 +10,7 @@
 # Vars:
 #   - AI_SEARCH_INSTANCE_ID  (default: tempo-global)
 #   - AI_SEARCH_MCP_URL      (AI Search MCP endpoint proxied by this Worker)
+#   - POSTHOG_HOST           (default: https://us.i.posthog.com)
 #   - SOURCES                (configured as JSON in wrangler.jsonc)
+# Secrets:
+#   - POSTHOG_PROJECT_API_KEY  (optional; enables MCP analytics)

--- a/apps/mcp-docs-indexer/src/index.ts
+++ b/apps/mcp-docs-indexer/src/index.ts
@@ -2,6 +2,7 @@ import { env } from 'cloudflare:workers'
 import { syncSource } from './lib/ingest.js'
 import { log } from './lib/log.js'
 import { handleMcp } from './lib/mcp.js'
+import { captureMcpAnalytics, parseJsonRpcRequest } from './lib/posthog-mcp.js'
 import { proxyMcp } from './lib/proxy.js'
 import { isForcedHour } from './lib/schedule.js'
 import { parseSources } from './lib/sources.js'
@@ -11,12 +12,16 @@ let cachedSourcesKey: string | undefined
 let cachedSources: Source[] | undefined
 
 export default {
-	async fetch(req) {
+	async fetch(req, env, ctx) {
+		const jsonRpcRequest = await parseJsonRpcRequest(req)
 		const response = await handleMcp(req, {
 			instance: env.AI_SEARCH.get(env.AI_SEARCH_INSTANCE_ID),
 			sources: sourcesFor(env.SOURCES),
 		})
-		if (response) return response
+		if (response) {
+			captureMcpAnalytics(req, jsonRpcRequest, response, env, ctx)
+			return response
+		}
 		return proxyMcp(req, env.AI_SEARCH_MCP_URL)
 	},
 	async scheduled(event) {

--- a/apps/mcp-docs-indexer/src/lib/mcp.test.ts
+++ b/apps/mcp-docs-indexer/src/lib/mcp.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { handleMcp } from './mcp.js'
+import { captureMcpAnalytics, parseJsonRpcRequest } from './posthog-mcp.js'
 import type { Source } from './sources.js'
 
 function instance(
@@ -1489,6 +1490,94 @@ Was this helpful?`,
 		)
 
 		expect(res).toBeUndefined()
+	})
+})
+
+describe('captureMcpAnalytics', () => {
+	it('does nothing without a PostHog project key', async () => {
+		const fetch = vi.fn()
+		vi.stubGlobal('fetch', fetch)
+		const ctx = { waitUntil: vi.fn() } as unknown as ExecutionContext
+		const req = new Request('https://mcp.tempo.xyz/', {
+			method: 'POST',
+			body: JSON.stringify({
+				jsonrpc: '2.0',
+				id: 1,
+				method: 'tools/list',
+			}),
+		})
+		const body = await parseJsonRpcRequest(req)
+
+		captureMcpAnalytics(
+			req,
+			body,
+			new Response(JSON.stringify({ jsonrpc: '2.0', id: 1, result: {} })),
+			{},
+			ctx,
+		)
+
+		expect(ctx.waitUntil).not.toHaveBeenCalled()
+		expect(fetch).not.toHaveBeenCalled()
+	})
+
+	it('captures redacted tool-call analytics when configured', async () => {
+		const fetch = vi.fn().mockResolvedValue(new Response('{}'))
+		vi.stubGlobal('fetch', fetch)
+		const waitUntil = vi.fn((promise: Promise<unknown>) => promise)
+		const ctx = { waitUntil } as unknown as ExecutionContext
+		const req = new Request('https://mcp.tempo.xyz/', {
+			method: 'POST',
+			headers: { 'mcp-session-id': 'session-1' },
+			body: JSON.stringify({
+				jsonrpc: '2.0',
+				id: 2,
+				method: 'tools/call',
+				params: {
+					name: 'search',
+					arguments: {
+						query: 'tempo docs',
+						api_key: 'secret',
+					},
+				},
+			}),
+		})
+		const body = await parseJsonRpcRequest(req)
+
+		captureMcpAnalytics(
+			req,
+			body,
+			new Response(
+				JSON.stringify({
+					jsonrpc: '2.0',
+					id: 2,
+					result: { content: [{ type: 'text', text: 'ok' }] },
+				}),
+			),
+			{ POSTHOG_PROJECT_API_KEY: 'phc_test' },
+			ctx,
+		)
+
+		await waitUntil.mock.calls[0][0]
+		expect(fetch).toHaveBeenCalledWith(
+			'https://us.i.posthog.com/capture/',
+			expect.objectContaining({
+				method: 'POST',
+			}),
+		)
+		const payload = JSON.parse(fetch.mock.calls[0][1].body)
+		expect(payload).toMatchObject({
+			api_key: 'phc_test',
+			event: '$mcp_tool_call',
+			distinct_id: 'session-1',
+		})
+		expect(payload.properties).toMatchObject({
+			$session_id: 'session-1',
+			$mcp_tool_name: 'search',
+			$mcp_parameters: {
+				query: 'tempo docs',
+				api_key: '[redacted]',
+			},
+		})
 	})
 })
 

--- a/apps/mcp-docs-indexer/src/lib/posthog-mcp.ts
+++ b/apps/mcp-docs-indexer/src/lib/posthog-mcp.ts
@@ -1,0 +1,224 @@
+type JsonRpcRequest = {
+	id?: string | number | null
+	method?: string
+	params?: {
+		name?: string
+		arguments?: unknown
+		uri?: unknown
+		_meta?: {
+			progressToken?: string | number
+		}
+	}
+}
+
+type JsonRpcResponse = {
+	result?: unknown
+	error?: {
+		code?: number
+		message?: string
+		data?: unknown
+	}
+}
+
+type PostHogEnv = {
+	POSTHOG_PROJECT_API_KEY?: string
+	POSTHOG_HOST?: string
+}
+
+const DEFAULT_POSTHOG_HOST = 'https://us.i.posthog.com'
+const MAX_PROPERTY_CHARS = 8000
+const REDACTED = '[redacted]'
+const SENSITIVE_KEY_PATTERN =
+	/(api[_-]?key|authorization|cookie|credential|password|secret|token)/i
+
+export function captureMcpAnalytics(
+	req: Request,
+	body: JsonRpcRequest | undefined,
+	response: Response,
+	env: PostHogEnv,
+	ctx: ExecutionContext,
+): void {
+	if (!env.POSTHOG_PROJECT_API_KEY || !body?.method) return
+
+	ctx.waitUntil(
+		captureMcpAnalyticsAsync(req, body, response, env).catch(() => undefined),
+	)
+}
+
+export async function parseJsonRpcRequest(
+	req: Request,
+): Promise<JsonRpcRequest | undefined> {
+	if (req.method !== 'POST') return undefined
+	try {
+		return (await req.clone().json()) as JsonRpcRequest
+	} catch {
+		return undefined
+	}
+}
+
+async function captureMcpAnalyticsAsync(
+	req: Request,
+	body: JsonRpcRequest,
+	response: Response,
+	env: PostHogEnv,
+): Promise<void> {
+	if (!env.POSTHOG_PROJECT_API_KEY || !body.method) return
+	const responseBody = await parseJsonRpcResponse(response)
+	const event = eventFor(body.method)
+	if (!event) return
+
+	const isError =
+		Boolean(responseBody?.error) || resultIsError(responseBody?.result)
+	const sessionId = sessionIdFor(req, body)
+	const properties: Record<string, unknown> = {
+		$process_person_profile: false,
+		$mcp_method: body.method,
+		$mcp_request_id: body.id ?? null,
+		$mcp_is_error: isError,
+		mcp_server: 'tempo-docs-indexer',
+	}
+
+	if (sessionId) properties.$session_id = sessionId
+	if (body.method === 'tools/call') {
+		properties.$mcp_tool_name = body.params?.name
+		properties.$mcp_parameters = sanitize(body.params?.arguments)
+		properties.$mcp_response = sanitize(responseBody?.result)
+	}
+	if (body.method === 'tools/list') {
+		properties.$mcp_tools = toolsFrom(responseBody?.result)
+	}
+	if (body.method === 'initialize') {
+		const clientInfo = (
+			body.params as { clientInfo?: { name?: unknown; version?: unknown } }
+		)?.clientInfo
+		properties.$mcp_client_name = clientInfo?.name
+		properties.$mcp_client_version = clientInfo?.version
+	}
+	if (body.method === 'resources/read') {
+		properties.$mcp_resource_uri = body.params?.uri
+		properties.$mcp_response = sanitize(responseBody?.result)
+	}
+	if (body.method === 'resources/list') {
+		properties.$mcp_resources = resourcesFrom(responseBody?.result)
+	}
+	if (responseBody?.error) {
+		properties.$mcp_error = sanitize(responseBody.error)
+	}
+
+	await posthogCapture(env, {
+		api_key: env.POSTHOG_PROJECT_API_KEY,
+		event,
+		distinct_id: sessionId ?? 'anonymous',
+		properties: sanitize(properties),
+	})
+}
+
+async function parseJsonRpcResponse(
+	response: Response,
+): Promise<JsonRpcResponse | undefined> {
+	try {
+		const text = await response.clone().text()
+		const payload = text.startsWith('event: message')
+			? text.match(/^data: (.*)$/m)?.[1]
+			: text
+		if (!payload) return undefined
+		return JSON.parse(payload) as JsonRpcResponse
+	} catch {
+		return undefined
+	}
+}
+
+function eventFor(method: string): string | undefined {
+	if (method === 'initialize') return '$mcp_initialize'
+	if (method === 'tools/list') return '$mcp_tools_list'
+	if (method === 'tools/call') return '$mcp_tool_call'
+	if (method === 'resources/list') return '$mcp_resources_list'
+	if (method === 'resources/read') return '$mcp_resource_read'
+	if (method === 'resources/templates/list')
+		return '$mcp_resource_templates_list'
+	return undefined
+}
+
+function resultIsError(result: unknown): boolean {
+	return (
+		typeof result === 'object' &&
+		result !== null &&
+		'isError' in result &&
+		(result as { isError?: unknown }).isError === true
+	)
+}
+
+function sessionIdFor(req: Request, body: JsonRpcRequest): string | undefined {
+	const progressToken = body.params?._meta?.progressToken
+	return (
+		req.headers.get('mcp-session-id') ??
+		req.headers.get('x-mcp-session-id') ??
+		(progressToken === undefined ? undefined : String(progressToken)) ??
+		undefined
+	)
+}
+
+function toolsFrom(result: unknown): unknown {
+	if (typeof result !== 'object' || result === null || !('tools' in result)) {
+		return undefined
+	}
+	return (result as { tools?: unknown[] }).tools?.map((tool) => {
+		if (typeof tool !== 'object' || tool === null) return tool
+		const named = tool as { name?: unknown; description?: unknown }
+		return { name: named.name, description: named.description }
+	})
+}
+
+function resourcesFrom(result: unknown): unknown {
+	if (
+		typeof result !== 'object' ||
+		result === null ||
+		!('resources' in result)
+	) {
+		return undefined
+	}
+	return (result as { resources?: unknown[] }).resources?.map((resource) => {
+		if (typeof resource !== 'object' || resource === null) return resource
+		const named = resource as { uri?: unknown; name?: unknown }
+		return { uri: named.uri, name: named.name }
+	})
+}
+
+function sanitize(value: unknown, depth = 0): unknown {
+	if (depth > 8) return '[truncated]'
+	if (value == null) return value
+	if (typeof value === 'string') return truncate(value)
+	if (typeof value !== 'object') return value
+	if (Array.isArray(value)) {
+		return value.slice(0, 50).map((item) => sanitize(item, depth + 1))
+	}
+
+	const result: Record<string, unknown> = {}
+	for (const [key, child] of Object.entries(value)) {
+		result[key] = SENSITIVE_KEY_PATTERN.test(key)
+			? REDACTED
+			: sanitize(child, depth + 1)
+	}
+	return result
+}
+
+function truncate(value: string): string {
+	if (value.length <= MAX_PROPERTY_CHARS) return value
+	return `${value.slice(0, MAX_PROPERTY_CHARS)}...[truncated]`
+}
+
+async function posthogCapture(
+	env: PostHogEnv,
+	payload: {
+		api_key: string
+		event: string
+		distinct_id: string
+		properties: unknown
+	},
+): Promise<void> {
+	await fetch(`${env.POSTHOG_HOST ?? DEFAULT_POSTHOG_HOST}/capture/`, {
+		method: 'POST',
+		headers: { 'content-type': 'application/json' },
+		body: JSON.stringify(payload),
+	})
+}

--- a/apps/mcp-docs-indexer/wrangler.jsonc
+++ b/apps/mcp-docs-indexer/wrangler.jsonc
@@ -42,6 +42,9 @@
 		// transparently proxy mcp.tempo.xyz -> this upstream so clients
 		// connect to a stable branded URL instead of the opaque hostname.
 		"AI_SEARCH_MCP_URL": "https://99c10de8-0264-4978-8212-176265f5de96.search.ai.cloudflare.com/mcp",
+		// PostHog host for MCP analytics. Set POSTHOG_PROJECT_API_KEY as a
+		// Worker secret to enable event capture.
+		"POSTHOG_HOST": "https://us.i.posthog.com",
 		// Docs sources to sync. Add sources here instead of changing Worker code.
 		// `indexPath` defaults to `/llms.txt`.
 		"SOURCES": [


### PR DESCRIPTION
## Summary
- Add opt-in PostHog MCP analytics capture for the mcp-docs-indexer Worker
- Capture local MCP initialize, tools/list, tools/call, resources/list, resource template list, and resources/read responses
- Redact sensitive argument/property keys and flush capture work through Cloudflare ctx.waitUntil

Prompted by: @brendanjryan

## Tests
- pnpm --filter mcp-docs-indexer check:biome
- pnpm --filter mcp-docs-indexer test
- pnpm --filter mcp-docs-indexer check:types