### PR TITLE
fix(explorer): source verified tokens from `/v1/verified-tokens`

### DIFF
--- a/apps/explorer/src/lib/server/verified-tokens.ts
+++ b/apps/explorer/src/lib/server/verified-tokens.ts
@@ -10,7 +10,7 @@ import { api } from '#lib/server/tempo-api'
 
 /** A row of the API's curated verified-token list (the token registry). */
 export type VerifiedToken = InferResponseType<
-	typeof api.v1.tokens.$get,
+	(typeof api.v1)['verified-tokens']['$get'],
 	200
 >['data'][number]
 
@@ -32,8 +32,8 @@ export async function getVerifiedTokens(
 
 	try {
 		const { data } = await parseResponse(
-			api.v1.tokens.$get({
-				query: { chainId: String(chainId), verified: 'true' },
+			api.v1['verified-tokens'].$get({
+				query: { chainId: String(chainId) },
 			}),
 		)
 		verifiedTokensCache.set(chainId, { tokens: data, ts: now })


### PR DESCRIPTION
Sources the explorer's curated verified-token set from `/v1/verified-tokens` instead of the `/v1/tokens?verified=true` filter, which served a stale list that omitted newer listed tokens (e.g. `USD1`, `goUSD`) and rendered them unverified.
