### PR TITLE
fix(fee-payer): reject admin requests when ADMIN_SECRET is unset

### DIFF
--- a/apps/fee-payer/src/lib/admin.ts
+++ b/apps/fee-payer/src/lib/admin.ts
@@ -24,6 +24,12 @@ admin.use('*', async (c, next) => {
 			503,
 		)
 	}
+	// Refuse to authenticate when no secret is configured. Otherwise the
+	// comparison string degrades to the literal "Bearer undefined", which any
+	// caller could send to gain full control over the API keys.
+	if (!env.ADMIN_SECRET) {
+		return c.json({ error: 'API key management not available in this environment' }, 503)
+	}
 	const auth = c.req.header('Authorization')
 	if (!auth || auth !== `Bearer ${env.ADMIN_SECRET}`) {
 		return c.json({ error: 'Unauthorized' }, 401)


### PR DESCRIPTION
# Harden admin guard against missing ADMIN_SECRET

- `ADMIN_SECRET` is optional (`env.d.ts`: `readonly ADMIN_SECRET?: string`).
- Admin guard only hard-requires the KV binding; the secret check was `auth !== \`Bearer ${env.ADMIN_SECRET}\``.
- If KV is bound but the secret is unset, the comparison becomes `"Bearer undefined"`.
- Anyone sending `Authorization: Bearer undefined` is then authenticated.
- That grants create / list / update / revoke on every sponsorship key.

Fix:

- Return `503` up front when `env.ADMIN_SECRET` is falsy — before any header comparison.
- Configured envs are unchanged; unconfigured envs can no longer be unlocked by guessing.

Notes:

- Comparison is still not constant-time; out of scope here, flagged for follow-up.
