### PR TITLE
feat(explorer): add light mode

### DIFF
--- a/apps/explorer/src/comps/Footer.tsx
+++ b/apps/explorer/src/comps/Footer.tsx
@@ -1,31 +1,88 @@
 import { Link as RouterLink } from '@tanstack/react-router'
+import * as React from 'react'
+import {
+	applyThemeMode,
+	defaultThemeMode,
+	getInitialThemeMode,
+	isThemeMode,
+	persistThemeMode,
+	themeStorageKey,
+	type ThemeMode,
+} from '#lib/theme'
+import MoonIcon from '~icons/lucide/moon'
+import SunIcon from '~icons/lucide/sun'
 
-export function Footer() {
+export function Footer(): React.JSX.Element {
 	return (
-		<footer className="pt-[24px] pb-[48px] relative print:hidden">
-			<ul className="text-ui-meta flex items-center justify-center gap-[24px] select-none">
-				<Footer.Link to="https://tempo.xyz" external>
-					About
-				</Footer.Link>
-				<Footer.Link to="https://docs.tempo.xyz" external>
-					Docs
-				</Footer.Link>
-				<Footer.Link to="https://github.com/tempoxyz" external>
-					GitHub
-				</Footer.Link>
-				<Footer.Link
-					to="https://github.com/tempoxyz/tempo-apps/discussions/categories/explorer"
-					external
-				>
-					Feedback
-				</Footer.Link>
-			</ul>
+		<footer className="@container px-[24px] @min-[1240px]:px-[84px] pt-[24px] pb-[48px] relative print:hidden">
+			<div className="relative flex min-h-[34px] items-center justify-center">
+				<Footer.ThemeToggle />
+				<ul className="text-ui-meta flex items-center justify-center gap-[24px] select-none">
+					<Footer.Link to="https://tempo.xyz" external>
+						About
+					</Footer.Link>
+					<Footer.Link to="https://docs.tempo.xyz" external>
+						Docs
+					</Footer.Link>
+					<Footer.Link to="https://github.com/tempoxyz" external>
+						GitHub
+					</Footer.Link>
+					<Footer.Link
+						to="https://github.com/tempoxyz/tempo-apps/discussions/categories/explorer"
+						external
+					>
+						Feedback
+					</Footer.Link>
+				</ul>
+			</div>
 		</footer>
 	)
 }
 
 export namespace Footer {
-	export function Link(props: Link.Props) {
+	export function ThemeToggle(): React.JSX.Element {
+		const [theme, setTheme] = React.useState<ThemeMode>(defaultThemeMode)
+		const nextTheme = theme === 'dark' ? 'light' : 'dark'
+
+		React.useEffect(() => {
+			const initialTheme = getInitialThemeMode()
+			setTheme(initialTheme)
+			applyThemeMode(initialTheme)
+
+			const handleStorage = (event: StorageEvent) => {
+				if (event.key !== themeStorageKey) return
+				const updatedTheme = isThemeMode(event.newValue)
+					? event.newValue
+					: getInitialThemeMode()
+				setTheme(updatedTheme)
+				applyThemeMode(updatedTheme)
+			}
+
+			window.addEventListener('storage', handleStorage)
+			return () => window.removeEventListener('storage', handleStorage)
+		}, [])
+
+		return (
+			<button
+				type="button"
+				onClick={() => {
+					persistThemeMode(nextTheme)
+					setTheme(nextTheme)
+				}}
+				className="absolute left-0 top-1/2 grid size-[34px] -translate-y-1/2 cursor-pointer place-items-center rounded-[10px] border border-base-border bg-base-plane-interactive text-secondary transition-colors press-down hover:bg-surface hover:text-primary"
+				aria-label={`Switch to ${nextTheme} mode`}
+				title={`Switch to ${nextTheme} mode`}
+			>
+				{nextTheme === 'light' ? (
+					<SunIcon className="size-[15px]" />
+				) : (
+					<MoonIcon className="size-[15px]" />
+				)}
+			</button>
+		)
+	}
+
+	export function Link(props: Link.Props): React.JSX.Element {
 		const { to, params, children, external } = props
 		return (
 			<li className="flex">

--- a/apps/explorer/src/comps/Header.tsx
+++ b/apps/explorer/src/comps/Header.tsx
@@ -203,7 +203,7 @@ export namespace Header {
 					aria-controls={isOpen ? menuId : undefined}
 					aria-expanded={isOpen}
 					aria-haspopup="menu"
-					className="flex h-[28px] shrink-0 items-center justify-center gap-[5px] rounded-[8px] border border-[#2C2C2F] bg-[#1A1A1A] px-[8px] py-[4px] text-[14px] font-medium leading-[140%] text-secondary transition-colors hover:border-accent hover:text-primary focus-visible:outline-none press-down"
+					className="flex h-[28px] shrink-0 items-center justify-center gap-[5px] rounded-[8px] border border-base-border bg-base-plane px-[8px] py-[4px] text-[14px] font-medium leading-[140%] text-secondary transition-colors hover:border-accent hover:text-primary focus-visible:outline-none press-down"
 					title={`Network: ${activeOption.label}`}
 					onClick={() => setIsOpen((value) => !value)}
 				>

--- a/apps/explorer/src/lib/theme.ts
+++ b/apps/explorer/src/lib/theme.ts
@@ -1,0 +1,45 @@
+export type ThemeMode = 'dark' | 'light'
+
+export const defaultThemeMode = 'dark' satisfies ThemeMode
+export const themeStorageKey = 'tempo-explorer-theme'
+
+export function isThemeMode(
+	value: string | null | undefined,
+): value is ThemeMode {
+	return value === 'dark' || value === 'light'
+}
+
+export function applyThemeMode(mode: ThemeMode): void {
+	if (typeof document === 'undefined') return
+
+	document.documentElement.dataset.theme = mode
+	document.documentElement.style.colorScheme = mode
+}
+
+export function getInitialThemeMode(): ThemeMode {
+	if (typeof document === 'undefined') return defaultThemeMode
+
+	const datasetTheme = document.documentElement.dataset.theme
+	if (isThemeMode(datasetTheme)) return datasetTheme
+
+	try {
+		const storedTheme = window.localStorage.getItem(themeStorageKey)
+		if (isThemeMode(storedTheme)) return storedTheme
+	} catch {
+		// Keep the default theme when storage is unavailable.
+	}
+
+	return defaultThemeMode
+}
+
+export function persistThemeMode(mode: ThemeMode): void {
+	applyThemeMode(mode)
+
+	try {
+		window.localStorage.setItem(themeStorageKey, mode)
+	} catch {
+		// Theme still applies for the current tab even if persistence fails.
+	}
+}
+
+export const themeBootScript = `(function(){try{var key='${themeStorageKey}';var stored=window.localStorage.getItem(key);var theme=stored==='light'||stored==='dark'?stored:'${defaultThemeMode}';document.documentElement.dataset.theme=theme;document.documentElement.style.colorScheme=theme;}catch(e){document.documentElement.dataset.theme='${defaultThemeMode}';document.documentElement.style.colorScheme='${defaultThemeMode}';}})();`

--- a/apps/explorer/src/routes/__root.tsx
+++ b/apps/explorer/src/routes/__root.tsx
@@ -18,6 +18,7 @@ import { IntroSeenProvider } from '#comps/Intro'
 import { TokenListMembershipProvider } from '#comps/TokenListMembership'
 import { OG_BASE_URL } from '#lib/og'
 import { ProgressLine } from '#comps/ProgressLine'
+import { defaultThemeMode, themeBootScript } from '#lib/theme'
 import {
 	type LoaderTiming,
 	captureEvent,
@@ -110,24 +111,47 @@ export const Route = createRootRouteWithContext<{
 			{
 				rel: 'icon',
 				type: 'image/svg+xml',
+				href: '/favicon-light.svg',
+				media: '(prefers-color-scheme: light)',
+			},
+			{
+				rel: 'icon',
+				type: 'image/svg+xml',
 				href: '/favicon-dark.svg',
+				media: '(prefers-color-scheme: dark)',
+			},
+			{
+				rel: 'icon',
+				type: 'image/png',
+				sizes: '32x32',
+				href: '/favicon-32x32-light.png',
+				media: '(prefers-color-scheme: light)',
 			},
 			{
 				rel: 'icon',
 				type: 'image/png',
 				sizes: '32x32',
 				href: '/favicon-32x32-dark.png',
+				media: '(prefers-color-scheme: dark)',
+			},
+			{
+				rel: 'icon',
+				type: 'image/png',
+				sizes: '16x16',
+				href: '/favicon-16x16-light.png',
+				media: '(prefers-color-scheme: light)',
 			},
 			{
 				rel: 'icon',
 				type: 'image/png',
 				sizes: '16x16',
 				href: '/favicon-16x16-dark.png',
+				media: '(prefers-color-scheme: dark)',
 			},
 			{
 				rel: 'apple-touch-icon',
 				sizes: '180x180',
-				href: '/favicon-dark.png',
+				href: '/favicon-light.png',
 			},
 		],
 	}),
@@ -375,8 +399,14 @@ function RootDocument({ children }: { children: React.ReactNode }) {
 	})
 
 	return (
-		<html lang="en" className="scrollbar-gutter-stable">
+		<html
+			lang="en"
+			className="scrollbar-gutter-stable"
+			data-theme={defaultThemeMode}
+			suppressHydrationWarning
+		>
 			<head>
+				<script>{themeBootScript}</script>
 				<HeadContent />
 			</head>
 			<body className="antialiased">

--- a/apps/explorer/src/routes/styles.css
+++ b/apps/explorer/src/routes/styles.css
@@ -6,9 +6,9 @@
 	/* Background Colors */
 	--color-background-inverse: light-dark(#202020, #fcfcfc);
 	--background-color-inverse: var(--color-background-inverse);
-	--color-background-primary: light-dark(#191919, #191919);
+	--color-background-primary: light-dark(#ffffff, #191919);
 	--background-color-primary: var(--color-background-primary);
-	--color-background-surface: light-dark(#1a1a1a, #1a1a1a);
+	--color-background-surface: light-dark(#ffffff, #1a1a1a);
 	--background-color-surface: var(--color-background-surface);
 	--color-background-alt: light-dark(#fcfcfc, #161616);
 	--background-alt: var(--color-background-alt);
@@ -23,11 +23,11 @@
 	--color-frame: var(--color-frame-background);
 
 	/* Content/Text Colors */
-	--color-content-primary: light-dark(#ffffff, #ffffff);
+	--color-content-primary: light-dark(#151515, #ffffff);
 	--content-primary: var(--color-content-primary);
-	--color-content-secondary: light-dark(#6e6e6e, #6e6e6e);
+	--color-content-secondary: light-dark(#525252, #6e6e6e);
 	--content-secondary: var(--color-content-secondary);
-	--color-content-tertiary: light-dark(#6e6e6e, #6e6e6e);
+	--color-content-tertiary: light-dark(#737373, #6e6e6e);
 	--content-tertiary: var(--color-content-tertiary);
 	--color-content-positive: light-dark(#16a34a, #22c55e);
 	--content-positive: var(--color-content-positive);
@@ -55,11 +55,11 @@
 	--color-focus: var(--color-accent);
 
 	/* Border Colors */
-	--color-border-primary: light-dark(#232323, #232323);
+	--color-border-primary: light-dark(#e5e5e5, #232323);
 	--border-primary: var(--color-border-primary);
-	--color-border-secondary: light-dark(#232323, #232323);
+	--color-border-secondary: light-dark(#e5e5e5, #232323);
 	--border-secondary: var(--color-border-secondary);
-	--color-border-tertiary: light-dark(#232323, #232323);
+	--color-border-tertiary: light-dark(#eeeeee, #232323);
 	--border-tertiary: var(--color-border-tertiary);
 	--color-border-negative: light-dark(#dc2626, #ef4444);
 	--border-negative: var(--color-border-negative);
@@ -91,20 +91,20 @@
 	/* Card */
 	--color-card: light-dark(#f9f9f9, #222222);
 	--color-card-header: light-dark(#f9f9f9, #191919);
-	--color-card-border: light-dark(#232323, #232323);
+	--color-card-border: light-dark(#e5e5e5, #232323);
 
 	/* Other Colors */
-	--color-base-background: light-dark(#191919, #191919);
-	--color-base-plane: light-dark(#1a1a1a, #1a1a1a);
-	--color-base-plane-background: light-dark(#1a1a1a, #1a1a1a);
+	--color-base-background: light-dark(#ffffff, #191919);
+	--color-base-plane: light-dark(#ffffff, #1a1a1a);
+	--color-base-plane-background: light-dark(#ffffff, #1a1a1a);
 	--color-base-plane-interactive: light-dark(#f8f8f8, #1c1c1c);
-	--color-base-alt: light-dark(#232323, #232323);
-	--color-base-border: light-dark(#232323, #232323);
-	--color-base-content: light-dark(#ffffff, #ffffff);
-	--color-base-content-secondary: light-dark(#6e6e6e, #6e6e6e);
+	--color-base-alt: light-dark(#f5f5f5, #232323);
+	--color-base-border: light-dark(#e5e5e5, #232323);
+	--color-base-content: light-dark(#151515, #ffffff);
+	--color-base-content-secondary: light-dark(#525252, #6e6e6e);
 	--color-base-content-positive: light-dark(#30a46c, #30a46c);
 	--color-base-content-negative: light-dark(#e5484d, #e5484d);
-	--color-distinct: light-dark(#e8e8e8, #313131);
+	--color-distinct: light-dark(#ececec, #313131);
 	--color-warning: light-dark(#e2a336, #8f6424);
 	--color-warning-background: light-dark(#fdf5c2, #252018);
 
@@ -128,6 +128,14 @@ html,
 	html {
 		color-scheme: dark;
 	}
+}
+
+html[data-theme="light"] {
+	color-scheme: light;
+}
+
+html[data-theme="dark"] {
+	color-scheme: dark;
 }
 
 body {
@@ -162,7 +170,7 @@ input[type="number"] {
 }
 
 @utility text-ui-meta {
-	color: #fff;
+	color: var(--color-primary);
 	text-align: center;
 	leading-trim: both;
 	text-edge: cap;
@@ -175,7 +183,7 @@ input[type="number"] {
 }
 
 @utility text-search-input {
-	color: #6e6e6e;
+	color: light-dark(var(--color-primary), #6e6e6e);
 	font-family: "Satoshi", ui-sans-serif, sans-serif;
 	font-size: 16px;
 	font-style: normal;


### PR DESCRIPTION
## Summary

- Adds persisted light/dark theme support for the explorer with early document bootstrapping to avoid a theme flash.
- Moves the icon-only theme toggle to the footer bottom-left so the top nav stays focused on network and block status.
- Updates light-mode color tokens, favicon variants, and the network selector surface to render correctly in both themes.