### PR TITLE
Normalize explorer font usage

### DIFF
--- a/apps/explorer/src/comps/DataGrid.tsx
+++ b/apps/explorer/src/comps/DataGrid.tsx
@@ -170,7 +170,7 @@ export function DataGrid(props: DataGrid.Props) {
 														key={key}
 														className={cx(
 															'px-[10px] py-[12px] flex items-start min-h-[48px]',
-															'text-primary font-mono',
+															'text-primary font-sans',
 															isFirstColumn && 'pl-[16px]',
 															isLastColumn && 'pr-[16px]',
 															column?.align === 'end'

--- a/apps/explorer/src/comps/Header.tsx
+++ b/apps/explorer/src/comps/Header.tsx
@@ -235,7 +235,7 @@ export namespace Header {
 									aria-checked={isActive}
 									aria-current={isActive ? 'page' : undefined}
 									className={cx(
-										'flex items-center gap-[8px] rounded-[7px] px-[10px] py-[9px] text-[13px] font-medium text-secondary transition-colors hover:bg-surface hover:text-primary focus-visible:outline-none',
+										'flex items-center gap-[8px] rounded-[7px] px-[10px] py-[9px] text-[14px] font-medium leading-[140%] text-secondary transition-colors hover:bg-surface hover:text-primary focus-visible:outline-none',
 										isActive && 'bg-surface text-primary',
 									)}
 									onClick={() => setIsOpen(false)}

--- a/apps/explorer/src/routes/_layout/blocks.tsx
+++ b/apps/explorer/src/routes/_layout/blocks.tsx
@@ -289,14 +289,16 @@ function RouteComponent() {
 												cells: [
 													<span
 														key="number"
-														className="tabular-nums text-accent font-medium"
+														className="font-mono tabular-nums text-accent font-medium"
 													>
 														#{blockNumber}
 													</span>,
-													<Midcut key="hash" value={blockHash} prefix="0x" />,
+													<span key="hash" className="font-mono w-full min-w-0">
+														<Midcut value={blockHash} prefix="0x" />
+													</span>,
 													<span
 														key="time"
-														className="text-secondary tabular-nums whitespace-nowrap"
+														className="font-mono text-secondary tabular-nums whitespace-nowrap"
 													>
 														<FormattedTimestamp
 															timestamp={block.timestamp}
@@ -305,7 +307,7 @@ function RouteComponent() {
 													</span>,
 													<span
 														key="txns"
-														className="text-secondary tabular-nums"
+														className="font-mono text-secondary tabular-nums"
 													>
 														{txCount}
 													</span>,

--- a/apps/explorer/src/routes/_layout/fee-amm.tsx
+++ b/apps/explorer/src/routes/_layout/fee-amm.tsx
@@ -188,7 +188,7 @@ function FeeAmmPage(): React.JSX.Element {
 														[
 															<span
 																key="supply"
-																className="text-secondary tabular-nums"
+																className="font-mono text-secondary tabular-nums"
 																title={PriceFormatter.format(pool.liquidityUsd)}
 															>
 																{PriceFormatter.format(pool.liquidityUsd, {
@@ -238,7 +238,7 @@ function renderTimestamp(
 		<FormattedTimestamp
 			timestamp={BigInt(timestamp)}
 			format={format}
-			className="text-secondary whitespace-nowrap"
+			className="font-mono text-secondary whitespace-nowrap"
 		/>
 	)
 }

--- a/apps/explorer/src/routes/_layout/tokens.tsx
+++ b/apps/explorer/src/routes/_layout/tokens.tsx
@@ -174,7 +174,7 @@ function TokensPage() {
 											<span key="currency" className="text-secondary">
 												{token.currency}
 											</span>,
-											<span key="holders" className="text-secondary">
+											<span key="holders" className="font-mono text-secondary">
 												{formatHoldersCount(token)}
 											</span>,
 											<Address
@@ -185,7 +185,7 @@ function TokensPage() {
 											token.createdAt == null ? (
 												<span
 													key="created"
-													className="text-secondary whitespace-nowrap"
+													className="font-mono text-secondary whitespace-nowrap"
 												>
 													-
 												</span>
@@ -194,7 +194,7 @@ function TokensPage() {
 													key="created"
 													timestamp={BigInt(token.createdAt)}
 													format={timeFormat}
-													className="text-secondary whitespace-nowrap"
+													className="font-mono text-secondary whitespace-nowrap"
 												/>
 											),
 										],

--- a/apps/explorer/src/routes/styles.css
+++ b/apps/explorer/src/routes/styles.css
@@ -109,6 +109,7 @@
 	--color-warning-background: light-dark(#fdf5c2, #252018);
 
 	--font-display: "Satoshi", ui-sans-serif, sans-serif;
+	--font-sans: var(--font-display);
 	--font-mono: "Geist Mono", ui-monospace, monospace;
 }
 


### PR DESCRIPTION
## Summary

- Map explorer `font-sans` to Satoshi so section chrome, tabs, labels, and controls use the same UI font as the body.
- Make data grid cells default to Satoshi, then opt block hashes, addresses, timestamps, counts, and liquidity values back into Geist Mono.
- Normalize the network dropdown item size to match the closed network selector.

## Validation

- `pnpm exec biome check apps/explorer/src/comps/Header.tsx apps/explorer/src/routes/styles.css apps/explorer/src/comps/DataGrid.tsx apps/explorer/src/routes/_layout/blocks.tsx apps/explorer/src/routes/_layout/tokens.tsx apps/explorer/src/routes/_layout/fee-amm.tsx`
- `pnpm --filter explorer gen:types && pnpm --filter explorer check:types`
- Local mainnet preview at `http://127.0.0.1:3000/` with annotated screenshot review