### PR TITLE
docs: clarify app repository structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,28 @@
 # Tempo Apps
 
-Monorepo for Tempo Apps
+Tempo Apps is the monorepo for the applications and services that make up Tempo's developer-facing infrastructure, including block exploration, account tooling, documentation search, and network services. Developers working with Tempo can use these projects as reference implementations or hosted services for block exploration, fee sponsorship, token metadata, smart contract verification, and related workflows.
+
+These apps are maintained by the Tempo team and complement the core [`tempo`](https://github.com/tempoxyz/tempo) node. See the [Tempo developer documentation](https://tempo.xyz/developers/docs) for integration guides and protocol documentation.
 
 ## Apps
 
-| Workspace | Description | URL |
-| --------- | ----------- | ----------- |
-| [`apps/explorer`](apps/explorer) | Mainnet, Testnet & Devnet Explorer | [`explore.tempo.xyz`](<https://explore.tempo.xyz>) |
-| [`apps/fee-payer`](apps/fee-payer) | Fee payer | [`sponsor.testnet.tempo.xyz`](<https://sponsor.testnet.tempo.xyz>) |
-| [`apps/tokenlist`](apps/tokenlist) | Tokenlist Registry & API | [`tokenlist.tempo.xyz`](<https://tokenlist.tempo.xyz>) |
-| [`apps/contract-verification`](apps/contract-verification) | Smart contract verification service | [`contracts.tempo.xyz`](<https://contracts.tempo.xyz>) |
-| [`apps/key-manager`](apps/key-manager) | WebAuthn key management service | [`keys.tempo.xyz`](<https://keys.tempo.xyz>) |
-| [`apps/og`](apps/og)  | OpenGraph image generation worker | [`og.tempo.xyz`](<https://og.tempo.xyz>) |
-| [`apps/reth-snapshots-viewer`](apps/reth-snapshots-viewer) | Reth snapshots viewer | [`snapshots.reth.rs`](<https://snapshots.reth.rs>) |
-| [`apps/tempo-snapshots-viewer`](apps/tempo-snapshots-viewer) | Tempo snapshots viewer | [`snapshots.tempo.xyz`](<https://snapshots.tempo.xyz>) |
+| Category | Workspace | Description | URL |
+| -------- | --------- | ----------- | --- |
+| **Explorer** | [`apps/explorer`](apps/explorer) | Mainnet, testnet, and devnet explorer | [`explore.tempo.xyz`](<https://explore.tempo.xyz>) |
+| **Wallet and account management** | [`apps/fee-payer`](apps/fee-payer) | Transaction fee sponsorship service | [`sponsor.testnet.tempo.xyz`](<https://sponsor.testnet.tempo.xyz>) |
+| **Wallet and account management** | [`apps/key-manager`](apps/key-manager) | WebAuthn key management service | [`keys.tempo.xyz`](<https://keys.tempo.xyz>) |
+| **Developer services** | [`apps/tokenlist`](apps/tokenlist) | Tokenlist registry and API | [`tokenlist.tempo.xyz`](<https://tokenlist.tempo.xyz/docs>) |
+| **Developer services** | [`apps/contract-verification`](apps/contract-verification) | Smart contract verification service | [`contracts.tempo.xyz`](<https://contracts.tempo.xyz/docs>) |
+| **Developer services** | [`apps/og`](apps/og) | Open Graph image generation worker | [`og.tempo.xyz`](<https://og.tempo.xyz>) |
+| **Developer services** | [`apps/mcp-docs-indexer`](apps/mcp-docs-indexer) | MCP documentation indexer and search service | [`mcp.tempo.xyz`](<https://mcp.tempo.xyz>) |
+| **Network infrastructure** | [`apps/reth-snapshots-viewer`](apps/reth-snapshots-viewer) | Reth snapshots viewer | [`snapshots.reth.rs`](<https://snapshots.reth.rs>) |
+| **Network infrastructure** | [`apps/tempo-snapshots-viewer`](apps/tempo-snapshots-viewer) | Tempo snapshots viewer | [`snapshots.tempo.xyz`](<https://snapshots.tempo.xyz>) |
+
+## Related projects
+
+- [`tempoxyz/tempo`](https://github.com/tempoxyz/tempo): Core Tempo node and protocol implementation.
+- [`tempoxyz/tidx`](https://github.com/tempoxyz/tidx): Chain indexer for querying Tempo blocks, transactions, and logs.
+- [`tempoxyz/wallet-cli`](https://github.com/tempoxyz/wallet-cli): Command-line wallet and HTTP client for Tempo and MPP-enabled services.
 
 ## Contributing
 


### PR DESCRIPTION
Explains the role of Tempo Apps, groups current services by function, and adds direct documentation and related-project links. The table preserves all nine current applications, including the MCP documentation indexer.

Validation: `pnpm check`, `pnpm precommit`, 123 available tests, `git diff --check`, a direct-link audit, and a full README em-dash scan passed. Fee-payer tests that require Docker and a local Tempo node were unavailable.

Repo admin follow-up: set the description to `Monorepo for the Tempo explorer, account tooling, developer services, and network infrastructure.`, the homepage to `https://tempo.xyz/developers/docs`, and topics to `tempo`, `payments`, `stablecoins`, `developer-tools`, and `block-explorer`.