### PR TITLE
fix: correct address history pagination counts

### DIFF
--- a/apps/explorer/src/lib/server/address-history.ts
+++ b/apps/explorer/src/lib/server/address-history.ts
@@ -21,6 +21,7 @@ import {
 } from '#lib/server/build-tx-only-transactions'
 import {
 	fetchAddressDirectTxHistoryRows,
+	fetchAddressHistoryDistinctCount,
 	fetchAddressHistoryTxDetailsByHashes,
 	fetchAddressLogRowsByTxHashes,
 	fetchAddressReceiptRowsByHashes,
@@ -372,7 +373,25 @@ export async function fetchAddressHistoryData(params: {
 			transferResult.length >= bufferSize ||
 			emittedResult.length >= bufferSize
 
-		const countResult = {
+		const shouldFetchDistinctCount =
+			anySourceHitLimit && !statusFilter && after == null
+		const distinctCountResult = shouldFetchDistinctCount
+			? await fetchAddressHistoryDistinctCount({
+					address,
+					chainId,
+					includeSent,
+					includeReceived,
+					includeTxs: sources.txs,
+					includeTransfers: sources.transfers,
+					includeEmitted: sources.emitted,
+					countCap: HISTORY_COUNT_MAX,
+				}).catch((error) => {
+					console.error('[history] failed to fetch distinct count:', error)
+					return null
+				})
+			: null
+
+		const countResult = distinctCountResult ?? {
 			count: allHashes.size,
 			capped: anySourceHitLimit,
 		}
@@ -404,7 +423,11 @@ export async function fetchAddressHistoryData(params: {
 		}
 
 		const paginatedHashes = sortedHashes.slice(offset, offset + fetchSize)
-		hasMore = paginatedHashes.length > limit
+		hasMore = distinctCountResult
+			? distinctCountResult.capped ||
+				distinctCountResult.count >
+					offset + Math.min(limit, paginatedHashes.length)
+			: paginatedHashes.length > limit
 		finalHashes = hasMore ? paginatedHashes.slice(0, limit) : paginatedHashes
 
 		if (statusFilter) {

--- a/apps/explorer/src/lib/server/tempo-queries.ts
+++ b/apps/explorer/src/lib/server/tempo-queries.ts
@@ -28,6 +28,10 @@ function indexedAddresses(addresses: Address.Address[]): Address.Address[] {
 	return addresses.map(indexedAddress)
 }
 
+function indexedAddressTopic(address: Address.Address): Hex.Hex {
+	return `0x${address.toLowerCase().replace(/^0x/, '').padStart(64, '0')}` as Hex.Hex
+}
+
 export type TokenHolderBalance = { address: string; balance: bigint }
 
 type TokenHolderAggregationRow = {
@@ -720,51 +724,74 @@ export async function fetchAddressTransferEmittedDistinctCount(params: {
 export async function fetchAddressHistoryDistinctCount(
 	params: AddressHistoryCountParams,
 ): Promise<{ count: number; capped: boolean }> {
-	const [directCount, transferCount, emittedCount] = await Promise.all([
-		params.includeTxs
-			? fetchAddressDirectTxCount({
-					address: params.address,
-					chainId: params.chainId,
-					includeSent: params.includeSent,
-					includeReceived: params.includeReceived,
-					countCap: params.countCap,
-				})
-			: 0,
-		params.includeTransfers
-			? fetchAddressTransferDistinctCount({
-					address: params.address,
-					chainId: params.chainId,
-					includeSent: params.includeSent,
-					includeReceived: params.includeReceived,
-					countCap: params.countCap,
-				}).catch((error) => {
-					console.error('[tidx] transfer count query failed:', error)
-					return 0
-				})
-			: 0,
-		params.includeEmitted
-			? fetchAddressTransferEmittedDistinctCount({
-					address: params.address,
-					chainId: params.chainId,
-					countCap: params.countCap,
-				}).catch((error) => {
-					console.error('[tidx] emitted count query failed:', error)
-					return 0
-				})
-			: 0,
-	])
+	const address = indexedAddress(params.address)
+	const addressTopic = indexedAddressTopic(params.address)
+	const sourceQueries: string[] = []
 
-	const total = Math.min(
-		directCount + transferCount + emittedCount,
-		params.countCap,
-	)
-	const capped =
-		total >= params.countCap ||
-		directCount >= params.countCap ||
-		transferCount >= params.countCap ||
-		emittedCount >= params.countCap
+	if (params.includeTxs) {
+		const directFilters =
+			params.includeSent && params.includeReceived
+				? [`(txs."from" = '${address}' OR txs."to" = '${address}')`]
+				: params.includeSent
+					? [`txs."from" = '${address}'`]
+					: [`txs."to" = '${address}'`]
 
-	return { count: total, capped }
+		sourceQueries.push(`
+			SELECT txs.hash AS tx_hash
+			FROM txs
+			WHERE ${directFilters.join(' AND ')}
+		`)
+	}
+
+	if (params.includeTransfers) {
+		const transferFilters = [`logs.topic0 = '${TRANSFER_TOPIC0}'`]
+		if (params.includeSent && params.includeReceived) {
+			transferFilters.push(
+				`(logs.topic1 = '${addressTopic}' OR logs.topic2 = '${addressTopic}')`,
+			)
+		} else if (params.includeSent) {
+			transferFilters.push(`logs.topic1 = '${addressTopic}'`)
+		} else {
+			transferFilters.push(`logs.topic2 = '${addressTopic}'`)
+		}
+
+		sourceQueries.push(`
+			SELECT logs.tx_hash AS tx_hash
+			FROM logs
+			WHERE ${transferFilters.join(' AND ')}
+		`)
+	}
+
+	if (params.includeEmitted) {
+		sourceQueries.push(`
+			SELECT logs.tx_hash AS tx_hash
+			FROM logs
+			WHERE logs.topic0 = '${TRANSFER_TOPIC0}'
+				AND logs.address = '${address}'
+		`)
+	}
+
+	if (sourceQueries.length === 0) return { count: 0, capped: false }
+
+	const result = await tidx.fetch({
+		chainId: params.chainId,
+		query: `
+			SELECT count(*) AS count
+			FROM (
+				SELECT DISTINCT tx_hash
+				FROM (
+					${sourceQueries.join('\nUNION ALL\n')}
+				) AS matches
+				LIMIT ${params.countCap}
+			) AS capped
+		` as string,
+	})
+
+	const count = Number(result.rows[0]?.count ?? 0)
+	return {
+		count,
+		capped: count >= params.countCap,
+	}
 }
 
 export type TxDataRow = {
@@ -1392,8 +1419,7 @@ export async function fetchVirtualAddressTransferAggregate(
 	oldestTimestamp?: unknown
 	latestTimestamp?: unknown
 }> {
-	const topicAddress =
-		`0x${address.toLowerCase().replace(/^0x/, '').padStart(64, '0')}` as Hex.Hex
+	const topicAddress = indexedAddressTopic(address)
 
 	const fetchBoundary = async (
 		column: 'topic1' | 'topic2',

--- a/apps/explorer/test/tempo-queries.test.ts
+++ b/apps/explorer/test/tempo-queries.test.ts
@@ -1096,9 +1096,8 @@ describe('tempo-queries', () => {
 		).resolves.toBe(2)
 	})
 
-	it('fetchAddressHistoryDistinctCount sums counts and caps', async () => {
-		mockTidx.setResponses([[{ count: 5 }]])
-		mockQueryBuilder.setResponses([{ count: 4 }, { count: 3 }])
+	it('fetchAddressHistoryDistinctCount counts the capped distinct hash union', async () => {
+		mockTidx.setResponses([[{ count: 10 }]])
 
 		await expect(
 			fetchAddressHistoryDistinctCount({
@@ -1112,6 +1111,11 @@ describe('tempo-queries', () => {
 				countCap: 10,
 			}),
 		).resolves.toEqual({ count: 10, capped: true })
+
+		const request = mockTidx.getRequests()[0] as { query: string }
+		expect(request.query).toContain('SELECT DISTINCT tx_hash')
+		expect(request.query).toContain('UNION ALL')
+		expect(request.query).toContain('LIMIT 10')
 	})
 
 	it('fetchAddressHistoryDistinctCount returns zero when no sources selected', async () => {
@@ -1532,6 +1536,73 @@ describe('tempo-queries', () => {
 		expect(result.transactions.map((tx) => tx.hash)).toEqual([recentHash])
 		expect(result.total).toBe(1)
 		expect(result.hasMore).toBe(false)
+		expect(result.countCapped).toBe(false)
+	})
+
+	it('fetchAddressHistoryData counts truncated mixed-source history exactly', async () => {
+		const address =
+			'0x20c0000000000000000000000000000000000000' as Address.Address
+		const sender =
+			'0x1111111111111111111111111111111111111111' as Address.Address
+		const hashes = Array.from(
+			{ length: 7 },
+			(_, index) => `0x${String(index + 1).repeat(64)}` as Hex.Hex,
+		)
+
+		mockTidx.setResponses([[{ count: 25 }]])
+		mockQueryBuilder.setResponses([
+			[
+				{
+					hash: hashes[0],
+					block_num: 106n,
+					from: sender,
+					to: address,
+					value: 5n,
+				},
+			],
+			hashes.slice(1).map((hash, index) => ({
+				tx_hash: hash,
+				block_num: BigInt(105 - index),
+			})),
+			hashes.slice(0, 2).map((hash, index) => ({
+				tx_hash: hash,
+				block_num: BigInt(106 - index),
+				block_timestamp: 206 - index,
+				from: sender,
+				to: address,
+				status: 1,
+				gas_used: 21000n,
+				effective_gas_price: 2n,
+				contract_address: null,
+			})),
+			hashes.slice(0, 2).map((hash, index) => ({
+				hash,
+				block_num: BigInt(106 - index),
+				block_timestamp: 206 - index,
+				from: sender,
+				to: address,
+				value: 5n,
+				input: '0x00' as Hex.Hex,
+				calls: null,
+			})),
+		])
+
+		const result = await fetchAddressHistoryData({
+			address,
+			chainId: 1,
+			searchParams: {
+				offset: 0,
+				limit: 2,
+				sort: 'desc',
+				include: 'all',
+				sources: 'txs,transfers',
+			},
+			includeKnownEvents: false,
+		})
+
+		expect(result.transactions.map((tx) => tx.hash)).toEqual(hashes.slice(0, 2))
+		expect(result.total).toBe(25)
+		expect(result.hasMore).toBe(true)
 		expect(result.countCapped).toBe(false)
 	})
 


### PR DESCRIPTION
## Summary

Fixes address history pagination counts for mixed transaction and transfer history sources. Address pages now use an exact capped distinct transaction count when the first source window is truncated, instead of displaying a partial capped count like `> 44`.

## Motivation

The address history API counted only the limited page buffer for mixed `txs,transfers` history. That caused the UI to render unknown pagination (`1 of …`) and a misleading capped count even when the true count was available below the cap.

## Changes

- Added a capped distinct union count across direct transactions and transfer logs.
- Wired mixed-source address history to use that count when a source window reaches the fetch limit.
- Preserved a fallback to the existing capped-window behavior if the distinct count query fails.
- Added regression coverage for truncated mixed-source history counts.

## Testing

- `pnpm --filter explorer check:biome`
- `pnpm --dir apps/explorer exec tsc --project test/tsconfig.json --noEmit`
- Manual local API check: `/api/address/history/0x58Aa7CE42E1D13B2919E2ac7E006c4fBC171442c?include=all&limit=10&offset=0&sources=txs%2Ctransfers` returned `total: 4897`, `countCapped: false`, `hasMore: true`, `rows: 10`.
- `pnpm --filter explorer test -- tempo-queries.test.ts` could not run because the worker test runtime fails during bootstrap with `Missing "#tanstack-router-entry" specifier in "@tanstack/start-server-core"`.
- `pnpm check:types` is currently blocked by unrelated workspace type errors in `contract-verification`.

<img width="2882" height="1731" alt="image" src="https://github.com/user-attachments/assets/1657e277-e81d-45ab-9140-3ea87975cc09" />
