### PR TITLE
feat(explorer): add per-ip rate limiting

### DIFF
--- a/apps/explorer/src/index.server.ts
+++ b/apps/explorer/src/index.server.ts
@@ -51,6 +51,26 @@ function sanitizeUrl(rawUrl: string): string {
 	}
 }
 
+/** Per-IP limit for all worker requests (pages, API). Assets bypass the worker. Fails open when the binding is unavailable (local dev). */
+async function checkRateLimit(
+	request: Request,
+	env: Cloudflare.Env,
+): Promise<Response | undefined> {
+	if (!env.REQUESTS_RATE_LIMITER) return undefined
+	try {
+		const key = request.headers.get('cf-connecting-ip') ?? 'unknown'
+		const { success } = await env.REQUESTS_RATE_LIMITER.limit({ key })
+		if (!success)
+			return new Response('Rate limit exceeded', {
+				status: 429,
+				headers: { 'retry-after': '10' },
+			})
+	} catch (error) {
+		console.error('Rate limit check failed:', error)
+	}
+	return undefined
+}
+
 const serverEntry = createServerEntry({
 	fetch: async (request, opts) => {
 		const url = new URL(request.url)
@@ -103,7 +123,10 @@ export default Sentry.withSentry(
 		},
 	}),
 	{
-		fetch: (request, env, _context) => {
+		fetch: async (request, env, _context) => {
+			const rateLimited = await checkRateLimit(request, env)
+			if (rateLimited) return rateLimited
+
 			const processEnv = process.env as Record<string, string | undefined>
 			if (env) {
 				for (const [key, value] of Object.entries(env)) {

--- a/apps/explorer/wrangler.json
+++ b/apps/explorer/wrangler.json
@@ -10,6 +10,13 @@
 	"workers_dev": true,
 	"preview_urls": true,
 	"browser": { "binding": "BROWSER" },
+	"ratelimits": [
+		{
+			"name": "REQUESTS_RATE_LIMITER",
+			"namespace_id": "1001",
+			"simple": { "limit": 100, "period": 10 }
+		}
+	],
 	"env": {
 		"testnet": {
 			"name": "explorer-testnet",
@@ -50,6 +57,13 @@
 			},
 			"workers_dev": true,
 			"browser": { "binding": "BROWSER" },
+			"ratelimits": [
+				{
+					"name": "REQUESTS_RATE_LIMITER",
+					"namespace_id": "1001",
+					"simple": { "limit": 100, "period": 10 }
+				}
+			],
 			"observability": {
 				"enabled": true,
 				"logs": {
@@ -94,6 +108,13 @@
 			},
 			"workers_dev": true,
 			"browser": { "binding": "BROWSER" },
+			"ratelimits": [
+				{
+					"name": "REQUESTS_RATE_LIMITER",
+					"namespace_id": "1001",
+					"simple": { "limit": 100, "period": 10 }
+				}
+			],
 			"observability": {
 				"enabled": true,
 				"logs": {
@@ -133,6 +154,13 @@
 			},
 			"workers_dev": true,
 			"browser": { "binding": "BROWSER" },
+			"ratelimits": [
+				{
+					"name": "REQUESTS_RATE_LIMITER",
+					"namespace_id": "1001",
+					"simple": { "limit": 100, "period": 10 }
+				}
+			],
 			"observability": {
 				"enabled": true,
 				"logs": {
@@ -187,6 +215,13 @@
 			},
 			"workers_dev": true,
 			"browser": { "binding": "BROWSER" },
+			"ratelimits": [
+				{
+					"name": "REQUESTS_RATE_LIMITER",
+					"namespace_id": "1001",
+					"simple": { "limit": 100, "period": 10 }
+				}
+			],
 			"observability": {
 				"enabled": true,
 				"logs": {


### PR DESCRIPTION
Adds per-IP rate limiting (100 req / 10 s via a `REQUESTS_RATE_LIMITER` binding) to all explorer worker requests: SSR pages, `/api/*`, and `/dd-proxy`. Fails open when the binding is unavailable (local dev).
