### PR TITLE
Limit sponsored MPP channel opens per address

### DIFF
--- a/apps/fee-payer/src/lib/channel-open-limit.ts
+++ b/apps/fee-payer/src/lib/channel-open-limit.ts
@@ -1,0 +1,82 @@
+import { env } from 'cloudflare:workers'
+
+export const CHANNEL_OPEN_DAILY_LIMIT = 5
+export const TIP20_CHANNEL_RESERVE_ADDRESS =
+	'0x4d50500000000000000000000000000000000000'
+export const TIP20_CHANNEL_OPEN_SELECTOR = '0xedc53b00'
+
+type TempoCall = {
+	to?: string
+	input?: string
+	data?: string
+}
+
+type TempoTransaction = {
+	from?: string
+	to?: string
+	input?: string
+	data?: string
+	calls?: TempoCall[]
+}
+
+function utcDay(date = new Date()) {
+	return date.toISOString().slice(0, 10)
+}
+
+function secondsUntilNextUtcDay(date = new Date()) {
+	const nextDay = new Date(date)
+	nextDay.setUTCHours(24, 0, 0, 0)
+	return Math.max(1, Math.ceil((nextDay.getTime() - date.getTime()) / 1_000))
+}
+
+function channelOpenKvKey(from: string, day = utcDay()) {
+	return `channel-open:${from.toLowerCase()}:${day}`
+}
+
+export function isTip20ChannelOpen(transaction: TempoTransaction) {
+	const call = transaction.calls?.[0]
+	const to = (call?.to ?? transaction.to ?? '').toLowerCase()
+	const input = (
+		call?.input ??
+		call?.data ??
+		transaction.input ??
+		transaction.data ??
+		''
+	).toLowerCase()
+
+	return (
+		to === TIP20_CHANNEL_RESERVE_ADDRESS &&
+		input.startsWith(TIP20_CHANNEL_OPEN_SELECTOR)
+	)
+}
+
+/**
+ * Reserves one daily sponsored channel-open slot for a payer address.
+ *
+ * Cloudflare KV does not provide atomic increments, so this is a best-effort
+ * guard. Reserving before relay sponsorship prevents a single sequential client
+ * from exceeding the quota and reduces the blast radius of bursty clients.
+ */
+export async function reserveChannelOpenSponsorship(
+	from: string,
+	limit = CHANNEL_OPEN_DAILY_LIMIT,
+): Promise<{ allowed: boolean; count: number; limit: number }> {
+	if (!env.SponsorApiKeyStore) {
+		throw new Error('SponsorApiKeyStore binding is not configured')
+	}
+
+	const key = channelOpenKvKey(from)
+	const current = Number.parseInt(
+		(await env.SponsorApiKeyStore.get(key)) ?? '0',
+		10,
+	)
+	const count = Number.isFinite(current) ? current : 0
+	if (count >= limit) return { allowed: false, count, limit }
+
+	const next = count + 1
+	await env.SponsorApiKeyStore.put(key, next.toString(), {
+		expirationTtl: secondsUntilNextUtcDay(),
+	})
+
+	return { allowed: true, count: next, limit }
+}

--- a/apps/fee-payer/src/lib/rate-limit.ts
+++ b/apps/fee-payer/src/lib/rate-limit.ts
@@ -7,6 +7,10 @@ import { Transaction } from 'viem/tempo'
 import * as z from 'zod/mini'
 import type { ApiKeyRecord } from './api-keys.js'
 import { checkBudget, recordSpend } from './api-key-budget.js'
