### PR TITLE
Add Storage Credits precompile to explorer

### DIFF
--- a/apps/contract-verification/scripts/precompile-seed/manifest.ts
+++ b/apps/contract-verification/scripts/precompile-seed/manifest.ts
@@ -113,6 +113,54 @@ const addressRegistryAbi = Abis.addressRegistry
 
 const signatureVerifierAbi = Abis.signatureVerifier
 
+const storageCreditsAbi = [
+	{
+		type: 'error',
+		name: 'DelegateCallNotAllowed',
+		inputs: [],
+	},
+	{
+		type: 'error',
+		name: 'InvalidMode',
+		inputs: [],
+	},
+	{
+		type: 'function',
+		name: 'balanceOf',
+		stateMutability: 'view',
+		inputs: [{ name: 'account', type: 'address' }],
+		outputs: [{ name: '', type: 'uint64' }],
+	},
+	{
+		type: 'function',
+		name: 'modeOf',
+		stateMutability: 'view',
+		inputs: [{ name: 'account', type: 'address' }],
+		outputs: [{ name: '', type: 'uint8' }],
+	},
+	{
+		type: 'function',
+		name: 'budgetOf',
+		stateMutability: 'view',
+		inputs: [{ name: 'account', type: 'address' }],
+		outputs: [{ name: '', type: 'uint64' }],
+	},
+	{
+		type: 'function',
+		name: 'setMode',
+		stateMutability: 'nonpayable',
+		inputs: [{ name: 'newMode', type: 'uint8' }],
+		outputs: [],
+	},
+	{
+		type: 'function',
+		name: 'setBudget',
+		stateMutability: 'nonpayable',
+		inputs: [{ name: 'creditBudget', type: 'uint64' }],
+		outputs: [],
+	},
+] as const satisfies Abi
+
 const validatorConfigAddress = Addresses.validator
 const validatorConfigV2Address =
 	'0xcccccccc00000000000000000000000000000001' as const
@@ -126,6 +174,8 @@ const addressRegistryAddress =
 	'0xfdc0000000000000000000000000000000000000' as const
 const signatureVerifierAddress =
 	'0x5165300000000000000000000000000000000000' as const
+const storageCreditsAddress =
+	'0x1060000000000000000000000000000000000000' as const
 
 export const validatorConfigManifest = {
 	id: 'validator-config',
@@ -365,6 +415,32 @@ export const signatureVerifierManifest = {
 	}),
 } as const satisfies NativeContractManifestEntry
 
