### PR TITLE
fix(explorer): use /rpc Tempo API endpoint instead of /v1/rpc

### DIFF
--- a/apps/explorer/src/wagmi.config.ts
+++ b/apps/explorer/src/wagmi.config.ts
@@ -86,7 +86,7 @@ const getTempoTransport = createIsomorphicFn()
 			apiKey &&
 			(chain.id === tempoMainnet.id || chain.id === tempoTestnet.id)
 		)
-			return http(`${tempoApiUrl}/v1/rpc?chainId=${chain.id}`, {
+			return http(`${tempoApiUrl}/rpc?chainId=${chain.id}`, {
 				fetchOptions: { headers: { 'tempo-api-key': apiKey } },
 			})
 


### PR DESCRIPTION
The Tempo API RPC passthrough endpoint moved from `/v1/rpc` to `/rpc`. Updates the explorer wagmi config accordingly.

Other `tempoApiUrl` endpoints (`/v1/tokens`, `/v1/indexer`, token logo) are unaffected and keep their `/v1` prefix.