### PR TITLE
feat(explorer): harden rate limiting against IP rotation

### DIFF
--- a/apps/explorer/src/index.server.ts
+++ b/apps/explorer/src/index.server.ts
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/cloudflare'
 import handler, { createServerEntry } from '@tanstack/react-start/server-entry'
 import { handleDatadogProxy } from '#lib/server/datadog-proxy'
+import { checkRateLimit } from '#lib/server/rate-limit'
 import { checkRequestGuard } from '#lib/server/request-guard'
 
 export const redirects: Array<{
@@ -50,26 +51,6 @@ function sanitizeUrl(rawUrl: string): string {
 	} catch {
 		return rawUrl
 	}
-}
-
-/** Per-IP limit for all worker requests (pages, API). Assets bypass the worker. Fails open when the binding is unavailable (local dev). */
-async function checkRateLimit(
-	request: Request,
-	env: Cloudflare.Env,
-): Promise<Response | undefined> {
-	if (!env.REQUESTS_RATE_LIMITER) return undefined
-	try {
-		const key = request.headers.get('cf-connecting-ip') ?? 'unknown'
-		const { success } = await env.REQUESTS_RATE_LIMITER.limit({ key })
-		if (!success)
-			return new Response('Rate limit exceeded', {
-				status: 429,
-				headers: { 'retry-after': '10' },
-			})
-	} catch (error) {
-		console.error('Rate limit check failed:', error)
-	}
-	return undefined
 }
 
 const serverEntry = createServerEntry({
@@ -128,7 +109,11 @@ export default Sentry.withSentry(
 			const blocked = checkRequestGuard(request, env.BLOCKED_ASNS)
 			if (blocked) return blocked
 
-			const rateLimited = await checkRateLimit(request, env)
+			const rateLimited = await checkRateLimit(request, {
+				asn: env.ASN_RATE_LIMITER,
+				global: env.GLOBAL_RATE_LIMITER,
+				ip: env.REQUESTS_RATE_LIMITER,
+			})
 			if (rateLimited) return rateLimited
 
 			const processEnv = process.env as Record<string, string | undefined>

--- a/apps/explorer/src/lib/server/rate-limit.ts
+++ b/apps/explorer/src/lib/server/rate-limit.ts
@@ -1,0 +1,65 @@
+type RateLimiter = {
+	limit(options: { key: string }): Promise<{ success: boolean }>
+}
+
+export type RateLimiters = {
+	/** Coarse per-network backstop; catches clients rotating addresses within one ASN. */
+	asn?: RateLimiter | undefined
+	/** Fixed-key circuit breaker capping total throughput per colo. */
+	global?: RateLimiter | undefined
+	/** Per-client limit, keyed by IPv4 address or IPv6 /64 prefix. */
+	ip?: RateLimiter | undefined
+}
+
+/** Layered per-client, per-ASN, and global limits. Fails open when bindings are unavailable (local dev). */
+export async function checkRateLimit(
+	request: Request,
+	limiters: RateLimiters,
+): Promise<Response | undefined> {
+	try {
+		const checks: Array<Promise<{ success: boolean }>> = []
+		if (limiters.ip) checks.push(limiters.ip.limit({ key: clientKey(request) }))
+		const asn = request.cf?.asn
+		if (limiters.asn && asn !== undefined)
+			checks.push(limiters.asn.limit({ key: `asn:${asn}` }))
+		if (limiters.global) checks.push(limiters.global.limit({ key: 'global' }))
+
+		const results = await Promise.all(checks)
+		if (results.some((result) => !result.success))
+			return new Response('Rate limit exceeded', {
+				status: 429,
+				headers: { 'retry-after': '10' },
+			})
+	} catch (error) {
+		console.error('Rate limit check failed:', error)
+	}
+	return undefined
+}
+
+/** IPv4 clients key by address; IPv6 clients by /64 prefix so they cannot rotate within their allocation. */
+export function clientKey(request: Request): string {
+	const ip = request.headers.get('cf-connecting-ip')
+	if (!ip) return 'unknown'
+	if (ip.includes('.')) return ip
+	return ipv6Prefix(ip)
+}
+
+/** First four hextets of an IPv6 address, with `::` expanded. */
+function ipv6Prefix(ip: string): string {
+	const [address = ''] = ip.split('%')
+	const [head = '', tail = ''] = address.split('::')
+	const left = head ? head.split(':') : []
+	const right = tail ? tail.split(':') : []
+	const groups = [
+		...left,
+		...Array.from(
+			{ length: Math.max(8 - left.length - right.length, 0) },
+			() => '0',
+		),
+		...right,
+	]
+	return groups
+		.slice(0, 4)
+		.map((group) => Number.parseInt(group || '0', 16).toString(16))
+		.join(':')
+}

--- a/apps/explorer/test/rate-limit.test.ts
+++ b/apps/explorer/test/rate-limit.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest'
+import { checkRateLimit, clientKey } from '../src/lib/server/rate-limit'
+
+const allow = { limit: async () => ({ success: true }) }
+const deny = { limit: async () => ({ success: false }) }
+
+function request(ip?: string, asn?: number) {
+	return new Request('https://explore.testnet.tempo.xyz/tx/0x123', {
+		...(ip === undefined ? {} : { headers: { 'cf-connecting-ip': ip } }),
+		...(asn === undefined ? {} : { cf: { asn } }),
+	})
+}
+
+describe('clientKey', () => {
+	it('keys ipv4 clients by address', () => {
+		expect(clientKey(request('203.0.113.7'))).toBe('203.0.113.7')
+	})
+
+	it('buckets ipv6 clients by /64 prefix', () => {
+		expect([
+			clientKey(request('2001:db8:abcd:12::1')),
+			clientKey(request('2001:db8:abcd:12:ffff:ffff:ffff:ffff')),
+			clientKey(request('2001:db8:abcd:12:1234::5')),
+			clientKey(request('2001:0db8:abcd:0012::1')),
+		]).toEqual([
+			'2001:db8:abcd:12',
+			'2001:db8:abcd:12',
+			'2001:db8:abcd:12',
+			'2001:db8:abcd:12',
+		])
+	})
+
+	it('separates distinct /64 prefixes', () => {
+		expect(clientKey(request('2001:db8:abcd:13::1'))).not.toBe(
+			clientKey(request('2001:db8:abcd:12::1')),
+		)
+	})
+
+	it('expands leading ::', () => {
+		expect(clientKey(request('::1'))).toBe('0:0:0:0')
+	})
+
+	it('falls back when the header is missing', () => {
+		expect(clientKey(request())).toBe('unknown')
+	})
+})
+
+describe('checkRateLimit', () => {
+	it('allows when all limiters allow', async () => {
+		const response = await checkRateLimit(request('203.0.113.7', 64512), {
+			asn: allow,
+			global: allow,
+			ip: allow,
+		})
+		expect(response).toBeUndefined()
+	})
+
+	it('rejects when any limiter denies', async () => {
+		const responses = await Promise.all([
+			checkRateLimit(request('203.0.113.7', 64512), { asn: deny, ip: allow }),
+			checkRateLimit(request('203.0.113.7'), { global: deny, ip: allow }),
+			checkRateLimit(request('203.0.113.7'), { ip: deny }),
+		])
+		expect(
+			responses.map((response) => ({
+				retryAfter: response?.headers.get('retry-after'),
+				status: response?.status,
+			})),
+		).toEqual([
+			{ retryAfter: '10', status: 429 },
+			{ retryAfter: '10', status: 429 },
+			{ retryAfter: '10', status: 429 },
+		])
+	})
+
+	it('keys each limiter separately', async () => {
+		const keys: string[] = []
+		const recording = {
+			limit: async ({ key }: { key: string }) => {
+				keys.push(key)
+				return { success: true }
+			},
+		}
+		await checkRateLimit(request('2001:db8:abcd:12::1', 64512), {
+			asn: recording,
+			global: recording,
+			ip: recording,
+		})
+		expect(keys).toEqual(['2001:db8:abcd:12', 'asn:64512', 'global'])
+	})
+
+	it('skips the asn limiter when asn is unavailable', async () => {
+		const response = await checkRateLimit(request('203.0.113.7'), {
+			asn: deny,
+			ip: allow,
+		})
+		expect(response).toBeUndefined()
+	})
+
+	it('fails open without bindings', async () => {
+		expect(await checkRateLimit(request('203.0.113.7'), {})).toBeUndefined()
+	})
+
+	it('fails open when a limiter throws', async () => {
+		const throwing = {
+			limit: async (): Promise<{ success: boolean }> => {
+				throw new Error('unavailable')
+			},
+		}
+		expect(
+			await checkRateLimit(request('203.0.113.7'), { ip: throwing }),
+		).toBeUndefined()
+	})
+})

--- a/apps/explorer/wrangler.json
+++ b/apps/explorer/wrangler.json
@@ -15,6 +15,16 @@
 			"name": "REQUESTS_RATE_LIMITER",
 			"namespace_id": "1001",
 			"simple": { "limit": 100, "period": 10 }
+		},
+		{
+			"name": "ASN_RATE_LIMITER",
+			"namespace_id": "1003",
+			"simple": { "limit": 2000, "period": 10 }
+		},
+		{
+			"name": "GLOBAL_RATE_LIMITER",
+			"namespace_id": "1004",
+			"simple": { "limit": 10000, "period": 10 }
 		}
 	],
 	"env": {
@@ -75,6 +85,16 @@
 					"name": "REQUESTS_RATE_LIMITER",
 					"namespace_id": "1001",
 					"simple": { "limit": 100, "period": 10 }
+				},
+				{
+					"name": "ASN_RATE_LIMITER",
+					"namespace_id": "1003",
+					"simple": { "limit": 2000, "period": 10 }
+				},
+				{
+					"name": "GLOBAL_RATE_LIMITER",
+					"namespace_id": "1004",
+					"simple": { "limit": 10000, "period": 10 }
 				}
 			],
 			"observability": {
@@ -126,6 +146,16 @@
 					"name": "REQUESTS_RATE_LIMITER",
 					"namespace_id": "1001",
 					"simple": { "limit": 100, "period": 10 }
+				},
+				{
+					"name": "ASN_RATE_LIMITER",
+					"namespace_id": "1003",
+					"simple": { "limit": 2000, "period": 10 }
+				},
+				{
+					"name": "GLOBAL_RATE_LIMITER",
+					"namespace_id": "1004",
+					"simple": { "limit": 10000, "period": 10 }
 				}
 			],
 			"observability": {
@@ -172,6 +202,16 @@
 					"name": "REQUESTS_RATE_LIMITER",
 					"namespace_id": "1001",
 					"simple": { "limit": 100, "period": 10 }
+				},
+				{
+					"name": "ASN_RATE_LIMITER",
+					"namespace_id": "1003",
+					"simple": { "limit": 2000, "period": 10 }
+				},
+				{
+					"name": "GLOBAL_RATE_LIMITER",
+					"namespace_id": "1004",
+					"simple": { "limit": 10000, "period": 10 }
 				}
 			],
 			"observability": {
@@ -233,6 +273,16 @@
 					"name": "REQUESTS_RATE_LIMITER",
 					"namespace_id": "1001",
 					"simple": { "limit": 100, "period": 10 }
+				},
+				{
+					"name": "ASN_RATE_LIMITER",
+					"namespace_id": "1003",
+					"simple": { "limit": 2000, "period": 10 }
+				},
+				{
+					"name": "GLOBAL_RATE_LIMITER",
+					"namespace_id": "1004",
+					"simple": { "limit": 10000, "period": 10 }
 				}
 			],
 			"observability": {


### PR DESCRIPTION
Hardens explorer rate limiting against IP rotation: keys IPv6 clients by /64 prefix, adds a per-ASN backstop (`ASN_RATE_LIMITER`), and a global circuit breaker (`GLOBAL_RATE_LIMITER`).

Follow-up to https://github.com/tempoxyz/tempo-apps/pull/1131 and https://github.com/tempoxyz/tempo-apps/pull/1133.
