### PR TITLE
fix(rpc-utils): guard Error.captureStackTrace so browser RPC errors are not masked

### DIFF
--- a/packages/rpc-utils/package.json
+++ b/packages/rpc-utils/package.json
@@ -12,12 +12,14 @@
 	"scripts": {
 		"check": "pnpm check:biome && pnpm check:types",
 		"check:biome": "biome check --write --unsafe",
-		"check:types": "tsgo --project tsconfig.json --noEmit"
+		"check:types": "tsgo --project tsconfig.json --noEmit",
+		"test": "vitest"
 	},
 	"dependencies": {
 		"viem": "catalog:"
 	},
 	"devDependencies": {
-		"@types/node": "catalog:"
+		"@types/node": "catalog:",
+		"vitest": "catalog:"
 	}
 }

--- a/packages/rpc-utils/src/utils/queue.ts
+++ b/packages/rpc-utils/src/utils/queue.ts
@@ -184,7 +184,10 @@ export const createQueue = <ReturnType, TaskType = void>({
 			next()
 
 			return promise.catch((error) => {
-				if (error instanceof Error) {
+				if (
+					error instanceof Error &&
+					typeof Error.captureStackTrace === 'function'
+				) {
 					Error.captureStackTrace(error)
 				}
 

--- a/packages/rpc-utils/test/queue.test.ts
+++ b/packages/rpc-utils/test/queue.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createQueue } from '../src/utils/queue'
+
+describe('createQueue add()', () => {
+	const original = Error.captureStackTrace
+
+	afterEach(() => {
+		Error.captureStackTrace = original
+	})
+
+	it('propagates the original rejection when Error.captureStackTrace is unavailable (Safari/iOS < 17.2, Firefox < 138)', async () => {
+		// JavaScriptCore (older Safari + older iOS WebKit) and older SpiderMonkey
+		// do not implement this V8-originated API. Simulate that runtime.
+		// @ts-expect-error deliberately remove the method to emulate those engines
+		Error.captureStackTrace = undefined
+
+		const rpcError = new Error('execution reverted: insufficient balance')
+		const queue = createQueue<never>({
+			concurrency: 1,
+			initialStart: true,
+			worker: () => Promise.reject(rpcError),
+		})
+
+		// Must surface the real error, not a "captureStackTrace is not a function" TypeError.
+		await expect(queue.add()).rejects.toBe(rpcError)
+	})
+
+	it('still enriches the stack when Error.captureStackTrace is available (V8)', async () => {
+		const spy = vi.fn(original)
+		Error.captureStackTrace = spy as typeof Error.captureStackTrace
+
+		const rpcError = new Error('boom')
+		const queue = createQueue<never>({
+			concurrency: 1,
+			initialStart: true,
+			worker: () => Promise.reject(rpcError),
+		})
+
+		await expect(queue.add()).rejects.toBe(rpcError)
+		expect(spy).toHaveBeenCalledWith(rpcError)
+	})
+})

--- a/packages/rpc-utils/vitest.config.ts
+++ b/packages/rpc-utils/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+	test: {
+		include: ['test/**/*.test.ts'],
+	},
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -855,6 +855,9 @@ importers:
       '@types/node':
         specifier: 'catalog:'
         version: 25.5.2
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.5.2)(@vitest/ui@4.1.0)(vite@8.0.7(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
 
 packages:
 


### PR DESCRIPTION
## Summary

`packages/rpc-utils/src/utils/queue.ts` calls `Error.captureStackTrace(error)` unconditionally inside `createQueue().add()`'s rejection handler. That method is a V8-originated API. On JavaScript engines that don't implement it, the call itself throws `TypeError: Error.captureStackTrace is not a function`, **replacing the real rejection reason** the caller was supposed to receive.

This queue backs the browser transport: `apps/explorer/src/wagmi.config.ts` (the `.client()` branch) wraps every RPC request in `rateLimit(...)` -> `createQueue`. So on affected engines, any failed RPC on explore.tempo.xyz (revert, timeout, 429, network error) surfaces a meaningless `TypeError` instead of the actual error.

## Scope / affected engines

Verified against MDN browser-compat-data: `Error.captureStackTrace` was added in Chrome 3, Node 0.10, **Safari 17.2** (Dec 2023, incl. iOS/WebView via mirror) and **Firefox 138** (~Apr 2025).

So this only reproduces on **Safari / iOS < 17.2** and **Firefox < 138** — it is not a current-browser bug. It does still permanently affect older iOS devices that cannot update past iOS 16 (iPhone X and earlier), which continue to visit the explorer. Treat this as a small robustness fix, not a widespread outage.

## Fix

Guard the call:

```ts
if (error instanceof Error && typeof Error.captureStackTrace === 'function') {
  Error.captureStackTrace(error)
}
```

On V8, behaviour is unchanged (stack still enriched); elsewhere the original error propagates untouched.

## Tests

`packages/rpc-utils` had no tests. Added `test/queue.test.ts` (+ `vitest.config.ts`):
1. with `Error.captureStackTrace` removed, `queue.add()` rejects with the **original** error;
2. with it present (V8), it is still called with the error.


## AI assistance disclosure

The fix and the accompanying tests in this PR were written primarily with Claude
Code (Claude Fable 5). I directed the work, reviewed the output, and ran the
required checks (`pnpm check`, `pnpm check:types`, and the rpc-utils test suite)
locally to confirm everything passes.
