### PR TITLE
feat(explorer): add receipt exports and transaction summaries

### DIFF
--- a/apps/explorer/src/comps/Receipt.tsx
+++ b/apps/explorer/src/comps/Receipt.tsx
@@ -18,6 +18,10 @@ import {
 } from '#lib/pricing'
 import { getFeeTokenForChain } from '#lib/fee-token'
 import { getTempoChain } from '#wagmi.config.ts'
+import BracesIcon from '~icons/lucide/braces'
+import DownloadIcon from '~icons/lucide/download'
+import FileTextIcon from '~icons/lucide/file-text'
+import ShareIcon from '~icons/lucide/share-2'
 
 const TEMPO_CHAIN_ID = getTempoChain().id
 const TEMPO_FEE_TOKEN = getFeeTokenForChain(TEMPO_CHAIN_ID)
@@ -38,6 +42,7 @@ export function Receipt(props: Receipt.Props) {
 	} = props
 	const [hashExpanded, setHashExpanded] = useState(false)
 	const copyHash = useCopy()
+	const copyShare = useCopy({ timeout: 2_000 })
 	const { isTokenListed } = useTokenListMembership()
 	const formattedTime = DateFormatter.formatTimestampTime(timestamp)
 
@@ -57,6 +62,18 @@ export function Receipt(props: Receipt.Props) {
 			event.type !== 'active key count changed' &&
 			event.type !== 'nonce incremented',
 	)
