### PR TITLE
fix(fee-payer): normalize billing payload hashes

### DIFF
--- a/apps/fee-payer/src/lib/billing.ts
+++ b/apps/fee-payer/src/lib/billing.ts
@@ -1,6 +1,6 @@
 import { env } from 'cloudflare:workers'
 import { Bytes, Hash, Hex } from 'ox'
-import { type TempoAddress, TxEnvelopeTempo } from 'ox/tempo'
+import { type TempoAddress, Transaction, TxEnvelopeTempo } from 'ox/tempo'
 
 type JsonRpcRequest = {
 	method: string
@@ -160,12 +160,11 @@ function sponsorshipDetailsFromFill(
 		numberValue(tx.chainId) ??
 		numberValue(requestTx?.chainId) ??
 		fallbackChainId
-	const envelope = TxEnvelopeTempo.from({
-		...requestTx,
-		...tx,
+	const envelope = buildFeePayerEnvelope({
 		chainId,
-		calls: tx.calls ?? requestTx?.calls ?? callsFromLegacyRequest(requestTx),
-	} as never)
+		requestTx,
+		tx,
+	})
 
 	return {
 		chainId,
@@ -174,6 +173,48 @@ function sponsorshipDetailsFromFill(
 		}),
 		feePayerSignature: tx.feePayerSignature,
 	}
+}
+
+function buildFeePayerEnvelope(options: {
+	chainId: number
+	requestTx: Record<string, unknown> | undefined
+	tx: Record<string, unknown>
+}) {
+	const merged = { ...options.requestTx, ...options.tx }
+	const transaction = { ...merged }
+	delete transaction.data
+	delete transaction.input
+	delete transaction.to
+	delete transaction.value
+
+	return TxEnvelopeTempo.from(
+		Transaction.fromRpc({
+			...transaction,
+			calls: mergeCalls(options.requestTx, options.tx),
+			chainId: Hex.fromNumber(options.chainId),
+			nonceKey: emptyHexAsUndefined(transaction.nonceKey),
+			type: '0x76',
+			validAfter: emptyHexAsUndefined(transaction.validAfter),
+			validBefore: emptyHexAsUndefined(transaction.validBefore),
+		} as never) as never,
+	)
+}
+
+function mergeCalls(
+	requestTx: Record<string, unknown> | undefined,
+	tx: Record<string, unknown>,
+) {
+	const fallbackCalls =
+		recordArrayValue(requestTx?.calls) ??
+		recordArrayValue(callsFromLegacyRequest(requestTx))
+	const responseCalls = recordArrayValue(tx.calls)
+
+	if (!responseCalls) return fallbackCalls
+
+	return responseCalls.map((call, index) => ({
+		...fallbackCalls?.[index],
+		...call,
+	}))
 }
 
 function parseRpcRequest(value: unknown): JsonRpcRequest | null {
@@ -238,9 +279,18 @@ function numberValue(value: unknown): number | undefined {
 	if (typeof value === 'bigint') return Number(value)
 	if (typeof value !== 'string') return undefined
 
-	const parsed = value.startsWith('0x') ? Number(BigInt(value)) : Number(value)
+	const parsed =
+		value === '0x'
+			? 0
+			: Hex.validate(value)
+				? Hex.toNumber(value)
+				: Number(value)
 	if (!Number.isFinite(parsed)) return undefined
 	return parsed
+}
+
+function emptyHexAsUndefined(value: unknown): unknown {
+	return value === '0x' ? undefined : value
 }
 
 function stringValue(value: unknown): string | undefined {
@@ -251,4 +301,14 @@ function asRecord(value: unknown): Record<string, unknown> | undefined {
 	if (!value || typeof value !== 'object' || Array.isArray(value))
 		return undefined
 	return value as Record<string, unknown>
+}
+
+function recordArrayValue(
+	value: unknown,
+): Array<Record<string, unknown>> | undefined {
+	if (!Array.isArray(value)) return undefined
+	return value.flatMap((item) => {
+		const record = asRecord(item)
+		return record ? [record] : []
+	})
 }

--- a/apps/fee-payer/test/billing.test.ts
+++ b/apps/fee-payer/test/billing.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+import { TxEnvelopeTempo } from 'ox/tempo'
 import {
 	buildSponsorshipIntentMessage,
 	hashApiKey,
@@ -142,6 +143,55 @@ describe('billing sponsorship intents', () => {
 		expect(differentPayload?.event.idempotencyKey).not.toBe(
 			first?.event.idempotencyKey,
 		)
+	})
+
+	it('normalizes fill RPC quantities before hashing the fee-payer payload', () => {
+		const chainId = `0x${tempoChain.id.toString(16)}`
+		const nonceKey =
+			'0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff'
+		const validBefore = '0x6a39d553'
+		const message = buildSponsorshipIntentMessage({
+			apiKey,
+			fallbackChainId: tempoChain.id,
+			requestBody: fillRequest({
+				chainId,
+				calls: [{ to: target, value: '0x', data: '0x' }],
+				nonce: '0x0',
+				nonceKey,
+				type: '0x76',
+				validBefore,
+			}),
+			responseBody: fillResponse({
+				chainId,
+				calls: [{ to: target, data: '0x' }],
+				gas: '0xd492',
+				maxFeePerGas: '0x4a817c800',
+				maxPriorityFeePerGas: '0x0',
+				nonce: '0x0',
+				validBefore,
+			}),
+			signedAt,
+			sponsorAddress,
+		})
+		const equivalentMinedEnvelope = TxEnvelopeTempo.from({
+			accessList: [],
+			authorizationList: [],
+			calls: [{ to: target, value: 0n, data: '0x' }],
+			chainId: tempoChain.id,
+			feeToken,
+			gas: 0xd492n,
+			maxFeePerGas: 0x4a817c800n,
+			maxPriorityFeePerGas: 0n,
+			nonce: 0n,
+			nonceKey: BigInt(nonceKey),
+			validBefore: Number(BigInt(validBefore)),
+		})
+		const expectedHash = TxEnvelopeTempo.getFeePayerSignPayload(
+			equivalentMinedEnvelope,
+			{ sender },
+		)
+
+		expect(message?.event.feePayerPayloadHash).toBe(expectedHash)
 	})
 
 	it('does not build a message for failed or unsigned responses', () => {


### PR DESCRIPTION
## Summary

Normalizes fee-payer fill request/response data before computing the billing `feePayerPayloadHash`.

## Motivation

Production smoke testing showed billing-srv consumed the sponsored transaction intent and scanned the canary block, but reconciliation left the receipt unmatched because the queued intent hash was computed from unnormalized JSON-RPC fill fields and did not match the mined transaction payload hash.

## Changes

- Added fee-payer billing envelope normalization for hex quantity strings, nonce fields, validity windows, access lists, and call data/value shapes.
- Preserved request call fields as fallbacks when fill responses omit fields such as `value`.
- Added a regression test that compares a production-shaped fill response to the equivalent mined transaction envelope hash.

## Testing

- `biome check --write src/lib/billing.ts test/billing.test.ts`
- `tsgo --project tsconfig.json --noEmit` from `apps/fee-payer` with generated Worker bindings present
- Focused `test/billing.test.ts` via a temporary Vitest config without localnet global setup: 6 tests passed