+import {
+	isTip20ChannelOpen,
+	reserveChannelOpenSponsorship,
+} from './channel-open-limit.js'
 
 /**
  * Middleware that rate limits requests based on the transaction's `from` address.
@@ -64,7 +68,9 @@ export function rateLimitMiddleware(opts: { keyed: boolean }) {
 				const transaction = Transaction.deserialize(serialized) as {
 					from?: string
 					to?: string
-					calls?: Array<{ to?: string }>
+					input?: string
+					data?: string
+					calls?: Array<{ to?: string; input?: string; data?: string }>
 					gas?: bigint
 					maxFeePerGas?: bigint
 				}
@@ -82,6 +88,8 @@ export function rateLimitMiddleware(opts: { keyed: boolean }) {
 
 				const { success } = await limiter.limit({ key: from })
 				if (!success) return c.json({ error: 'Rate limit exceeded' }, 429)
+
+				const isChannelOpen = isTip20ChannelOpen(transaction)
 
 				// Expose an upper-bound fee estimate for analytics. This is
 				// `gasLimit * maxFeePerGas` (the user's authorized ceiling),
@@ -122,6 +130,18 @@ export function rateLimitMiddleware(opts: { keyed: boolean }) {
 						// Record spend after request completes successfully.
 						c.executionCtx.waitUntil(
 							recordSpend(apiKey, transaction.gas, transaction.maxFeePerGas),
+						)
+					}
+				}
+
+				if (isChannelOpen) {
+					const reservation = await reserveChannelOpenSponsorship(from)
+					if (!reservation.allowed) {
+						return c.json(
+							{
+								error: `Daily sponsored channel open limit exceeded (${reservation.limit}/day)`,
+							},
+							429,
 						)
 					}
 				}

--- a/apps/fee-payer/test/channel-open-limit.test.ts
+++ b/apps/fee-payer/test/channel-open-limit.test.ts
@@ -1,0 +1,70 @@
+import { env } from 'cloudflare:workers'
+import { describe, expect, it } from 'vitest'
+import {
+	isTip20ChannelOpen,
+	reserveChannelOpenSponsorship,
+	TIP20_CHANNEL_OPEN_SELECTOR,
+	TIP20_CHANNEL_RESERVE_ADDRESS,
+} from '../src/lib/channel-open-limit.js'
+
+describe('channel open sponsorship limit', () => {
+	it('detects TIP20 channel reserve open calls', () => {
+		expect(
+			isTip20ChannelOpen({
+				calls: [
+					{
+						to: TIP20_CHANNEL_RESERVE_ADDRESS,
+						input: `${TIP20_CHANNEL_OPEN_SELECTOR}${'00'.repeat(32)}`,
+					},
+				],
+			}),
+		).toBe(true)
+
+		expect(
+			isTip20ChannelOpen({
+				calls: [
+					{
+						to: TIP20_CHANNEL_RESERVE_ADDRESS,
+						input: `0xdc48471e${'00'.repeat(32)}`,
+					},
+				],
+			}),
+		).toBe(false)
+
+		expect(
+			isTip20ChannelOpen({
+				calls: [
+					{
+						to: '0x20c000000000000000000000b9537d11c60e8b50',
+						input: TIP20_CHANNEL_OPEN_SELECTOR,
+					},
+				],
+			}),
+		).toBe(false)
+	})
+
+	it('limits sponsored channel opens per address per UTC day', async () => {
+		const from = `0x${'1'.repeat(40)}`
+
+		for (let i = 0; i < 5; i++) {
+			await expect(reserveChannelOpenSponsorship(from)).resolves.toMatchObject({
+				allowed: true,
+				count: i + 1,
+				limit: 5,
+			})
+		}
+
+		await expect(reserveChannelOpenSponsorship(from)).resolves.toMatchObject({
+			allowed: false,
+			count: 5,
+			limit: 5,
+		})
+
+		const today = new Date().toISOString().slice(0, 10)
+		expect(
+			await env.SponsorApiKeyStore.get(
+				`channel-open:${from.toLowerCase()}:${today}`,
+			),
+		).toBe('5')
+	})
+})


### PR DESCRIPTION
## Summary
- add a daily 5 sponsored channel-open limit per payer address using the existing SponsorApiKeyStore KV cache
- detect TIP20 channel reserve open calls by reserve address and selector
- reject excess sponsored opens with 429 before relaying the request

## Validation
- pnpm --filter fee-payer check:biome
- pnpm --filter fee-payer check:types
- pnpm --filter fee-payer test -- channel-open-limit.test.ts rate-limit.test.ts (blocked: local Tempo/Docker setup did not respond at http://localhost:9545/1)

Prompted by: @grandizzy