### PR TITLE
feat(explorer): proxy browser rpc through worker `/api/rpc`

### DIFF
--- a/apps/explorer/src/index.server.ts
+++ b/apps/explorer/src/index.server.ts
@@ -51,15 +51,19 @@ function sanitizeUrl(rawUrl: string): string {
 	}
 }
 
-/** Per-IP limit for all worker requests (pages, API). Assets bypass the worker. Fails open when the binding is unavailable (local dev). */
+/** Per-IP limit for all worker requests; `/api/rpc` uses the looser RPC limiter. Fails open when bindings are unavailable (local dev). */
 async function checkRateLimit(
 	request: Request,
 	env: Cloudflare.Env,
 ): Promise<Response | undefined> {
-	if (!env.REQUESTS_RATE_LIMITER) return undefined
+	const isRpc = new URL(request.url).pathname === '/api/rpc'
+	const limiter = isRpc
+		? (env.RPC_RATE_LIMITER ?? env.REQUESTS_RATE_LIMITER)
+		: env.REQUESTS_RATE_LIMITER
+	if (!limiter) return undefined
 	try {
 		const key = request.headers.get('cf-connecting-ip') ?? 'unknown'
-		const { success } = await env.REQUESTS_RATE_LIMITER.limit({ key })
+		const { success } = await limiter.limit({ key })
 		if (!success)
 			return new Response('Rate limit exceeded', {
 				status: 429,

--- a/apps/explorer/src/routeTree.gen.ts
+++ b/apps/explorer/src/routeTree.gen.ts
@@ -15,6 +15,7 @@ import { Route as LayoutIndexRouteImport } from './routes/_layout/index'
 import { Route as ApiVerifiedTokensRouteImport } from './routes/api/verified-tokens'
 import { Route as ApiTip20RolesRouteImport } from './routes/api/tip20-roles'
 import { Route as ApiSearchRouteImport } from './routes/api/search'
+import { Route as ApiRpcRouteImport } from './routes/api/rpc'
 import { Route as ApiHealthRouteImport } from './routes/api/health'
 import { Route as ApiCodeRouteImport } from './routes/api/code'
 import { Route as LayoutTokensRouteImport } from './routes/_layout/tokens'
@@ -67,6 +68,11 @@ const ApiTip20RolesRoute = ApiTip20RolesRouteImport.update({
 const ApiSearchRoute = ApiSearchRouteImport.update({
   id: '/api/search',
   path: '/api/search',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiRpcRoute = ApiRpcRouteImport.update({
+  id: '/api/rpc',
+  path: '/api/rpc',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ApiHealthRoute = ApiHealthRouteImport.update({
@@ -203,6 +209,7 @@ export interface FileRoutesByFullPath {
   '/tokens': typeof LayoutTokensRoute
   '/api/code': typeof ApiCodeRoute
   '/api/health': typeof ApiHealthRoute
+  '/api/rpc': typeof ApiRpcRoute
   '/api/search': typeof ApiSearchRoute
   '/api/tip20-roles': typeof ApiTip20RolesRoute
   '/api/verified-tokens': typeof ApiVerifiedTokensRoute
@@ -233,6 +240,7 @@ export interface FileRoutesByTo {
   '/tokens': typeof LayoutTokensRoute
   '/api/code': typeof ApiCodeRoute
   '/api/health': typeof ApiHealthRoute
+  '/api/rpc': typeof ApiRpcRoute
   '/api/search': typeof ApiSearchRoute
   '/api/tip20-roles': typeof ApiTip20RolesRoute
   '/api/verified-tokens': typeof ApiVerifiedTokensRoute
@@ -266,6 +274,7 @@ export interface FileRoutesById {
   '/_layout/tokens': typeof LayoutTokensRoute
   '/api/code': typeof ApiCodeRoute
   '/api/health': typeof ApiHealthRoute
+  '/api/rpc': typeof ApiRpcRoute
   '/api/search': typeof ApiSearchRoute
   '/api/tip20-roles': typeof ApiTip20RolesRoute
   '/api/verified-tokens': typeof ApiVerifiedTokensRoute
@@ -300,6 +309,7 @@ export interface FileRouteTypes {
     | '/tokens'
     | '/api/code'
     | '/api/health'
+    | '/api/rpc'
     | '/api/search'
     | '/api/tip20-roles'
     | '/api/verified-tokens'
@@ -330,6 +340,7 @@ export interface FileRouteTypes {
     | '/tokens'
     | '/api/code'
     | '/api/health'
+    | '/api/rpc'
     | '/api/search'
     | '/api/tip20-roles'
     | '/api/verified-tokens'
@@ -362,6 +373,7 @@ export interface FileRouteTypes {
     | '/_layout/tokens'
     | '/api/code'
     | '/api/health'
+    | '/api/rpc'
     | '/api/search'
     | '/api/tip20-roles'
     | '/api/verified-tokens'
@@ -392,6 +404,7 @@ export interface RootRouteChildren {
   SearchRoute: typeof SearchRoute
   ApiCodeRoute: typeof ApiCodeRoute
   ApiHealthRoute: typeof ApiHealthRoute
+  ApiRpcRoute: typeof ApiRpcRoute
   ApiSearchRoute: typeof ApiSearchRoute
   ApiTip20RolesRoute: typeof ApiTip20RolesRoute
   ApiVerifiedTokensRoute: typeof ApiVerifiedTokensRoute
@@ -447,6 +460,13 @@ declare module '@tanstack/react-router' {
       path: '/api/search'
       fullPath: '/api/search'
       preLoaderRoute: typeof ApiSearchRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/rpc': {
+      id: '/api/rpc'
+      path: '/api/rpc'
+      fullPath: '/api/rpc'
+      preLoaderRoute: typeof ApiRpcRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/health': {
@@ -664,6 +684,7 @@ const rootRouteChildren: RootRouteChildren = {
   SearchRoute: SearchRoute,
   ApiCodeRoute: ApiCodeRoute,
   ApiHealthRoute: ApiHealthRoute,
+  ApiRpcRoute: ApiRpcRoute,
   ApiSearchRoute: ApiSearchRoute,
   ApiTip20RolesRoute: ApiTip20RolesRoute,
   ApiVerifiedTokensRoute: ApiVerifiedTokensRoute,

--- a/apps/explorer/src/routes/api/rpc.ts
+++ b/apps/explorer/src/routes/api/rpc.ts
@@ -1,0 +1,71 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { tempoMainnet, tempoTestnet } from '#lib/chains'
+import { serverEnv, tempoApiUrl } from '#lib/server/env'
+import { getTempoChain } from '#wagmi.config.ts'
+
+const RPC_PROXY_URL = 'https://proxy.tempo.xyz/rpc'
+
+/**
+ * Same-origin JSON-RPC proxy for browser traffic. Keeps RPC credentials
+ * server-side and puts RPC calls behind the worker's per-IP rate limiting.
+ */
+export const Route = createFileRoute('/api/rpc')({
+	server: {
+		handlers: {
+			POST: async ({ request }) => {
+				const body = await request.text()
+				if (!body) return new Response(null, { status: 400 })
+
+				const { id: chainId } = getTempoChain()
+
+				// Tempo API RPC passthrough (mainnet + testnet; requires an API key).
+				const upstream: { url: string; headers: Record<string, string> } =
+					serverEnv.TEMPO_API_KEY &&
+					(chainId === tempoMainnet.id || chainId === tempoTestnet.id)
+						? {
+								url: `${tempoApiUrl}/rpc/${chainId}`,
+								headers: { 'tempo-api-key': serverEnv.TEMPO_API_KEY },
+							}
+						: {
+								// Shared proxy injects env RPC keys for allowlisted origins.
+								url: `${RPC_PROXY_URL}/${chainId}`,
+								headers: { origin: new URL(request.url).origin },
+							}
+
+				try {
+					const response = await fetch(upstream.url, {
+						method: 'POST',
+						headers: {
+							'content-type': 'application/json',
+							...upstream.headers,
+						},
+						body,
+					})
+
+					// Upstream 401 means the worker's credential failed; surface as
+					// a gateway error rather than an auth challenge for the browser.
+					if (response.status === 401)
+						return Response.json(
+							{ error: 'Upstream RPC unavailable' },
+							{ status: 502 },
+						)
+
+					// Buffered (not streamed) to keep response framing simple.
+					const result = await response.text()
+					return new Response(result, {
+						status: response.status,
+						headers: {
+							'content-type':
+								response.headers.get('content-type') ?? 'application/json',
+						},
+					})
+				} catch {
+					return Response.json(
+						{ error: 'Upstream RPC unavailable' },
+						{ status: 502 },
+					)
+				}
+			},
+		},
+	},
+})

--- a/apps/explorer/src/wagmi.config.ts
+++ b/apps/explorer/src/wagmi.config.ts
@@ -67,12 +67,10 @@ const getFallbackUrls = createIsomorphicFn()
 
 const getTempoTransport = createIsomorphicFn()
 	.client(() => {
-		const proxy = getRpcProxyUrl()
-
-		// Browser traffic should only hit the RPC proxy. Direct chain RPC endpoints
-		// may require credentials that are only available server-side.
+		// Browser traffic goes through the same-origin RPC proxy (`/api/rpc`) so
+		// credentials stay server-side and requests are rate limited per IP.
 		return loadBalance([
-			rateLimit(http(proxy.http), {
+			rateLimit(http(`${window.location.origin}/api/rpc`), {
 				requestsPerSecond: 20,
 			}),
 		])

--- a/apps/explorer/wrangler.json
+++ b/apps/explorer/wrangler.json
@@ -15,6 +15,11 @@
 			"name": "REQUESTS_RATE_LIMITER",
 			"namespace_id": "1001",
 			"simple": { "limit": 100, "period": 10 }
+		},
+		{
+			"name": "RPC_RATE_LIMITER",
+			"namespace_id": "1002",
+			"simple": { "limit": 300, "period": 10 }
 		}
 	],
 	"env": {
@@ -62,6 +67,11 @@
 					"name": "REQUESTS_RATE_LIMITER",
 					"namespace_id": "1001",
 					"simple": { "limit": 100, "period": 10 }
+				},
+				{
+					"name": "RPC_RATE_LIMITER",
+					"namespace_id": "1002",
+					"simple": { "limit": 300, "period": 10 }
 				}
 			],
 			"observability": {
@@ -113,6 +123,11 @@
 					"name": "REQUESTS_RATE_LIMITER",
 					"namespace_id": "1001",
 					"simple": { "limit": 100, "period": 10 }
+				},
+				{
+					"name": "RPC_RATE_LIMITER",
+					"namespace_id": "1002",
+					"simple": { "limit": 300, "period": 10 }
 				}
 			],
 			"observability": {
@@ -159,6 +174,11 @@
 					"name": "REQUESTS_RATE_LIMITER",
 					"namespace_id": "1001",
 					"simple": { "limit": 100, "period": 10 }
+				},
+				{
+					"name": "RPC_RATE_LIMITER",
+					"namespace_id": "1002",
+					"simple": { "limit": 300, "period": 10 }
 				}
 			],
 			"observability": {
@@ -220,6 +240,11 @@
 					"name": "REQUESTS_RATE_LIMITER",
 					"namespace_id": "1001",
 					"simple": { "limit": 100, "period": 10 }
+				},
+				{
+					"name": "RPC_RATE_LIMITER",
+					"namespace_id": "1002",
+					"simple": { "limit": 300, "period": 10 }
 				}
 			],
 			"observability": {


### PR DESCRIPTION
Browser JSON-RPC now goes through a same-origin `/api/rpc` route instead of `proxy.tempo.xyz`, so RPC traffic is per-IP rate limited by the worker (dedicated `RPC_RATE_LIMITER`, 300 req/10s). The route forwards to `api.tempo.xyz` with `TEMPO_API_KEY`, falling back to the shared proxy.
