### PR TITLE
fix(explorer): include transfer-backed address history

### DIFF
--- a/apps/explorer/src/lib/server/address-history.ts
+++ b/apps/explorer/src/lib/server/address-history.ts
@@ -62,6 +62,10 @@ type TransactionRow = InferResponseType<
 	typeof api.v1.transactions.$get,
 	200
 >['data'][number]
+type TransferRow = InferResponseType<
+	typeof api.v1.transfers.$get,
+	200
+>['data'][number]
 
 function serializeBigInts<T>(value: T): T {
 	if (typeof value === 'bigint') {
@@ -187,6 +191,65 @@ export function toEnrichedTransaction(
 	}
 }
 
+export function toTransferTransaction(row: TransferRow): EnrichedTransaction {
+	const from = Address.checksum(row.sender as Address.Address)
+	const to = Address.checksum(row.recipient as Address.Address)
+	const tokenAddress = row.sourceToken.address as Address.Address
+
+	return {
+		hash: row.transactionHash as `0x${string}`,
+		blockNumber: toHexQuantity(row.blockNumber),
+		timestamp: parseTimestamp(row.timestamp) ?? 0,
+		from,
+		to,
+		value: '0x0',
+		status: 'success',
+		gasUsed: '0x0',
+		effectiveGasPrice: '0x0',
+		knownEvents: serializeBigInts([
+			{
+				type: 'send',
+				parts: [
+					{ type: 'action', value: 'Send' },
+					{
+						type: 'amount',
+						value: {
+							token: tokenAddress,
+							value: BigInt(row.sourceToken.amount),
+						},
+					},
+					{ type: 'text', value: 'to' },
+					{ type: 'account', value: to },
+				],
+				meta: { from, to },
+			},
+		]),
+	}
+}
+
+function sortTransactions(
+	transactions: readonly EnrichedTransaction[],
+	sort: 'asc' | 'desc',
+): EnrichedTransaction[] {
+	return [...transactions].sort((a, b) => {
+		const timeDiff =
+			sort === 'desc' ? b.timestamp - a.timestamp : a.timestamp - b.timestamp
+		if (timeDiff !== 0) return timeDiff
+
+		const aBlockNumber = Hex.toBigInt(a.blockNumber as Hex.Hex)
+		const bBlockNumber = Hex.toBigInt(b.blockNumber as Hex.Hex)
+		const blockDiff =
+			sort === 'desc'
+				? Number(bBlockNumber) - Number(aBlockNumber)
+				: Number(aBlockNumber) - Number(bBlockNumber)
+		if (blockDiff !== 0) return blockDiff
+
+		return sort === 'desc'
+			? b.hash.localeCompare(a.hash)
+			: a.hash.localeCompare(b.hash)
+	})
+}
+
 export async function fetchAddressHistoryData(params: {
 	address: Address.Address
 	chainId: number
@@ -229,42 +292,93 @@ export async function fetchAddressHistoryData(params: {
 				? { recipient: address }
 				: { address }
 
-	const result = await parseResponse(
-		api.v1.transactions.$get({
-			query: {
-				chainId: String(chainId),
-				...sideFilter,
-				...(searchParams.status ? { status: searchParams.status } : {}),
-				...(searchParams.after
-					? {
-							'timestamp.from': new Date(
-								searchParams.after * 1000,
-							).toISOString(),
-						}
-					: {}),
-				order: searchParams.sort,
-				limit: String(limit),
-				...(page > 1 ? { page: String(page) } : {}),
-				include: 'receipt,totalCount',
-			},
-		}),
-	)
+	const [result, transferResult] = await Promise.all([
+		parseResponse(
+			api.v1.transactions.$get({
+				query: {
+					chainId: String(chainId),
+					...sideFilter,
+					...(searchParams.status ? { status: searchParams.status } : {}),
+					...(searchParams.after
+						? {
+								'timestamp.from': new Date(
+									searchParams.after * 1000,
+								).toISOString(),
+							}
+						: {}),
+					order: searchParams.sort,
+					limit: String(limit),
+					...(page > 1 ? { page: String(page) } : {}),
+					include: 'receipt,totalCount',
+				},
+			}),
+		),
+		searchParams.include === 'all' && !searchParams.status
+			? parseResponse(
+					api.v1.transfers.$get({
+						query: {
+							chainId: String(chainId),
+							address,
+							...(searchParams.after
+								? {
+										'timestamp.from': new Date(
+											searchParams.after * 1000,
+										).toISOString(),
+									}
+								: {}),
+							order: searchParams.sort,
+							limit: String(limit),
+							...(page > 1 ? { page: String(page) } : {}),
+							include: 'totalCount',
+						},
+					}),
+				).catch((error) => {
+					console.error('[history] failed to fetch transfer history:', error)
+					return undefined
+				})
+			: Promise.resolve(undefined),
+	])
 
 	const getTokenMetadata = includeKnownEvents
 		? await buildTokenMetadataLookup(result.data)
 		: () => undefined
 
-	const transactions = result.data.map((row) =>
+	const transactionsByHash = new Map<string, EnrichedTransaction>()
+	for (const transaction of result.data.map((row) =>
 		toEnrichedTransaction(row, { includeKnownEvents, getTokenMetadata }),
-	)
+	)) {
+		transactionsByHash.set(transaction.hash.toLowerCase(), transaction)
+	}
+	for (const transaction of (transferResult?.data ?? []).map(
+		toTransferTransaction,
+	)) {
+		if (!transactionsByHash.has(transaction.hash.toLowerCase())) {
+			transactionsByHash.set(transaction.hash.toLowerCase(), transaction)
+		}
+	}
+
+	const transactions = sortTransactions(
+		[...transactionsByHash.values()],
+		searchParams.sort,
+	).slice(0, limit)
 
 	const { total, totalCapped } = resolveTotal({
-		exactCount: result.meta?.totalCount,
-		exactCountCapped: result.meta?.totalCountCapped,
+		exactCount:
+			result.meta?.totalCount === undefined &&
+			transferResult?.meta?.totalCount === undefined
+				? undefined
+				: Math.max(
+						result.meta?.totalCount ?? 0,
+						transferResult?.meta?.totalCount ?? 0,
+					),
+		exactCountCapped:
+			result.meta?.totalCountCapped || transferResult?.meta?.totalCountCapped,
 		page,
 		limit,
 		rows: transactions.length,
-		exhausted: result.nextCursor === null,
+		exhausted:
+			result.nextCursor === null &&
+			(transferResult?.nextCursor ?? null) === null,
 	})
 
 	return {
@@ -272,7 +386,9 @@ export async function fetchAddressHistoryData(params: {
 		total,
 		page,
 		limit,
-		hasMore: result.nextCursor !== null,
+		hasMore:
+			result.nextCursor !== null ||
+			(transferResult ? transferResult.nextCursor !== null : false),
 		countCapped: totalCapped,
 		error: null,
 	}

--- a/apps/explorer/test/address-history.node.test.ts
+++ b/apps/explorer/test/address-history.node.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest'
-import { toEnrichedTransaction } from '#lib/server/address-history'
+import {
+	toEnrichedTransaction,
+	toTransferTransaction,
+} from '#lib/server/address-history'
 
 const SENDER = '0x286ad6cfc7279c8a6d86d15dcefcb77a65aa7e92'
 const RECIPIENT = '0x20c0000000000000000000000000000000000003'
@@ -88,5 +91,37 @@ describe('toEnrichedTransaction', () => {
 		)
 
 		expect(result.status).toBe('reverted')
+	})
+})
+
+describe('toTransferTransaction', () => {
+	it('maps an account transfer row to an event-backed transaction row', () => {
+		const result = toTransferTransaction({
+			blockNumber: 21_900_000,
+			recipient: RECIPIENT,
+			sender: SENDER,
+			sourceToken: {
+				address: '0x20c0000000000000000000000000000000000000',
+				amount: '12345',
+			},
+			timestamp: '2026-06-24T12:00:00.000Z',
+			transactionHash: HASH,
+		} as never)
+
+		expect(result.hash).toBe(HASH)
+		expect(result.timestamp).toBe(Date.parse('2026-06-24T12:00:00.000Z') / 1000)
+		expect(result.from).toBe('0x286ad6cfc7279C8a6D86D15dcEFcB77A65Aa7E92')
+		expect(result.to).toBe('0x20C0000000000000000000000000000000000003')
+		expect(result.knownEvents[0]).toMatchObject({
+			type: 'send',
+			meta: { from: result.from, to: result.to },
+		})
+		expect(result.knownEvents[0]?.parts[1]).toEqual({
+			type: 'amount',
+			value: {
+				token: '0x20c0000000000000000000000000000000000000',
+				value: '12345',
+			},
+		})
 	})
 })


### PR DESCRIPTION
## Summary
- address history now augments direct `/v1/transactions` rows with account-scoped `/v1/transfers` rows for the All filter
- transfer-only hashes get event-backed transaction rows so recent token-transfer activity appears in the Transactions tab again
- added coverage for transfer-row mapping

## Verification
- `pnpm --filter explorer test -- --run test/address-history.node.test.ts`
- `pnpm --filter explorer check:types`

Prompted by: @struong