### PR TITLE
fix(explorer): lowercase address in tx-only history query

### DIFF
--- a/apps/explorer/src/lib/server/tempo-queries.ts
+++ b/apps/explorer/src/lib/server/tempo-queries.ts
@@ -1042,8 +1042,11 @@ export async function fetchAddressTxOnlyHistoryPageWithJoins(
 		'txs.input',
 		'txs.calls',
 	].join(', ')
+	// Addresses are stored lowercased in the index; normalize the checksummed
+	// input before comparing or every mixed-case address matches zero rows.
+	const address = indexedAddress(params.address)
 	const whereForSide = (side: 'from' | 'to') =>
-		[`txs."${side}" = '${params.address}'`, ...filters].join(' AND ')
+		[`txs."${side}" = '${address}'`, ...filters].join(' AND ')
 	const sideQuery = (side: 'from' | 'to', limit: number) =>
 		`(SELECT ${columns} FROM txs ${statusJoin} WHERE ${whereForSide(side)} ORDER BY txs.block_num ${sortDirection}, txs.hash ${sortDirection} LIMIT ${limit})`
 	const singleSideQuery = (side: 'from' | 'to') =>


### PR DESCRIPTION
fix(explorer): lowercase address in tx-only history query

## summary

The transaction-only address history page returns an empty list for any
address that contains a hex letter (a–f), even when that address clearly has
transactions. The summary counter on the same page shows a non-zero number,
so the UI ends up claiming "N transactions" above an empty table.

## root cause

`fetchAddressTxOnlyHistoryPageWithJoins` built its `WHERE` clause directly from
`params.address`:

```sql
txs."from" = '0xAbC...'   -- checksummed, mixed case
```

Indexed addresses are persisted **lowercased** (see `indexedAddress`), and every
other query in this module — including the companion count query
`fetchAddressDirectTxCount` — normalizes through `indexedAddress(params.address)`
first. This one query was the only path that compared against the raw,
EIP-55-checksummed value coming out of `zAddress()`, so the equality never
matched a stored row.

## fix

Normalize once at the top of the function and use the lowercased value in the
`WHERE` builder, matching the rest of the file:

```ts
const address = indexedAddress(params.address)
const whereForSide = (side) => [`txs."${side}" = '${address}'`, ...filters].join(' AND ')
```

No behavior change for all-lowercase addresses; mixed-case addresses now resolve
their transactions correctly and the list matches the count.