+export const storageCreditsManifest = {
+	id: 'storage-credits',
+	name: 'Storage Credits',
+	runtimeType: 'precompile',
+	language: 'Rust',
+	abi: storageCreditsAbi,
+	repository: tempoRepository,
+	commit: tempoCommit,
+	commitUrl: tempoCommitUrl,
+	docsUrl: 'https://docs.tempo.xyz/protocol/tips/tip-1060',
+	sourceRoot: 'crates/precompiles/src/storage_credits',
+	paths: [
+		'crates/precompiles/src/storage_credits/mod.rs',
+		'crates/precompiles/src/storage_credits/dispatch.rs',
+	],
+	entrypoints: ['crates/precompiles/src/storage_credits/mod.rs'],
+	deployments: buildDeployments(
+		storageCreditsAddress,
+		buildProtocolActivation('T7'),
+	),
+	references: buildReferences({
+		abiReferencePaths: ['crates/contracts/src/precompiles/storage_credits.rs'],
+		specificationPaths: ['tips/tip-1060.md'],
+	}),
+} as const satisfies NativeContractManifestEntry
+
 export const nativeContractsManifest = [
 	validatorConfigManifest,
 	validatorConfigV2Manifest,
@@ -376,4 +452,5 @@ export const nativeContractsManifest = [
 	stablecoinDexManifest,
 	addressRegistryManifest,
 	signatureVerifierManifest,
+	storageCreditsManifest,
 ] as const satisfies ReadonlyArray<NativeContractManifestEntry>

--- a/apps/explorer/src/lib/abis.ts
+++ b/apps/explorer/src/lib/abis.ts
@@ -3,6 +3,18 @@ import { Abis as ViemTempoAbis, Channel as ViemTempoChannel } from 'viem/tempo'
 
 export const tip20ChannelReserveAbi = ViemTempoAbis.tip20ChannelReserve
 export const tip20ChannelReserveAddress = ViemTempoChannel.address
+export const storageCreditsAddress =
+	'0x1060000000000000000000000000000000000000' as const
+
+export const storageCreditsAbi = parseAbi([
+	'error DelegateCallNotAllowed()',
+	'error InvalidMode()',
+	'function balanceOf(address account) view returns (uint64)',
+	'function modeOf(address account) view returns (uint8)',
+	'function budgetOf(address account) view returns (uint64)',
+	'function setMode(uint8 newMode)',
+	'function setBudget(uint64 creditBudget)',
+])
 
 export const streamChannelAbi = [
 	{
@@ -237,6 +249,7 @@ export const Abis = {
 	...ViemTempoAbis,
 	receivePolicyGuard: receivePolicyGuardAbi,
 	stablecoinDex: stablecoinDexAbi,
+	storageCredits: storageCreditsAbi,
 	streamChannel: streamChannelAbi,
 	zonePortal: zonePortalAbi,
 	zoneFactory: zoneFactoryAbi,

--- a/apps/explorer/src/lib/domain/contracts.ts
+++ b/apps/explorer/src/lib/domain/contracts.ts
@@ -12,6 +12,8 @@ import {
 	Abis,
 	stablecoinDexAbi,
 	streamChannelAbi,
+	storageCreditsAbi,
+	storageCreditsAddress,
 	tip20ChannelReserveAbi,
 	tip20ChannelReserveAddress,
 } from '#lib/abis'
@@ -324,6 +326,18 @@ export const systemContractRegistry = new Map<Address.Address, ContractInfo>(<
 			category: 'system',
 			docsUrl: 'https://tips.sh/1034-1',
 			address: tip20ChannelReserveAddress,
+		},
+	],
+	[
+		storageCreditsAddress,
+		{
+			name: 'Storage Credits',
+			code: '0xef',
+			description: 'Per-account storage credit accounting precompile',
+			abi: storageCreditsAbi,
+			category: 'system',
+			docsUrl: 'https://docs.tempo.xyz/protocol/tips/tip-1060',
+			address: storageCreditsAddress,
 		},
 	],
 	[

--- a/apps/explorer/test/storage-credits.node.test.ts
+++ b/apps/explorer/test/storage-credits.node.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import { decodeFunctionData, encodeFunctionData, getAbiItem } from 'viem'
+import { storageCreditsAbi, storageCreditsAddress } from '#lib/abis'
+import { autoloadAbi, getContractInfo } from '#lib/domain/contracts'
+
+describe('Storage Credits precompile ABI', () => {
+	it('registers the TIP-1060 precompile address for ABI rendering', () => {
+		const info = getContractInfo(storageCreditsAddress)
+
+		expect(info?.name).toBe('Storage Credits')
+		expect(info?.abi).toBe(storageCreditsAbi)
+		expect(
+			getAbiItem({
+				abi: info?.abi ?? [],
+				name: 'balanceOf',
+			}),
+		).toBeDefined()
+	})
+
+	it('decodes storage credit calldata', () => {
+		const data = encodeFunctionData({
+			abi: storageCreditsAbi,
+			functionName: 'setBudget',
+			args: [12n],
+		})
+
+		const decoded = decodeFunctionData({
+			abi: storageCreditsAbi,
+			data,
+		})
+
+		expect(decoded.functionName).toBe('setBudget')
+		expect(decoded.args[0]).toBe(12n)
+	})
+
+	it('returns the known registry ABI from autoload before network lookup', async () => {
+		await expect(autoloadAbi(storageCreditsAddress)).resolves.toBe(
+			storageCreditsAbi,
+		)
+	})
+})


### PR DESCRIPTION
## Summary
- register the TIP-1060 Storage Credits precompile in the explorer known contract registry
- add a local ABI/address export so calls can decode and ABI autoload resolves locally
- seed native contract-verification metadata for source links to the Tempo implementation

Prompted by: @0xalpharush

## Testing
- pnpm --filter explorer test --run --config vitest.node.config.ts test/storage-credits.node.test.ts test/tip20-channel-reserve.node.test.ts
- pnpm --filter explorer check:types
- pnpm --filter contracts exec tsx -e "import('./scripts/precompile-seed/manifest.ts').then(m => { const e = m.nativeContractsManifest.find(x => x.id === 'storage-credits'); if (!e) throw new Error('missing storage-credits'); console.log(e.name, e.deployments[0].address, e.references.specificationPaths[0]); })"

Note: contract-verification full typecheck currently fails on existing generated Cloudflare Env bindings unrelated to this change.