### PR TITLE
fix(explorer): stop self-fetching own API routes for social-card SSR

### DIFF
--- a/apps/explorer/.claude/skills/verify/SKILL.md
+++ b/apps/explorer/.claude/skills/verify/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: verify
+description: Build, launch, and drive the Tempo explorer app to verify changes end-to-end. Use when verifying explorer changes at runtime (SSR meta tags, API routes, pages).
+---
+
+# Verifying the explorer app
+
+## Launch
+
+```bash
+cd apps/explorer
+pnpm dev:testnet   # vite dev on http://localhost:3000, ready in ~5s
+```
+
+No env vars needed for read-only flows; anonymous api.tempo.xyz requests are
+rate-limited and occasionally 502 (transient — retry before concluding).
+
+## Drive
+
+- SSR surface (OG/social cards, head tags): `curl -sL http://localhost:3000/address/<addr>`
+  and inspect `<meta property="og:image" ...>`. Always pass `-L`: non-checksummed
+  addresses 307-redirect to the checksummed path, returning an empty body without it.
+- Piping SSR HTML through `grep` can silently fail (macOS grep treats the payload
+  as binary). Use `grep -a`, or `tr '>' '>\n'` first, or save to a file and `head -c`.
+- API routes: `curl http://localhost:3000/api/address/metadata/<addr>` etc.
+- Cold address-metadata lookups take 7–9s upstream (count queries); warm repeats
+  are sub-second (30s in-process cache). Set `--max-time 90` on cold fetches.
+
+## OG card rendering (apps/og)
+
+Cards render in a separate worker (og.tempo.xyz). To see actual pixels locally:
+
+```bash
+cd apps/og && pnpm exec wrangler dev --port 8799
+curl "http://localhost:8799/token/<addr>?name=X&symbol=Y&supply=1.00" -o card.webp
+sips -s format png card.webp --out card.png   # then Read the png
+```
+
+## Useful fixtures (testnet, chainId 42431)
+
+- Verified token with holders/created: `0x20C0000000000000000000000000000000000001` (AlphaUSD)
+- Unverified token (no upstream holderCount): any recent token from
+  `https://api.tempo.xyz/v1/tokens?chainId=42431&limit=25`
+- Production comparison: `https://explore.testnet.tempo.xyz/...` (same routes)

--- a/apps/explorer/src/lib/server/address-balances.ts
+++ b/apps/explorer/src/lib/server/address-balances.ts
@@ -1,6 +1,8 @@
+import { createServerFn } from '@tanstack/react-start'
 import { type InferResponseType, parseResponse } from 'hono/client'
 import type { Address } from 'ox'
 import { formatUnits } from 'viem'
