### PR TITLE
feat: add fee-payer sponsorship intent billing

### DIFF
--- a/apps/fee-payer/src/index.ts
+++ b/apps/fee-payer/src/index.ts
@@ -10,6 +10,7 @@ import { privateKeyToAccount } from 'viem/accounts'
 import * as z from 'zod'
 import { admin } from './lib/admin.js'
 import { apiKeyMiddleware } from './lib/api-key-middleware.js'
+import { enqueueSponsorshipIntent } from './lib/billing.js'
 import { tempoChain } from './lib/chain.js'
 import { httpMetrics, rpcMetrics } from './lib/observability/middleware.js'
 import {
@@ -21,6 +22,7 @@ import { rateLimitMiddleware } from './lib/rate-limit.js'
 import { getUsage } from './lib/usage.js'
 
 const USAGE_CACHE_TTL = 60
+const ATTRIBUTION_KEY_HEADER = 'x-tempo-attribution-key'
 
 const app = new Hono()
 
@@ -42,7 +44,7 @@ app.use(
 			return null
 		},
 		allowMethods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
-		allowHeaders: ['Content-Type', 'Authorization'],
+		allowHeaders: ['Content-Type', 'Authorization', ATTRIBUTION_KEY_HEADER],
 		maxAge: 86400,
 	}),
 )
@@ -120,6 +122,8 @@ async function feePayerHandler(c: Context) {
 	const apiKeyLabel = apiKeyRecord?.label
 	const rpcMethod = c.get('rpcMethod') as string | undefined
 	const estimatedFeeUsd = c.get('estimatedFeeUsd') as number | undefined
+	const attributionKey =
+		c.req.header(ATTRIBUTION_KEY_HEADER)?.trim() || undefined
 
 	if (rpcMethod) {
 		c.executionCtx.waitUntil(
@@ -141,11 +145,29 @@ async function feePayerHandler(c: Context) {
 	}
 
 	const raw = c.req.raw
+	const billingRequest =
+		apiKey && apiKeyRecord?.billable ? raw.clone() : undefined
+	const billingSignedAt = billingRequest ? new Date().toISOString() : undefined
 	const url = new URL(raw.url)
 	const target =
 		url.pathname === '/' ? raw : new Request(new URL('/', url), raw)
 
-	return relayHandler.fetch(target)
+	const response = await relayHandler.fetch(target)
+	if (apiKey && billingRequest && apiKeyRecord?.billable) {
+		c.executionCtx.waitUntil(
+			enqueueSponsorshipIntent({
+				apiKey,
+				attributionKey,
+				fallbackChainId: tempoChain.id,
+				request: billingRequest,
+				response: response.clone(),
+				signedAt: billingSignedAt,
+				sponsorAddress: sponsorAccount.address,
+			}),
+		)
+	}
+
+	return response
 }
 
 // Keyed path: https://sponsor.tempo.xyz/tp_abc123

--- a/apps/fee-payer/src/lib/admin.ts
+++ b/apps/fee-payer/src/lib/admin.ts
@@ -40,6 +40,7 @@ admin.post(
 			label: z.string(),
 			dailyLimitUsd: z.string().nullable().optional().default(null),
 			allowedDestinations: z.array(z.string()).optional().default([]),
+			billable: z.boolean().optional().default(false),
 		}),
 	),
 	async (c) => {
@@ -48,6 +49,7 @@ admin.post(
 			label: body.label,
 			dailyLimitUsd: body.dailyLimitUsd,
 			allowedDestinations: body.allowedDestinations,
+			billable: body.billable,
 		})
 		return c.json({ key }, 201)
 	},
@@ -77,6 +79,7 @@ admin.patch(
 			label: z.string().optional(),
 			dailyLimitUsd: z.string().nullable().optional(),
 			allowedDestinations: z.array(z.string()).optional(),
+			billable: z.boolean().optional(),
 			active: z.boolean().optional(),
 		}),
 	),

