### PR TITLE
test(fee-payer): cover pathUSD fee sponsorship

### DIFF
--- a/apps/fee-payer/test/e2e.test.ts
+++ b/apps/fee-payer/test/e2e.test.ts
@@ -4,7 +4,7 @@ import { createClient, custom, http, parseUnits } from 'viem'
 import { sendTransactionSync } from 'viem/actions'
 import { Account, Actions, withRelay } from 'viem/tempo'
 import { beforeAll, describe, expect, it } from 'vitest'
-import { pathUsd } from '../src/lib/consts.js'
+import { alphaUsd, pathUsd } from '../src/lib/consts.js'
 import {
 	sponsorAddress,
 	createTestAccount,
@@ -12,6 +12,13 @@ import {
 	tempoTransport,
 	testMnemonic,
 } from './helpers.js'
+
+const sponsorAccount = Account.fromSecp256k1(
+	Mnemonic.toPrivateKey(testMnemonic, {
+		as: 'Hex',
+		path: Mnemonic.path({ account: 0 }),
+	}),
+)
 
 function createFeePayerTransportWithSpy() {
 	const requests: Array<{ method: string; params: unknown }> = []
@@ -48,13 +55,6 @@ function createFeePayerTransportWithSpy() {
 
 // Mint liquidity for fee tokens.
 beforeAll(async () => {
-	const sponsorAccount = Account.fromSecp256k1(
-		Mnemonic.toPrivateKey(testMnemonic, {
-			as: 'Hex',
-			path: Mnemonic.path({ account: 0 }),
-		}),
-	)
-
 	const client = createClient({
 		account: sponsorAccount,
 		chain: tempoChain,
@@ -230,6 +230,107 @@ describe('fee-payer integration', () => {
 			expect(sponsorshipRequests).toHaveLength(1)
 			expect(sponsorshipRequests[0].method).toBe('eth_fillTransaction')
 			expect(sponsorshipRequests[0].params).toBeDefined()
+		})
+
+		// Reproduces the outage: the sponsor's on-chain fee-token preference was
+		// a non-pathUSD token routing through an illiquid FeeAMM pool. The worker
+		// must pin pathUSD and ignore that preference.
+		it('settles in pathUSD even when the sponsor has a non-pathUSD on-chain userToken', async () => {
+			const sponsorClient = createClient({
+				account: sponsorAccount,
+				chain: tempoChain,
+				transport: http(env.TEMPO_RPC_URL),
+			})
+
+			// Set the sponsor's on-chain preference away from pathUSD.
+			await Actions.fee.setUserTokenSync(sponsorClient, {
+				account: sponsorAccount,
+				token: alphaUsd,
+				nonceKey: 'expiring',
+			})
+
+			try {
+				const { transport: feePayerTransport } =
+					createFeePayerTransportWithSpy()
+				const account = createTestAccount()
+				const client = createClient({
+					account,
+					chain: tempoChain,
+					transport: withRelay(tempoTransport(), feePayerTransport, {
+						policy: 'sign-and-broadcast',
+					}),
+				})
+
+				const receipt = await sendTransactionSync(client, {
+					feePayer: true,
+					to: '0x0000000000000000000000000000000000000002',
+					value: 0n,
+				})
+
+				expect(receipt.status).toBe('success')
+				expect(receipt.feePayer?.toLowerCase()).toBe(
+					sponsorAddress.toLowerCase(),
+				)
+				// The worker pins pathUSD, overriding the sponsor's on-chain preference.
+				expect(receipt.feeToken?.toLowerCase()).toBe(pathUsd.toLowerCase())
+			} finally {
+				// Restore so tests remain order-independent.
+				await Actions.fee.setUserTokenSync(sponsorClient, {
+					account: sponsorAccount,
+					token: pathUsd,
+					nonceKey: 'expiring',
+				})
+			}
+		})
+
+		// The prod failure only hit TIP-20 transfer activities, not the native
+		// value transfers the other tests exercise.
+		it('sponsors a TIP-20 transfer out of the sender', async () => {
+			const sponsorClient = createClient({
+				account: sponsorAccount,
+				chain: tempoChain,
+				transport: http(env.TEMPO_RPC_URL),
+			})
+
+			const account = createTestAccount()
+			const recipient = createTestAccount()
+
+			// Fund the sender with pathUSD to transfer out.
+			await Actions.token.transferSync(sponsorClient, {
+				account: sponsorAccount,
+				token: pathUsd,
+				to: account.address,
+				amount: parseUnits('1', 6),
+				nonceKey: 'expiring',
+			})
+
+			const { transport: feePayerTransport } = createFeePayerTransportWithSpy()
+			const client = createClient({
+				account,
+				chain: tempoChain,
+				transport: withRelay(tempoTransport(), feePayerTransport, {
+					policy: 'sign-and-broadcast',
+				}),
+			})
+
+			const amount = parseUnits('0.25', 6)
+			const { receipt } = await Actions.token.transferSync(client, {
+				feePayer: true,
+				token: pathUsd,
+				to: recipient.address,
+				amount,
+			})
+
+			expect(receipt.status).toBe('success')
+			expect(receipt.from.toLowerCase()).toBe(account.address.toLowerCase())
+			expect(receipt.feePayer?.toLowerCase()).toBe(sponsorAddress.toLowerCase())
+			expect(receipt.feeToken?.toLowerCase()).toBe(pathUsd.toLowerCase())
+
+			const balance = await Actions.token.getBalance(sponsorClient, {
+				token: pathUsd,
+				account: recipient.address,
+			})
+			expect(balance).toBe(amount)
 		})
 	})
 })

--- a/apps/fee-payer/test/e2e.test.ts
+++ b/apps/fee-payer/test/e2e.test.ts
@@ -4,7 +4,7 @@ import { createClient, custom, http, parseUnits } from 'viem'
 import { sendTransactionSync } from 'viem/actions'
 import { Account, Actions, withRelay } from 'viem/tempo'
 import { beforeAll, describe, expect, it } from 'vitest'
-import { alphaUsd, pathUsd } from '../src/lib/consts.js'
+import { pathUsd } from '../src/lib/consts.js'
 import {
 	sponsorAddress,
 	createTestAccount,
@@ -19,6 +19,7 @@ const sponsorAccount = Account.fromSecp256k1(
 		path: Mnemonic.path({ account: 0 }),
 	}),
 )
+const thetaUsd = '0x20c0000000000000000000000000000000000003' as const
 
 function createFeePayerTransportWithSpy() {
 	const requests: Array<{ method: string; params: unknown }> = []
@@ -242,63 +243,32 @@ describe('fee-payer integration', () => {
 				transport: http(env.TEMPO_RPC_URL),
 			})
 
-			const originalUserToken = await Actions.fee.getUserToken(sponsorClient, {
+			// Simulates an account-level preference that previously overrode sponsored fee settlement.
+			await Actions.fee.setUserTokenSync(sponsorClient, {
 				account: sponsorAccount,
+				token: thetaUsd,
+				nonceKey: 'expiring',
 			})
-			const originalToken = originalUserToken?.address
-			if (!originalToken)
-				throw new Error('expected sponsor to have an initial user token')
 
-			const adversarialToken =
-				originalToken.toLowerCase() !== pathUsd.toLowerCase()
-					? originalToken
-					: alphaUsd
-			const changedUserToken =
-				originalToken.toLowerCase() !== adversarialToken.toLowerCase()
+			const { transport: feePayerTransport } = createFeePayerTransportWithSpy()
+			const account = createTestAccount()
+			const client = createClient({
+				account,
+				chain: tempoChain,
+				transport: withRelay(tempoTransport(), feePayerTransport, {
+					policy: 'sign-and-broadcast',
+				}),
+			})
 
-			try {
-				// Ensure the sponsor's on-chain preference is away from pathUSD.
-				if (changedUserToken) {
-					await Actions.fee.setUserTokenSync(sponsorClient, {
-						account: sponsorAccount,
-						token: adversarialToken,
-						nonceKey: 'expiring',
-					})
-				}
+			const receipt = await sendTransactionSync(client, {
+				feePayer: true,
+				to: '0x0000000000000000000000000000000000000002',
+				value: 0n,
+			})
 
-				const { transport: feePayerTransport } =
-					createFeePayerTransportWithSpy()
-				const account = createTestAccount()
-				const client = createClient({
-					account,
-					chain: tempoChain,
-					transport: withRelay(tempoTransport(), feePayerTransport, {
-						policy: 'sign-and-broadcast',
-					}),
-				})
-
-				const receipt = await sendTransactionSync(client, {
-					feePayer: true,
-					to: '0x0000000000000000000000000000000000000002',
-					value: 0n,
-				})
-
-				expect(receipt.status).toBe('success')
-				expect(receipt.feePayer?.toLowerCase()).toBe(
-					sponsorAddress.toLowerCase(),
-				)
-				// The worker pins pathUSD, overriding the sponsor's on-chain preference.
-				expect(receipt.feeToken?.toLowerCase()).toBe(pathUsd.toLowerCase())
-			} finally {
-				// Restore so tests remain order-independent.
-				if (changedUserToken && originalToken) {
-					await Actions.fee.setUserTokenSync(sponsorClient, {
-						account: sponsorAccount,
-						token: originalToken,
-						nonceKey: 'expiring',
-					})
-				}
-			}
+			expect(receipt.status).toBe('success')
+			expect(receipt.feePayer?.toLowerCase()).toBe(sponsorAddress.toLowerCase())
+			expect(receipt.feeToken?.toLowerCase()).toBe(pathUsd.toLowerCase())
 		})
 
 		// The prod failure only hit TIP-20 transfer activities, not the native

--- a/apps/fee-payer/test/e2e.test.ts
+++ b/apps/fee-payer/test/e2e.test.ts
@@ -19,6 +19,7 @@ const sponsorAccount = Account.fromSecp256k1(
 		path: Mnemonic.path({ account: 0 }),
 	}),
 )
+const betaUsd = '0x20c0000000000000000000000000000000000002' as const
 const thetaUsd = '0x20c0000000000000000000000000000000000003' as const
 
 function createFeePayerTransportWithSpy() {
@@ -233,47 +234,7 @@ describe('fee-payer integration', () => {
 			expect(sponsorshipRequests[0].params).toBeDefined()
 		})
 
-		// Reproduces the outage: the sponsor's on-chain fee-token preference was
-		// a non-pathUSD token routing through an illiquid FeeAMM pool. The worker
-		// must pin pathUSD and ignore that preference.
-		it('settles in pathUSD even when the sponsor has a non-pathUSD on-chain userToken', async () => {
-			const sponsorClient = createClient({
-				account: sponsorAccount,
-				chain: tempoChain,
-				transport: http(env.TEMPO_RPC_URL),
-			})
-
-			// Simulates an account-level preference that previously overrode sponsored fee settlement.
-			await Actions.fee.setUserTokenSync(sponsorClient, {
-				account: sponsorAccount,
-				token: thetaUsd,
-				nonceKey: 'expiring',
-			})
-
-			const { transport: feePayerTransport } = createFeePayerTransportWithSpy()
-			const account = createTestAccount()
-			const client = createClient({
-				account,
-				chain: tempoChain,
-				transport: withRelay(tempoTransport(), feePayerTransport, {
-					policy: 'sign-and-broadcast',
-				}),
-			})
-
-			const receipt = await sendTransactionSync(client, {
-				feePayer: true,
-				to: '0x0000000000000000000000000000000000000002',
-				value: 0n,
-			})
-
-			expect(receipt.status).toBe('success')
-			expect(receipt.feePayer?.toLowerCase()).toBe(sponsorAddress.toLowerCase())
-			expect(receipt.feeToken?.toLowerCase()).toBe(pathUsd.toLowerCase())
-		})
-
-		// The prod failure only hit TIP-20 transfer activities, not the native
-		// value transfers the other tests exercise.
-		it('sponsors a TIP-20 transfer out of the sender', async () => {
+		it('sponsors a betaUSD transfer while the sponsor prefers thetaUSD', async () => {
 			const sponsorClient = createClient({
 				account: sponsorAccount,
 				chain: tempoChain,
@@ -283,10 +244,16 @@ describe('fee-payer integration', () => {
 			const account = createTestAccount()
 			const recipient = createTestAccount()
 
-			// Fund the sender with pathUSD to transfer out.
+			// ThetaUSD simulates a sponsor preference that previously overrode sponsored TIP-20 fee settlement.
+			await Actions.fee.setUserTokenSync(sponsorClient, {
+				account: sponsorAccount,
+				token: thetaUsd,
+				nonceKey: 'expiring',
+			})
+
 			await Actions.token.transferSync(sponsorClient, {
 				account: sponsorAccount,
-				token: pathUsd,
+				token: betaUsd,
 				to: account.address,
 				amount: parseUnits('1', 6),
 				nonceKey: 'expiring',
@@ -304,7 +271,7 @@ describe('fee-payer integration', () => {
 			const amount = parseUnits('0.25', 6)
 			const { receipt } = await Actions.token.transferSync(client, {
 				feePayer: true,
-				token: pathUsd,
+				token: betaUsd,
 				to: recipient.address,
 				amount,
 			})
@@ -315,7 +282,7 @@ describe('fee-payer integration', () => {
 			expect(receipt.feeToken?.toLowerCase()).toBe(pathUsd.toLowerCase())
 
 			const balance = await Actions.token.getBalance(sponsorClient, {
-				token: pathUsd,
+				token: betaUsd,
 				account: recipient.address,
 			})
 			expect(balance).toBe(amount)

--- a/apps/fee-payer/test/e2e.test.ts
+++ b/apps/fee-payer/test/e2e.test.ts
@@ -242,14 +242,30 @@ describe('fee-payer integration', () => {
 				transport: http(env.TEMPO_RPC_URL),
 			})
 
-			// Set the sponsor's on-chain preference away from pathUSD.
-			await Actions.fee.setUserTokenSync(sponsorClient, {
+			const originalUserToken = await Actions.fee.getUserToken(sponsorClient, {
 				account: sponsorAccount,
-				token: alphaUsd,
-				nonceKey: 'expiring',
 			})
+			const originalToken = originalUserToken?.address
+			if (!originalToken)
+				throw new Error('expected sponsor to have an initial user token')
+
+			const adversarialToken =
+				originalToken.toLowerCase() !== pathUsd.toLowerCase()
+					? originalToken
+					: alphaUsd
+			const changedUserToken =
+				originalToken.toLowerCase() !== adversarialToken.toLowerCase()
 
 			try {
+				// Ensure the sponsor's on-chain preference is away from pathUSD.
+				if (changedUserToken) {
+					await Actions.fee.setUserTokenSync(sponsorClient, {
+						account: sponsorAccount,
+						token: adversarialToken,
+						nonceKey: 'expiring',
+					})
+				}
+
 				const { transport: feePayerTransport } =
 					createFeePayerTransportWithSpy()
 				const account = createTestAccount()
@@ -275,11 +291,13 @@ describe('fee-payer integration', () => {
 				expect(receipt.feeToken?.toLowerCase()).toBe(pathUsd.toLowerCase())
 			} finally {
 				// Restore so tests remain order-independent.
-				await Actions.fee.setUserTokenSync(sponsorClient, {
-					account: sponsorAccount,
-					token: pathUsd,
-					nonceKey: 'expiring',
-				})
+				if (changedUserToken && originalToken) {
+					await Actions.fee.setUserTokenSync(sponsorClient, {
+						account: sponsorAccount,
+						token: originalToken,
+						nonceKey: 'expiring',
+					})
+				}
 			}
 		})
 


### PR DESCRIPTION
## Summary

Adds fee-payer e2e coverage for sponsored TIP-20 transfers settling fees in pathUSD when the sponsor account has a different user-token preference.

## Motivation

Sponsored fees must ignore account-level fee-token preferences and consistently use pathUSD. The previous e2e coverage did not exercise the production failure shape: a TIP-20 transfer with a non-pathUSD sponsor preference.

## Changes

- Hoisted the deterministic sponsor account for shared setup and test actions.
- Added a combined regression test that sets the sponsor user token to `thetaUsd`, transfers `betaUsd`, and asserts sponsored fees settle with `pathUsd`.

## Testing

- `node_modules/.bin/biome check --write apps/fee-payer/test/e2e.test.ts`
- `node_modules/.bin/tsgo --project apps/fee-payer/tsconfig.json --noEmit`
- Pre-commit hooks passed on commit `bc8a0abb`.
- Focused local e2e could not complete because local Tempo did not become ready at `http://localhost:9545/1`; CI should run the container-backed e2e suite.