### PR TITLE
feat(explorer): add Datadog RUM collection

### DIFF
--- a/apps/explorer/.env.example
+++ b/apps/explorer/.env.example
@@ -13,6 +13,12 @@ TIDX_BASE_URL="https://tidx.tempo.xyz"
 # RPC auth key (server-side)
 TEMPO_RPC_KEY=""
 
+# Datadog browser RUM application ID/client token.
+# These stay server-side and are injected into outgoing intake requests by /dd-proxy.
+# DATADOG_APPLICATION_ID=""
+# DATADOG_CLIENT_TOKEN=""
+# DATADOG_SITE="us5.datadoghq.com"
+
 # --------------------------------------------------------
 # Client runtime (VITE_ prefix = available in browser)
 # --------------------------------------------------------
@@ -22,6 +28,15 @@ VITE_BASE_URL=""
 # If you need to run explorer against local contract-verification service
 # you can set this to localhost
 VITE_CONTRACT_VERIFICATION_API_BASE_URL="https://contracts.tempo.xyz"
+
+# Datadog browser RUM collection. The browser sends to same-origin /dd-proxy.
+# VITE_DATADOG_ENABLED=false
+# VITE_DATADOG_SERVICE="explorer"
+# VITE_DATADOG_ENV="development"
+# VITE_DATADOG_SESSION_SAMPLE_RATE=100
+# VITE_DATADOG_SESSION_REPLAY_SAMPLE_RATE=0
+# VITE_DATADOG_TRACE_SAMPLE_RATE=20
+# VITE_DATADOG_ALLOWED_TRACING_URLS=""
 
 # --------------------------------------------------------
 # Sentry (server + client)

