### PR TITLE
fix(fee-payer): pin sponsored fees to pathUSD

### DIFF
--- a/apps/fee-payer/src/index.ts
+++ b/apps/fee-payer/src/index.ts
@@ -12,6 +12,7 @@ import { admin } from './lib/admin.js'
 import { apiKeyMiddleware } from './lib/api-key-middleware.js'
 import { enqueueSponsorshipIntent } from './lib/billing.js'
 import { tempoChain } from './lib/chain.js'
+import { pathUsd } from './lib/consts.js'
 import { httpMetrics, rpcMetrics } from './lib/observability/middleware.js'
 import {
 	FeePayerEvents,
@@ -105,6 +106,8 @@ const relayHandler = Handler.relay({
 	features: 'all',
 	feePayer: {
 		account: sponsorAccount,
+		// Always use PathUSD as fee token.
+		feeToken: pathUsd,
 		name: 'Tempo Sponsor',
 		url: 'https://sponsor.tempo.xyz',
 	},

--- a/apps/fee-payer/src/lib/usage.ts
+++ b/apps/fee-payer/src/lib/usage.ts
@@ -5,6 +5,7 @@ import type { Address } from 'ox'
 import { createPublicClient, formatUnits, http } from 'viem'
 import { Actions, Addresses } from 'viem/tempo'
 import { tempoChain } from './chain.js'
+import { pathUsd } from './consts.js'
 
 const IS = IDX.IndexSupply.create({
 	apiKey: env.INDEXSUPPLY_API_KEY,
@@ -70,7 +71,7 @@ export async function getUsage(
 					env.TEMPO_RPC_URL ?? tempoChain.rpcUrls.default.http[0],
 				),
 			}),
-			{ token: tempoChain.feeToken },
+			{ token: pathUsd },
 		)
 	}
 

--- a/apps/fee-payer/test/api-keys.test.ts
+++ b/apps/fee-payer/test/api-keys.test.ts
@@ -1,6 +1,7 @@
 import { env, exports } from 'cloudflare:workers'
 import { sendTransactionSync } from 'viem/actions'
 import { describe, expect, it } from 'vitest'
+import { pathUsd } from '../src/lib/consts.js'
 import {
 	buildSponsorClient,
 	createTestAccount,
@@ -499,6 +500,6 @@ describe('API key sponsorship integration', () => {
 		expect(receipt.status).toBe('success')
 		expect(receipt.from.toLowerCase()).toBe(account.address.toLowerCase())
 		expect(receipt.feePayer?.toLowerCase()).toBe(sponsorAddress.toLowerCase())
-		expect(receipt.feeToken).toMatch(/^0x[a-fA-F0-9]{40}$/)
+		expect(receipt.feeToken?.toLowerCase()).toBe(pathUsd.toLowerCase())
 	})
 })

--- a/apps/fee-payer/test/billing.test.ts
+++ b/apps/fee-payer/test/billing.test.ts
@@ -4,12 +4,12 @@ import {
 	buildSponsorshipIntentMessage,
 	hashApiKey,
 } from '../src/lib/billing.js'
+import { pathUsd } from '../src/lib/consts.js'
 import { tempoChain } from './helpers.js'
 
 const apiKey = 'tp_test_key'
 const sender = '0x0000000000000000000000000000000000000003'
 const sponsorAddress = '0x0000000000000000000000000000000000000004'
-const feeToken = '0x20c0000000000000000000000000000000000000'
 const target = '0x0000000000000000000000000000000000000005'
 const signedAt = '2026-06-20T12:00:00.000Z'
 const attributionKey = 'privy-app-123'
@@ -49,7 +49,7 @@ function fillResponse(tx = {}) {
 				maxPriorityFeePerGas: '0x1',
 				nonce: '0x0',
 				calls: [{ to: target, value: '0x0', data: '0x' }],
-				feeToken,
+				feeToken: pathUsd,
 				feePayerSignature,
 				...tx,
 			},

