### PR TITLE
fix(explorer): resolve mainnet env for bare explore.tempo.xyz domain

### DIFF
--- a/apps/explorer/src/lib/env.ts
+++ b/apps/explorer/src/lib/env.ts
@@ -24,7 +24,8 @@ export function inferTempoEnvFromHostname(
 		host.includes('explorer-mainnet') ||
 		host.includes('explore.mainnet.') ||
 		host.includes('explore.presto.') ||
-		host.includes('explore.4217.')
+		host.includes('explore.4217.') ||
+		host === 'explore.tempo.xyz'
 	) {
 		return 'mainnet'
 	}


### PR DESCRIPTION
## Problem

`https://explore.tempo.xyz/` renders as **Testnet**.

The worker for `explore.tempo.xyz` is correctly wired to the `mainnet` env in `wrangler.json`, but the app resolves its active env from the **hostname** via `getTempoEnv()` in `apps/explorer/src/lib/env.ts`:

1. infer env from hostname, else
2. fall back to the build-time `VITE_TEMPO_ENV`.

`inferTempoEnvFromHostname` matched mainnet only on `explore.mainnet.`, `explore.presto.`, `explore.4217.`, and `explorer-mainnet` — **not** the canonical bare domain `explore.tempo.xyz`. So that host returned `undefined` and fell back to the baked `VITE_TEMPO_ENV`, which in the deployed bundle is `"testnet"` (`normalizeTempoEnv` also defaults unknowns to `testnet`).

Verified the live JS bundle contains `VITE_TEMPO_ENV:"testnet"`.

## Fix

Recognize the bare production domain `explore.tempo.xyz` as `mainnet` in `inferTempoEnvFromHostname`, so it resolves correctly on both client and server regardless of the baked build value.

## Notes

There is also a latent deploy bug: `predeploy` runs `build.sh` but `--env mainnet` isn't forwarded to it (npm doesn't pass args to pre-scripts, likely why the mainnet build baked . Not addressed here — happy to follow up.
