### PR TITLE
Fix TIP-20 spec links in explorer

### DIFF
--- a/apps/explorer/src/comps/Contract.tsx
+++ b/apps/explorer/src/comps/Contract.tsx
@@ -84,7 +84,7 @@ export function ContractTabContent(props: {
 					<span className="whitespace-nowrap">TIP-20 Native Precompile</span>
 					<span className="text-tertiary">·</span>
 					<a
-						href="https://docs.tempo.xyz/protocol/tip20/spec#tip20-1"
+						href="https://tempo.xyz/developers/docs/protocol/tip20/spec/#tip20"
 						target="_blank"
 						rel="noopener noreferrer"
 						className="text-accent hover:underline whitespace-nowrap"

--- a/apps/explorer/src/comps/Tip20ContractInfo.tsx
+++ b/apps/explorer/src/comps/Tip20ContractInfo.tsx
@@ -96,7 +96,7 @@ export function Tip20TokenTabContent(
 				<span className="whitespace-nowrap">TIP-20 Native Token</span>
 				<span className="text-tertiary">·</span>
 				<a
-					href="https://docs.tempo.xyz/protocol/tip20/spec#tip20-1"
+					href="https://tempo.xyz/developers/docs/protocol/tip20/spec/#tip20"
 					target="_blank"
 					rel="noopener noreferrer"
 					className="text-accent hover:underline whitespace-nowrap"


### PR DESCRIPTION
## Summary
- Update TIP-20 Spec links in the explorer contract and token banners to the current docs URL without the stale anchor.

## Validation
- pnpm --filter explorer check:types
- pnpm --filter explorer check:biome

Prompted by: @joshitzko