--- a/apps/fee-payer/src/lib/api-keys.ts
+++ b/apps/fee-payer/src/lib/api-keys.ts
@@ -9,6 +9,8 @@ const ApiKeyRecord = z.object({
 	dailyLimitUsd: z.string().nullable(),
 	/** Allowed destination addresses. Empty = any destination. */
 	allowedDestinations: z.array(z.string()),
+	/** Whether this key emits sponsorship intents for billing. */
+	billable: z.boolean().default(false),
 	/** ISO timestamp of creation. */
 	createdAt: z.string(),
 	/** Whether the key is active. */
@@ -64,7 +66,7 @@ export async function updateApiKey(
 	updates: Partial<
 		Pick<
 			ApiKeyRecord,
-			'label' | 'dailyLimitUsd' | 'allowedDestinations' | 'active'
+			'label' | 'dailyLimitUsd' | 'allowedDestinations' | 'billable' | 'active'
 		>
 	>,
 ): Promise<boolean> {

--- a/apps/fee-payer/src/lib/billing.ts
+++ b/apps/fee-payer/src/lib/billing.ts
@@ -1,0 +1,254 @@
+import { env } from 'cloudflare:workers'
+import { Bytes, Hash, Hex } from 'ox'
+import { type TempoAddress, TxEnvelopeTempo } from 'ox/tempo'
+
+type JsonRpcRequest = {
+	method: string
+	params?: readonly unknown[] | undefined
+}
+
+type JsonRpcResponse = {
+	error?: unknown
+	result?: unknown
+}
+
+type SponsorshipDetails = {
+	chainId: number
+	feePayerPayloadHash: `0x${string}`
+	feePayerSignature?: unknown
+}
+
+export type SponsorshipIntentMessage = {
+	type: 'sponsorship_intent'
+	event: {
+		idempotencyKey: string
+		apiKeyHash: string
+		attributionKey?: string
+		chainId: number
+		sponsorAddress: string
+		feePayerPayloadHash: `0x${string}`
+		feePayerSignature?: unknown
+		signedAt: string
+	}
+}
+
+type BuildSponsorshipIntentMessageOptions = {
+	apiKey: string
+	attributionKey?: string | undefined
+	fallbackChainId: number
+	requestBody: unknown
+	responseBody: unknown
+	signedAt?: string | undefined
+	sponsorAddress: string
+}
+
+type EnqueueSponsorshipIntentOptions = {
+	apiKey: string
+	attributionKey?: string | undefined
+	fallbackChainId: number
+	request: Request
+	response: Response
+	signedAt?: string | undefined
+	sponsorAddress: string
+}
+
+type BillingEnv = {
+	BILLING_QUEUE?: Queue<SponsorshipIntentMessage> | undefined
+}
+
+/** Enqueues a billing sponsorship intent from a successful fee-payer response. */
+export async function enqueueSponsorshipIntent(
+	options: EnqueueSponsorshipIntentOptions,
+) {
+	const queue = (env as Cloudflare.Env & BillingEnv).BILLING_QUEUE
+	if (!queue) return
+
+	try {
+		const [requestBody, responseBody] = await Promise.all([
+			options.request.json(),
+			options.response.json(),
+		])
+		const message = buildSponsorshipIntentMessage({
+			apiKey: options.apiKey,
+			attributionKey: options.attributionKey,
+			fallbackChainId: options.fallbackChainId,
+			requestBody,
+			responseBody,
+			signedAt: options.signedAt,
+			sponsorAddress: options.sponsorAddress,
+		})
+		if (!message) return
+
+		await queue.send(message, { contentType: 'json' })
+	} catch (error) {
+		console.error('fee_payer.billing.sponsorship_intent_failed', error)
+	}
+}
+
+/** Builds the billing queue message accepted by billing-srv. */
+export function buildSponsorshipIntentMessage(
+	options: BuildSponsorshipIntentMessageOptions,
+): SponsorshipIntentMessage | null {
+	const request = parseRpcRequest(options.requestBody)
+	const response = parseRpcResponse(options.responseBody)
+	if (!request || !response || response.error) return null
+
+	const details = sponsorshipDetailsFromRpc(
+		request,
+		response,
+		options.fallbackChainId,
+	)
+	if (!details) return null
+
+	const apiKeyHash = hashApiKey(options.apiKey)
+	const idempotencyKey = sponsorshipIdempotencyKey({
+		apiKeyHash,
+		chainId: details.chainId,
+		feePayerPayloadHash: details.feePayerPayloadHash,
+		sponsorAddress: options.sponsorAddress,
+	})
+
+	return {
+		type: 'sponsorship_intent',
+		event: {
+			idempotencyKey,
+			apiKeyHash,
+			...(options.attributionKey
+				? { attributionKey: options.attributionKey }
+				: {}),
+			chainId: details.chainId,
+			sponsorAddress: options.sponsorAddress,
+			feePayerPayloadHash: details.feePayerPayloadHash,
+			...(typeof details.feePayerSignature !== 'undefined'
+				? { feePayerSignature: details.feePayerSignature }
+				: {}),
+			signedAt: options.signedAt ?? new Date().toISOString(),
+		},
+	}
+}
+
+/** Hashes the raw API key before sending it to billing-srv. */
+export function hashApiKey(apiKey: string): string {
+	return Hex.fromBytes(Hash.sha256(Bytes.fromString(apiKey)))
+}
+
+function sponsorshipDetailsFromRpc(
+	request: JsonRpcRequest,
+	response: JsonRpcResponse,
+	fallbackChainId: number,
+): SponsorshipDetails | null {
+	if (request.method === 'eth_fillTransaction')
+		return sponsorshipDetailsFromFill(request, response, fallbackChainId)
+
+	return null
+}
+
+function sponsorshipDetailsFromFill(
+	request: JsonRpcRequest,
+	response: JsonRpcResponse,
+	fallbackChainId: number,
+): SponsorshipDetails | null {
+	const result = asRecord(response.result)
+	const tx = asRecord(result?.tx)
+	if (!tx?.feePayerSignature) return null
+
+	const requestTx = asRecord(request.params?.[0])
+	const sender = stringValue(tx.from) ?? stringValue(requestTx?.from)
+	if (!sender) return null
+
+	const chainId =
+		numberValue(tx.chainId) ??
+		numberValue(requestTx?.chainId) ??
+		fallbackChainId
+	const envelope = TxEnvelopeTempo.from({
+		...requestTx,
+		...tx,
+		chainId,
+		calls: tx.calls ?? requestTx?.calls ?? callsFromLegacyRequest(requestTx),
+	} as never)
+
+	return {
+		chainId,
+		feePayerPayloadHash: TxEnvelopeTempo.getFeePayerSignPayload(envelope, {
+			sender: sender as TempoAddress.Address,
+		}),
+		feePayerSignature: tx.feePayerSignature,
+	}
+}
+
+function parseRpcRequest(value: unknown): JsonRpcRequest | null {
+	const request = asRecord(value)
+	if (!request || typeof request.method !== 'string') return null
+	return {
+		method: request.method,
+		params: Array.isArray(request.params) ? request.params : undefined,
+	}
+}
+
+function parseRpcResponse(value: unknown): JsonRpcResponse | null {
+	const response = asRecord(value)
+	if (!response) return null
+	return {
+		error: response.error,
+		result: response.result,
+	}
+}
+
+function sponsorshipIdempotencyKey(options: {
+	apiKeyHash: string
+	chainId: number
+	feePayerPayloadHash: string
+	sponsorAddress: string
+}) {
+	const digest = Hex.fromBytes(
+		Hash.keccak256(
+			Bytes.fromString(
+				[
+					options.apiKeyHash.toLowerCase(),
+					options.chainId,
+					options.sponsorAddress.toLowerCase(),
+					options.feePayerPayloadHash.toLowerCase(),
+				].join(':'),
+			),
+		),
+	)
+	return `sintent_${digest.slice(2)}`
+}
+
+function callsFromLegacyRequest(request: Record<string, unknown> | undefined) {
+	if (!request) return undefined
+	if (
+		typeof request.to === 'undefined' &&
+		typeof request.data === 'undefined' &&
+		typeof request.value === 'undefined'
+	)
+		return undefined
+
+	return [
+		{
+			...(typeof request.to !== 'undefined' ? { to: request.to } : {}),
+			...(typeof request.data !== 'undefined' ? { data: request.data } : {}),
+			...(typeof request.value !== 'undefined' ? { value: request.value } : {}),
+		},
+	]
+}
+
+function numberValue(value: unknown): number | undefined {
+	if (typeof value === 'number' && Number.isFinite(value)) return value
+	if (typeof value === 'bigint') return Number(value)
+	if (typeof value !== 'string') return undefined
+
+	const parsed = value.startsWith('0x') ? Number(BigInt(value)) : Number(value)
+	if (!Number.isFinite(parsed)) return undefined
+	return parsed
+}
+
+function stringValue(value: unknown): string | undefined {
+	return typeof value === 'string' ? value : undefined
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+	if (!value || typeof value !== 'object' || Array.isArray(value))
+		return undefined
+	return value as Record<string, unknown>
+}

--- a/apps/fee-payer/test/api-keys.test.ts
+++ b/apps/fee-payer/test/api-keys.test.ts
@@ -94,11 +94,19 @@ describe('admin API key management', () => {
 					label: 'Full Key',
 					dailyLimitUsd: '10.00',
 					allowedDestinations: ['0x0000000000000000000000000000000000000001'],
+					billable: true,
 				}),
 			)
 			expect(response.status).toBe(201)
 			const data = (await response.json()) as { key: string }
 			expect(data.key).toMatch(/^tp_/)
+
+			const listRes = await exports.default.fetch(adminRequest('GET', '/keys'))
+			const list = (await listRes.json()) as {
+				keys: Array<{ key: string; record: { billable: boolean } }>
+			}
+			const entry = list.keys.find((k) => k.key === data.key)
+			expect(entry?.record.billable).toBe(true)
 		})
 
 		it('rejects create with missing label', async () => {
@@ -106,6 +114,37 @@ describe('admin API key management', () => {
 				adminRequest('POST', '/keys', {}),
 			)
 			expect(response.status).toBe(400)
+		})
+
+		it('defaults new and legacy keys to non-billable', async () => {
+			const createRes = await exports.default.fetch(
+				adminRequest('POST', '/keys', { label: 'Non-Billable Default' }),
+			)
+			const { key } = (await createRes.json()) as { key: string }
+
+			const legacyKey = 'tp_legacy_non_billable_default'
+			await env.SponsorApiKeyStore.put(
+				`api-key:${legacyKey}`,
+				JSON.stringify({
+					label: 'Legacy Non-Billable Default',
+					dailyLimitUsd: null,
+					allowedDestinations: [],
+					createdAt: '2026-06-20T12:00:00.000Z',
+					active: true,
+				}),
+			)
+
+			const response = await exports.default.fetch(adminRequest('GET', '/keys'))
+			expect(response.status).toBe(200)
+			const data = (await response.json()) as {
+				keys: Array<{ key: string; record: { billable: boolean } }>
+			}
+			expect(
+				data.keys.find((entry) => entry.key === key)?.record.billable,
+			).toBe(false)
+			expect(
+				data.keys.find((entry) => entry.key === legacyKey)?.record.billable,
+			).toBe(false)
 		})
 
 		it('lists keys', async () => {
@@ -162,6 +201,7 @@ describe('admin API key management', () => {
 				adminRequest('PATCH', `/keys/${key}`, {
 					label: 'Updated',
 					dailyLimitUsd: '5.00',
+					billable: true,
 				}),
 			)
 			expect(updateRes.status).toBe(200)
@@ -171,12 +211,17 @@ describe('admin API key management', () => {
 			const data = (await listRes.json()) as {
 				keys: Array<{
 					key: string
-					record: { label: string; dailyLimitUsd: string | null }
+					record: {
+						label: string
+						dailyLimitUsd: string | null
+						billable: boolean
+					}
 				}>
 			}
 			const updated = data.keys.find((k) => k.key === key)
 			expect(updated?.record.label).toBe('Updated')
 			expect(updated?.record.dailyLimitUsd).toBe('5.00')
+			expect(updated?.record.billable).toBe(true)
 		})
 
 		it('returns 404 for updating nonexistent key', async () => {

--- a/apps/fee-payer/test/billing.test.ts
+++ b/apps/fee-payer/test/billing.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it } from 'vitest'
+import {
+	buildSponsorshipIntentMessage,
+	hashApiKey,
+} from '../src/lib/billing.js'
+import { tempoChain } from './helpers.js'
+
+const apiKey = 'tp_test_key'
+const sender = '0x0000000000000000000000000000000000000003'
+const sponsorAddress = '0x0000000000000000000000000000000000000004'
+const feeToken = '0x20c0000000000000000000000000000000000000'
+const target = '0x0000000000000000000000000000000000000005'
+const signedAt = '2026-06-20T12:00:00.000Z'
+const attributionKey = 'privy-app-123'
+const feePayerSignature = {
+	r: `0x${'11'.repeat(32)}`,
+	s: `0x${'22'.repeat(32)}`,
+	yParity: '0x0',
+}
+
+function fillRequest(params = {}) {
+	return {
+		jsonrpc: '2.0',
+		id: 1,
+		method: 'eth_fillTransaction',
+		params: [
+			{
+				from: sender,
+				chainId: tempoChain.id,
+				feePayer: true,
+				calls: [{ to: target, value: '0x0', data: '0x' }],
+				...params,
+			},
+		],
+	}
+}
+
+function fillResponse(tx = {}) {
+	return {
+		jsonrpc: '2.0',
+		id: 1,
+		result: {
+			tx: {
+				from: sender,
+				chainId: tempoChain.id,
+				gas: '0xc350',
+				maxFeePerGas: '0x4a817c800',
+				maxPriorityFeePerGas: '0x1',
+				nonce: '0x0',
+				calls: [{ to: target, value: '0x0', data: '0x' }],
+				feeToken,
+				feePayerSignature,
+				...tx,
+			},
+		},
+	}
+}
+
+function buildFillMessage(overrides = {}) {
+	return buildSponsorshipIntentMessage({
+		apiKey,
+		fallbackChainId: tempoChain.id,
+		requestBody: fillRequest(),
+		responseBody: fillResponse(),
+		signedAt,
+		sponsorAddress,
+		...overrides,
+	})
+}
+
+describe('billing sponsorship intents', () => {
+	it('builds a sponsorship_intent message from eth_fillTransaction', () => {
+		const message = buildFillMessage()
+
+		expect(message).toMatchObject({
+			type: 'sponsorship_intent',
+			event: {
+				apiKeyHash: hashApiKey(apiKey),
+				chainId: tempoChain.id,
+				feePayerSignature,
+				signedAt,
+				sponsorAddress,
+			},
+		})
+		expect(message?.event.idempotencyKey).toMatch(/^sintent_[0-9a-f]{64}$/)
+		expect(message?.event.feePayerPayloadHash).toMatch(/^0x[0-9a-f]{64}$/)
+	})
+
+	it('emits only the fields accepted by billing-srv', () => {
+		const message = buildFillMessage()
+		expect(message).not.toBeNull()
+		if (!message) throw new Error('expected sponsorship intent message')
+
+		expect(Object.keys(message).sort()).toEqual(['event', 'type'])
+		expect(Object.keys(message.event).sort()).toEqual([
+			'apiKeyHash',
+			'chainId',
+			'feePayerPayloadHash',
+			'feePayerSignature',
+			'idempotencyKey',
+			'signedAt',
+			'sponsorAddress',
+		])
+
+		const serialized = JSON.stringify(message)
+		expect(serialized).not.toContain('signing_event')
+		expect(serialized).not.toContain('eventId')
+		expect(serialized).not.toContain('feePayerSigningPayloadHash')
+		expect(serialized).not.toContain('appId')
+		expect(serialized).not.toContain('accountId')
+		expect(serialized).not.toContain('requestId')
+	})
+
+	it('includes an attribution key when provided', () => {
+		const message = buildFillMessage({ attributionKey })
+
+		expect(message?.event.attributionKey).toBe(attributionKey)
+		expect(Object.keys(message?.event ?? {}).sort()).toEqual([
+			'apiKeyHash',
+			'attributionKey',
+			'chainId',
+			'feePayerPayloadHash',
+			'feePayerSignature',
+			'idempotencyKey',
+			'signedAt',
+			'sponsorAddress',
+		])
+	})
+
+	it('builds deterministic idempotency keys for queue retries', () => {
+		const first = buildFillMessage()
+		const second = buildFillMessage()
+		const differentApiKey = buildFillMessage({ apiKey: 'tp_other_key' })
+		const differentPayload = buildFillMessage({
+			responseBody: fillResponse({ nonce: '0x1' }),
+		})
+
+		expect(first?.event.idempotencyKey).toBe(second?.event.idempotencyKey)
+		expect(differentApiKey?.event.idempotencyKey).not.toBe(
+			first?.event.idempotencyKey,
+		)
+		expect(differentPayload?.event.idempotencyKey).not.toBe(
+			first?.event.idempotencyKey,
+		)
+	})
+
+	it('does not build a message for failed or unsigned responses', () => {
+		expect(
+			buildSponsorshipIntentMessage({
+				apiKey,
+				fallbackChainId: tempoChain.id,
+				requestBody: fillRequest(),
+				responseBody: {
+					jsonrpc: '2.0',
+					id: 1,
+					error: { code: -32000, message: 'Sponsorship rejected' },
+				},
+				sponsorAddress,
+			}),
+		).toBeNull()
+
+		expect(
+			buildSponsorshipIntentMessage({
+				apiKey,
+				fallbackChainId: tempoChain.id,
+				requestBody: {
+					jsonrpc: '2.0',
+					id: 1,
+					method: 'eth_sendRawTransactionSync',
+					params: [`0x76${'00'.repeat(80)}`],
+				},
+				responseBody: {
+					jsonrpc: '2.0',
+					id: 1,
+					result: `0x${'aa'.repeat(32)}`,
+				},
+				sponsorAddress,
+			}),
+		).toBeNull()
+
+		expect(
+			buildSponsorshipIntentMessage({
+				apiKey,
+				fallbackChainId: tempoChain.id,
+				requestBody: fillRequest(),
+				responseBody: fillResponse({ feePayerSignature: undefined }),
+				sponsorAddress,
+			}),
+		).toBeNull()
+
+		expect(
+			buildSponsorshipIntentMessage({
+				apiKey,
+				fallbackChainId: tempoChain.id,
+				requestBody: {
+					jsonrpc: '2.0',
+					id: 1,
+					method: 'eth_chainId',
+				},
+				responseBody: { jsonrpc: '2.0', id: 1, result: '0x1' },
+				sponsorAddress,
+			}),
+		).toBeNull()
+	})
+})

--- a/apps/fee-payer/test/e2e.test.ts
+++ b/apps/fee-payer/test/e2e.test.ts
@@ -125,11 +125,16 @@ describe('fee-payer integration', () => {
 					headers: {
 						Origin: 'https://example.com',
 						'Access-Control-Request-Method': 'POST',
+						'Access-Control-Request-Headers':
+							'Content-Type, X-Tempo-Attribution-Key',
 					},
 				}),
 			)
 
 			expect([200, 204]).toContain(response.status)
+			expect(response.headers.get('Access-Control-Allow-Headers')).toContain(
+				'x-tempo-attribution-key',
+			)
 		})
 
 		it('handles health check / root path', async () => {

--- a/apps/fee-payer/wrangler.json
+++ b/apps/fee-payer/wrangler.json
@@ -134,6 +134,14 @@
 					"id": "08ce4ce226fe4dd3869ca91d5e3dd700"
 				}
 			],
+			"queues": {
+				"producers": [
+					{
+						"binding": "BILLING_QUEUE",
+						"queue": "billing-events"
+					}
+				]
+			},
 			"ratelimits": [
 				{
 					"name": "AddressRateLimiter",


### PR DESCRIPTION
## Summary

Adds billable API-key support to fee-payer and emits `sponsorship_intent` messages to billing-srv after sponsored `eth_fillTransaction` responses.

## Motivation

Billing-srv needs a queue-backed sponsorship intent before reconciliation can match sponsored onchain receipts and account for billable API-key spend.

## Changes

- Added a `billable` API-key field with admin create/update support and non-billable defaults for new and legacy keys.
- Added sponsorship-intent message construction using billing-srv’s current `idempotencyKey` contract.
- Enqueued billing messages from `executionCtx.waitUntil` only for billable keyed `eth_fillTransaction` requests.
- Passed `x-tempo-attribution-key` through to billing as `attributionKey` and allowed it in CORS preflight.
- Added the mainnet `BILLING_QUEUE` producer binding and focused API-key/billing tests.

## Testing

- `pnpm --filter fee-payer exec biome check --write src/lib/billing.ts test/billing.test.ts`
- `pnpm --filter fee-payer check:types`
- Isolated billing Vitest run with a temporary config skipping local Tempo global setup: 1 file passed, 5 tests passed.
- Standard `pnpm --filter fee-payer test` is blocked in this environment because local Tempo does not come up at `http://localhost:9545/1` without Docker/local node support.