### PR TITLE
fix(explorer): advance address-history cursor by hashes consumed

### DIFF
--- a/apps/explorer/src/routes/api/address/$address.ts
+++ b/apps/explorer/src/routes/api/address/$address.ts
@@ -291,7 +291,14 @@ export const Route = createFileRoute('/api/address/$address')({
 							})
 					}
 
-					const nextOffset = offset + transactions.length
+					// Advance the cursor by the number of hashes consumed from the
+					// sorted page, not by how many tx rows came back. Some hashes
+					// originate from transfer/log sources that have no row in the
+					// `txs` table, so `transactions.length` can be smaller than the
+					// page size — using it would re-select the skipped hashes next
+					// page (duplicates) or, if a whole page is missing tx data,
+					// never advance at all.
+					const nextOffset = offset + finalHashes.length
 
 					return Response.json({
 						transactions,


### PR DESCRIPTION
## What happened

I was paging through the activity feed for a busy address and noticed the list
just… stopped advancing. Same rows kept coming back, and for one address the
"load more" button spun forever without ever moving past a certain point.

After digging in, here's what's going on. The address endpoint assembles a page
of hashes from a few different places — the `txs` table, but also transfer rows
and emitted-log rows, plus the contract-creation tx. We then call
`fetchTxDataByHashes` to hydrate them, and that helper *only* reads the `txs`
table. So any hash that came from the transfer/log side has no matching tx row
and gets quietly filtered out.

That filtering is fine on its own — the trouble is what we did next. The
pagination cursor was computed from the hydrated count:

```ts
const nextOffset = offset + transactions.length
```

If a 20-hash page hydrates to only 15 rows, the cursor moves forward by 15, not
20. Next request starts at offset 15 and happily re-selects the five hashes we
already skipped — duplicates, stalled progress. And in the worst case (a whole
page with no tx data) `transactions.length` is 0 while `hasMore` is still true,
so the client loops on the same offset forever.