### PR TITLE
feat(explorer): detect system theme

### DIFF
--- a/apps/explorer/src/comps/Footer.tsx
+++ b/apps/explorer/src/comps/Footer.tsx
@@ -4,8 +4,11 @@ import {
 	applyThemeMode,
 	defaultThemeMode,
 	getInitialThemeMode,
+	getStoredThemeMode,
+	getSystemThemeMode,
 	isThemeMode,
 	persistThemeMode,
+	themeMediaQuery,
 	themeStorageKey,
 	type ThemeMode,
 } from '#lib/theme'
@@ -53,13 +56,25 @@ export namespace Footer {
 				if (event.key !== themeStorageKey) return
 				const updatedTheme = isThemeMode(event.newValue)
 					? event.newValue
-					: getInitialThemeMode()
+					: getSystemThemeMode()
+				setTheme(updatedTheme)
+				applyThemeMode(updatedTheme)
+			}
+			const colorScheme = window.matchMedia(themeMediaQuery)
+			const handleColorScheme = (event: MediaQueryListEvent) => {
+				if (getStoredThemeMode()) return
+
+				const updatedTheme = event.matches ? 'light' : 'dark'
 				setTheme(updatedTheme)
 				applyThemeMode(updatedTheme)
 			}
 
 			window.addEventListener('storage', handleStorage)
-			return () => window.removeEventListener('storage', handleStorage)
+			colorScheme.addEventListener('change', handleColorScheme)
+			return () => {
+				window.removeEventListener('storage', handleStorage)
+				colorScheme.removeEventListener('change', handleColorScheme)
+			}
 		}, [])
 
 		return (

--- a/apps/explorer/src/lib/theme.ts
+++ b/apps/explorer/src/lib/theme.ts
@@ -2,6 +2,7 @@ export type ThemeMode = 'dark' | 'light'
 
 export const defaultThemeMode = 'dark' satisfies ThemeMode
 export const themeStorageKey = 'tempo-explorer-theme'
+export const themeMediaQuery = '(prefers-color-scheme: light)'
 
 export function isThemeMode(
 	value: string | null | undefined,
@@ -16,20 +17,35 @@ export function applyThemeMode(mode: ThemeMode): void {
 	document.documentElement.style.colorScheme = mode
 }
 
+export function getSystemThemeMode(): ThemeMode {
+	if (
+		typeof window === 'undefined' ||
+		typeof window.matchMedia !== 'function'
+	) {
+		return defaultThemeMode
+	}
+
+	return window.matchMedia(themeMediaQuery).matches ? 'light' : 'dark'
+}
+
+export function getStoredThemeMode(): ThemeMode | undefined {
+	if (typeof window === 'undefined') return undefined
+
+	try {
+		const storedTheme = window.localStorage.getItem(themeStorageKey)
+		return isThemeMode(storedTheme) ? storedTheme : undefined
+	} catch {
+		return undefined
+	}
+}
+
 export function getInitialThemeMode(): ThemeMode {
 	if (typeof document === 'undefined') return defaultThemeMode
 
 	const datasetTheme = document.documentElement.dataset.theme
 	if (isThemeMode(datasetTheme)) return datasetTheme
 
-	try {
-		const storedTheme = window.localStorage.getItem(themeStorageKey)
-		if (isThemeMode(storedTheme)) return storedTheme
-	} catch {
-		// Keep the default theme when storage is unavailable.
-	}
-
-	return defaultThemeMode
+	return getStoredThemeMode() ?? getSystemThemeMode()
 }
 
 export function persistThemeMode(mode: ThemeMode): void {
@@ -42,4 +58,4 @@ export function persistThemeMode(mode: ThemeMode): void {
 	}
 }
 
-export const themeBootScript = `(function(){try{var key='${themeStorageKey}';var stored=window.localStorage.getItem(key);var theme=stored==='light'||stored==='dark'?stored:'${defaultThemeMode}';document.documentElement.dataset.theme=theme;document.documentElement.style.colorScheme=theme;}catch(e){document.documentElement.dataset.theme='${defaultThemeMode}';document.documentElement.style.colorScheme='${defaultThemeMode}';}})();`
+export const themeBootScript = `(function(){var stored;try{stored=window.localStorage.getItem('${themeStorageKey}');}catch(e){}var theme=stored==='light'||stored==='dark'?stored:typeof window.matchMedia==='function'&&window.matchMedia('${themeMediaQuery}').matches?'light':'${defaultThemeMode}';document.documentElement.dataset.theme=theme;document.documentElement.style.colorScheme=theme;})();`

--- a/apps/explorer/test/theme.node.test.ts
+++ b/apps/explorer/test/theme.node.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+	getInitialThemeMode,
+	getStoredThemeMode,
+	getSystemThemeMode,
+	themeBootScript,
+	themeMediaQuery,
+} from '#lib/theme'
+
+afterEach(() => {
+	vi.unstubAllGlobals()
+})
+
+function stubBrowser(options: {
+	datasetTheme?: string
+	storedTheme?: string | null
+	systemPrefersLight?: boolean
+}): void {
+	const {
+		datasetTheme,
+		storedTheme = null,
+		systemPrefersLight = false,
+	} = options
+
+	vi.stubGlobal('document', {
+		documentElement: {
+			dataset: { theme: datasetTheme },
+			style: {},
+		},
+	})
+	vi.stubGlobal('window', {
+		localStorage: {
+			getItem: () => storedTheme,
+		},
+		matchMedia: (query: string) => ({
+			matches: query === themeMediaQuery && systemPrefersLight,
+		}),
+	})
+}
+
+describe('theme detection', () => {
+	it('uses the system color scheme when no theme is saved', () => {
+		stubBrowser({ systemPrefersLight: true })
+
+		expect(getStoredThemeMode()).toBeUndefined()
+		expect(getSystemThemeMode()).toBe('light')
+		expect(getInitialThemeMode()).toBe('light')
+	})
+
+	it('prefers a saved theme over the system color scheme', () => {
+		stubBrowser({ storedTheme: 'dark', systemPrefersLight: true })
+
+		expect(getStoredThemeMode()).toBe('dark')
+		expect(getInitialThemeMode()).toBe('dark')
+	})
+
+	it('applies system detection in the boot script', () => {
+		stubBrowser({ systemPrefersLight: true })
+
+		Function(themeBootScript)()
+
+		expect(document.documentElement.dataset.theme).toBe('light')
+		expect(document.documentElement.style.colorScheme).toBe('light')
+	})
+})


### PR DESCRIPTION
## Summary
- detect the system color scheme when no Explorer theme is saved
- follow live OS color-scheme changes until the user selects an explicit theme
- preserve saved light/dark selections across reloads and system changes
- add coverage for system detection, saved overrides, and the pre-hydration boot script

## Screenshots

| Before | After |
|--------|-------|
| Unsaved sessions defaulted to dark mode | Unsaved sessions match the system theme; no layout changes |

## Validation
- `pnpm --filter explorer check`
- `pnpm --filter explorer exec vitest run` (47 tests)
- `pnpm --filter explorer build`
- browser verification: light preference → light theme, live switch to dark → dark theme, manual light override remains light through later system changes

## Notes
- Repo-wide `pnpm check` remains blocked by existing contract-verification type errors unrelated to this change.
- `pnpm precommit` could not initialize `pre-commit-hooks` because GitHub rejected the hook clone credential in this sandbox.

Prompted by: @pepyakin
