### PR TITLE
fix(explorer): lowercase address in tx-only history query

### DIFF
--- a/apps/fee-payer/src/lib/rate-limit.ts
+++ b/apps/fee-payer/src/lib/rate-limit.ts
@@ -95,11 +95,16 @@ export function rateLimitMiddleware(opts: { keyed: boolean }) {
 				const apiKey = c.get('apiKey') as string | undefined
 				const apiKeyRecord = c.get('apiKeyRecord') as ApiKeyRecord | undefined
 				if (apiKey && apiKeyRecord) {
-					if (apiKeyRecord.allowedDestinations.length > 0 && to) {
-						const dest = to.toLowerCase()
-						const allowed = apiKeyRecord.allowedDestinations.some(
-							(a) => a.toLowerCase() === dest,
-						)
+					if (apiKeyRecord.allowedDestinations.length > 0) {
+						// Fail closed: a key restricted to specific destinations must not
+						// sponsor a transaction whose destination cannot be determined
+						// (e.g. contract creation, or an envelope with no `to`).
+						const dest = to?.toLowerCase()
+						const allowed =
+							dest !== undefined &&
+							apiKeyRecord.allowedDestinations.some(
+								(a) => a.toLowerCase() === dest,
+							)
 						if (!allowed) {
 							return c.json(
 								{ error: 'Destination address not allowed for this API key' },


### PR DESCRIPTION
# Security Advisory: API-key destination allowlist bypass

| | |
|---|---|
| **Severity** | High |
| **Class** | Authorization bypass / fee-sponsorship abuse |
| **Component** | `apps/fee-payer` rate-limit middleware |
| **Status** | Fixed in this change |

## ⚠️ Impact

A sponsorship API key may be provisioned with `allowedDestinations` to restrict
which contracts it is permitted to pay gas for. The enforcement check was gated
behind a truthiness test on the resolved destination:

```ts
if (apiKeyRecord.allowedDestinations.length > 0 && to) { ... }
```

`to` is resolved as `transaction.calls?.[0]?.to ?? transaction.to`. For a
**contract-creation transaction** — or any deserialized envelope where neither
field is present — `to` is `undefined`. The `&& to` guard then short-circuits
and the entire allowlist branch is skipped, so the request is sponsored
**regardless of the key's configured allowlist**.

A holder of a restricted key can therefore have arbitrary `to`-less
transactions (including contract deployments) paid for by the sponsor,
defeating the destination restriction entirely.

## Resolution

The check now **fails closed**. When an allowlist is configured, an
undeterminable destination is treated as "not allowed" and the request is
rejected with `403`:

```ts
if (apiKeyRecord.allowedDestinations.length > 0) {
  const dest = to?.toLowerCase()
  const allowed = dest !== undefined &&
    apiKeyRecord.allowedDestinations.some((a) => a.toLowerCase() === dest)
  if (!allowed) return c.json({ error: 'Destination address not allowed ...' }, 403)
}
```

Keys with an empty `allowedDestinations` array are unaffected (unrestricted).