+	const handleShare = async () => {
+		const url = new URL(`/receipt/${hash}`, window.location.origin).toString()
+		if (navigator.share) {
+			try {
+				await navigator.share({ title: 'Tempo receipt', url })
+				return
+			} catch (error) {
+				if (error instanceof DOMException && error.name === 'AbortError') return
+			}
+		}
+		await copyShare.copy(url)
+	}
 
 	return (
 		<>
@@ -373,6 +390,19 @@ export function Receipt(props: Receipt.Props) {
 
 			<div className="flex flex-col items-center -mt-8 w-full print:hidden">
 				<div className="max-w-[360px] w-full">
+					<div className="grid grid-cols-4 border border-base-border bg-base-plane-interactive text-[12px] text-tertiary">
+						<button
+							type="button"
+							onClick={() => void handleShare()}
+							className="inline-flex h-[40px] items-center justify-center gap-[6px] border-r border-base-border transition-colors press-down hover:bg-base-plane hover:text-primary"
+						>
+							<ShareIcon className="size-[13px]" />
+							<span>{copyShare.notifying ? 'Copied' : 'Share'}</span>
+						</button>
+						<Receipt.ExportLink hash={hash} format="pdf" />
+						<Receipt.ExportLink hash={hash} format="txt" />
+						<Receipt.ExportLink hash={hash} format="json" />
+					</div>
 					<Link
 						to="/tx/$hash"
 						params={{ hash }}
@@ -409,5 +439,34 @@ export namespace Receipt {
 		symbol?: string
 		token?: Address.Address
 		payer?: Address.Address
+	}
+
+	export function ExportLink(props: ExportLink.Props): React.JSX.Element {
+		const { hash, format } = props
+		const icon =
+			format === 'pdf' ? (
+				<DownloadIcon className="size-[13px]" />
+			) : format === 'txt' ? (
+				<FileTextIcon className="size-[13px]" />
+			) : (
+				<BracesIcon className="size-[13px]" />
+			)
+
+		return (
+			<a
+				href={`/receipt/${hash}.${format}`}
+				className="inline-flex h-[40px] items-center justify-center gap-[6px] border-r border-base-border uppercase transition-colors press-down last:border-r-0 hover:bg-base-plane hover:text-primary"
+			>
+				{icon}
+				<span>{format}</span>
+			</a>
+		)
+	}
+
+	export namespace ExportLink {
+		export interface Props {
+			hash: Hex.Hex
+			format: 'pdf' | 'txt' | 'json'
+		}
 	}
 }

--- a/apps/explorer/src/comps/Receipt.tsx
+++ b/apps/explorer/src/comps/Receipt.tsx
@@ -79,7 +79,7 @@ export function Receipt(props: Receipt.Props) {
 		<>
 			<div
 				data-receipt
-				className="flex flex-col w-[360px] bg-base-alt border border-base-border border-b-0 shadow-[0px_4px_44px_rgba(0,0,0,0.25)] rounded-[10px] rounded-br-none rounded-bl-none text-base-content"
+				className="flex w-[min(480px,calc(100vw_-_32px))] flex-col bg-base-alt border border-base-border border-b-0 shadow-[0px_4px_44px_rgba(0,0,0,0.25)] rounded-[10px] rounded-br-none rounded-bl-none text-base-content"
 			>
 				<div className="flex items-start gap-[40px] px-[20px] pt-[24px] pb-[16px]">
 					<div className="shrink-0">
@@ -389,7 +389,7 @@ export function Receipt(props: Receipt.Props) {
 			</div>
 
 			<div className="flex flex-col items-center -mt-8 w-full print:hidden">
-				<div className="max-w-[360px] w-full">
+				<div className="w-[min(480px,calc(100vw_-_32px))]">
 					<div className="grid grid-cols-4 border border-base-border bg-base-plane-interactive text-[12px] text-tertiary">
 						<button
 							type="button"

--- a/apps/explorer/src/comps/Receipt.tsx
+++ b/apps/explorer/src/comps/Receipt.tsx
@@ -79,7 +79,7 @@ export function Receipt(props: Receipt.Props) {
 		<>
 			<div
 				data-receipt
-				className="flex w-[min(480px,calc(100vw_-_32px))] flex-col bg-base-alt border border-base-border border-b-0 shadow-[0px_4px_44px_rgba(0,0,0,0.25)] rounded-[10px] rounded-br-none rounded-bl-none text-base-content"
+				className="flex w-[360px] flex-col bg-base-alt border border-base-border border-b-0 shadow-[0px_4px_44px_rgba(0,0,0,0.25)] rounded-[10px] rounded-br-none rounded-bl-none text-base-content"
 			>
 				<div className="flex items-start gap-[40px] px-[20px] pt-[24px] pb-[16px]">
 					<div className="shrink-0">
@@ -389,7 +389,7 @@ export function Receipt(props: Receipt.Props) {
 			</div>
 
 			<div className="flex flex-col items-center -mt-8 w-full print:hidden">
-				<div className="w-[min(480px,calc(100vw_-_32px))]">
+				<div className="max-w-[360px] w-full">
 					<div className="grid grid-cols-4 border border-base-border bg-base-plane-interactive text-[12px] text-tertiary">
 						<button
 							type="button"

--- a/apps/explorer/src/comps/Receipt.tsx
+++ b/apps/explorer/src/comps/Receipt.tsx
@@ -39,6 +39,7 @@ export function Receipt(props: Receipt.Props) {
 		feeDisplay,
 		totalDisplay,
 		feeBreakdown = [],
+		exportSearch = '',
 	} = props
 	const [hashExpanded, setHashExpanded] = useState(false)
 	const copyHash = useCopy()
@@ -63,7 +64,10 @@ export function Receipt(props: Receipt.Props) {
 			event.type !== 'nonce incremented',
 	)
 	const handleShare = async () => {
-		const url = new URL(`/receipt/${hash}`, window.location.origin).toString()
+		const url = new URL(
+			`/receipt/${hash}${exportSearch}`,
+			window.location.origin,
+		).toString()
 		if (navigator.share) {
 			try {
 				await navigator.share({ title: 'Tempo receipt', url })
@@ -399,9 +403,21 @@ export function Receipt(props: Receipt.Props) {
 							<ShareIcon className="size-[13px]" />
 							<span>{copyShare.notifying ? 'Copied' : 'Share'}</span>
 						</button>
-						<Receipt.ExportLink hash={hash} format="pdf" />
-						<Receipt.ExportLink hash={hash} format="txt" />
-						<Receipt.ExportLink hash={hash} format="json" />
+						<Receipt.ExportLink
+							hash={hash}
+							format="pdf"
+							exportSearch={exportSearch}
+						/>
+						<Receipt.ExportLink
+							hash={hash}
+							format="txt"
+							exportSearch={exportSearch}
+						/>
+						<Receipt.ExportLink
+							hash={hash}
+							format="json"
+							exportSearch={exportSearch}
+						/>
 					</div>
 					<Link
 						to="/tx/$hash"
@@ -430,6 +446,7 @@ export namespace Receipt {
 		total?: number
 		totalDisplay?: string
 		feeBreakdown?: FeeBreakdownItem[]
+		exportSearch?: string | undefined
 	}
 
 	export interface FeeBreakdownItem {
@@ -442,7 +459,7 @@ export namespace Receipt {
 	}
 
 	export function ExportLink(props: ExportLink.Props): React.JSX.Element {
-		const { hash, format } = props
+		const { hash, format, exportSearch = '' } = props
 		const icon =
 			format === 'pdf' ? (
 				<DownloadIcon className="size-[13px]" />
@@ -454,7 +471,7 @@ export namespace Receipt {
 
 		return (
 			<a
-				href={`/receipt/${hash}.${format}`}
+				href={`/receipt/${hash}.${format}${exportSearch}`}
 				className="inline-flex h-[40px] items-center justify-center gap-[6px] border-r border-base-border uppercase transition-colors press-down last:border-r-0 hover:bg-base-plane hover:text-primary"
 			>
 				{icon}
@@ -467,6 +484,7 @@ export namespace Receipt {
 		export interface Props {
 			hash: Hex.Hex
 			format: 'pdf' | 'txt' | 'json'
+			exportSearch?: string | undefined
 		}
 	}
 }

--- a/apps/explorer/src/comps/TxTransactionCard.tsx
+++ b/apps/explorer/src/comps/TxTransactionCard.tsx
@@ -8,7 +8,8 @@ import { useCopy } from '#lib/hooks'
 import CopyIcon from '~icons/lucide/copy'
 
 export function TxTransactionCard(props: TxTransactionCard.Props) {
-	const { hash, status, blockNumber, timestamp, from, to, className } = props
+	const { hash, status, error, blockNumber, timestamp, from, to, className } =
+		props
 	const { copy, notifying } = useCopy()
 	const { timeFormat, cycleTimeFormat, formatLabel } = useTimeFormat()
 	return (
@@ -20,6 +21,18 @@ export function TxTransactionCard(props: TxTransactionCard.Props) {
 					label: 'Status',
 					value: <StatusBadge status={status} />,
 				},
+				...(status === 'reverted' && error
+					? [
+							{
+								label: 'Error',
+								value: (
+									<span className="text-right font-sans text-[13px] text-primary">
+										{error}
+									</span>
+								),
+							},
+						]
+					: []),
 				<button
 					key="hash"
 					type="button"
@@ -149,6 +162,7 @@ export declare namespace TxTransactionCard {
 	type Props = {
 		hash: Hex.Hex
 		status: 'success' | 'reverted'
+		error?: string | undefined
 		blockNumber: bigint
 		timestamp: bigint
 		from: Address.Address

--- a/apps/explorer/src/lib/domain/tx-summary.ts
+++ b/apps/explorer/src/lib/domain/tx-summary.ts
@@ -1,7 +1,8 @@
 import * as Hex from 'ox/Hex'
 import * as Value from 'ox/Value'
+import type * as Address from 'ox/Address'
 import type { TransactionReceipt } from 'viem'
-import { decodeErrorResult, decodeFunctionData } from 'viem'
+import { decodeErrorResult, decodeFunctionData, parseAbi } from 'viem'
 import { allAbis } from '#lib/abis'
 import { getContractInfo } from '#lib/domain/contracts'
 import {
@@ -18,6 +19,7 @@ export type TxSummary = {
 	tone: 'success' | 'failure' | 'neutral'
 	headline: string
 	details: string[]
+	error?: string
 	rawReason?: string
 }
 
@@ -26,16 +28,31 @@ type DecodedTraceError = {
 	args: readonly unknown[]
 }
 
+const fallbackErrorAbi = parseAbi(['error UnknownFunctionSelector(bytes4)'])
+
+type SummaryTransaction = {
+	input?: Hex.Hex | undefined
+	data?: Hex.Hex | undefined
+	to?: Address.Address | null | undefined
+}
+
 export function buildTxSummary(params: {
 	receipt: TransactionReceipt
 	knownEvents: KnownEvent[]
 	trace: CallTrace | null
+	transaction?: SummaryTransaction
 	balanceChangesData?: BalanceChangesData
 }): TxSummary {
-	const { receipt, knownEvents, trace, balanceChangesData } = params
+	const { receipt, knownEvents, trace, transaction, balanceChangesData } =
+		params
 
 	if (receipt.status === 'reverted') {
-		return buildFailureSummary({ trace, balanceChangesData })
+		return buildFailureSummary({
+			trace,
+			transaction,
+			knownEvents,
+			balanceChangesData,
+		})
 	}
 
 	const event = knownEvents.find(preferredEventsFilter) ?? knownEvents[0]
@@ -62,6 +79,8 @@ export function buildTxSummary(params: {
 
 function buildFailureSummary(params: {
 	trace: CallTrace | null
+	transaction?: SummaryTransaction
+	knownEvents: KnownEvent[]
 	balanceChangesData?: BalanceChangesData
 }): TxSummary {
 	const failedTrace = findDeepestFailedTrace(params.trace)
@@ -77,15 +96,19 @@ function buildFailureSummary(params: {
 	})
 	if (insufficientBalance) return insufficientBalance
 
-	const functionName = failedTrace ? decodeTraceFunctionName(failedTrace) : null
-	const contractName = failedTrace?.to
-		? getContractInfo(failedTrace.to)?.name
+	const functionName =
+		(failedTrace ? decodeTraceFunctionName(failedTrace) : null) ??
+		decodeTransactionFunctionName(params.transaction) ??
+		decodeKnownEventFunctionName(params.knownEvents)
+	const contractAddress = failedTrace?.to ?? params.transaction?.to
+	const contractName = contractAddress
+		? getContractInfo(contractAddress)?.name
 		: undefined
 	const action = functionName
 		? `${sentenceCase(functionName)} failed`
-		: 'Transaction failed'
+		: (failureActionFromKnownEvents(params.knownEvents) ?? 'Transaction failed')
 	const reason = decodedError?.errorName
-		? humanizeIdentifier(decodedError.errorName)
+		? humanizeErrorName(decodedError.errorName)
 		: humanizeRawReason(rawReason)
 
 	const details: string[] = []
@@ -99,8 +122,9 @@ function buildFailureSummary(params: {
 
 	return {
 		tone: 'failure',
-		headline: reason ? `${action}: ${reason}.` : `${action}.`,
+		headline: `${action}.`,
 		details,
+		...(reason ? { error: reason } : {}),
 		rawReason,
 	}
 }
@@ -151,6 +175,7 @@ function buildInsufficientBalanceSummary(params: {
 		tone: 'failure',
 		headline: `Transfer failed: insufficient ${balanceLabel}.${amountDetail}`,
 		details,
+		error: `insufficient ${balanceLabel}`,
 		rawReason,
 	}
 }
@@ -183,19 +208,68 @@ function decodeTraceError(trace: CallTrace): DecodedTraceError | null {
 			args: decoded.args ?? [],
 		}
 	} catch {
-		return null
+		try {
+			const decoded = decodeErrorResult({ abi: fallbackErrorAbi, data })
+			return {
+				errorName: decoded.errorName,
+				args: decoded.args ?? [],
+			}
+		} catch {
+			return null
+		}
 	}
 }
 
 function decodeTraceFunctionName(trace: CallTrace): string | null {
-	if (!trace.input || trace.input === '0x') return null
+	return decodeInputFunctionName(trace.input)
+}
+
+function decodeTransactionFunctionName(
+	transaction: SummaryTransaction | undefined,
+): string | null {
+	return decodeInputFunctionName(transaction?.input ?? transaction?.data)
+}
+
+function decodeKnownEventFunctionName(
+	events: readonly KnownEvent[],
+): string | null {
+	for (const event of events) {
+		for (const part of event.parts) {
+			if (part.type !== 'contractCall') continue
+			const functionName = decodeInputFunctionName(part.value.input)
+			if (functionName) return functionName
+		}
+	}
+
+	return null
+}
+
+function decodeInputFunctionName(input: Hex.Hex | undefined): string | null {
+	if (!input || input === '0x') return null
 
 	try {
-		const decoded = decodeFunctionData({ abi: allAbis, data: trace.input })
+		const decoded = decodeFunctionData({ abi: allAbis, data: input })
 		return decoded.functionName
 	} catch {
 		return null
 	}
+}
+
+function failureActionFromKnownEvents(
+	events: readonly KnownEvent[],
+): string | undefined {
+	const event = events.find(preferredEventsFilter) ?? events[0]
+	if (!event) return undefined
+
+	const contractCall = event.parts.find((part) => part.type === 'contractCall')
+	if (contractCall) {
+		return 'Contract call failed'
+	}
+
+	const action = formatKnownEvent(event)
+	if (!action) return undefined
+
+	return `${sentenceCase(action)} failed`
 }
 
 function getRevertData(trace: CallTrace): Hex.Hex | null {
@@ -269,6 +343,12 @@ function humanizeIdentifier(value: string): string {
 		.replace(/[_-]+/g, ' ')
 		.replace(/^tip 20\s+/i, 'TIP-20 ')
 		.toLowerCase()
+}
+
+function humanizeErrorName(value: string): string {
+	if (value === 'UnknownFunctionSelector')
+		return 'unsupported function selector'
+	return humanizeIdentifier(value)
 }
 
 function humanizeRawReason(value: string | undefined): string | undefined {

--- a/apps/explorer/src/lib/domain/tx-summary.ts
+++ b/apps/explorer/src/lib/domain/tx-summary.ts
@@ -1,0 +1,283 @@
+import * as Hex from 'ox/Hex'
+import * as Value from 'ox/Value'
+import type { TransactionReceipt } from 'viem'
+import { decodeErrorResult, decodeFunctionData } from 'viem'
+import { allAbis } from '#lib/abis'
+import { getContractInfo } from '#lib/domain/contracts'
+import {
+	preferredEventsFilter,
+	type KnownEvent,
+	type KnownEventPart,
+} from '#lib/domain/known-events'
+import { isTip20Address } from '#lib/domain/tip20'
+import { HexFormatter, PriceFormatter } from '#lib/formatting'
+import type { BalanceChangesData } from '#lib/queries/balance-changes'
+import type { CallTrace } from '#lib/queries/trace'
+
+export type TxSummary = {
+	tone: 'success' | 'failure' | 'neutral'
+	headline: string
+	details: string[]
+	rawReason?: string
+}
+
+type DecodedTraceError = {
+	errorName: string
+	args: readonly unknown[]
+}
+
+export function buildTxSummary(params: {
+	receipt: TransactionReceipt
+	knownEvents: KnownEvent[]
+	trace: CallTrace | null
+	balanceChangesData?: BalanceChangesData
+}): TxSummary {
+	const { receipt, knownEvents, trace, balanceChangesData } = params
+
+	if (receipt.status === 'reverted') {
+		return buildFailureSummary({ trace, balanceChangesData })
+	}
+
+	const event = knownEvents.find(preferredEventsFilter) ?? knownEvents[0]
+	if (!event) {
+		return {
+			tone: 'success',
+			headline: 'Transaction succeeded.',
+			details: ['No high-level events were detected for this transaction.'],
+		}
+	}
+
+	const headline = sentenceCase(formatKnownEvent(event))
+	const details =
+		knownEvents.length > 1
+			? [`${knownEvents.length.toLocaleString()} interpreted events detected.`]
+			: ['1 interpreted event detected.']
+
+	return {
+		tone: 'success',
+		headline: `${headline}.`,
+		details,
+	}
+}
+
+function buildFailureSummary(params: {
+	trace: CallTrace | null
+	balanceChangesData?: BalanceChangesData
+}): TxSummary {
+	const failedTrace = findDeepestFailedTrace(params.trace)
+	const decodedError = failedTrace ? decodeTraceError(failedTrace) : null
+	const rawReason =
+		failedTrace?.revertReason || failedTrace?.error || decodedError?.errorName
+
+	const insufficientBalance = buildInsufficientBalanceSummary({
+		decodedError,
+		failedTrace,
+		balanceChangesData: params.balanceChangesData,
+		rawReason,
+	})
+	if (insufficientBalance) return insufficientBalance
+
+	const functionName = failedTrace ? decodeTraceFunctionName(failedTrace) : null
+	const contractName = failedTrace?.to
+		? getContractInfo(failedTrace.to)?.name
+		: undefined
+	const action = functionName
+		? `${sentenceCase(functionName)} failed`
+		: 'Transaction failed'
+	const reason = decodedError?.errorName
+		? humanizeIdentifier(decodedError.errorName)
+		: humanizeRawReason(rawReason)
+
+	const details: string[] = []
+	if (contractName && functionName) {
+		details.push(`Failed call: ${contractName}.${functionName}().`)
+	} else if (contractName) {
+		details.push(`Failed contract: ${contractName}.`)
+	}
+	if (rawReason && rawReason !== reason)
+		details.push(`Raw reason: ${rawReason}`)
+
+	return {
+		tone: 'failure',
+		headline: reason ? `${action}: ${reason}.` : `${action}.`,
+		details,
+		rawReason,
+	}
+}
+
+function buildInsufficientBalanceSummary(params: {
+	decodedError: DecodedTraceError | null
+	failedTrace: CallTrace | null
+	balanceChangesData?: BalanceChangesData
+	rawReason?: string
+}): TxSummary | null {
+	const { decodedError, failedTrace, balanceChangesData, rawReason } = params
+	const errorText = `${decodedError?.errorName ?? ''} ${rawReason ?? ''}`
+	if (!/insufficient/i.test(errorText) || !/balance/i.test(errorText)) {
+		return null
+	}
+
+	const token =
+		failedTrace?.to && isTip20Address(failedTrace.to)
+			? failedTrace.to
+			: undefined
+	const metadata = token ? balanceChangesData?.tokenMetadata[token] : undefined
+	const amounts = decodedError?.args.filter(
+		(arg): arg is bigint => typeof arg === 'bigint',
+	)
+	const available = amounts && amounts.length >= 2 ? amounts.at(-2) : undefined
+	const required = amounts && amounts.length >= 2 ? amounts.at(-1) : undefined
+	const balanceLabel = metadata?.symbol
+		? `${metadata.symbol} balance`
+		: token
+			? 'TIP-20 balance'
+			: 'token balance'
+
+	const amountDetail =
+		available !== undefined && required !== undefined
+			? ` Available ${formatTokenAmount(available, metadata)}, required ${formatTokenAmount(required, metadata)}.`
+			: ''
+
+	const details: string[] = []
+	if (failedTrace?.to) {
+		const contractName = getContractInfo(failedTrace.to)?.name
+		details.push(
+			`Failed at ${contractName ?? HexFormatter.truncate(failedTrace.to)}.`,
+		)
+	}
+	if (rawReason) details.push(`Raw reason: ${rawReason}`)
+
+	return {
+		tone: 'failure',
+		headline: `Transfer failed: insufficient ${balanceLabel}.${amountDetail}`,
+		details,
+		rawReason,
+	}
+}
+
+function findDeepestFailedTrace(trace: CallTrace | null): CallTrace | null {
+	if (!trace) return null
+
+	let failed: CallTrace | null =
+		trace.error || trace.revertReason ? trace : null
+	const stack = [...(trace.calls ?? [])]
+
+	while (stack.length > 0) {
+		const current = stack.pop()
+		if (!current) continue
+		if (current.error || current.revertReason) failed = current
+		if (current.calls) stack.push(...current.calls)
+	}
+
+	return failed
+}
+
+function decodeTraceError(trace: CallTrace): DecodedTraceError | null {
+	const data = getRevertData(trace)
+	if (!data) return null
+
+	try {
+		const decoded = decodeErrorResult({ abi: allAbis, data })
+		return {
+			errorName: decoded.errorName,
+			args: decoded.args ?? [],
+		}
+	} catch {
+		return null
+	}
+}
+
+function decodeTraceFunctionName(trace: CallTrace): string | null {
+	if (!trace.input || trace.input === '0x') return null
+
+	try {
+		const decoded = decodeFunctionData({ abi: allAbis, data: trace.input })
+		return decoded.functionName
+	} catch {
+		return null
+	}
+}
+
+function getRevertData(trace: CallTrace): Hex.Hex | null {
+	if (trace.output && trace.output !== '0x' && Hex.validate(trace.output)) {
+		return trace.output
+	}
+
+	const raw = trace.revertReason || trace.error
+	const [data] = raw?.match(/0x[0-9a-fA-F]+/) ?? []
+	if (data && Hex.validate(data)) return data as Hex.Hex
+	return null
+}
+
+function formatKnownEvent(event: KnownEvent): string {
+	return event.parts.map(formatKnownEventPart).filter(Boolean).join(' ')
+}
+
+function formatKnownEventPart(part: KnownEventPart): string {
+	switch (part.type) {
+		case 'account':
+			return HexFormatter.truncate(part.value)
+		case 'action':
+		case 'text':
+			return part.value
+		case 'amount':
+			return formatTokenAmount(part.value.value, part.value)
+		case 'contractCall':
+			return `call ${HexFormatter.truncate(part.value.address)}`
+		case 'duration':
+			return `${part.value.toLocaleString()}s`
+		case 'hex':
+		case 'role':
+			return HexFormatter.truncate(part.value)
+		case 'number': {
+			const value = part.value
+			if (Array.isArray(value)) return Value.format(value[0], value[1])
+			return value.toLocaleString()
+		}
+		case 'tick':
+			return part.value.toLocaleString()
+		case 'token':
+			return part.value.symbol ?? HexFormatter.truncate(part.value.address)
+	}
+}
+
+function formatTokenAmount(
+	value: bigint,
+	metadata?: {
+		decimals?: number
+		symbol?: string
+		currency?: string
+	},
+): string {
+	if (metadata?.decimals === undefined) return value.toLocaleString()
+
+	const formatted = PriceFormatter.formatAmount(
+		Value.format(value, metadata.decimals),
+	)
+	const suffix = metadata.symbol ?? metadata.currency
+	return suffix ? `${formatted} ${suffix}` : formatted
+}
+
+function sentenceCase(value: string): string {
+	if (!value) return value
+	return `${value[0]?.toUpperCase() ?? ''}${value.slice(1)}`
+}
+
+function humanizeIdentifier(value: string): string {
+	return value
+		.replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+		.replace(/[_-]+/g, ' ')
+		.replace(/^tip 20\s+/i, 'TIP-20 ')
+		.toLowerCase()
+}
+
+function humanizeRawReason(value: string | undefined): string | undefined {
+	if (!value) return undefined
+	const cleaned = value
+		.replace(/^execution reverted:?\s*/i, '')
+		.replace(/^reverted:?\s*/i, '')
+		.trim()
+
+	if (!cleaned || cleaned.startsWith('0x')) return undefined
+	return cleaned
+}

--- a/apps/explorer/src/lib/domain/tx-summary.ts
+++ b/apps/explorer/src/lib/domain/tx-summary.ts
@@ -183,18 +183,21 @@ function buildInsufficientBalanceSummary(params: {
 function findDeepestFailedTrace(trace: CallTrace | null): CallTrace | null {
 	if (!trace) return null
 
-	let failed: CallTrace | null =
-		trace.error || trace.revertReason ? trace : null
-	const stack = [...(trace.calls ?? [])]
+	let failed: { trace: CallTrace; depth: number } | null = null
+	const stack = [{ trace, depth: 0 }]
 
 	while (stack.length > 0) {
 		const current = stack.pop()
 		if (!current) continue
-		if (current.error || current.revertReason) failed = current
-		if (current.calls) stack.push(...current.calls)
+		if (current.trace.error || current.trace.revertReason) {
+			if (!failed || current.depth > failed.depth) failed = current
+		}
+		for (const call of current.trace.calls ?? []) {
+			stack.push({ trace: call, depth: current.depth + 1 })
+		}
 	}
 
-	return failed
+	return failed?.trace ?? null
 }
 
 function decodeTraceError(trace: CallTrace): DecodedTraceError | null {

--- a/apps/explorer/src/routes/_layout/receipt/$hash.tsx
+++ b/apps/explorer/src/routes/_layout/receipt/$hash.tsx
@@ -255,6 +255,7 @@ export const Route = createFileRoute('/_layout/receipt/$hash')({
 					})
 					const summary = buildTxSummary({
 						receipt: data.receipt,
+						transaction: data.transaction,
 						knownEvents: data.knownEvents,
 						trace: null,
 					})
@@ -592,9 +593,11 @@ namespace TextRenderer {
 	const indent = '  '
 
 	export function render(data: Awaited<ReturnType<typeof fetchReceiptData>>) {
-		const { knownEvents, lineItems, receipt, timestampFormatted } = data
+		const { knownEvents, lineItems, receipt, timestampFormatted, transaction } =
+			data
 		const summary = buildTxSummary({
 			receipt,
+			transaction,
 			knownEvents,
 			trace: null,
 		})

--- a/apps/explorer/src/routes/_layout/receipt/$hash.tsx
+++ b/apps/explorer/src/routes/_layout/receipt/$hash.tsx
@@ -24,6 +24,7 @@ import {
 } from '#lib/domain/known-events'
 import { calculateKnownEventsTotal } from '#lib/domain/known-event-totals'
 import { getFeeBreakdown, LineItems } from '#lib/domain/receipt'
+import { buildTxSummary } from '#lib/domain/tx-summary'
 import * as Tip20 from '#lib/domain/tip20'
 import { DateFormatter, PriceFormatter } from '#lib/formatting'
 import { useKeyboardShortcut } from '#lib/hooks'
@@ -248,12 +249,28 @@ export const Route = createFileRoute('/_layout/receipt/$hash')({
 				if (type === 'application/json') {
 					if (!hash)
 						return Response.json({ error: 'Not found' }, { status: 404 })
-					const { lineItems, receipt } = await fetchReceiptData({
+					const data = await fetchReceiptData({
 						hash,
 						rpcUrl,
 					})
+					const summary = buildTxSummary({
+						receipt: data.receipt,
+						knownEvents: data.knownEvents,
+						trace: null,
+					})
 					return Response.json(
-						JSON.parse(Json.stringify({ lineItems, receipt })),
+						JSON.parse(
+							Json.stringify({
+								version: 1,
+								summary,
+								block: data.block,
+								transaction: data.transaction,
+								receipt: data.receipt,
+								knownEvents: data.knownEvents,
+								feeBreakdown: data.feeBreakdown,
+								lineItems: data.lineItems,
+							}),
+						),
 					)
 				}
 
@@ -575,7 +592,12 @@ namespace TextRenderer {
 	const indent = '  '
 
 	export function render(data: Awaited<ReturnType<typeof fetchReceiptData>>) {
-		const { lineItems, receipt, timestampFormatted } = data
+		const { knownEvents, lineItems, receipt, timestampFormatted } = data
+		const summary = buildTxSummary({
+			receipt,
+			knownEvents,
+			trace: null,
+		})
 
 		const lines: string[] = []
 
@@ -588,6 +610,7 @@ namespace TextRenderer {
 		lines.push(`Date: ${timestampFormatted}`)
 		lines.push(`Block: ${receipt.blockNumber.toString()}`)
 		lines.push(`Sender: ${receipt.from}`)
+		lines.push(`Summary: ${summary.headline}`)
 		lines.push('')
 		lines.push('-'.repeat(width))
 		lines.push('')

--- a/apps/explorer/src/routes/_layout/receipt/$hash.tsx
+++ b/apps/explorer/src/routes/_layout/receipt/$hash.tsx
@@ -5,6 +5,7 @@ import {
 	createFileRoute,
 	notFound,
 	rootRouteId,
+	useLocation,
 	useNavigate,
 } from '@tanstack/react-router'
 import * as Address from 'ox/Address'
@@ -413,6 +414,7 @@ function parseVoucherParam(
 function Component() {
 	const { hash } = Route.useParams()
 	const { voucher: voucherRaw } = Route.useSearch()
+	const location = useLocation()
 	const navigate = useNavigate()
 	const loaderData = Route.useLoaderData() as Awaited<
 		ReturnType<typeof fetchReceiptData>
@@ -541,6 +543,7 @@ function Component() {
 				timestamp={block.timestamp}
 				total={total}
 				totalDisplay={totalDisplay}
+				exportSearch={location.searchStr}
 			/>
 		</div>
 	)

--- a/apps/explorer/src/routes/_layout/tx/$hash.tsx
+++ b/apps/explorer/src/routes/_layout/tx/$hash.tsx
@@ -35,6 +35,7 @@ import { TxTransactionCard } from '#comps/TxTransactionCard'
 import { cx } from '#lib/css'
 import { apostrophe } from '#lib/chars'
 import type { KnownEvent } from '#lib/domain/known-events'
+import { buildTxSummary, type TxSummary } from '#lib/domain/tx-summary'
 import {
 	type EventGroup,
 	groupRelatedEvents,
@@ -60,7 +61,11 @@ import {
 import { withLoaderTiming } from '#lib/profiling'
 import { zHash } from '#lib/zod'
 import { fetchBalanceChanges } from '#routes/api/tx/balance-changes/$hash'
+import BracesIcon from '~icons/lucide/braces'
 import ChevronDownIcon from '~icons/lucide/chevron-down'
+import DownloadIcon from '~icons/lucide/download'
+import FileTextIcon from '~icons/lucide/file-text'
+import ReceiptIcon from '~icons/lucide/receipt'
 
 const defaultSearchValues = {
 	tab: 'overview',
@@ -205,6 +210,16 @@ function RouteComponent() {
 				}>)
 			: undefined
 	const hasCalls = Boolean(calls && calls.length > 0)
+	const summary = React.useMemo(
+		() =>
+			buildTxSummary({
+				receipt,
+				knownEvents,
+				trace: traceData.trace,
+				balanceChangesData,
+			}),
+		[receipt, knownEvents, traceData.trace, balanceChangesData],
+	)
 
 	const setActiveSection = (newIndex: number) => {
 		navigate({
@@ -307,13 +322,98 @@ function RouteComponent() {
 				to={receipt.to}
 				className="self-start"
 			/>
-			<Sections
-				mode={mode}
-				sections={sections}
-				activeSection={activeSection}
-				onSectionChange={setActiveSection}
-			/>
+			<div className="flex min-w-0 flex-col gap-[14px]">
+				<TxSummaryCard hash={receipt.transactionHash} summary={summary} />
+				<Sections
+					mode={mode}
+					sections={sections}
+					activeSection={activeSection}
+					onSectionChange={setActiveSection}
+				/>
+			</div>
 		</div>
+	)
+}
+
+function TxSummaryCard(props: {
+	hash: Hex.Hex
+	summary: TxSummary
+}): React.JSX.Element {
+	const { hash, summary } = props
+	const isFailure = summary.tone === 'failure'
+
+	return (
+		<section
+			className={cx(
+				'rounded-[10px] border px-[18px] py-[16px] flex flex-col gap-[12px] bg-card',
+				isFailure ? 'border-negative/40' : 'border-card-border',
+			)}
+		>
+			<div className="flex flex-col gap-[6px]">
+				<div
+					className={cx(
+						'text-[12px] font-medium uppercase',
+						isFailure ? 'text-negative' : 'text-tertiary',
+					)}
+				>
+					Summary
+				</div>
+				<div className="text-[16px] leading-[22px] font-medium text-primary">
+					{summary.headline}
+				</div>
+				{summary.details.length > 0 && (
+					<div className="flex flex-col gap-[4px] text-[13px] leading-[18px] text-secondary">
+						{summary.details.map((detail) => (
+							<div key={detail} className="break-words">
+								{detail}
+							</div>
+						))}
+					</div>
+				)}
+			</div>
+			<div className="flex flex-wrap gap-[8px] text-[12px]">
+				<Link
+					to="/receipt/$hash"
+					params={{ hash }}
+					className="inline-flex items-center gap-[6px] rounded-[8px] border border-base-border bg-base-plane-interactive px-[10px] py-[6px] text-secondary transition-colors press-down hover:bg-surface hover:text-primary"
+				>
+					<ReceiptIcon className="size-[13px]" />
+					<span>Receipt</span>
+				</Link>
+				<TxSummaryExportLink hash={hash} format="pdf" />
+				<TxSummaryExportLink hash={hash} format="txt" />
+				<TxSummaryExportLink hash={hash} format="json" />
+			</div>
+		</section>
+	)
+}
+
+type TxSummaryExportLinkProps = {
+	hash: Hex.Hex
+	format: 'pdf' | 'txt' | 'json'
+}
+
+function TxSummaryExportLink(
+	props: TxSummaryExportLinkProps,
+): React.JSX.Element {
+	const { hash, format } = props
+	const icon =
+		format === 'pdf' ? (
+			<DownloadIcon className="size-[13px]" />
+		) : format === 'txt' ? (
+			<FileTextIcon className="size-[13px]" />
+		) : (
+			<BracesIcon className="size-[13px]" />
+		)
+
+	return (
+		<a
+			href={`/receipt/${hash}.${format}`}
+			className="inline-flex items-center gap-[6px] rounded-[8px] border border-base-border bg-base-plane-interactive px-[10px] py-[6px] uppercase text-secondary transition-colors press-down hover:bg-surface hover:text-primary"
+		>
+			{icon}
+			<span>{format}</span>
+		</a>
 	)
 }
 

--- a/apps/explorer/src/routes/_layout/tx/$hash.tsx
+++ b/apps/explorer/src/routes/_layout/tx/$hash.tsx
@@ -18,6 +18,7 @@ import * as z from 'zod/mini'
 import { Address } from '#comps/Address'
 import { BreadcrumbsSlot } from '#comps/Breadcrumbs'
 import { DataGrid } from '#comps/DataGrid'
+import { InfoCard } from '#comps/InfoCard'
 import { InfoRow } from '#comps/InfoRow'
 import { Midcut } from '#comps/Midcut'
 import { NotFound } from '#comps/NotFound'
@@ -61,11 +62,7 @@ import {
 import { withLoaderTiming } from '#lib/profiling'
 import { zHash } from '#lib/zod'
 import { fetchBalanceChanges } from '#routes/api/tx/balance-changes/$hash'
-import BracesIcon from '~icons/lucide/braces'
 import ChevronDownIcon from '~icons/lucide/chevron-down'
-import DownloadIcon from '~icons/lucide/download'
-import FileTextIcon from '~icons/lucide/file-text'
-import ReceiptIcon from '~icons/lucide/receipt'
 
 const defaultSearchValues = {
 	tab: 'overview',
@@ -323,7 +320,7 @@ function RouteComponent() {
 				className="self-start"
 			/>
 			<div className="flex min-w-0 flex-col gap-[14px]">
-				<TxSummaryCard hash={receipt.transactionHash} summary={summary} />
+				<TxSummaryCard summary={summary} />
 				<Sections
 					mode={mode}
 					sections={sections}
@@ -335,85 +332,29 @@ function RouteComponent() {
 	)
 }
 
-function TxSummaryCard(props: {
-	hash: Hex.Hex
-	summary: TxSummary
-}): React.JSX.Element {
-	const { hash, summary } = props
+function TxSummaryCard(props: { summary: TxSummary }): React.JSX.Element {
+	const { summary } = props
 	const isFailure = summary.tone === 'failure'
 
 	return (
-		<section
+		<InfoCard
+			title={<InfoCard.Title>Summary</InfoCard.Title>}
 			className={cx(
-				'rounded-[10px] border px-[18px] py-[16px] flex flex-col gap-[12px] bg-card',
+				'min-[1240px]:w-full',
 				isFailure ? 'border-negative/40' : 'border-card-border',
 			)}
-		>
-			<div className="flex flex-col gap-[6px]">
+			sections={[
 				<div
+					key="headline"
 					className={cx(
-						'text-[12px] font-medium uppercase',
-						isFailure ? 'text-negative' : 'text-tertiary',
+						'text-[16px] leading-[22px] font-medium text-primary',
+						isFailure && 'text-negative',
 					)}
 				>
-					Summary
-				</div>
-				<div className="text-[16px] leading-[22px] font-medium text-primary">
-					{summary.headline}
-				</div>
-				{summary.details.length > 0 && (
-					<div className="flex flex-col gap-[4px] text-[13px] leading-[18px] text-secondary">
-						{summary.details.map((detail) => (
-							<div key={detail} className="break-words">
-								{detail}
-							</div>
-						))}
-					</div>
-				)}
-			</div>
-			<div className="flex flex-wrap gap-[8px] text-[12px]">
-				<Link
-					to="/receipt/$hash"
-					params={{ hash }}
-					className="inline-flex items-center gap-[6px] rounded-[8px] border border-base-border bg-base-plane-interactive px-[10px] py-[6px] text-secondary transition-colors press-down hover:bg-surface hover:text-primary"
-				>
-					<ReceiptIcon className="size-[13px]" />
-					<span>Receipt</span>
-				</Link>
-				<TxSummaryExportLink hash={hash} format="pdf" />
-				<TxSummaryExportLink hash={hash} format="txt" />
-				<TxSummaryExportLink hash={hash} format="json" />
-			</div>
-		</section>
-	)
-}
-
-type TxSummaryExportLinkProps = {
-	hash: Hex.Hex
-	format: 'pdf' | 'txt' | 'json'
-}
-
-function TxSummaryExportLink(
-	props: TxSummaryExportLinkProps,
-): React.JSX.Element {
-	const { hash, format } = props
-	const icon =
-		format === 'pdf' ? (
-			<DownloadIcon className="size-[13px]" />
-		) : format === 'txt' ? (
-			<FileTextIcon className="size-[13px]" />
-		) : (
-			<BracesIcon className="size-[13px]" />
-		)
-
-	return (
-		<a
-			href={`/receipt/${hash}.${format}`}
-			className="inline-flex items-center gap-[6px] rounded-[8px] border border-base-border bg-base-plane-interactive px-[10px] py-[6px] uppercase text-secondary transition-colors press-down hover:bg-surface hover:text-primary"
-		>
-			{icon}
-			<span>{format}</span>
-		</a>
+					{summary.headline.replace(/\.$/, '')}
+				</div>,
+			]}
+		/>
 	)
 }
 

--- a/apps/explorer/src/routes/_layout/tx/$hash.tsx
+++ b/apps/explorer/src/routes/_layout/tx/$hash.tsx
@@ -18,7 +18,6 @@ import * as z from 'zod/mini'
 import { Address } from '#comps/Address'
 import { BreadcrumbsSlot } from '#comps/Breadcrumbs'
 import { DataGrid } from '#comps/DataGrid'
-import { InfoCard } from '#comps/InfoCard'
 import { InfoRow } from '#comps/InfoRow'
 import { Midcut } from '#comps/Midcut'
 import { NotFound } from '#comps/NotFound'
@@ -36,7 +35,7 @@ import { TxTransactionCard } from '#comps/TxTransactionCard'
 import { cx } from '#lib/css'
 import { apostrophe } from '#lib/chars'
 import type { KnownEvent } from '#lib/domain/known-events'
-import { buildTxSummary, type TxSummary } from '#lib/domain/tx-summary'
+import { buildTxSummary } from '#lib/domain/tx-summary'
 import {
 	type EventGroup,
 	groupRelatedEvents,
@@ -211,11 +210,12 @@ function RouteComponent() {
 		() =>
 			buildTxSummary({
 				receipt,
+				transaction,
 				knownEvents,
 				trace: traceData.trace,
 				balanceChangesData,
 			}),
-		[receipt, knownEvents, traceData.trace, balanceChangesData],
+		[receipt, knownEvents, traceData.trace, balanceChangesData, transaction],
 	)
 
 	const setActiveSection = (newIndex: number) => {
@@ -313,6 +313,7 @@ function RouteComponent() {
 			<TxTransactionCard
 				hash={receipt.transactionHash}
 				status={receipt.status}
+				error={summary.error}
 				blockNumber={receipt.blockNumber}
 				timestamp={block.timestamp}
 				from={receipt.from}
@@ -320,7 +321,6 @@ function RouteComponent() {
 				className="self-start"
 			/>
 			<div className="flex min-w-0 flex-col gap-[14px]">
-				<TxSummaryCard summary={summary} />
 				<Sections
 					mode={mode}
 					sections={sections}
@@ -329,32 +329,6 @@ function RouteComponent() {
 				/>
 			</div>
 		</div>
-	)
-}
-
-function TxSummaryCard(props: { summary: TxSummary }): React.JSX.Element {
-	const { summary } = props
-	const isFailure = summary.tone === 'failure'
-
-	return (
-		<InfoCard
-			title={<InfoCard.Title>Summary</InfoCard.Title>}
-			className={cx(
-				'min-[1240px]:w-full',
-				isFailure ? 'border-negative/40' : 'border-card-border',
-			)}
-			sections={[
-				<div
-					key="headline"
-					className={cx(
-						'text-[16px] leading-[22px] font-medium text-primary',
-						isFailure && 'text-negative',
-					)}
-				>
-					{summary.headline.replace(/\.$/, '')}
-				</div>,
-			]}
-		/>
 	)
 }
 


### PR DESCRIPTION
## Summary

- Adds share, PDF, TXT, and JSON controls to Tempo receipts.
- Expands receipt TXT/JSON exports with a human-readable transaction summary and structured receipt context.
- Shows decoded failure reasons, such as unsupported function selectors, as an Error row on failed transaction cards.