--- a/apps/fee-payer/test/billing.test.ts
+++ b/apps/fee-payer/test/billing.test.ts
@@ -178,7 +178,7 @@ describe('billing sponsorship intents', () => {
 			authorizationList: [],
 			calls: [{ to: target, value: 0n, data: '0x' }],
 			chainId: tempoChain.id,
-			feeToken,
+			feeToken: pathUsd,
 			gas: 0xd492n,
 			maxFeePerGas: 0x4a817c800n,
 			maxPriorityFeePerGas: 0n,

--- a/apps/fee-payer/test/e2e.test.ts
+++ b/apps/fee-payer/test/e2e.test.ts
@@ -4,6 +4,7 @@ import { createClient, custom, http, parseUnits } from 'viem'
 import { sendTransactionSync } from 'viem/actions'
 import { Account, Actions, withRelay } from 'viem/tempo'
 import { beforeAll, describe, expect, it } from 'vitest'
+import { pathUsd } from '../src/lib/consts.js'
 import {
 	sponsorAddress,
 	createTestAccount,
@@ -64,10 +65,10 @@ beforeAll(async () => {
 		[1n, 2n, 3n].map((id) =>
 			Actions.amm.mintSync(client, {
 				account: sponsorAccount,
-				feeToken: '0x20c0000000000000000000000000000000000000',
+				feeToken: pathUsd,
 				nonceKey: 'expiring',
 				userTokenAddress: id,
-				validatorTokenAddress: '0x20c0000000000000000000000000000000000000',
+				validatorTokenAddress: pathUsd,
 				validatorTokenAmount: parseUnits('1000', 6),
 				to: sponsorAccount.address,
 			}),
@@ -173,11 +174,10 @@ describe('fee-payer integration', () => {
 			expect(receipt.transactionHash).toBeDefined()
 			expect(receipt.from.toLowerCase()).toBe(account.address.toLowerCase())
 			expect(receipt.feePayer?.toLowerCase()).toBe(sponsorAddress.toLowerCase())
-			// Regression: the broadcast envelope must carry a feeToken the
-			// chain can charge. Without it the chain falls back to the
-			// sender's default account token and the tx reverts at
-			// validation with `insufficient liquidity in FeeAMM pool`.
-			expect(receipt.feeToken).toMatch(/^0x[a-fA-F0-9]{40}$/)
+			// Regression: sponsored transactions must pay with PathUSD,
+			// avoiding account-level fee token preferences that can route
+			// through illiquid FeeAMM pools.
+			expect(receipt.feeToken?.toLowerCase()).toBe(pathUsd.toLowerCase())
 
 			// Assert RPC methods sent to fee-payer service
 			const sponsorshipRequests = feePayerRequests.filter((request) =>
@@ -216,11 +216,10 @@ describe('fee-payer integration', () => {
 			expect(receipt.from.toLowerCase()).toBe(account.address.toLowerCase())
 			expect(receipt.feePayer?.toLowerCase()).toBe(sponsorAddress.toLowerCase())
 			expect(receipt.status).toBe('success')
-			// Regression: the broadcast envelope must carry a feeToken the
-			// chain can charge. Without it the chain falls back to the
-			// sender's default account token and the tx reverts at
-			// validation with `insufficient liquidity in FeeAMM pool`.
-			expect(receipt.feeToken).toMatch(/^0x[a-fA-F0-9]{40}$/)
+			// Regression: sponsored transactions must pay with PathUSD,
+			// avoiding account-level fee token preferences that can route
+			// through illiquid FeeAMM pools.
+			expect(receipt.feeToken?.toLowerCase()).toBe(pathUsd.toLowerCase())
 
 			// Assert RPC methods sent to fee-payer service
 			const sponsorshipRequests = feePayerRequests.filter((request) =>


### PR DESCRIPTION
## Summary

Pins the fee-payer sponsor token to pathUSD for sponsored transactions. Updates fee usage metadata and regression tests to expect pathUSD as the fee token.

## Motivation

Production sponsored fills currently return a fee-payer signature with `feeToken: null`, so Tempo can fall back to the sponsor account's configured fee token and route settlement through an illiquid FeeAMM pool. The sponsor should always pay in pathUSD.

## Changes

- Set `feePayer.feeToken` to `pathUsd` in the fee-payer relay config.
- Read usage fee-token metadata from `pathUsd`.
- Tightened sponsorship tests and fixtures to assert/use `pathUsd` directly.

## Testing

- `pnpm install`
- `pnpm exec biome check --write apps/fee-payer/src/index.ts apps/fee-payer/src/lib/usage.ts apps/fee-payer/test/e2e.test.ts apps/fee-payer/test/api-keys.test.ts apps/fee-payer/test/billing.test.ts`
- `pnpm --filter fee-payer check:types`
- `pnpm --filter fee-payer build`
- Commit pre-commit hooks passed.
- Attempted `TEMPO_ENV=moderato pnpm --filter fee-payer test -- test/billing.test.ts`, but the existing global setup still tried to start local Tempo and failed because Docker/OrbStack is unavailable in this environment.