### PR TITLE
feat(mcp-docs-indexer): add title to AI Search metadata

### DIFF
--- a/apps/mcp-docs-indexer/ai-search-custom-metadata.json
+++ b/apps/mcp-docs-indexer/ai-search-custom-metadata.json
@@ -10,5 +10,9 @@
 	{
 		"field_name": "source_description",
 		"data_type": "text"
+	},
+	{
+		"field_name": "title",
+		"data_type": "text"
 	}
 ]

--- a/apps/mcp-docs-indexer/src/lib/ingest.test.ts
+++ b/apps/mcp-docs-indexer/src/lib/ingest.test.ts
@@ -185,6 +185,7 @@ describe('syncSource — page uploads', () => {
 			expect(u.metadata).toEqual({
 				source: 'viem',
 				url: expect.any(String),
+				title: expect.any(String),
 			})
 		}
 		expect(store.get('etag:viem')).toBe('W/"new"')
@@ -273,6 +274,40 @@ Copy page for AI`,
 		expect(uploads[0]?.content).toBe(
 			'# MCP Server\n\nExpose your docs and source code to AI assistants.',
 		)
+	})
+
+	it('sets title metadata from the first markdown H1', async () => {
+		const { instance, uploads } = fakeInstance()
+		const { kv } = fakeKv()
+
+		fetchMock.mockImplementation(async (url: string) => {
+			if (url === 'https://viem.sh/llms.txt') {
+				return mockResponse({ body: '- [Foo](/foo)' })
+			}
+			return mockResponse({
+				body: '# Connect To Wallets\n\nBody text here.',
+			})
+		})
+
+		await syncSource({ source: SOURCE, instance, etagCache: kv })
+
+		expect(uploads[0]?.metadata).toMatchObject({ title: 'Connect To Wallets' })
+	})
+
+	it('omits title metadata when the page has no H1', async () => {
+		const { instance, uploads } = fakeInstance()
+		const { kv } = fakeKv()
+
+		fetchMock.mockImplementation(async (url: string) => {
+			if (url === 'https://viem.sh/llms.txt') {
+				return mockResponse({ body: '- [Foo](/foo)' })
+			}
+			return mockResponse({ body: '## Subheading only\n\nBody text.' })
+		})
+
+		await syncSource({ source: SOURCE, instance, etagCache: kv })
+
+		expect(uploads[0]?.metadata).not.toHaveProperty('title')
 	})
 })
 

--- a/apps/mcp-docs-indexer/src/lib/ingest.ts
+++ b/apps/mcp-docs-indexer/src/lib/ingest.ts
@@ -219,6 +219,8 @@ async function syncPage(args: {
 			}
 		}
 
+		const title = extractTitle(content)
+
 		// Use upload() not uploadAndPoll(): we don't need to block on indexing
 		// completion (AI Search indexes in the background). Polling per page
 		// serializes with our 8-way concurrency and trips the internal poll
@@ -230,6 +232,7 @@ async function syncPage(args: {
 				...(source.description
 					? { source_description: source.description }
 					: {}),
+				...(title ? { title } : {}),
 			},
 		})
 		const etag = res.headers.get('etag') ?? undefined
@@ -254,6 +257,15 @@ async function sha256(content: string): Promise<string> {
 	return [...new Uint8Array(digest)]
 		.map((byte) => byte.toString(16).padStart(2, '0'))
 		.join('')
+}
+
+/** First markdown H1 (`# Title`) becomes the canonical page title. */
+function extractTitle(content: string): string | undefined {
+	for (const line of content.split('\n')) {
+		const match = /^#\s+(.+?)\s*$/.exec(line.trim())
+		if (match) return match[1]
+	}
+	return undefined
 }
 
 function preparePageContent(content: string): string {


### PR DESCRIPTION
## Summary

Cloudflare AI Search does **not** infer page titles, so downstream search consumers (e.g. Vocs RAG search) fell back to humanizing URL slugs (`connect-to-wallets` → `Connect To Wallets`). This adds a real, canonical `title` to each indexed chunk.

- Declare a `title` custom-metadata field in `ai-search-custom-metadata.json`
- Populate `title` from each page's first markdown H1 in `syncPage()` upload metadata
- Tests for H1 extraction and the no-H1 fallback

## Rollout

1. Register the new field: `pnpm configure:metadata` (needs `CLOUDFLARE_ACCOUNT_ID` + `CLOUDFLARE_API_TOKEN`)
2. Force a full re-index so existing chunks gain `title` (new field only attaches to freshly uploaded items)

## Test plan

- `pnpm vitest --run src/lib/ingest.test.ts` — 17 passing
- `pnpm check:biome` — clean