### PR TITLE
Add missing docs MCP sources

### DIFF
--- a/apps/mcp-docs-indexer/src/lib/llms-txt.test.ts
+++ b/apps/mcp-docs-indexer/src/lib/llms-txt.test.ts
@@ -35,6 +35,19 @@ describe('parseLlmsTxt', () => {
 		])
 	})
 
+	it('extracts TIP pages from the tips.sh root index', () => {
+		const body = `
+- **TIP-0000**: TIP Process (Approved)
+- **TIP-1026**: Token Logo URI (Approved)
+- **TIP-1061-1**: Native Multisig Accounts (Draft)
+`
+		expect(parseLlmsTxt(body, 'https://tips.sh')).toEqual([
+			'https://tips.sh/0000.md',
+			'https://tips.sh/1026.md',
+			'https://tips.sh/1061-1.md',
+		])
+	})
+
 	it('drops off-origin links', () => {
 		const body = '- [In](/in)\n- [Out](https://other.example.com/out)'
 		expect(parseLlmsTxt(body, 'https://viem.sh')).toEqual([

--- a/apps/mcp-docs-indexer/src/lib/llms-txt.ts
+++ b/apps/mcp-docs-indexer/src/lib/llms-txt.ts
@@ -15,6 +15,8 @@ export function parseLlmsTxt(body: string, base: string): string[] {
 		const match = line.match(/^\s*[-*]\s+(https?:\/\/\S+|\/\S+)/)
 		const raw = match?.[1]?.replace(/:$/, '')
 		addUrl(urls, raw, origin)
+		const tip = line.match(/^\s*[-*]\s+\*\*TIP-(\d{4}(?:-\d+)?)\*\*:/)
+		addUrl(urls, tip ? `/${tip[1]}.md` : undefined, origin)
 	}
 	return [...urls]
 }

--- a/apps/mcp-docs-indexer/wrangler.jsonc
+++ b/apps/mcp-docs-indexer/wrangler.jsonc
@@ -74,6 +74,17 @@
 				"description": "Machine Payments Protocol documentation"
 			},
 			{
+				"id": "accounts",
+				"base": "https://accounts.tempo.xyz",
+				"description": "Tempo Accounts SDK documentation"
+			},
+			{
+				"id": "tips",
+				"base": "https://tips.sh",
+				"indexPath": "/",
+				"description": "Tempo Improvement Proposals"
+			},
+			{
 				"id": "regen",
 				"base": "https://regen.tempo.xyz",
 				"description": "Tempo Regen UI component documentation"


### PR DESCRIPTION
## Summary
- Add `tips.sh` to the MCP docs indexer source config.
- Add `accounts.tempo.xyz` after auditing major Tempo docs surfaces for missing `llms.txt` coverage.
- Teach the index parser to extract TIP page URLs from the `tips.sh` root Markdown index because `https://tips.sh/llms.txt` currently returns 500.

## Audit notes
- `accounts.tempo.xyz/llms.txt` is valid and was not indexed.
- `tokenlist.tempo.xyz/llms.txt` returns 404, so it was not added.
- `explorer.tempo.xyz/llms.txt` redirects instead of exposing a docs index, so it was not added.

## Validation
- `pnpm --filter mcp-docs-indexer test`
- `pnpm --filter mcp-docs-indexer check:biome`
- `pnpm --filter mcp-docs-indexer check:types`
- Live parse check: `https://tips.sh/` parses to 62 TIP page URLs.

Prompted by: @brendanjryan