### PR TITLE
Add docs MCP Datadog metrics

### DIFF
--- a/apps/mcp-docs-indexer/README.md
+++ b/apps/mcp-docs-indexer/README.md
@@ -290,6 +290,30 @@ pnpm --filter mcp-docs-indexer tail --format json
 Query historical runs in the Cloudflare dashboard → Workers → `mcp-docs-indexer` →
 Logs, e.g. `$.event = "source.failed"` to surface broken sources.
 
+The Worker also emits `cloudflare-worker-metrics` lines for the existing
+Cloudflare Logpush → metrics exporter → Datadog path. Metric names use the
+`tempo_docs_mcp_` prefix and global tags `repository:tempo-apps`,
+`component:docs_mcp`, and `service:tempo-docs-mcp`.
+
+Important metrics:
+
+- `tempo_docs_mcp_health_ok`
+- `tempo_docs_mcp_health_check_ok`
+- `tempo_docs_mcp_http_request_count`
+- `tempo_docs_mcp_http_response_duration_ms`
+- `tempo_docs_mcp_http_error_count`
+- `tempo_docs_mcp_jsonrpc_error_count`
+- `tempo_docs_mcp_tool_call_count`
+- `tempo_docs_mcp_tool_duration_ms`
+- `tempo_docs_mcp_ai_search_request_count`
+- `tempo_docs_mcp_ai_search_duration_ms`
+- `tempo_docs_mcp_ai_search_empty_result_count`
+- `tempo_docs_mcp_proxy_fallback_count`
+- `tempo_docs_mcp_ingest_ok`
+- `tempo_docs_mcp_ingest_duration_ms`
+- `tempo_docs_mcp_source_sync_count`
+- `tempo_docs_mcp_source_pages_failed`
+
 ## Deploy
 
 ```bash

--- a/apps/mcp-docs-indexer/package.json
+++ b/apps/mcp-docs-indexer/package.json
@@ -22,6 +22,7 @@
 		"@cloudflare/codemode": "catalog:",
 		"@modelcontextprotocol/sdk": "catalog:",
 		"ai": "catalog:",
+		"cloudflare-worker-metrics": "catalog:",
 		"zod": "catalog:"
 	},
 	"devDependencies": {

--- a/apps/mcp-docs-indexer/src/index.ts
+++ b/apps/mcp-docs-indexer/src/index.ts
@@ -1,8 +1,13 @@
 import { DynamicWorkerExecutor } from '@cloudflare/codemode'
-import { env } from 'cloudflare:workers'
+import { healthMetrics } from './lib/health.js'
 import { syncSource } from './lib/ingest.js'
 import { log } from './lib/log.js'
 import { handleMcp } from './lib/mcp.js'
+import {
+	flushWorkerMetrics,
+	recordHttpRequestMetrics,
+	recordIngestMetrics,
+} from './lib/metrics.js'
 import { captureMcpAnalytics, parseJsonRpcRequest } from './lib/posthog-mcp.js'
 import { proxyMcp } from './lib/proxy.js'
 import { isForcedHour } from './lib/schedule.js'
@@ -14,63 +19,127 @@ let cachedSources: Source[] | undefined
 
 export default {
 	async fetch(req, env, ctx) {
-		const jsonRpcRequest = await parseJsonRpcRequest(req)
-		let response: Response | undefined
-		try {
-			response = await handleMcp(req, {
-				instance: env.AI_SEARCH.get(env.AI_SEARCH_INSTANCE_ID),
-				sources: sourcesFor(env.SOURCES),
-				executor: new DynamicWorkerExecutor({ loader: env.LOADER }),
-			})
-		} catch (error) {
-			log.error('mcp.local_failed', {
-				error: error instanceof Error ? error.message : String(error),
-			})
-		}
-		if (response) {
-			captureMcpAnalytics(req, jsonRpcRequest, response, env, ctx)
-			return response
-		}
-		return proxyMcp(req, env.AI_SEARCH_MCP_URL)
+		const url = new URL(req.url)
+		return trackRequest(req, routeName(url.pathname, req.method), async () => {
+			const jsonRpcRequest = await parseJsonRpcRequest(req)
+			let response: Response | undefined
+			try {
+				response = await handleMcp(req, {
+					instance: env.AI_SEARCH.get(env.AI_SEARCH_INSTANCE_ID),
+					sources: sourcesFor(env.SOURCES),
+					executor: new DynamicWorkerExecutor({ loader: env.LOADER }),
+				})
+			} catch (error) {
+				log.error('mcp.local_failed', {
+					error: error instanceof Error ? error.message : String(error),
+				})
+			}
+			if (response) {
+				captureMcpAnalytics(req, jsonRpcRequest, response, env, ctx)
+				return response
+			}
+			return proxyMcp(req, env.AI_SEARCH_MCP_URL)
+		})
 	},
-	async scheduled(event) {
-		const startedAt = performance.now()
-		// Once per UTC day, bypass all ETag caches as a backstop for sources
-		// whose llms.txt ETag doesn't track page changes correctly.
-		const force = isForcedHour(event.scheduledTime)
-		const sources = parseSources(env.SOURCES)
-		log.info('cron.start', {
-			cron: event.cron,
-			scheduled_time: new Date(event.scheduledTime).toISOString(),
-			instance: env.AI_SEARCH_INSTANCE_ID,
-			sources: sources.length,
-			force,
-		})
-
-		const instance = env.AI_SEARCH.get(env.AI_SEARCH_INSTANCE_ID)
-		const reports = []
-		for (const source of sources) {
-			const report = await syncSource({
-				source,
-				instance,
-				etagCache: env.ETAG_CACHE,
-				force,
-			})
-			if (report.status === 'error') log.error('source.failed', report)
-			else log.info('source.complete', report)
-			reports.push(report)
+	async scheduled(event, env, ctx) {
+		if (event.cron === '* * * * *') {
+			ctx.waitUntil(runHealthCheck(event, env))
+			return
 		}
-		log.info('cron.complete', {
-			cron: event.cron,
-			duration_ms: Math.round(performance.now() - startedAt),
-			sources: reports.length,
-			synced: reports.filter((r) => r.status === 'synced').length,
-			unchanged: reports.filter((r) => r.status === 'unchanged').length,
-			errors: reports.filter((r) => r.status === 'error').length,
-			force,
-		})
+		ctx.waitUntil(runSync(event, env))
 	},
 } satisfies ExportedHandler<Env>
+
+async function trackRequest(
+	req: Request,
+	route: string,
+	handler: () => Promise<Response>,
+): Promise<Response> {
+	const startedAt = performance.now()
+	try {
+		const response = await handler()
+		recordHttpRequestMetrics({
+			durationMs: Math.round(performance.now() - startedAt),
+			method: req.method,
+			route,
+			status: response.status,
+		})
+		return response
+	} catch (error) {
+		recordHttpRequestMetrics({
+			durationMs: Math.round(performance.now() - startedAt),
+			method: req.method,
+			route,
+			status: 500,
+			thrown: true,
+		})
+		throw error
+	} finally {
+		flushWorkerMetrics()
+	}
+}
+
+async function runHealthCheck(
+	event: ScheduledController,
+	env: Env,
+): Promise<void> {
+	const startedAt = performance.now()
+	await healthMetrics(env)
+	flushWorkerMetrics()
+	log.info('mcp.health_complete', {
+		cron: event.cron,
+		scheduled_time: new Date(event.scheduledTime).toISOString(),
+		duration_ms: Math.round(performance.now() - startedAt),
+	})
+}
+
+async function runSync(event: ScheduledController, env: Env): Promise<void> {
+	const startedAt = performance.now()
+	const force = isForcedHour(event.scheduledTime)
+	const sources = parseSources(env.SOURCES)
+	log.info('cron.start', {
+		cron: event.cron,
+		scheduled_time: new Date(event.scheduledTime).toISOString(),
+		instance: env.AI_SEARCH_INSTANCE_ID,
+		sources: sources.length,
+		force,
+	})
+
+	const instance = env.AI_SEARCH.get(env.AI_SEARCH_INSTANCE_ID)
+	const reports = []
+	for (const source of sources) {
+		const report = await syncSource({
+			source,
+			instance,
+			etagCache: env.ETAG_CACHE,
+			force,
+		})
+		if (report.status === 'error') log.error('source.failed', report)
+		else log.info('source.complete', report)
+		reports.push(report)
+	}
+	const durationMs = Math.round(performance.now() - startedAt)
+	recordIngestMetrics({ durationMs, force, reports })
+	flushWorkerMetrics()
+	log.info('cron.complete', {
+		cron: event.cron,
+		duration_ms: durationMs,
+		sources: reports.length,
+		synced: reports.filter((r) => r.status === 'synced').length,
+		unchanged: reports.filter((r) => r.status === 'unchanged').length,
+		errors: reports.filter((r) => r.status === 'error').length,
+		force,
+	})
+}
+
+function routeName(pathname: string, method: string): string {
+	if (method === 'OPTIONS') return 'options'
+	if (method === 'POST' && (pathname === '/' || pathname === '/mcp')) {
+		return 'mcp'
+	}
+	if (pathname === '/') return 'root'
+	return 'proxy'
+}
 
 function sourcesFor(config: Env['SOURCES']): Source[] {
 	const key = typeof config === 'string' ? config : JSON.stringify(config)

--- a/apps/mcp-docs-indexer/src/lib/health.test.ts
+++ b/apps/mcp-docs-indexer/src/lib/health.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { healthMetrics } from './health.js'
+import { flushWorkerMetrics } from './metrics.js'
+
+const fetchMock = vi.fn()
+
+beforeEach(() => {
+	fetchMock.mockReset()
+	vi.stubGlobal('fetch', fetchMock)
+	vi.spyOn(console, 'log').mockImplementation(() => {})
+	vi.spyOn(console, 'error').mockImplementation(() => {})
+})
+
+afterEach(() => {
+	flushWorkerMetrics()
+	vi.unstubAllGlobals()
+	vi.restoreAllMocks()
+})
+
+describe('healthMetrics', () => {
+	it('checks the public MCP surface and emits health metrics', async () => {
+		const logs: string[] = []
+		vi.mocked(console.log).mockImplementation((message) => {
+			logs.push(String(message))
+		})
+		fetchMock
+			.mockResolvedValueOnce(
+				json({ result: { serverInfo: { name: 'ai-search' } } }),
+			)
+			.mockResolvedValueOnce(
+				json({
+					result: {
+						tools: [
+							{ name: 'search' },
+							{ name: 'find_pages' },
+							{ name: 'read_page' },
+						],
+					},
+				}),
+			)
+			.mockResolvedValueOnce(
+				json({
+					result: { resources: [{ uri: 'tempo-docs://sources' }] },
+				}),
+			)
+			.mockResolvedValueOnce(
+				json({
+					result: {
+						structuredContent: { result: { chunks: [{ text: 'Tempo' }] } },
+					},
+				}),
+			)
+			.mockResolvedValueOnce(
+				json({
+					result: {
+						structuredContent: {
+							result: { pages: [{ url: 'https://docs.tempo.xyz/foo' }] },
+						},
+					},
+				}),
+			)
+			.mockResolvedValueOnce(
+				json({
+					result: {
+						structuredContent: { result: { text: 'Tempo docs page' } },
+					},
+				}),
+			)
+
+		await healthMetrics({ PUBLIC_MCP_ENDPOINT: 'https://mcp.tempo.xyz/' })
+		flushWorkerMetrics()
+
+		const metrics = logs
+			.filter((message) => message.startsWith('cwm-'))
+			.flatMap((message) => JSON.parse(message.slice('cwm-'.length)))
+		expect(metrics).toContainEqual(
+			expect.objectContaining({
+				n: 'tempo_docs_mcp_health_ok',
+				v: 1,
+			}),
+		)
+		expect(fetchMock).toHaveBeenCalledTimes(6)
+	})
+
+	it('parses server-sent JSON-RPC responses', async () => {
+		fetchMock
+			.mockResolvedValueOnce(
+				sse({ result: { serverInfo: { name: 'ai-search' } } }),
+			)
+			.mockResolvedValueOnce(
+				json({
+					result: {
+						tools: [
+							{ name: 'search' },
+							{ name: 'find_pages' },
+							{ name: 'read_page' },
+						],
+					},
+				}),
+			)
+			.mockResolvedValueOnce(
+				json({ result: { resources: [{ uri: 'tempo-docs://sources' }] } }),
+			)
+			.mockResolvedValueOnce(
+				json({
+					result: {
+						structuredContent: { result: { chunks: [{ text: 'Tempo' }] } },
+					},
+				}),
+			)
+			.mockResolvedValueOnce(
+				json({
+					result: {
+						structuredContent: {
+							result: { pages: [{ url: 'https://docs.tempo.xyz/foo' }] },
+						},
+					},
+				}),
+			)
+			.mockResolvedValueOnce(
+				json({
+					result: {
+						structuredContent: { result: { text: 'Tempo docs page' } },
+					},
+				}),
+			)
+
+		await healthMetrics({ PUBLIC_MCP_ENDPOINT: 'https://mcp.tempo.xyz/' })
+
+		expect(console.error).not.toHaveBeenCalled()
+	})
+})
+
+function json(body: unknown): Response {
+	return new Response(JSON.stringify({ jsonrpc: '2.0', id: 1, ...body }), {
+		headers: { 'content-type': 'application/json' },
+	})
+}
+
+function sse(body: unknown): Response {
+	return new Response(
+		`event: message\ndata: ${JSON.stringify({ jsonrpc: '2.0', id: 1, ...body })}\n\n`,
+		{ headers: { 'content-type': 'text/event-stream' } },
+	)
+}

--- a/apps/mcp-docs-indexer/src/lib/health.ts
+++ b/apps/mcp-docs-indexer/src/lib/health.ts
@@ -1,0 +1,236 @@
+import { recordHealthMetrics, type HealthMetricResult } from './metrics.js'
+
+type JsonObject = Record<string, unknown>
+type CheckFn = () => Promise<void>
+
+const DEFAULT_ENDPOINT = 'https://mcp.tempo.xyz/'
+const HEALTH_FETCH_TIMEOUT_MS = 5000
+const REQUIRED_TOOLS = ['search', 'find_pages', 'read_page']
+
+export async function healthMetrics(env: {
+	PUBLIC_MCP_ENDPOINT?: string
+}): Promise<void> {
+	const startedAt = performance.now()
+	const endpoint = env.PUBLIC_MCP_ENDPOINT || DEFAULT_ENDPOINT
+	const checks = await runChecks(endpoint)
+	recordHealthMetrics({
+		checks,
+		durationMs: Math.round(performance.now() - startedAt),
+	})
+
+	const failures = checks.filter((check) => !check.ok)
+	if (failures.length > 0) {
+		console.error(
+			JSON.stringify({
+				message: 'mcp.health_failed',
+				endpoint,
+				failures: failures.map((failure) => ({
+					check: failure.name,
+					error: failure.error,
+				})),
+			}),
+		)
+	}
+}
+
+async function runChecks(endpoint: string): Promise<HealthMetricResult[]> {
+	let tempoPage: JsonObject | undefined
+	const checks: Array<[string, CheckFn]> = [
+		['initialize', () => assertInitialize(endpoint)],
+		['tools_list', () => assertTools(endpoint)],
+		['resources_list', () => assertResources(endpoint)],
+		['search_tempo', () => assertSearch(endpoint)],
+		[
+			'find_pages_tempo',
+			async () => {
+				tempoPage = await firstTempoPage(endpoint)
+			},
+		],
+		['read_page_tempo', () => assertReadPage(endpoint, tempoPage)],
+	]
+	const results: HealthMetricResult[] = []
+	for (const [name, fn] of checks) results.push(await measure(name, fn))
+	return results
+}
+
+async function measure(name: string, fn: CheckFn): Promise<HealthMetricResult> {
+	const startedAt = performance.now()
+	try {
+		await fn()
+		return {
+			name,
+			ok: true,
+			durationMs: Math.round(performance.now() - startedAt),
+		}
+	} catch (error) {
+		return {
+			name,
+			ok: false,
+			durationMs: Math.round(performance.now() - startedAt),
+			error: error instanceof Error ? error.message : String(error),
+		}
+	}
+}
+
+async function assertInitialize(endpoint: string): Promise<void> {
+	const result = await rpc(endpoint, 'initialize', {
+		protocolVersion: '2025-06-18',
+		capabilities: {},
+		clientInfo: { name: 'tempo-docs-health', version: '1.0.0' },
+	})
+	if (!stringValue(object(result.serverInfo).name)) {
+		throw new Error('initialize missing serverInfo.name')
+	}
+}
+
+async function assertTools(endpoint: string): Promise<void> {
+	const result = await rpc(endpoint, 'tools/list')
+	const names = new Set(
+		arrayValue(result.tools)
+			.map((tool) => object(tool).name)
+			.filter((name): name is string => typeof name === 'string'),
+	)
+	for (const tool of REQUIRED_TOOLS) {
+		if (!names.has(tool)) throw new Error(`missing tool ${tool}`)
+	}
+}
+
+async function assertResources(endpoint: string): Promise<void> {
+	const result = await rpc(endpoint, 'resources/list')
+	const uris = new Set(
+		arrayValue(result.resources)
+			.map((resource) => object(resource).uri)
+			.filter((uri): uri is string => typeof uri === 'string'),
+	)
+	if (!uris.has('tempo-docs://sources')) {
+		throw new Error('missing sources resource')
+	}
+}
+
+async function assertSearch(endpoint: string): Promise<void> {
+	const result = structuredResult(
+		await callTool(endpoint, 'search', {
+			query: 'Tempo transactions',
+			source: 'tempo',
+			max_results: 1,
+			response_format: 'structured',
+		}),
+	)
+	if (arrayValue(object(result).chunks).length === 0) {
+		throw new Error('search returned no chunks')
+	}
+}
+
+async function assertReadPage(
+	endpoint: string,
+	page: JsonObject | undefined,
+): Promise<void> {
+	if (!page) throw new Error('missing page from find_pages')
+	const result = structuredResult(
+		await callTool(endpoint, 'read_page', {
+			source: 'tempo',
+			url: stringValue(page.url),
+			max_chars: 500,
+			response_format: 'structured',
+		}),
+	)
+	if (stringValue(object(result).text).trim().length === 0) {
+		throw new Error('read_page returned empty text')
+	}
+}
+
+async function firstTempoPage(endpoint: string): Promise<JsonObject> {
+	const result = structuredResult(
+		await callTool(endpoint, 'find_pages', {
+			source: 'tempo',
+			query: 'transactions',
+			max_results: 1,
+			response_format: 'structured',
+		}),
+	)
+	const [page] = arrayValue(object(result).pages)
+	if (!page) throw new Error('find_pages returned no pages')
+	return object(page)
+}
+
+async function callTool(
+	endpoint: string,
+	name: string,
+	args: JsonObject,
+): Promise<JsonObject> {
+	const result = await rpc(endpoint, 'tools/call', {
+		name,
+		arguments: args,
+	})
+	if (result.isError === true) throw new Error(`tool returned isError: ${name}`)
+	return result
+}
+
+async function rpc(
+	endpoint: string,
+	method: string,
+	params: JsonObject = {},
+): Promise<JsonObject> {
+	const body = await fetchJsonRpc(endpoint, {
+		method: 'POST',
+		headers: {
+			accept: 'application/json, text/event-stream',
+			'content-type': 'application/json',
+		},
+		body: JSON.stringify({ jsonrpc: '2.0', id: 1, method, params }),
+	})
+	if (body.error) {
+		throw new Error(
+			`json-rpc error: ${stringValue(object(body.error).message)}`,
+		)
+	}
+	return object(body.result)
+}
+
+async function fetchJsonRpc(
+	url: string,
+	init: RequestInit,
+): Promise<JsonObject> {
+	const res = await fetchWithTimeout(url, init)
+	if (!res.ok) throw new Error(`HTTP ${res.status}`)
+	const text = await res.text()
+	const data = sseData(text) ?? text
+	return object(JSON.parse(data))
+}
+
+async function fetchWithTimeout(
+	url: string,
+	init: RequestInit,
+): Promise<Response> {
+	const controller = new AbortController()
+	const timeout = setTimeout(() => controller.abort(), HEALTH_FETCH_TIMEOUT_MS)
+	try {
+		return await fetch(url, { ...init, signal: controller.signal })
+	} finally {
+		clearTimeout(timeout)
+	}
+}
+
+function sseData(text: string): string | undefined {
+	const line = text.split('\n').find((entry) => entry.startsWith('data: '))
+	return line?.slice('data: '.length)
+}
+
+function structuredResult(result: JsonObject): unknown {
+	return object(object(result.structuredContent).result)
+}
+
+function object(value: unknown): JsonObject {
+	if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
+		return value as JsonObject
+	}
+	return {}
+}
+
+function arrayValue(value: unknown): unknown[] {
+	return Array.isArray(value) ? value : []
+}
+
+function stringValue(value: unknown): string {
+	return typeof value === 'string' ? value : ''
+}

--- a/apps/mcp-docs-indexer/src/lib/mcp.ts
+++ b/apps/mcp-docs-indexer/src/lib/mcp.ts
@@ -10,6 +10,11 @@ import {
 	type Tool,
 } from '@modelcontextprotocol/sdk/types.js'
 import { toMarkdownUrl } from './llms-txt.js'
+import {
+	recordAiSearchRequest,
+	recordJsonRpcError,
+	recordToolCall,
+} from './metrics.js'
 import type { Source } from './sources.js'
 
 type JsonRpcRequest = {
@@ -201,11 +206,11 @@ export async function handleMcp(
 	if (body.method === 'resources/read') {
 		const uri = (body.params as { uri?: unknown } | undefined)?.uri
 		if (typeof uri !== 'string') {
-			return jsonRpcError(req, body.id, -32602, 'uri must be a string')
+			return jsonRpcErrorFor(req, body, -32602, 'uri must be a string')
 		}
 		const contents = await readResource(uri, context.sources ?? [])
 		if (!contents) {
-			return jsonRpcError(req, body.id, -32002, `resource not found: ${uri}`)
+			return jsonRpcErrorFor(req, body, -32002, `resource not found: ${uri}`)
 		}
 		return jsonRpc(req, body.id, { contents })
 	}
@@ -214,74 +219,89 @@ export async function handleMcp(
 		return undefined
 	}
 	if (body.params?.name === CODE_TOOL_NAME) {
-		const executor = context.executor
-		if (!executor) {
-			return jsonRpcError(req, body.id, -32601, 'code tool is not available')
-		}
-		const codeServer = await createCodeServer(
-			toolSchemas(context.sources ?? []),
-			{ ...context, executor },
-		)
-		const result = await callServerTool(codeServer, {
-			name: CODE_TOOL_NAME,
-			arguments: body.params.arguments as Record<string, unknown> | undefined,
+		return trackToolCall(CODE_TOOL_NAME, async () => {
+			const executor = context.executor
+			if (!executor) {
+				return jsonRpcErrorFor(req, body, -32601, 'code tool is not available')
+			}
+			const codeServer = await createCodeServer(
+				toolSchemas(context.sources ?? []),
+				{ ...context, executor },
+			)
+			const result = await callServerTool(codeServer, {
+				name: CODE_TOOL_NAME,
+				arguments: body.params?.arguments as
+					| Record<string, unknown>
+					| undefined,
+			})
+			return jsonRpc(req, body.id, result)
 		})
-		return jsonRpc(req, body.id, result)
 	}
 	if (body.params?.name === 'read_page') {
-		return handleReadPage(req, body, context.sources ?? [])
+		return trackToolCall('read_page', () =>
+			handleReadPage(req, body, context.sources ?? []),
+		)
 	}
 	if (body.params?.name === 'find_pages') {
-		return handleFindPages(req, body, context.sources ?? [])
+		return trackToolCall('find_pages', () =>
+			handleFindPages(req, body, context.sources ?? []),
+		)
 	}
 	if (body.params?.name !== 'search') return undefined
+	const args = body.params.arguments
 
-	const query = body.params.arguments?.query
-	if (typeof query !== 'string' || query.trim().length === 0) {
-		return jsonRpcError(
-			req,
-			body.id,
-			-32602,
-			'query must be a non-empty string',
-		)
-	}
+	return trackToolCall('search', async () => {
+		const query = args?.query
+		if (typeof query !== 'string' || query.trim().length === 0) {
+			return jsonRpcErrorFor(
+				req,
+				body,
+				-32602,
+				'query must be a non-empty string',
+			)
+		}
 
-	const sourceError = validateSources(
-		body.params.arguments,
-		context.sources ?? [],
-	)
-	if (sourceError) {
-		return jsonRpcError(req, body.id, -32602, sourceError)
-	}
+		const sourceError = validateSources(args, context.sources ?? [])
+		if (sourceError) return jsonRpcErrorFor(req, body, -32602, sourceError)
 
-	try {
-		const args = body.params.arguments
-		const effectiveArgs = argsWithInferredSource(
-			query.trim(),
-			args,
-			context.sources ?? [],
-		)
-		const result = await cachedSearch(
-			query.trim(),
-			effectiveArgs,
-			context.instance,
-			context.sources ?? [],
-		)
-		const formatted = formatResult(result, effectiveArgs, context.sources ?? [])
+		try {
+			const effectiveArgs = argsWithInferredSource(
+				query.trim(),
+				args,
+				context.sources ?? [],
+			)
+			const result = await cachedSearch(
+				query.trim(),
+				effectiveArgs,
+				context.instance,
+				context.sources ?? [],
+			)
+			const formatted = formatResult(
+				result,
+				effectiveArgs,
+				context.sources ?? [],
+			)
 
-		return toolResult(req, body.id, effectiveArgs, formatted, 'search complete')
-	} catch (err) {
-		const message = err instanceof Error ? err.message : String(err)
-		return jsonRpc(req, body.id, {
-			content: [
-				{
-					type: 'text',
-					text: JSON.stringify({ success: false, error: message }),
-				},
-			],
-			isError: true,
-		})
-	}
+			return toolResult(
+				req,
+				body.id,
+				effectiveArgs,
+				formatted,
+				'search complete',
+			)
+		} catch (err) {
+			const message = err instanceof Error ? err.message : String(err)
+			return jsonRpc(req, body.id, {
+				content: [
+					{
+						type: 'text',
+						text: JSON.stringify({ success: false, error: message }),
+					},
+				],
+				isError: true,
+			})
+		}
+	})
 }
 
 async function createCodeServer(
@@ -407,13 +427,13 @@ async function handleFindPages(
 	const sourceId = typeof args?.source === 'string' ? args.source.trim() : ''
 	const source = sources.find((entry) => entry.id === sourceId)
 	if (!source) {
-		return jsonRpcError(req, body.id, -32602, `unknown source: ${sourceId}`)
+		return jsonRpcErrorFor(req, body, -32602, `unknown source: ${sourceId}`)
 	}
 	const query = typeof args?.query === 'string' ? args.query.trim() : ''
 	if (!query) {
-		return jsonRpcError(
+		return jsonRpcErrorFor(
 			req,
-			body.id,
+			body,
 			-32602,
 			'query must be a non-empty string',
 		)
@@ -462,12 +482,12 @@ async function handleReadPage(
 	const sourceId = typeof args?.source === 'string' ? args.source.trim() : ''
 	const source = sources.find((entry) => entry.id === sourceId)
 	if (!source) {
-		return jsonRpcError(req, body.id, -32602, `unknown source: ${sourceId}`)
+		return jsonRpcErrorFor(req, body, -32602, `unknown source: ${sourceId}`)
 	}
 
 	const pageUrl = resolvePageUrl(args, source)
 	if (!pageUrl) {
-		return jsonRpcError(req, body.id, -32602, 'path or url must be provided')
+		return jsonRpcErrorFor(req, body, -32602, 'path or url must be provided')
 	}
 
 	try {
@@ -603,14 +623,20 @@ async function runSearch(
 ): Promise<AiSearchSearchResponse> {
 	const wantedSources = selectedSources(args)
 	const skipSourceFilter = shouldSkipSourceFilter(wantedSources)
-	let result = await instance.search({
-		query,
-		ai_search_options: normalizeOptions(args, {
-			includeSourceFilter: !skipSourceFilter,
-			maxResults: upstreamMaxResultsFor(args),
-			...(skipSourceFilter ? { maxResults: fallbackMaxResultsFor(args) } : {}),
-		}),
-	})
+	let result = await searchWithMetrics(
+		instance,
+		{
+			query,
+			ai_search_options: normalizeOptions(args, {
+				includeSourceFilter: !skipSourceFilter,
+				maxResults: upstreamMaxResultsFor(args),
+				...(skipSourceFilter
+					? { maxResults: fallbackMaxResultsFor(args) }
+					: {}),
+			}),
+		},
+		{ path: 'primary', sourceCount: wantedSources.length },
+	)
 	if (skipSourceFilter) {
 		result = filterSourceChunks(
 			result,
@@ -619,13 +645,17 @@ async function runSearch(
 		)
 	} else if (result.chunks.length === 0 && wantedSources.length > 0) {
 		rememberStaleSourceFilters(wantedSources)
-		const fallback = await instance.search({
-			query,
-			ai_search_options: normalizeOptions(args, {
-				includeSourceFilter: false,
-				maxResults: fallbackMaxResultsFor(args),
-			}),
-		})
+		const fallback = await searchWithMetrics(
+			instance,
+			{
+				query,
+				ai_search_options: normalizeOptions(args, {
+					includeSourceFilter: false,
+					maxResults: fallbackMaxResultsFor(args),
+				}),
+			},
+			{ path: 'unfiltered_fallback', sourceCount: wantedSources.length },
+		)
 		const filtered = filterSourceChunks(
 			fallback,
 			wantedSources,
@@ -642,6 +672,22 @@ async function runSearch(
 			result,
 		)
 	}
+	return result
+}
+
+async function searchWithMetrics(
+	instance: AiSearchInstance,
+	request: AiSearchSearchRequest,
+	tags: { path: string; sourceCount: number },
+): Promise<AiSearchSearchResponse> {
+	const startedAt = performance.now()
+	const result = await instance.search(request)
+	recordAiSearchRequest({
+		chunks: result.chunks.length,
+		durationMs: Math.round(performance.now() - startedAt),
+		path: tags.path,
+		sourceCount: tags.sourceCount,
+	})
 	return result
 }
 
@@ -1320,12 +1366,26 @@ function toolResult(
 	})
 }
 
+function jsonRpcErrorFor(
+	req: Request,
+	body: JsonRpcRequest,
+	code: number,
+	message: string,
+): Response {
+	return jsonRpcError(req, body.id, code, message, {
+		method: body.method,
+		toolName: body.params?.name,
+	})
+}
+
 function jsonRpcError(
 	req: Request,
 	id: JsonRpcRequest['id'],
 	code: number,
 	message: string,
+	metrics?: { method?: unknown; toolName?: unknown },
 ): Response {
+	recordJsonRpcError(metrics?.method, code, metrics?.toolName)
 	const payload = JSON.stringify({
 		jsonrpc: '2.0',
 		id: id ?? null,
@@ -1343,6 +1403,44 @@ function mcpResponse(req: Request, payload: string): Response {
 	return new Response(payload, {
 		headers: { 'content-type': 'application/json' },
 	})
+}
+
+async function trackToolCall(
+	toolName: string,
+	handler: () => Promise<Response>,
+): Promise<Response> {
+	const startedAt = performance.now()
+	try {
+		const response = await handler()
+		recordToolCall(
+			toolName,
+			(await responseIsError(response)) ? 'error' : 'success',
+			Math.round(performance.now() - startedAt),
+		)
+		return response
+	} catch (error) {
+		recordToolCall(toolName, 'error', Math.round(performance.now() - startedAt))
+		throw error
+	}
+}
+
+async function responseIsError(response: Response): Promise<boolean> {
+	if (!response.ok) return true
+	try {
+		const text = await response.clone().text()
+		const payload = JSON.parse(sseData(text) ?? text) as {
+			error?: unknown
+			result?: { isError?: unknown }
+		}
+		return Boolean(payload.error) || payload.result?.isError === true
+	} catch {
+		return false
+	}
+}
+
+function sseData(text: string): string | undefined {
+	const line = text.split('\n').find((entry) => entry.startsWith('data: '))
+	return line?.slice('data: '.length)
 }
 
 function toolSchemas(sources: Source[]): Tool[] {

--- a/apps/mcp-docs-indexer/src/lib/metrics.test.ts
+++ b/apps/mcp-docs-indexer/src/lib/metrics.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+	flushWorkerMetrics,
+	recordHealthMetrics,
+	recordHttpRequestMetrics,
+	recordToolCall,
+} from './metrics.js'
+
+describe('worker metrics', () => {
+	afterEach(() => {
+		flushWorkerMetrics()
+		vi.restoreAllMocks()
+	})
+
+	it('flushes cwm lines with docs MCP global tags', () => {
+		const logs: string[] = []
+		vi.spyOn(console, 'log').mockImplementation((message) => {
+			logs.push(String(message))
+		})
+
+		recordHttpRequestMetrics({
+			durationMs: 12,
+			method: 'POST',
+			route: 'mcp',
+			status: 200,
+		})
+		recordToolCall('search', 'success', 9)
+		recordHealthMetrics({
+			durationMs: 20,
+			checks: [{ name: 'tools_list', ok: true, durationMs: 3 }],
+		})
+		flushWorkerMetrics()
+
+		const metrics = logs
+			.filter((message) => message.startsWith('cwm-'))
+			.flatMap((message) => JSON.parse(message.slice('cwm-'.length)))
+		expect(metrics).toContainEqual(
+			expect.objectContaining({
+				n: 'tempo_docs_mcp_http_request_count',
+				tags: expect.objectContaining({
+					component: 'docs_mcp',
+					repository: 'tempo-apps',
+					service: 'tempo-docs-mcp',
+					route: 'mcp',
+				}),
+				v: 1,
+			}),
+		)
+		expect(metrics).toContainEqual(
+			expect.objectContaining({
+				n: 'tempo_docs_mcp_tool_call_count',
+				tags: expect.objectContaining({
+					outcome: 'success',
+					tool_name: 'search',
+				}),
+				v: 1,
+			}),
+		)
+		expect(metrics).toContainEqual(
+			expect.objectContaining({
+				n: 'tempo_docs_mcp_health_ok',
+				v: 1,
+			}),
+		)
+	})
+})

--- a/apps/mcp-docs-indexer/src/lib/metrics.ts
+++ b/apps/mcp-docs-indexer/src/lib/metrics.ts
@@ -1,0 +1,249 @@
+import { createMetrics } from 'cloudflare-worker-metrics'
+import type { SyncReport } from './ingest.js'
+
+type EmptyTags = Record<string, never>
+type HttpTags = { method: string; route: string; status_class: string }
+type EndpointTags = { endpoint: string }
+type HealthCheckTags = EndpointTags & { check: string }
+type JsonRpcErrorTags = {
+	error_code: string
+	mcp_method: string
+	tool_name: string
+}
+type ToolTags = { outcome: string; tool_name: string }
+type AiSearchTags = { path: string; source_filter: string }
+type ProxyTags = { status_class: string }
+type SourceTags = { force: string; source: string; status: string }
+
+type DocsMcpMetricRegistry = {
+	tempo_docs_mcp_http_request_count: HttpTags
+	tempo_docs_mcp_http_response_duration_ms: HttpTags
+	tempo_docs_mcp_http_error_count: HttpTags & { error_class: string }
+	tempo_docs_mcp_health_ok: EndpointTags
+	tempo_docs_mcp_health_duration_ms: EndpointTags
+	tempo_docs_mcp_health_check_ok: HealthCheckTags
+	tempo_docs_mcp_health_check_duration_ms: HealthCheckTags
+	tempo_docs_mcp_jsonrpc_error_count: JsonRpcErrorTags
+	tempo_docs_mcp_tool_call_count: ToolTags
+	tempo_docs_mcp_tool_duration_ms: ToolTags
+	tempo_docs_mcp_ai_search_request_count: AiSearchTags
+	tempo_docs_mcp_ai_search_duration_ms: AiSearchTags
+	tempo_docs_mcp_ai_search_empty_result_count: AiSearchTags
+	tempo_docs_mcp_proxy_fallback_count: ProxyTags
+	tempo_docs_mcp_proxy_fallback_duration_ms: ProxyTags
+	tempo_docs_mcp_ingest_ok: EmptyTags
+	tempo_docs_mcp_ingest_duration_ms: EmptyTags
+	tempo_docs_mcp_source_sync_count: SourceTags
+	tempo_docs_mcp_source_pages_uploaded: SourceTags
+	tempo_docs_mcp_source_pages_failed: SourceTags
+	tempo_docs_mcp_source_pages_deleted: SourceTags
+}
+
+export type HealthMetricResult = {
+	name: string
+	ok: boolean
+	durationMs: number
+	error?: string
+}
+
+const KNOWN_METHODS = new Set([
+	'initialize',
+	'notifications/initialized',
+	'ping',
+	'tools/list',
+	'tools/call',
+	'resources/list',
+	'resources/read',
+	'resources/templates/list',
+])
+
+const KNOWN_TOOLS = new Set(['search', 'find_pages', 'read_page', 'code'])
+
+export const workerMetrics = createMetrics<DocsMcpMetricRegistry>({
+	globalTags: {
+		component: 'docs_mcp',
+		repository: 'tempo-apps',
+		service: 'tempo-docs-mcp',
+	},
+})
+
+export function flushWorkerMetrics(): void {
+	workerMetrics.flush()
+}
+
+export function recordHttpRequestMetrics(args: {
+	durationMs: number
+	method: string
+	route: string
+	status: number
+	thrown?: boolean
+}): void {
+	const tags = {
+		method: args.method,
+		route: args.route,
+		status_class: statusClass(args.status),
+	}
+	workerMetrics.count('tempo_docs_mcp_http_request_count', 1, tags)
+	workerMetrics.histogram(
+		'tempo_docs_mcp_http_response_duration_ms',
+		args.durationMs,
+		tags,
+	)
+	if (args.thrown || args.status >= 500) {
+		workerMetrics.count('tempo_docs_mcp_http_error_count', 1, {
+			...tags,
+			error_class: 'server',
+		})
+	}
+}
+
+export function recordHealthMetrics(args: {
+	checks: HealthMetricResult[]
+	durationMs: number
+}): void {
+	const endpoint = 'public'
+	const ok = args.checks.every((check) => check.ok)
+	workerMetrics.gauge('tempo_docs_mcp_health_ok', ok ? 1 : 0, { endpoint })
+	workerMetrics.histogram(
+		'tempo_docs_mcp_health_duration_ms',
+		args.durationMs,
+		{
+			endpoint,
+		},
+	)
+	for (const check of args.checks) {
+		const tags = { check: check.name, endpoint }
+		workerMetrics.gauge(
+			'tempo_docs_mcp_health_check_ok',
+			check.ok ? 1 : 0,
+			tags,
+		)
+		workerMetrics.histogram(
+			'tempo_docs_mcp_health_check_duration_ms',
+			check.durationMs,
+			tags,
+		)
+	}
+}
+
+export function recordJsonRpcError(
+	method: unknown,
+	errorCode: number | string,
+	toolName?: unknown,
+): void {
+	workerMetrics.count('tempo_docs_mcp_jsonrpc_error_count', 1, {
+		error_code: String(errorCode),
+		mcp_method: metricMcpMethod(method),
+		tool_name: metricToolName(toolName),
+	})
+}
+
+export function recordToolCall(
+	toolName: unknown,
+	outcome: string,
+	durationMs: number,
+): void {
+	const tags = {
+		outcome,
+		tool_name: metricToolName(toolName),
+	}
+	workerMetrics.count('tempo_docs_mcp_tool_call_count', 1, tags)
+	workerMetrics.histogram('tempo_docs_mcp_tool_duration_ms', durationMs, tags)
+}
+
+export function recordAiSearchRequest(args: {
+	chunks: number
+	durationMs: number
+	path: string
+	sourceCount: number
+}): void {
+	const tags = {
+		path: args.path,
+		source_filter: sourceFilterTag(args.sourceCount),
+	}
+	workerMetrics.count('tempo_docs_mcp_ai_search_request_count', 1, tags)
+	workerMetrics.histogram(
+		'tempo_docs_mcp_ai_search_duration_ms',
+		args.durationMs,
+		tags,
+	)
+	if (args.chunks === 0) {
+		workerMetrics.count('tempo_docs_mcp_ai_search_empty_result_count', 1, tags)
+	}
+}
+
+export function recordProxyFallback(status: number, durationMs: number): void {
+	const tags = { status_class: statusClass(status) }
+	workerMetrics.count('tempo_docs_mcp_proxy_fallback_count', 1, tags)
+	workerMetrics.histogram(
+		'tempo_docs_mcp_proxy_fallback_duration_ms',
+		durationMs,
+		tags,
+	)
+}
+
+export function recordIngestMetrics(args: {
+	durationMs: number
+	force: boolean
+	reports: SyncReport[]
+}): void {
+	const ok = args.reports.every((report) => report.status !== 'error')
+	workerMetrics.gauge('tempo_docs_mcp_ingest_ok', ok ? 1 : 0, {})
+	workerMetrics.histogram(
+		'tempo_docs_mcp_ingest_duration_ms',
+		args.durationMs,
+		{},
+	)
+	for (const report of args.reports) {
+		const tags = {
+			force: String(args.force),
+			source: report.source,
+			status: report.status,
+		}
+		workerMetrics.count('tempo_docs_mcp_source_sync_count', 1, tags)
+		if (report.status === 'synced') {
+			workerMetrics.count(
+				'tempo_docs_mcp_source_pages_uploaded',
+				report.pages,
+				tags,
+			)
+			workerMetrics.count(
+				'tempo_docs_mcp_source_pages_failed',
+				report.failed,
+				tags,
+			)
+			workerMetrics.count(
+				'tempo_docs_mcp_source_pages_deleted',
+				report.deleted,
+				tags,
+			)
+		}
+		if (report.status === 'error') {
+			workerMetrics.count('tempo_docs_mcp_source_pages_failed', 1, tags)
+		}
+	}
+}
+
+function metricMcpMethod(method: unknown): string {
+	if (typeof method !== 'string' || method.trim() === '') return 'none'
+	return KNOWN_METHODS.has(method) ? method : 'other'
+}
+
+function metricToolName(name: unknown): string {
+	if (typeof name !== 'string' || name.trim() === '') return 'none'
+	return KNOWN_TOOLS.has(name) ? name : 'unknown'
+}
+
+function sourceFilterTag(count: number): string {
+	if (count <= 0) return 'none'
+	if (count === 1) return 'single'
+	return 'multi'
+}
+
+function statusClass(status: number): string {
+	if (status >= 500) return '5xx'
+	if (status >= 400) return '4xx'
+	if (status >= 300) return '3xx'
+	if (status >= 200) return '2xx'
+	return 'other'
+}

--- a/apps/mcp-docs-indexer/src/lib/proxy.ts
+++ b/apps/mcp-docs-indexer/src/lib/proxy.ts
@@ -1,3 +1,5 @@
+import { recordProxyFallback } from './metrics.js'
+
 /**
  * Transparent proxy from this worker (mcp.tempo.xyz) to the Cloudflare AI
  * Search MCP endpoint. AI Search assigns each instance an opaque hostname
@@ -13,6 +15,7 @@ export async function proxyMcp(
 	req: Request,
 	upstreamBase: string,
 ): Promise<Response> {
+	const startedAt = performance.now()
 	const incoming = new URL(req.url)
 	const upstream = new URL(upstreamBase)
 	// Keep upstream base path if it has one (e.g. ".../mcp"); otherwise
@@ -45,5 +48,15 @@ export async function proxyMcp(
 		init.body = req.body
 	}
 
-	return fetch(target.toString(), init)
+	try {
+		const response = await fetch(target.toString(), init)
+		recordProxyFallback(
+			response.status,
+			Math.round(performance.now() - startedAt),
+		)
+		return response
+	} catch (error) {
+		recordProxyFallback(500, Math.round(performance.now() - startedAt))
+		throw error
+	}
 }

--- a/apps/mcp-docs-indexer/wrangler.jsonc
+++ b/apps/mcp-docs-indexer/wrangler.jsonc
@@ -8,19 +8,22 @@
 	"workers_dev": false,
 	"preview_urls": true,
 	"keep_vars": true,
+	"logpush": true,
 	"observability": {
 		"enabled": true,
 		"head_sampling_rate": 1,
 		"logs": {
 			"enabled": true,
 			"head_sampling_rate": 1,
-			"invocation_logs": true
+			"invocation_logs": true,
+			"persist": true
 		}
 	},
 	"triggers": {
+		// Public health probe for Datadog metrics.
 		// Hourly resolver pass: re-pulls llms.txt for each source and uploads
 		// any changed pages to AI Search built-in storage.
-		"crons": ["0 * * * *"]
+		"crons": ["* * * * *", "0 * * * *"]
 	},
 	"ai_search_namespaces": [
 		{
@@ -43,6 +46,7 @@
 		// transparently proxy mcp.tempo.xyz -> this upstream so clients
 		// connect to a stable branded URL instead of the opaque hostname.
 		"AI_SEARCH_MCP_URL": "https://99c10de8-0264-4978-8212-176265f5de96.search.ai.cloudflare.com/mcp",
+		"PUBLIC_MCP_ENDPOINT": "https://mcp.tempo.xyz/",
 		// PostHog host for MCP analytics. Set POSTHOG_PROJECT_API_KEY as a
 		// Worker secret to enable event capture.
 		"POSTHOG_HOST": "https://us.i.posthog.com",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -702,6 +702,9 @@ importers:
       ai:
         specifier: 'catalog:'
         version: 6.0.202(zod@4.3.6)
+      cloudflare-worker-metrics:
+        specifier: 'catalog:'
+        version: 1.4.0
       zod:
         specifier: 'catalog:'
         version: 4.3.6


### PR DESCRIPTION
## Summary
- add `cloudflare-worker-metrics` instrumentation for docs MCP request, health, tool, AI Search, proxy fallback, and ingest paths
- add a one-minute public health cron and Logpush/persisted log config for the existing Cloudflare Logpush -> metrics exporter -> Datadog path
- document the `tempo_docs_mcp_*` metric surface

## Validation
- `pnpm --filter mcp-docs-indexer test`
- `pnpm --filter mcp-docs-indexer check:types`
- `pnpm --filter mcp-docs-indexer check:biome`