### PR TITLE
fix(explorer): use chain path for API RPC transport

### DIFF
--- a/apps/explorer/src/wagmi.config.ts
+++ b/apps/explorer/src/wagmi.config.ts
@@ -86,7 +86,7 @@ const getTempoTransport = createIsomorphicFn()
 			apiKey &&
 			(chain.id === tempoMainnet.id || chain.id === tempoTestnet.id)
 		)
-			return http(`${tempoApiUrl}/rpc?chainId=${chain.id}`, {
+			return http(`${tempoApiUrl}/rpc/${chain.id}`, {
 				fetchOptions: { headers: { 'tempo-api-key': apiKey } },
 			})
 


### PR DESCRIPTION
## Summary

- Route Explorer server-side Cadent RPC calls through `/rpc/:chainId` instead of `/rpc?chainId=...`.
- Keeps testnet fresh-load receipt/transaction requests on chain `42431`; the query selector was ignored by Cadent, so the API defaulted to mainnet and returned `null` for testnet transaction hashes.

CLOSES SU-310
