### PR TITLE
chore: deduplicate docs MCP tool error responses

### DIFF
--- a/apps/mcp-docs-indexer/src/lib/mcp.ts
+++ b/apps/mcp-docs-indexer/src/lib/mcp.ts
@@ -290,16 +290,7 @@ export async function handleMcp(
 				'search complete',
 			)
 		} catch (err) {
-			const message = err instanceof Error ? err.message : String(err)
-			return jsonRpc(req, body.id, {
-				content: [
-					{
-						type: 'text',
-						text: JSON.stringify({ success: false, error: message }),
-					},
-				],
-				isError: true,
-			})
+			return toolErrorResponse(req, body.id, err)
 		}
 	})
 }
@@ -460,16 +451,7 @@ async function handleFindPages(
 			'page candidates found',
 		)
 	} catch (err) {
-		const message = err instanceof Error ? err.message : String(err)
-		return jsonRpc(req, body.id, {
-			content: [
-				{
-					type: 'text',
-					text: JSON.stringify({ success: false, error: message }),
-				},
-			],
-			isError: true,
-		})
+		return toolErrorResponse(req, body.id, err)
 	}
 }
 
@@ -508,16 +490,7 @@ async function handleReadPage(
 			'page read complete',
 		)
 	} catch (err) {
-		const message = err instanceof Error ? err.message : String(err)
-		return jsonRpc(req, body.id, {
-			content: [
-				{
-					type: 'text',
-					text: JSON.stringify({ success: false, error: message }),
-				},
-			],
-			isError: true,
-		})
+		return toolErrorResponse(req, body.id, err)
 	}
 }
 
@@ -1363,6 +1336,23 @@ function toolResult(
 				text: JSON.stringify({ success: true, result }),
 			},
 		],
+	})
+}
+
+function toolErrorResponse(
+	req: Request,
+	id: JsonRpcRequest['id'],
+	err: unknown,
+): Response {
+	const message = err instanceof Error ? err.message : String(err)
+	return jsonRpc(req, id, {
+		content: [
+			{
+				type: 'text',
+				text: JSON.stringify({ success: false, error: message }),
+			},
+		],
+		isError: true,
 	})
 }
 


### PR DESCRIPTION
## Summary
- add a shared helper for docs MCP tool error responses
- replace repeated catch-block JSON-RPC result construction in `search`, `find_pages`, and `read_page`

## Validation
- `pnpm --filter mcp-docs-indexer test`
- `pnpm --filter mcp-docs-indexer check:types`
- `pnpm --filter mcp-docs-indexer check:biome`
- `git diff --check`