### PR TITLE
Fix explorer direct route fallback

### DIFF
--- a/apps/explorer/wrangler.json
+++ b/apps/explorer/wrangler.json
@@ -6,6 +6,9 @@
 		"binding": "CF_VERSION_METADATA"
 	},
 	"main": "./src/index.server.ts",
+	"assets": {
+		"not_found_handling": "single-page-application"
+	},
 	"keep_vars": true,
 	"workers_dev": true,
 	"preview_urls": true,


### PR DESCRIPTION
## Summary
- add Cloudflare Workers static-asset SPA fallback for the explorer
- lets direct navigation to client routes like `/receipt/:hash` serve `index.html` instead of a Cloudflare 404

## Repro
- `curl -I -L https://explore.testnet.tempo.xyz/receipt/0x89b9db17800b831edcc19515918986e72707bdbbbcf75d7da23e2e3d5bfc6da9` currently returns `404 Not Found`

## Validation
- `pnpm --filter explorer check:types`
- `pnpm --filter explorer check:env`
- `CLOUDFLARE_ENV=testnet pnpm --filter explorer build`
- `pnpm --filter explorer exec wrangler deploy --env testnet --dry-run`

Prompted by: @max-digi