### PR TITLE
fix(explorer): remove nested code scrollbar

### DIFF
--- a/apps/explorer/src/comps/ContractSource.tsx
+++ b/apps/explorer/src/comps/ContractSource.tsx
@@ -324,7 +324,7 @@ function SourceFile(props: {
 						<div
 							// biome-ignore lint/security/noDangerouslySetInnerHtml: trusted shiki output from server
 							dangerouslySetInnerHTML={{ __html: highlightedHtml }}
-							className="shiki shiki-block text-primary whitespace-pre bg-card-header! pl-0!"
+							className="text-primary bg-card-header!"
 						/>
 					) : (
 						<pre className="shiki shiki-block text-primary whitespace-pre bg-card-header! pl-0!">


### PR DESCRIPTION
## Summary
- remove `shiki-block` overflow styles from the highlighted source wrapper
- keep scrolling on the generated Shiki `<pre>` only
- prevent nested horizontal and vertical scrollbars in contract source panes

## Screenshots

| Before | After |
|--------|-------|
| Highlighted source wrapper and generated `<pre>` both scroll | Generated `<pre>` is the single scroll container |

The sandbox could load the page shell, but upstream RPC/API requests timed out before contract source rendered, so an after screenshot could not be captured reliably.

## Validation
- `pnpm --filter explorer check:biome`
- `pnpm --filter explorer check:types`
- `pnpm --filter explorer test -- --run` (47 tests passed)
- `pnpm --filter explorer build`
- `pnpm precommit` blocked while cloning `gitleaks` due invalid GitHub credentials
- monorepo `pnpm check` reaches unrelated existing failures in `apps/fee-payer` and `apps/contract-verification`

Prompted by: @shekhirin