--- a/apps/explorer/env.d.ts
+++ b/apps/explorer/env.d.ts
@@ -1,4 +1,7 @@
 interface EnvironmentVariables {
+	readonly DATADOG_APPLICATION_ID: string | undefined
+	readonly DATADOG_CLIENT_TOKEN: string | undefined
+	readonly DATADOG_SITE: string | undefined
 	readonly TIDX_BASIC_AUTH: string | undefined
 	readonly SENTRY_AUTH_TOKEN: string | undefined
 	readonly SENTRY_ORG: string | undefined
@@ -9,6 +12,13 @@ interface EnvironmentVariables {
 	readonly VITE_SENTRY_TRACES_SAMPLE_RATE: string | undefined
 
 	readonly VITE_CONTRACT_VERIFICATION_API_BASE_URL: string
+	readonly VITE_DATADOG_ALLOWED_TRACING_URLS: string | undefined
+	readonly VITE_DATADOG_ENABLED: string | undefined
+	readonly VITE_DATADOG_ENV: string | undefined
+	readonly VITE_DATADOG_SERVICE: string | undefined
+	readonly VITE_DATADOG_SESSION_REPLAY_SAMPLE_RATE: string | undefined
+	readonly VITE_DATADOG_SESSION_SAMPLE_RATE: string | undefined
+	readonly VITE_DATADOG_TRACE_SAMPLE_RATE: string | undefined
 
 	readonly VITE_TEMPO_ENV: 'testnet' | 'devnet' | 'nextfork' | 'mainnet'
 

--- a/apps/explorer/package.json
+++ b/apps/explorer/package.json
@@ -37,6 +37,7 @@
 	},
 	"dependencies": {
 		"accounts": "catalog:",
+		"@datadog/browser-rum-slim": "catalog:",
 		"@sentry/cloudflare": "catalog:",
 		"@sentry/react": "catalog:",
 		"@shazow/whatsabi": "catalog:",

--- a/apps/explorer/src/index.server.ts
+++ b/apps/explorer/src/index.server.ts
@@ -1,5 +1,6 @@
 import * as Sentry from '@sentry/cloudflare'
 import handler, { createServerEntry } from '@tanstack/react-start/server-entry'
+import { handleDatadogProxy } from '#lib/server/datadog-proxy'
 
 export const redirects: Array<{
 	from: RegExp
@@ -53,6 +54,10 @@ function sanitizeUrl(rawUrl: string): string {
 const serverEntry = createServerEntry({
 	fetch: async (request, opts) => {
 		const url = new URL(request.url)
+
+		if (url.pathname === '/dd-proxy') {
+			return handleDatadogProxy(request)
+		}
 
 		for (const { from, to } of redirects) {
 			const match = url.pathname.match(from)

--- a/apps/explorer/src/lib/build-env.ts
+++ b/apps/explorer/src/lib/build-env.ts
@@ -44,6 +44,13 @@ export const buildEnvSchema = z.object({
 	SENTRY_ORG: z.optional(z.string()),
 	SENTRY_PROJECT: z.optional(z.string()),
 	VITE_BASE_URL: z.prefault(z.string(), ''),
+	VITE_DATADOG_ALLOWED_TRACING_URLS: z.prefault(z.string(), ''),
+	VITE_DATADOG_ENABLED: z.prefault(enabledSchema, 'false'),
+	VITE_DATADOG_ENV: z.optional(z.string()),
+	VITE_DATADOG_SERVICE: z.prefault(z.string(), 'explorer'),
+	VITE_DATADOG_SESSION_REPLAY_SAMPLE_RATE: z.prefault(z.string(), '0'),
+	VITE_DATADOG_SESSION_SAMPLE_RATE: z.prefault(z.string(), '100'),
+	VITE_DATADOG_TRACE_SAMPLE_RATE: z.prefault(z.string(), '20'),
 	VITE_ENABLE_DEVTOOLS: z.prefault(enabledSchema, 'false'),
 	VITE_TEMPO_ENV: tempoEnvSchema,
 })

--- a/apps/explorer/src/lib/domain/contract-source.ts
+++ b/apps/explorer/src/lib/domain/contract-source.ts
@@ -1,4 +1,3 @@
-import { getApiUrl, clientEnv } from '#lib/env.ts'
 import { queryOptions } from '@tanstack/react-query'
 import type { Address } from 'ox'
 import { isAddress } from 'viem'
@@ -204,6 +203,7 @@ export async function fetchContractSourceDirect(params: {
 	signal?: AbortSignal
 }): Promise<ContractSource> {
 	const { address, chainId, signal } = params
+	const { clientEnv } = await import('#lib/env.ts')
 
 	const apiUrl = new URL(
 		`${clientEnv.CONTRACT_VERIFICATION_API_BASE_URL}/v2/contract/${chainId}/${address.toLowerCase()}`,
@@ -232,6 +232,7 @@ export async function fetchContractSource(params: {
 	const { address, chainId, highlight = true, signal } = params
 
 	try {
+		const { getApiUrl } = await import('#lib/env.ts')
 		const url = getApiUrl(
 			'/api/code',
 			new URLSearchParams({

--- a/apps/explorer/src/lib/server/datadog-proxy.ts
+++ b/apps/explorer/src/lib/server/datadog-proxy.ts
@@ -1,0 +1,163 @@
+const hosts = {
+	'ap1.datadoghq.com': 'browser-intake-ap1-datadoghq.com',
+	'ap2.datadoghq.com': 'browser-intake-ap2-datadoghq.com',
+	'datadoghq.com': 'browser-intake-datadoghq.com',
+	'datadoghq.eu': 'browser-intake-datadoghq.eu',
+	'ddog-gov.com': 'browser-intake-ddog-gov.com',
+	'us2.ddog-gov.com': 'browser-intake-us2-ddog-gov.com',
+	'us3.datadoghq.com': 'browser-intake-us3-datadoghq.com',
+	'us5.datadoghq.com': 'browser-intake-us5-datadoghq.com',
+} as const
+
+const placeholderApplicationId = '00000000-0000-0000-0000-000000000000'
+const placeholderClientToken = 'explorer-dd-proxy'
+
+type Config = {
+	applicationId: string
+	clientToken: string
+	host: string
+}
+
+type Forward = {
+	token: string
+	url: URL
+}
+
+export async function handleDatadogProxy(request: Request): Promise<Response> {
+	if (request.method !== 'POST') {
+		return new Response('Method not allowed', { status: 405 })
+	}
+
+	const config = getConfig()
+	if (!config)
+		return new Response('Datadog proxy misconfigured', { status: 503 })
+
+	const contentLength = request.headers.get('content-length')
+	if (contentLength && Number.parseInt(contentLength, 10) > 10_000_000) {
+		return new Response('Payload too large', { status: 413 })
+	}
+
+	const url = new URL(request.url)
+	const forward = getForward(url.searchParams.get('ddforward'))
+	if (!forward)
+		return new Response('Invalid Datadog forward path', { status: 400 })
+	if (forward.token !== placeholderClientToken) {
+		return new Response('Datadog client token not allowed', { status: 403 })
+	}
+	if (url.searchParams.has('ddforwardSubdomain')) {
+		return new Response('Datadog subdomain forwarding is not enabled', {
+			status: 400,
+		})
+	}
+
+	const body = await getBody(request, config.applicationId)
+	if (body === undefined)
+		return new Response('Invalid Datadog payload', { status: 400 })
+
+	const headers = getHeaders(request, config.host)
+	const upstream = await fetch(getUrl(config, forward), {
+		body,
+		headers,
+		method: request.method,
+		redirect: 'manual',
+	})
+
+	return new Response(upstream.body, {
+		headers: upstream.headers,
+		status: upstream.status,
+		statusText: upstream.statusText,
+	})
+}
+
+function getConfig(): Config | undefined {
+	const applicationId = process.env.DATADOG_APPLICATION_ID
+	const clientToken = process.env.DATADOG_CLIENT_TOKEN
+	const host = getHost(process.env.DATADOG_SITE || 'datadoghq.com')
+	if (!applicationId || !clientToken || !host) return undefined
+	return { applicationId, clientToken, host }
+}
+
+function getHost(site: string): string | undefined {
+	return hosts[site as keyof typeof hosts]
+}
+
+function getForward(value: string | null): Forward | undefined {
+	if (!value?.startsWith('/') || value.startsWith('//')) return undefined
+
+	let url: URL
+	try {
+		url = new URL(value, 'https://browser-intake.datadog.invalid')
+	} catch {
+		return undefined
+	}
+
+	if (url.pathname !== '/api/v2/rum' || url.hash) return undefined
+
+	const tokens = url.searchParams.getAll('dd-api-key')
+	if (tokens.length !== 1) return undefined
+	const [token] = tokens
+	if (!token) return undefined
+
+	return { token, url }
+}
+
+function getHeaders(request: Request, host: string): Headers {
+	const headers = new Headers(request.headers)
+	headers.delete('authorization')
+	headers.delete('content-length')
+	headers.delete('cookie')
+	headers.delete('set-cookie')
+	headers.delete('x-api-key')
+	headers.set('host', host)
+
+	const ip = request.headers.get('cf-connecting-ip')
+	if (ip) headers.set('x-forwarded-for', ip)
+
+	return headers
+}
+
+function getUrl(config: Config, forward: Forward): string {
+	const url = new URL(`https://${config.host}${forward.url.pathname}`)
+	for (const [key, value] of forward.url.searchParams) {
+		url.searchParams.append(
+			key,
+			key === 'dd-api-key' ? config.clientToken : value,
+		)
+	}
+	return url.toString()
+}
+
+async function getBody(
+	request: Request,
+	applicationId: string,
+): Promise<string | undefined> {
+	const body = await request.text()
+	const lines: string[] = []
+	for (const line of body.split('\n')) {
+		const rewritten = rewriteEvent(line, applicationId)
+		if (rewritten === undefined) return undefined
+		lines.push(rewritten)
+	}
+	return lines.join('\n')
+}
+
+function rewriteEvent(line: string, applicationId: string): string | undefined {
+	if (!line) return line
+
+	let event: unknown
+	try {
+		event = JSON.parse(line)
+	} catch {
+		return undefined
+	}
+
+	if (!isObject(event) || !isObject(event.application)) return undefined
+	if (event.application.id !== placeholderApplicationId) return undefined
+
+	event.application.id = applicationId
+	return JSON.stringify(event)
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+	return !!value && typeof value === 'object' && !Array.isArray(value)
+}

--- a/apps/explorer/src/lib/server/env.ts
+++ b/apps/explorer/src/lib/server/env.ts
@@ -9,6 +9,9 @@ import * as z from 'zod/mini'
  * handlers and are not included here.
  */
 export const serverEnvSchema = z.object({
+	DATADOG_APPLICATION_ID: z.optional(z.string()),
+	DATADOG_CLIENT_TOKEN: z.optional(z.string()),
+	DATADOG_SITE: z.prefault(z.string(), 'datadoghq.com'),
 	TEMPO_RPC_KEY: z.optional(z.string()),
 	TIDX_BASIC_AUTH: z.optional(z.string()),
 	TIDX_BASE_URL: z.prefault(z.url(), 'https://tidx.tempo.xyz'),

--- a/apps/explorer/src/lib/telemetry/datadog.ts
+++ b/apps/explorer/src/lib/telemetry/datadog.ts
@@ -1,0 +1,114 @@
+import type {
+	PropagatorType,
+	ProxyFn,
+	RumInitConfiguration,
+} from '@datadog/browser-rum-slim'
+
+type DatadogRumImpl = typeof import('@datadog/browser-rum-slim')
+
+const applicationId = '00000000-0000-0000-0000-000000000000'
+const clientToken = 'explorer-dd-proxy'
+const enabled = import.meta.env.VITE_DATADOG_ENABLED === 'true'
+const env =
+	import.meta.env.VITE_DATADOG_ENV ??
+	import.meta.env.VITE_TEMPO_ENV ??
+	import.meta.env.MODE
+const proxyPath = '/dd-proxy'
+const service = import.meta.env.VITE_DATADOG_SERVICE ?? 'explorer'
+const tracingUrls = import.meta.env.VITE_DATADOG_ALLOWED_TRACING_URLS
+const propagatorTypes: PropagatorType[] = ['tracecontext', 'datadog']
+
+let impl: DatadogRumImpl | undefined
+let initialized = false
+let initPromise: Promise<void> | undefined
+
+export function initDatadogRum(): Promise<void> {
+	if (initPromise) return initPromise
+	if (initialized || import.meta.env.DEV || typeof window === 'undefined') {
+		return Promise.resolve()
+	}
+	if (!enabled) return Promise.resolve()
+
+	initPromise = (async () => {
+		impl = await import('@datadog/browser-rum-slim')
+		impl.datadogRum.init({
+			allowedTracingUrls: getAllowedTracingUrls(),
+			applicationId,
+			clientToken,
+			defaultPrivacyLevel: 'mask-user-input',
+			enablePrivacyForActionName: true,
+			env,
+			proxy,
+			service,
+			sessionReplaySampleRate: percent(
+				import.meta.env.VITE_DATADOG_SESSION_REPLAY_SAMPLE_RATE,
+				0,
+			),
+			sessionSampleRate: percent(
+				import.meta.env.VITE_DATADOG_SESSION_SAMPLE_RATE,
+				100,
+			),
+			traceContextInjection: 'sampled',
+			traceSampleRate: percent(
+				import.meta.env.VITE_DATADOG_TRACE_SAMPLE_RATE,
+				20,
+			),
+			trackLongTasks: true,
+			trackResources: true,
+			trackUserInteractions: true,
+			version: __BUILD_VERSION__,
+		})
+		impl.datadogRum.setGlobalContext({
+			tempo_app_id: 'explorer',
+			tempo_runtime: 'browser',
+		})
+		initialized = true
+	})().catch((error) => {
+		initPromise = undefined
+		impl = undefined
+		initialized = false
+		throw error
+	})
+
+	return initPromise
+}
+
+function getAllowedTracingUrls(): RumInitConfiguration['allowedTracingUrls'] {
+	const urls = (tracingUrls ?? '')
+		.split(',')
+		.map((url) => url.trim())
+		.filter(Boolean)
+
+	return [
+		{ match: isApiUrl, propagatorTypes },
+		...urls.map((match) => ({ match, propagatorTypes })),
+	]
+}
+
+const proxy: ProxyFn = (options) => {
+	const query = new URLSearchParams({
+		ddforward: `${options.path}?${options.parameters}`,
+	})
+	if (options.subdomain) query.set('ddforwardSubdomain', options.subdomain)
+	return `${proxyPath}?${query.toString()}`
+}
+
+function isApiUrl(input: string): boolean {
+	try {
+		const url = new URL(input, window.location.href)
+		return (
+			url.origin === window.location.origin &&
+			(url.pathname === '/api' || url.pathname.startsWith('/api/'))
+		)
+	} catch {
+		return false
+	}
+}
+
+function percent(value: string | undefined, fallback: number): number {
+	if (!value?.trim()) return fallback
+
+	const n = Number.parseFloat(value)
+	if (!Number.isFinite(n)) return fallback
+	return Math.min(Math.max(n, 0), 100)
+}

--- a/apps/explorer/src/routes/__root.tsx
+++ b/apps/explorer/src/routes/__root.tsx
@@ -26,6 +26,7 @@ import {
 	normalizePathPattern,
 	ProfileEvents,
 } from '#lib/profiling'
+import { initDatadogRum } from '#lib/telemetry/datadog'
 import { getWagmiConfig, getWagmiStateSSR } from '#wagmi.config.ts'
 import css from './styles.css?url'
 
@@ -268,6 +269,12 @@ function useAppBoot() {
 	}, [])
 }
 
+function useDatadogRum() {
+	React.useEffect(() => {
+		void initDatadogRum().catch(() => {})
+	}, [])
+}
+
 function useLoaderTiming() {
 	const matches = useMatches()
 	const reportedRef = React.useRef<Set<string>>(new Set())
@@ -351,6 +358,7 @@ function RootDocument({ children }: { children: React.ReactNode }) {
 	useFirstDrawTiming()
 	useErrorTracking()
 	useAppBoot()
+	useDatadogRum()
 
 	const { queryClient } = Route.useRouteContext()
 	const [config] = React.useState(() => getWagmiConfig())

--- a/apps/explorer/test/datadog-proxy.node.test.ts
+++ b/apps/explorer/test/datadog-proxy.node.test.ts
@@ -1,0 +1,196 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { handleDatadogProxy } from '../src/lib/server/datadog-proxy'
+
+const env = process.env as Record<string, string | undefined>
+
+let previousApplicationId: string | undefined
+let previousClientToken: string | undefined
+let previousSite: string | undefined
+
+beforeEach(() => {
+	previousApplicationId = env.DATADOG_APPLICATION_ID
+	previousClientToken = env.DATADOG_CLIENT_TOKEN
+	previousSite = env.DATADOG_SITE
+	env.DATADOG_APPLICATION_ID = 'real-application-id'
+	env.DATADOG_CLIENT_TOKEN = 'real-token'
+	env.DATADOG_SITE = 'us5.datadoghq.com'
+})
+
+afterEach(() => {
+	env.DATADOG_APPLICATION_ID = previousApplicationId
+	env.DATADOG_CLIENT_TOKEN = previousClientToken
+	env.DATADOG_SITE = previousSite
+	vi.unstubAllGlobals()
+})
+
+describe('Datadog proxy', () => {
+	it('forwards RUM batches to the configured Datadog site', async () => {
+		const fetch = vi.fn<typeof globalThis.fetch>(
+			async () => new Response('ok', { status: 202 }),
+		)
+		vi.stubGlobal('fetch', fetch)
+
+		const url = new URL('https://explore.tempo.xyz/dd-proxy')
+		url.searchParams.set(
+			'ddforward',
+			'/api/v2/rum?ddsource=browser&dd-api-key=explorer-dd-proxy',
+		)
+
+		const res = await handleDatadogProxy(
+			new Request(url, {
+				body: [
+					JSON.stringify({
+						application: { id: '00000000-0000-0000-0000-000000000000' },
+						type: 'view',
+					}),
+					JSON.stringify({
+						application: { id: '00000000-0000-0000-0000-000000000000' },
+						type: 'resource',
+					}),
+				].join('\n'),
+				headers: {
+					authorization: 'Bearer should-not-forward',
+					'cf-connecting-ip': '203.0.113.10',
+					'content-type': 'text/plain',
+					cookie: 'session=secret',
+				},
+				method: 'POST',
+			}),
+		)
+
+		const call = fetch.mock.calls[0]
+		expect(call).toBeDefined()
+		if (!call) throw new Error('Expected Datadog intake fetch')
+		const [input, init] = call
+		const headers = Object.fromEntries(new Headers(init?.headers).entries())
+		const body = String(init?.body)
+
+		expect({
+			forwardedUrl: String(input),
+			hasAuthorization: 'authorization' in headers,
+			hasCookie: 'cookie' in headers,
+			host: headers.host,
+			ip: headers['x-forwarded-for'],
+			method: init?.method,
+			responseStatus: res.status,
+			rewrittenApplicationIds: body
+				.split('\n')
+				.map((line) => JSON.parse(line).application.id as string),
+			usesPlaceholderToken: String(input).includes('explorer-dd-proxy'),
+		}).toMatchInlineSnapshot(`
+			{
+			  "forwardedUrl": "https://browser-intake-us5-datadoghq.com/api/v2/rum?ddsource=browser&dd-api-key=real-token",
+			  "hasAuthorization": false,
+			  "hasCookie": false,
+			  "host": "browser-intake-us5-datadoghq.com",
+			  "ip": "203.0.113.10",
+			  "method": "POST",
+			  "responseStatus": 202,
+			  "rewrittenApplicationIds": [
+			    "real-application-id",
+			    "real-application-id",
+			  ],
+			  "usesPlaceholderToken": false,
+			}
+		`)
+	})
+
+	it('rejects invalid forwarding inputs', async () => {
+		const fetch = vi.fn<typeof globalThis.fetch>()
+		vi.stubGlobal('fetch', fetch)
+
+		const cases = await Promise.all([
+			handleDatadogProxy(new Request('https://explore.tempo.xyz/dd-proxy')),
+			handleDatadogProxy(
+				new Request(
+					'https://explore.tempo.xyz/dd-proxy?ddforward=https://evil.example/api/v2/rum',
+					{ method: 'POST' },
+				),
+			),
+			handleDatadogProxy(
+				new Request(
+					'https://explore.tempo.xyz/dd-proxy?ddforward=/api/v2/logs',
+					{ method: 'POST' },
+				),
+			),
+			handleDatadogProxy(
+				new Request(
+					'https://explore.tempo.xyz/dd-proxy?ddforward=/api/v2/rum&ddforwardSubdomain=quota',
+					{ method: 'POST' },
+				),
+			),
+		])
+
+		expect(cases.map((res) => res.status)).toMatchInlineSnapshot(`
+			[
+			  405,
+			  400,
+			  400,
+			  400,
+			]
+		`)
+		expect(fetch).not.toHaveBeenCalled()
+	})
+
+	it('rejects batches for a different Datadog client token', async () => {
+		const fetch = vi.fn<typeof globalThis.fetch>()
+		vi.stubGlobal('fetch', fetch)
+
+		const url = new URL('https://explore.tempo.xyz/dd-proxy')
+		url.searchParams.set(
+			'ddforward',
+			'/api/v2/rum?ddsource=browser&dd-api-key=other',
+		)
+
+		const res = await handleDatadogProxy(
+			new Request(url, {
+				body: JSON.stringify({
+					application: { id: '00000000-0000-0000-0000-000000000000' },
+					type: 'view',
+				}),
+				method: 'POST',
+			}),
+		)
+
+		expect({
+			calledFetch: fetch.mock.calls.length,
+			status: res.status,
+		}).toMatchInlineSnapshot(`
+				{
+				  "calledFetch": 0,
+				  "status": 403,
+				}
+			`)
+	})
+
+	it('rejects batches without the placeholder application ID', async () => {
+		const fetch = vi.fn<typeof globalThis.fetch>()
+		vi.stubGlobal('fetch', fetch)
+
+		const url = new URL('https://explore.tempo.xyz/dd-proxy')
+		url.searchParams.set(
+			'ddforward',
+			'/api/v2/rum?ddsource=browser&dd-api-key=explorer-dd-proxy',
+		)
+
+		const res = await handleDatadogProxy(
+			new Request(url, {
+				body: JSON.stringify({
+					application: { id: 'other-application-id' },
+					type: 'view',
+				}),
+				method: 'POST',
+			}),
+		)
+
+		expect({
+			calledFetch: fetch.mock.calls.length,
+			status: res.status,
+		}).toMatchInlineSnapshot(`
+				{
+				  "calledFetch": 0,
+				  "status": 400,
+				}
+			`)
+	})
+})

--- a/apps/explorer/vite.config.ts
+++ b/apps/explorer/vite.config.ts
@@ -28,6 +28,29 @@ export default defineConfig((config) => {
 	if (!success) throw new Error(z.prettifyError(error))
 
 	const wranglerVars = wranglerJSON.env[envConfig.VITE_TEMPO_ENV].vars
+	const datadogEnv = {
+		VITE_DATADOG_ALLOWED_TRACING_URLS:
+			wranglerVars.VITE_DATADOG_ALLOWED_TRACING_URLS ??
+			envConfig.VITE_DATADOG_ALLOWED_TRACING_URLS,
+		VITE_DATADOG_ENABLED:
+			wranglerVars.VITE_DATADOG_ENABLED ??
+			String(envConfig.VITE_DATADOG_ENABLED),
+		VITE_DATADOG_ENV:
+			wranglerVars.VITE_DATADOG_ENV ??
+			envConfig.VITE_DATADOG_ENV ??
+			envConfig.VITE_TEMPO_ENV,
+		VITE_DATADOG_SERVICE:
+			wranglerVars.VITE_DATADOG_SERVICE ?? envConfig.VITE_DATADOG_SERVICE,
+		VITE_DATADOG_SESSION_REPLAY_SAMPLE_RATE:
+			wranglerVars.VITE_DATADOG_SESSION_REPLAY_SAMPLE_RATE ??
+			envConfig.VITE_DATADOG_SESSION_REPLAY_SAMPLE_RATE,
+		VITE_DATADOG_SESSION_SAMPLE_RATE:
+			wranglerVars.VITE_DATADOG_SESSION_SAMPLE_RATE ??
+			envConfig.VITE_DATADOG_SESSION_SAMPLE_RATE,
+		VITE_DATADOG_TRACE_SAMPLE_RATE:
+			wranglerVars.VITE_DATADOG_TRACE_SAMPLE_RATE ??
+			envConfig.VITE_DATADOG_TRACE_SAMPLE_RATE,
+	}
 	const tempoEnv = tempoEnvSchema.safeParse(wranglerVars.VITE_TEMPO_ENV)
 	if (!tempoEnv.success) throw new Error(z.prettifyError(tempoEnv.error))
 
@@ -139,6 +162,27 @@ export default defineConfig((config) => {
 			},
 		},
 		define: {
+			'import.meta.env.VITE_DATADOG_ALLOWED_TRACING_URLS': JSON.stringify(
+				datadogEnv.VITE_DATADOG_ALLOWED_TRACING_URLS,
+			),
+			'import.meta.env.VITE_DATADOG_ENABLED': JSON.stringify(
+				datadogEnv.VITE_DATADOG_ENABLED,
+			),
+			'import.meta.env.VITE_DATADOG_ENV': JSON.stringify(
+				datadogEnv.VITE_DATADOG_ENV,
+			),
+			'import.meta.env.VITE_DATADOG_SERVICE': JSON.stringify(
+				datadogEnv.VITE_DATADOG_SERVICE,
+			),
+			'import.meta.env.VITE_DATADOG_SESSION_REPLAY_SAMPLE_RATE': JSON.stringify(
+				datadogEnv.VITE_DATADOG_SESSION_REPLAY_SAMPLE_RATE,
+			),
+			'import.meta.env.VITE_DATADOG_SESSION_SAMPLE_RATE': JSON.stringify(
+				datadogEnv.VITE_DATADOG_SESSION_SAMPLE_RATE,
+			),
+			'import.meta.env.VITE_DATADOG_TRACE_SAMPLE_RATE': JSON.stringify(
+				datadogEnv.VITE_DATADOG_TRACE_SAMPLE_RATE,
+			),
 			'import.meta.env.VITE_TEMPO_ENV': JSON.stringify(
 				wranglerVars.VITE_TEMPO_ENV || envConfig.VITE_TEMPO_ENV,
 			),

--- a/apps/explorer/wrangler.json
+++ b/apps/explorer/wrangler.json
@@ -45,6 +45,14 @@
 				}
 			],
 			"vars": {
+				"DATADOG_SITE": "us5.datadoghq.com",
+				"VITE_DATADOG_ALLOWED_TRACING_URLS": "",
+				"VITE_DATADOG_ENABLED": "true",
+				"VITE_DATADOG_ENV": "testnet",
+				"VITE_DATADOG_SERVICE": "explorer",
+				"VITE_DATADOG_SESSION_REPLAY_SAMPLE_RATE": "0",
+				"VITE_DATADOG_SESSION_SAMPLE_RATE": "100",
+				"VITE_DATADOG_TRACE_SAMPLE_RATE": "20",
 				"VITE_TEMPO_ENV": "testnet",
 				"VITE_SENTRY_DSN": "https://0f252c4cc335811d53f9e996b8a3450a@o4510262603481088.ingest.us.sentry.io/4510858114564096",
 				"SENTRY_TRACES_SAMPLE_RATE": "0.5",
@@ -88,6 +96,14 @@
 				}
 			],
 			"vars": {
+				"DATADOG_SITE": "us5.datadoghq.com",
+				"VITE_DATADOG_ALLOWED_TRACING_URLS": "",
+				"VITE_DATADOG_ENABLED": "true",
+				"VITE_DATADOG_ENV": "devnet",
+				"VITE_DATADOG_SERVICE": "explorer",
+				"VITE_DATADOG_SESSION_REPLAY_SAMPLE_RATE": "0",
+				"VITE_DATADOG_SESSION_SAMPLE_RATE": "100",
+				"VITE_DATADOG_TRACE_SAMPLE_RATE": "20",
 				"VITE_TEMPO_ENV": "devnet",
 				"VITE_SENTRY_DSN": "https://0f252c4cc335811d53f9e996b8a3450a@o4510262603481088.ingest.us.sentry.io/4510858114564096",
 				"SENTRY_TRACES_SAMPLE_RATE": "0.5",
@@ -126,6 +142,14 @@
 				}
 			],
 			"vars": {
+				"DATADOG_SITE": "us5.datadoghq.com",
+				"VITE_DATADOG_ALLOWED_TRACING_URLS": "",
+				"VITE_DATADOG_ENABLED": "true",
+				"VITE_DATADOG_ENV": "nextfork",
+				"VITE_DATADOG_SERVICE": "explorer",
+				"VITE_DATADOG_SESSION_REPLAY_SAMPLE_RATE": "0",
+				"VITE_DATADOG_SESSION_SAMPLE_RATE": "100",
+				"VITE_DATADOG_TRACE_SAMPLE_RATE": "20",
 				"VITE_TEMPO_ENV": "nextfork",
 				"TIDX_BASE_URL": "https://tidx-nextfork.devnet.tempoxyz.dev",
 				"VITE_SENTRY_DSN": "https://0f252c4cc335811d53f9e996b8a3450a@o4510262603481088.ingest.us.sentry.io/4510858114564096",
@@ -180,6 +204,14 @@
 				}
 			],
 			"vars": {
+				"DATADOG_SITE": "us5.datadoghq.com",
+				"VITE_DATADOG_ALLOWED_TRACING_URLS": "",
+				"VITE_DATADOG_ENABLED": "true",
+				"VITE_DATADOG_ENV": "mainnet",
+				"VITE_DATADOG_SERVICE": "explorer",
+				"VITE_DATADOG_SESSION_REPLAY_SAMPLE_RATE": "0",
+				"VITE_DATADOG_SESSION_SAMPLE_RATE": "100",
+				"VITE_DATADOG_TRACE_SAMPLE_RATE": "20",
 				"VITE_TEMPO_ENV": "mainnet",
 				"VITE_SENTRY_DSN": "https://0f252c4cc335811d53f9e996b8a3450a@o4510262603481088.ingest.us.sentry.io/4510858114564096",
 				"SENTRY_TRACES_SAMPLE_RATE": "0.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,9 @@ catalogs:
     '@cloudflare/workers-types':
       specifier: ^4.20260531.1
       version: 4.20260531.1
+    '@datadog/browser-rum-slim':
+      specifier: ^7.2.0
+      version: 7.3.0
     '@hono/zod-validator':
       specifier: ^0.7.6
       version: 0.7.6
@@ -377,6 +380,9 @@ importers:
 
   apps/explorer:
     dependencies:
+      '@datadog/browser-rum-slim':
+        specifier: 'catalog:'
+        version: 7.3.0
       '@sentry/cloudflare':
         specifier: 'catalog:'
         version: 10.45.0(@cloudflare/workers-types@4.20260531.1)
@@ -1197,6 +1203,23 @@ packages:
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
+
+  '@datadog/browser-core@7.3.0':
+    resolution: {integrity: sha512-bP6QuYyxdjaKYHwqpvYRihSEXgz/8P1iPr1ZI6OJVeDSJ7Zz/kAqK3dU5O7y6FrP9u99CbFG+rRGDtb4ytyJiw==}
+
+  '@datadog/browser-rum-core@7.3.0':
+    resolution: {integrity: sha512-E+lBOxaE7UazwhBA3/i8qc0080MQZgxBmpdQsVxkt/UWmql523U8Hf8u/0D4eIauVCOeB6faBhNJhfa/lsRxVg==}
+
+  '@datadog/browser-rum-slim@7.3.0':
+    resolution: {integrity: sha512-Vgb/nmO8alhQA03d6vnJ/KTXyaV/Ul12Y52eaSQlHrkIMSofUfsuTzvsmBVgHBiOJWrWwkW7cJWYku4Hbwo9Fw==}
+    peerDependencies:
+      '@datadog/browser-logs': 7.3.0
+    peerDependenciesMeta:
+      '@datadog/browser-logs':
+        optional: true
+
+  '@datadog/js-core@0.0.2':
+    resolution: {integrity: sha512-tubNtQXlHiDovBB04M16MWQbUj4j0F7eu6lWMUmFo/+SD5j8adzSGcVxtSNdSR/u++IaghkCpqcAaR3ZAJh2jQ==}
 
   '@drizzle-team/brocli@0.10.2':
     resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
@@ -6609,6 +6632,22 @@ snapshots:
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
+
+  '@datadog/browser-core@7.3.0':
+    dependencies:
+      '@datadog/js-core': 0.0.2
+
+  '@datadog/browser-rum-core@7.3.0':
+    dependencies:
+      '@datadog/browser-core': 7.3.0
+      '@datadog/js-core': 0.0.2
+
+  '@datadog/browser-rum-slim@7.3.0':
+    dependencies:
+      '@datadog/browser-core': 7.3.0
+      '@datadog/browser-rum-core': 7.3.0
+
+  '@datadog/js-core@0.0.2': {}
 
   '@drizzle-team/brocli@0.10.2': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,6 +9,7 @@ catalog:
   '@cloudflare/vite-plugin': 1.30.3
   '@cloudflare/vitest-pool-workers': ^0.13.5
   '@cloudflare/workers-types': ^4.20260531.1
+  '@datadog/browser-rum-slim': ^7.2.0
   '@hono/zod-validator': ^0.7.6
   '@iconify/json': ^2.2.460
   '@logtape/config': ^2.0.4


### PR DESCRIPTION
- Initialize RUM from the root route effect so TanStack Start emits it
- Lazy-load @datadog/browser-rum-slim into a separate async chunk
- Proxy RUM intake through same-origin /dd-proxy
- Keep real Datadog application ID and client token server-side
- Add env wiring, Wrangler vars, and proxy tests
- Real parent diff at +139 KB raw / +48 KB gzip / +42 KB brotli
- Keep the Datadog SDK out of the initial hydration chunk