### PR TITLE
Fix explorer balance address clipping

### DIFF
--- a/apps/explorer/src/comps/TxBalanceChanges.tsx
+++ b/apps/explorer/src/comps/TxBalanceChanges.tsx
@@ -24,7 +24,7 @@ export function TxBalanceChanges(props: TxBalanceChanges.Props) {
 		)
 
 	const cols: DataGrid.Column[] = [
-		{ label: 'Address', align: 'start', width: '2fr' },
+		{ label: 'Address', align: 'start', width: '2fr', minWidth: 140 },
 		{ label: 'Token', align: 'start', width: '1fr', minWidth: 120 },
 		{ label: 'Before', align: 'end', width: '2fr', minWidth: 160 },
 		{ label: 'After', align: 'end', width: '2fr', minWidth: 160 },


### PR DESCRIPTION
## Summary
- Add a 140px minimum width to the transaction balance changes Address column.
- Root cause: the column used `width: '2fr'` without `minWidth`, so DataGrid emitted `minmax(0, 2fr)` in tab mode while cells use `overflow-hidden`; the address `Midcut` then had less room than its practical minimum and got visually clipped.

## Test plan
- `pnpm --filter explorer check:types`
- `pnpm --filter explorer check:biome`

Prompted by: @struong