### PR TITLE
fix(explorer): tolerate per-token metadata failures on block page

### DIFF
--- a/apps/explorer/src/lib/queries/blocks.ts
+++ b/apps/explorer/src/lib/queries/blocks.ts
@@ -110,7 +110,9 @@ export function blockKnownEventsQueryOptions(
 
 			const tip20Array = Array.from(allTip20Addresses) as Hex.Hex[]
 			const metadataResults = await Promise.all(
-				tip20Array.map((token) => client.token.getMetadata({ token })),
+				tip20Array.map((token) =>
+					client.token.getMetadata({ token }).catch(() => null),
+				),
 			)
 
 			const tokenMetadataMap = new Map<


### PR DESCRIPTION
# 🩹 One bad token shouldn't blank out a whole block's events

Hey! Small but annoying one here.

On the block page we collect every TIP-20 address that shows up in the
receipts, then fetch metadata for all of them at once:

```ts
const metadataResults = await Promise.all(
  tip20Array.map((token) => client.token.getMetadata({ token })),
)
```

Problem: `Promise.all` is all-or-nothing. If *one* token doesn't conform to the
TIP-20 metadata interface, or the RPC just hiccups on a single call, the whole
thing rejects — and `blockKnownEventsQueryOptions` fails with it. So a single
weird token means **none** of the transactions on that block get their
known-events rendered. 😬

The funny thing is the receipts fetch right above it already does the right
thing with `.catch(() => null)`, and the loop that consumes the metadata
already null-checks each entry. So this was just an inconsistency.

The fix is to make the metadata fetch match:

```ts
tip20Array.map((token) => client.token.getMetadata({ token }).catch(() => null))
```

Now a flaky/non-conforming token just doesn't get decorated metadata, and
everything else on the block renders fine. 👍