+import { getChainId } from 'wagmi/actions'
 
 import type { BalancesResponse, TokenBalance } from '#lib/address-balances'
 import {
@@ -9,6 +11,8 @@ import {
 	createTimestampedCsvFilename,
 } from '#lib/server/csv'
 import { api } from '#lib/server/tempo-api'
+import { zAddress } from '#lib/zod'
+import { getWagmiConfig } from '#wagmi.config.ts'
 
 export const TIP20_DECIMALS = 6
 export const MAX_TOKENS = 50
@@ -111,3 +115,12 @@ export async function fetchAddressBalancesData(params: {
 
 	return { balances: mapBalances(data) }
 }
+
+export const fetchAddressBalances = createServerFn({ method: 'GET' })
+	.inputValidator((input) => zAddress().parse(input))
+	.handler(({ data }) =>
+		fetchAddressBalancesData({
+			address: data,
+			chainId: getChainId(getWagmiConfig()),
+		}),
+	)

--- a/apps/explorer/src/lib/server/address-metadata.ts
+++ b/apps/explorer/src/lib/server/address-metadata.ts
@@ -1,9 +1,26 @@
+import { createServerFn } from '@tanstack/react-start'
 import { type InferResponseType, parseResponse } from 'hono/client'
 import type { Address } from 'ox'
-import type { ContractCreationData } from '#lib/server/contract-creation'
+import { VirtualAddress } from 'ox/tempo'
+import { getCode } from 'viem/actions'
+import { type AccountType, getAccountType } from '#lib/account'
+import { isTip20Address } from '#lib/domain/tip20'
+import {
+	type ContractCreationData,
+	fetchContractCreationData,
+} from '#lib/server/contract-creation'
 import { api } from '#lib/server/tempo-api'
-import type { ContractCreationReceiptRow } from '#lib/server/tempo-queries'
+import {
+	type ContractCreationReceiptRow,
+	fetchAddressOldestTx,
+	fetchAddressTxStats,
+	fetchContractCreationReceipt,
+	fetchTokenTransferBoundaries,
+	fetchVirtualAddressTransferStats,
+} from '#lib/server/tempo-queries'
 import { parseTimestamp } from '#lib/timestamp'
+import { zAddress } from '#lib/zod'
+import { getBatchedClient, getTempoChain } from '#wagmi.config.ts'
 
 /**
  * Token header stats: exact `holderCount` and the `TokenCreated` timestamp.
@@ -98,3 +115,158 @@ export function buildAddressTxMetadata(
 				: aggregate.oldestTxFrom,
 	}
 }
+
+export type AddressMetadata = {
+	address: string
+	chainId: number
+	accountType: AccountType
+	txCount?: number
+	holdersCount?: number
+	lastActivityTimestamp?: number
+	createdTimestamp?: number
+	createdTxHash?: string
+	createdBy?: string
+}
+
+const METADATA_CACHE_TTL = 30_000
+const METADATA_CACHE_MAX_ENTRIES = 50
+const metadataCache = new Map<
+	string,
+	{ promise: Promise<AddressMetadata>; timestamp: number }
+>()
+
+/**
+ * Address header/OG metadata (tx counts, holder counts, activity boundaries).
+ * Shared by the `/api/address/metadata` route and the `fetchAddressMetadata`
+ * server fn so SSR calls it in-process — the Worker cannot fetch its own
+ * hostname. Cached briefly (as the in-flight promise, so the loader and
+ * `head()` share one upstream round trip): the counts are slow (seconds)
+ * upstream and every SSR of an address page needs them.
+ */
+export function getAddressMetadata(
+	address: Address.Address,
+): Promise<AddressMetadata> {
+	const { id: chainId } = getTempoChain()
+	const cacheKey = `${chainId}-${address}`
+	const cached = metadataCache.get(cacheKey)
+	if (cached && Date.now() - cached.timestamp < METADATA_CACHE_TTL)
+		return cached.promise
+
+	if (
+		!metadataCache.has(cacheKey) &&
+		metadataCache.size >= METADATA_CACHE_MAX_ENTRIES
+	) {
+		const oldestKey = metadataCache.keys().next().value
+		if (oldestKey) metadataCache.delete(oldestKey)
+	}
+	const promise = loadAddressMetadata(address, chainId)
+	metadataCache.set(cacheKey, { promise, timestamp: Date.now() })
+	promise.catch(() => {
+		if (metadataCache.get(cacheKey)?.promise === promise)
+			metadataCache.delete(cacheKey)
+	})
+	return promise
+}
+
+async function loadAddressMetadata(
+	address: Address.Address,
+	chainId: number,
+): Promise<AddressMetadata> {
+	const client = getBatchedClient()
+	const isTip20 = isTip20Address(address)
+	const isVirtual = VirtualAddress.validate(address)
+
+	const bytecodePromise = getCode(client, { address }).catch(() => undefined)
+
+	let response: AddressMetadata
+
+	if (isVirtual) {
+		// One aggregate: exact distinct transfer-tx count + boundaries.
+		const [bytecode, stats] = await Promise.all([
+			bytecodePromise,
+			fetchVirtualAddressTransferStats(address, chainId).catch(() => ({
+				count: 0,
+				oldestTimestamp: undefined,
+				latestTimestamp: undefined,
+			})),
+		])
+		response = {
+			address,
+			chainId,
+			accountType: getAccountType(bytecode),
+			txCount: stats.count,
+			lastActivityTimestamp: parseTimestamp(stats.latestTimestamp),
+			createdTimestamp: parseTimestamp(stats.oldestTimestamp),
+		}
+	} else if (isTip20) {
+		// Exact holder count + TokenCreated timestamp from the API;
+		// transfer boundaries in one raw-logs aggregate. The API omits
+		// `holderCount` for tokens it has no holder index for — leave the
+		// count unset there rather than reporting zero.
+		const [bytecode, stats, boundaries] = await Promise.all([
+			bytecodePromise,
+			fetchTokenHeaderStats(chainId, address),
+			fetchTokenTransferBoundaries(address, chainId).catch(() => ({
+				oldestTimestamp: undefined,
+				latestTimestamp: undefined,
+			})),
+		])
+		const contractCreation =
+			stats?.createdAt == null
+				? await fetchContractCreationData(address).catch(() => null)
+				: null
+
+		response = {
+			address,
+			chainId,
+			accountType: getAccountType(bytecode),
+			holdersCount: stats?.holderCount,
+			lastActivityTimestamp: parseTimestamp(boundaries.latestTimestamp),
+			createdTimestamp: pickTip20CreatedTimestamp({
+				tokenCreatedTimestamp: stats?.createdAt,
+				firstTransferTimestamp: boundaries.oldestTimestamp,
+				contractCreationTimestamp: contractCreation?.timestamp,
+			}),
+		}
+	} else {
+		// One aggregate (exact distinct count + boundaries) + the oldest
+		// tx row for the "created by" stat. Creation receipt stays on
+		// the SQL lane (D4.1) with the existing RPC bisection fallback.
+		const [bytecode, stats, oldestTx, indexedCreation] = await Promise.all([
+			bytecodePromise,
+			fetchAddressTxStats(address, chainId),
+			fetchAddressOldestTx(address, chainId).catch(() => undefined),
+			fetchContractCreationReceipt(address, chainId).catch(() => undefined),
+		])
+		const accountType = getAccountType(bytecode)
+		const creation =
+			indexedCreation ??
+			(accountType === 'contract'
+				? await fetchContractCreationData(address).catch(() => null)
+				: undefined) ??
+			undefined
+		const metadata = buildAddressTxMetadata(
+			{
+				count: stats.count,
+				latestTxsBlockTimestamp: stats.latestTimestamp,
+				oldestTxsBlockTimestamp: stats.oldestTimestamp,
+				oldestTxHash: oldestTx?.hash,
+				oldestTxFrom: oldestTx?.from,
+			},
+			creation,
+		)
+
+		response = {
+			address,
+			chainId,
+			accountType,
+			...metadata,
+		}
+	}
+
+	return response
+}
+
+export const fetchAddressMetadata = createServerFn({ method: 'GET' })
+	.inputValidator((input) => zAddress({ lowercase: true }).parse(input))
+	.handler(({ data }) => getAddressMetadata(data))

--- a/apps/explorer/src/routes/_layout/address/$address.tsx
+++ b/apps/explorer/src/routes/_layout/address/$address.tsx
@@ -54,7 +54,6 @@ import { TransactionFilters } from '#comps/TransactionFilters'
 import { cx } from '#lib/css'
 import {
 	type AssetData,
-	type BalancesResponse,
 	balancesQueryOptions,
 	calculateTotalHoldings,
 	useBalancesData,
@@ -91,8 +90,9 @@ import {
 	holdersQueryOptions,
 	transfersQueryOptions,
 } from '#lib/queries/tokens'
-import { getApiUrl } from '#lib/env.ts'
 import { areUsdPricedTokens } from '#lib/pricing'
+import { fetchAddressBalances } from '#lib/server/address-balances'
+import { fetchAddressMetadata } from '#lib/server/address-metadata'
 import { getFeeTokenForChain } from '#lib/fee-token'
 import { getTempoChain, getWagmiConfig } from '#wagmi.config.ts'
 import type { EnrichedTransaction } from '#routes/api/address/history/$address.ts'
@@ -105,13 +105,6 @@ import EyeOffIcon from '~icons/lucide/eye-off'
 import XIcon from '~icons/lucide/x'
 
 type TokenMetadata = Actions.token.getMetadata.ReturnValue
-type AddressOgMetadata = {
-	accountType?: AccountType
-	txCount?: number | null
-	holdersCount?: number | null
-	lastActivityTimestamp?: number | null
-	createdTimestamp?: number | null
-}
 
 const TEMPO_CHAIN_ID = getTempoChain().id
 const TEMPO_FEE_TOKEN = getFeeTokenForChain(TEMPO_CHAIN_ID)
@@ -315,11 +308,12 @@ export const Route = createFileRoute('/_layout/address/$address')({
 					)
 				: Promise.resolve(undefined)
 
-			// Fetch address metadata through the API route so TIDX credentials stay
-			// server-side when loaders run in the browser. Goes through the query
-			// cache (shared with the component query) so paging within the same
-			// address reuses the entry instead of re-running the slow count query
-			// on every navigation.
+			// Fetch address metadata through a server fn (in-process during SSR —
+			// the Worker cannot fetch its own hostname — an RPC from the browser,
+			// keeping TIDX credentials server-side). Goes through the query cache
+			// (shared with the component query) so paging within the same address
+			// reuses the entry instead of re-running the slow count query on
+			// every navigation.
 			const ogMetaPromise = timeout(
 				context.queryClient
 					.ensureQueryData(addressMetadataQueryOptions(address))
@@ -376,7 +370,7 @@ export const Route = createFileRoute('/_layout/address/$address')({
 		const address = params.address as Address.Address
 		const ogMeta =
 			loaderData?.ogMeta ??
-			(await fetchAddressMetadata(address).catch(() => undefined))
+			(await fetchAddressMetadata({ data: address }).catch(() => undefined))
 		// Fallback to ogMeta.accountType only for contracts (receipts-proven)
 		// since 'empty' is the correct type for regular EOAs
 		let accountType = loaderData?.accountType ?? 'empty'
@@ -405,6 +399,7 @@ export const Route = createFileRoute('/_layout/address/$address')({
 				: 0
 
 			const formatSupply = (n: number): string => {
+				if (n >= 1e12) return `${(n / 1e12).toFixed(2)}T`
 				if (n >= 1e9) return `${(n / 1e9).toFixed(2)}B`
 				if (n >= 1e6) return `${(n / 1e6).toFixed(2)}M`
 				if (n >= 1e3)
@@ -443,7 +438,7 @@ export const Route = createFileRoute('/_layout/address/$address')({
 				ogMeta?.txCount ?? loaderData?.transactionsData?.total ?? 0
 			const balancesData =
 				loaderData?.balancesData ??
-				(await fetchAddressOgBalances(address).catch(() => undefined))
+				(await fetchAddressBalances({ data: address }).catch(() => undefined))
 			let lastActive: string | undefined
 			let created: string | undefined
 			let holdings = '—'
@@ -737,24 +732,6 @@ function RouteComponent() {
 	)
 }
 
-async function fetchAddressMetadata(address: Address.Address) {
-	const response = await fetch(getApiUrl(`/api/address/metadata/${address}`), {
-		headers: { 'Content-Type': 'application/json' },
-	})
-	if (!response.ok) throw new Error('Failed to fetch address metadata')
-	return response.json() as Promise<AddressOgMetadata>
-}
-
-async function fetchAddressOgBalances(
-	address: Address.Address,
-): Promise<BalancesResponse> {
-	const response = await fetch(getApiUrl(`/api/address/balances/${address}`), {
-		headers: { 'Content-Type': 'application/json' },
-	})
-	if (!response.ok) throw new Error('Failed to fetch address balances')
-	return response.json() as Promise<BalancesResponse>
-}
-
 /**
  * Shared by the route loader (OG meta) and the header component: one cache
  * entry per address, so search-param navigations (paging, tab switches)
@@ -763,7 +740,7 @@ async function fetchAddressOgBalances(
 function addressMetadataQueryOptions(address: Address.Address) {
 	return {
 		queryKey: ['address-metadata', address] as const,
-		queryFn: () => fetchAddressMetadata(address),
+		queryFn: () => fetchAddressMetadata({ data: address }),
 		staleTime: 30_000,
 	}
 }

--- a/apps/explorer/src/routes/api/address/metadata/$address.ts
+++ b/apps/explorer/src/routes/api/address/metadata/$address.ts
@@ -1,148 +1,19 @@
 import { createFileRoute } from '@tanstack/react-router'
-import * as Address from 'ox/Address'
-import { VirtualAddress } from 'ox/tempo'
-import { getCode } from 'viem/actions'
-import { getAccountType, type AccountType } from '#lib/account'
-import { isTip20Address } from '#lib/domain/tip20'
-import { fetchContractCreationData } from '#lib/server/contract-creation'
 import {
-	fetchAddressOldestTx,
-	fetchAddressTxStats,
-	fetchContractCreationReceipt,
-	fetchTokenTransferBoundaries,
-	fetchVirtualAddressTransferStats,
-} from '#lib/server/tempo-queries'
-import {
-	buildAddressTxMetadata,
-	fetchTokenHeaderStats,
-	pickTip20CreatedTimestamp,
+	type AddressMetadata,
+	getAddressMetadata,
 } from '#lib/server/address-metadata'
-import { parseTimestamp } from '#lib/timestamp'
 import { zAddress } from '#lib/zod'
-import { getBatchedClient, getTempoChain } from '#wagmi.config.ts'
 
-export type AddressMetadataResponse = {
-	address: string
-	chainId: number
-	accountType: AccountType
-	txCount?: number
-	holdersCount?: number
-	lastActivityTimestamp?: number
-	createdTimestamp?: number
-	createdTxHash?: string
-	createdBy?: string
-	error?: string
-}
+export type AddressMetadataResponse = AddressMetadata & { error?: string }
 
 export const Route = createFileRoute('/api/address/metadata/$address')({
 	server: {
 		handlers: {
 			GET: async ({ params }) => {
-				const fallback: AddressMetadataResponse = {
-					address: params.address,
-					chainId: 0,
-					accountType: 'empty',
-				}
-
 				try {
 					const address = zAddress({ lowercase: true }).parse(params.address)
-					Address.assert(address)
-
-					const client = getBatchedClient()
-					const { id: chainId } = getTempoChain()
-					const isTip20 = isTip20Address(address)
-					const isVirtual = VirtualAddress.validate(address)
-
-					const bytecodePromise = getCode(client, { address }).catch(
-						() => undefined,
-					)
-
-					let response: AddressMetadataResponse
-
-					if (isVirtual) {
-						// One aggregate: exact distinct transfer-tx count + boundaries.
-						const [bytecode, stats] = await Promise.all([
-							bytecodePromise,
-							fetchVirtualAddressTransferStats(address, chainId).catch(() => ({
-								count: 0,
-								oldestTimestamp: undefined,
-								latestTimestamp: undefined,
-							})),
-						])
-						response = {
-							address,
-							chainId,
-							accountType: getAccountType(bytecode),
-							txCount: stats.count,
-							lastActivityTimestamp: parseTimestamp(stats.latestTimestamp),
-							createdTimestamp: parseTimestamp(stats.oldestTimestamp),
-						}
-					} else if (isTip20) {
-						// Exact holder count + TokenCreated timestamp from the API;
-						// transfer boundaries in one raw-logs aggregate.
-						const [bytecode, stats, boundaries] = await Promise.all([
-							bytecodePromise,
-							fetchTokenHeaderStats(chainId, address),
-							fetchTokenTransferBoundaries(address, chainId).catch(() => ({
-								oldestTimestamp: undefined,
-								latestTimestamp: undefined,
-							})),
-						])
-						const contractCreation =
-							stats?.createdAt == null
-								? await fetchContractCreationData(address).catch(() => null)
-								: null
-
-						response = {
-							address,
-							chainId,
-							accountType: getAccountType(bytecode),
-							holdersCount: stats?.holderCount ?? 0,
-							lastActivityTimestamp: parseTimestamp(boundaries.latestTimestamp),
-							createdTimestamp: pickTip20CreatedTimestamp({
-								tokenCreatedTimestamp: stats?.createdAt,
-								firstTransferTimestamp: boundaries.oldestTimestamp,
-								contractCreationTimestamp: contractCreation?.timestamp,
-							}),
-						}
-					} else {
-						// One aggregate (exact distinct count + boundaries) + the oldest
-						// tx row for the "created by" stat. Creation receipt stays on
-						// the SQL lane (D4.1) with the existing RPC bisection fallback.
-						const [bytecode, stats, oldestTx, indexedCreation] =
-							await Promise.all([
-								bytecodePromise,
-								fetchAddressTxStats(address, chainId),
-								fetchAddressOldestTx(address, chainId).catch(() => undefined),
-								fetchContractCreationReceipt(address, chainId).catch(
-									() => undefined,
-								),
-							])
-						const accountType = getAccountType(bytecode)
-						const creation =
-							indexedCreation ??
-							(accountType === 'contract'
-								? await fetchContractCreationData(address).catch(() => null)
-								: undefined) ??
-							undefined
-						const metadata = buildAddressTxMetadata(
-							{
-								count: stats.count,
-								latestTxsBlockTimestamp: stats.latestTimestamp,
-								oldestTxsBlockTimestamp: stats.oldestTimestamp,
-								oldestTxHash: oldestTx?.hash,
-								oldestTxFrom: oldestTx?.from,
-							},
-							creation,
-						)
-
-						response = {
-							address,
-							chainId,
-							accountType,
-							...metadata,
-						}
-					}
+					const response = await getAddressMetadata(address)
 
 					return Response.json(response, {
 						headers: {
@@ -152,10 +23,13 @@ export const Route = createFileRoute('/api/address/metadata/$address')({
 				} catch (error) {
 					console.error(error)
 					const errorMessage = error instanceof Error ? error.message : error
-					return Response.json(
-						{ ...fallback, error: String(errorMessage) },
-						{ status: 500 },
-					)
+					const fallback: AddressMetadataResponse = {
+						address: params.address,
+						chainId: 0,
+						accountType: 'empty',
+						error: String(errorMessage),
+					}
+					return Response.json(fallback, { status: 500 })
 				}
 			},
 		},

--- a/apps/og/src/ui.tsx
+++ b/apps/og/src/ui.tsx
@@ -531,7 +531,7 @@ export function TokenCard({ data, icon }: { data: TokenData; icon: string }) {
 						style={holdersGrey ? { color: '#9ca3af' } : undefined}
 						tw={holdersGrey ? '' : 'text-gray-900'}
 					>
-						{holdersGrey ? '0' : truncateText(data.holders, 16)}
+						{holdersGrey ? '—' : truncateText(data.holders, 16)}
 					</span>
 				</div>
 				<div tw="flex w-full justify-between">


### PR DESCRIPTION
## Problem

Every address/token social card on production is missing its stats — verified tokens with millions of holders render "Holders 0 / Created —" (see e.g. the card for any token page). Audit of 13 tokens (all 6 verified + 7 active unverified): 13/13 broken, plus EOA cards showing `holdings=— txCount=0` for active accounts.

Root cause: during SSR, `head()` (and the loader) fetched the explorer's **own** `/api/address/metadata` and `/api/address/balances` routes. A Worker cannot subrequest its own hostname, so the fetch always failed and the `.catch(() => undefined)` silently dropped the data. Social scrapers only ever see SSR output. #1080 fixed exactly this ("Avoid self-fetches for address OG metadata"); #1079 merged after it and reintroduced the self-fetch.

## Fix

- Move the metadata logic from the API route into `lib/server/address-metadata.ts` as `getAddressMetadata()`, exposed via a `createServerFn` (in-process during SSR, RPC from the browser — TIDX credentials stay server-side). The API route remains as a thin wrapper.
- Cache the in-flight promise for 30s so the loader and `head()` share one round trip (the upstream count queries take 7–9s cold).
- Add a matching server fn for address balances (EOA card holdings).
- Leave `holdersCount` unset when the upstream API omits `holderCount` (it has no holder index for unverified tokens) instead of coercing to 0, and render the unknown count as a grey "—" on the OG card (`apps/og`).
- `formatSupply` gains a T tier (`18547.25T` instead of `18547246.96B`).

## Verification

Ran the explorer + og worker locally and drove the SSR surface:

- AlphaUSD og:image: `holders=6743347&created=Jan+8%2C+2026` (production today: neither param)
- Unverified token: `created` present, `holders` omitted → card renders grey "—"
- Active EOA: `holdings=%244M&txCount=3&lastActive=…&created=…`
- Concurrent cold SSRs share one upstream trip; warm repeats ~0.3s
- API route back-compat: same response shape, cache headers, and error fallback (invalid address → 500)

Note: cold pages now block on the metadata counts (~7–9s upstream) instead of returning an empty card; warm renders are cached. Already-shared links need a scraper re-crawl after deploy, and `apps/og` deploys separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)