### PR TITLE
Consolidate Tempo Explorer indexing signals

### DIFF
--- a/apps/explorer/src/index.server.ts
+++ b/apps/explorer/src/index.server.ts
@@ -114,15 +114,6 @@ export default Sentry.withSentry(
 			if (hostPolicy?.type === 'redirect') {
 				return Response.redirect(hostPolicy.location, 308)
 			}
-			if (hostPolicy?.type === 'retired') {
-				return new Response('The Tempo Andantino explorer has been retired.', {
-					headers: {
-						'Content-Type': 'text/plain; charset=utf-8',
-						'X-Robots-Tag': 'noindex, nofollow',
-					},
-					status: 410,
-				})
-			}
 
 			const blocked = checkRequestGuard(request, env.BLOCKED_ASNS)
 			if (blocked) return blocked

--- a/apps/explorer/src/index.server.ts
+++ b/apps/explorer/src/index.server.ts
@@ -1,5 +1,9 @@
 import * as Sentry from '@sentry/cloudflare'
 import handler, { createServerEntry } from '@tanstack/react-start/server-entry'
+import {
+	getExplorerHostPolicy,
+	withExplorerIndexingHeaders,
+} from '#lib/explorer-indexing'
 import { handleDatadogProxy } from '#lib/server/datadog-proxy'
 import { checkRateLimit } from '#lib/server/rate-limit'
 import { checkRequestGuard } from '#lib/server/request-guard'
@@ -106,6 +110,20 @@ export default Sentry.withSentry(
 	}),
 	{
 		fetch: async (request, env, _context) => {
+			const hostPolicy = getExplorerHostPolicy(request.url)
+			if (hostPolicy?.type === 'redirect') {
+				return Response.redirect(hostPolicy.location, 308)
+			}
+			if (hostPolicy?.type === 'retired') {
+				return new Response('The Tempo Andantino explorer has been retired.', {
+					headers: {
+						'Content-Type': 'text/plain; charset=utf-8',
+						'X-Robots-Tag': 'noindex, nofollow',
+					},
+					status: 410,
+				})
+			}
+
 			const blocked = checkRequestGuard(request, env.BLOCKED_ASNS)
 			if (blocked) return blocked
 
@@ -123,7 +141,8 @@ export default Sentry.withSentry(
 				}
 			}
 
-			return serverEntry.fetch(request, undefined)
+			const response = await serverEntry.fetch(request, undefined)
+			return withExplorerIndexingHeaders(request.url, response)
 		},
 	},
 )

--- a/apps/explorer/src/lib/explorer-indexing.ts
+++ b/apps/explorer/src/lib/explorer-indexing.ts
@@ -21,19 +21,13 @@ const NON_INDEXABLE_EXPLORER_HOSTS = new Set([
 	'explore.nextfork.devnet.tempo.xyz',
 ])
 
-export const RETIRED_ANDANTINO_HOST = 'explore.andantino.tempo.xyz'
-
-export type ExplorerHostPolicy =
-	| { type: 'redirect'; location: string }
-	| { type: 'retired' }
+export type ExplorerHostPolicy = { type: 'redirect'; location: string }
 
 export function getExplorerHostPolicy(
 	requestUrl: string | URL,
 ): ExplorerHostPolicy | undefined {
 	const url = new URL(requestUrl)
 	const hostname = url.hostname.toLowerCase()
-
-	if (hostname === RETIRED_ANDANTINO_HOST) return { type: 'retired' }
 
 	const canonicalHostname = EXPLORER_HOST_REDIRECTS.get(hostname)
 	if (!canonicalHostname) return undefined

--- a/apps/explorer/src/lib/explorer-indexing.ts
+++ b/apps/explorer/src/lib/explorer-indexing.ts
@@ -1,0 +1,106 @@
+import type { TempoEnv } from '#lib/env'
+
+export const EXPLORER_ORGANIZATION_ID = 'https://tempo.xyz/#organization'
+
+const CANONICAL_EXPLORER_ORIGINS: Partial<Record<TempoEnv, string>> = {
+	mainnet: 'https://explore.tempo.xyz',
+	testnet: 'https://explore.testnet.tempo.xyz',
+}
+
+const EXPLORER_HOST_REDIRECTS = new Map([
+	['explore.4217.tempo.xyz', 'explore.tempo.xyz'],
+	['explore.42431.tempo.xyz', 'explore.testnet.tempo.xyz'],
+	['explore.mainnet.tempo.xyz', 'explore.tempo.xyz'],
+	['explore.moderato.tempo.xyz', 'explore.testnet.tempo.xyz'],
+	['explore.presto.tempo.xyz', 'explore.tempo.xyz'],
+])
+
+const NON_INDEXABLE_EXPLORER_HOSTS = new Set([
+	'explore.31318.tempo.xyz',
+	'explore.devnet.tempo.xyz',
+	'explore.nextfork.devnet.tempo.xyz',
+])
+
+export const RETIRED_ANDANTINO_HOST = 'explore.andantino.tempo.xyz'
+
+export type ExplorerHostPolicy =
+	| { type: 'redirect'; location: string }
+	| { type: 'retired' }
+
+export function getExplorerHostPolicy(
+	requestUrl: string | URL,
+): ExplorerHostPolicy | undefined {
+	const url = new URL(requestUrl)
+	const hostname = url.hostname.toLowerCase()
+
+	if (hostname === RETIRED_ANDANTINO_HOST) return { type: 'retired' }
+
+	const canonicalHostname = EXPLORER_HOST_REDIRECTS.get(hostname)
+	if (!canonicalHostname) return undefined
+
+	url.protocol = 'https:'
+	url.hostname = canonicalHostname
+	url.port = ''
+
+	return { type: 'redirect', location: url.toString() }
+}
+
+export function isNonIndexableExplorerHost(hostname: string): boolean {
+	const host = hostname.toLowerCase()
+	return (
+		NON_INDEXABLE_EXPLORER_HOSTS.has(host) ||
+		host.includes('explorer-devnet') ||
+		host.includes('explorer-nextfork')
+	)
+}
+
+export function withExplorerIndexingHeaders(
+	requestUrl: string | URL,
+	response: Response,
+): Response {
+	const url = new URL(requestUrl)
+	if (!isNonIndexableExplorerHost(url.hostname)) return response
+
+	const headers = new Headers(response.headers)
+	headers.set('X-Robots-Tag', 'noindex, nofollow')
+
+	return new Response(response.body, {
+		headers,
+		status: response.status,
+		statusText: response.statusText,
+	})
+}
+
+export function getCanonicalExplorerUrl(
+	tempoEnv: TempoEnv,
+	pathname: string,
+): string | undefined {
+	const origin = CANONICAL_EXPLORER_ORIGINS[tempoEnv]
+	if (!origin) return undefined
+
+	const url = new URL(origin)
+	url.pathname = pathname.startsWith('/') ? pathname : `/${pathname}`
+	return url.toString()
+}
+
+export function getExplorerWebApplication(tempoEnv: TempoEnv) {
+	const origin = CANONICAL_EXPLORER_ORIGINS[tempoEnv]
+	if (!origin) return undefined
+
+	const name =
+		tempoEnv === 'testnet' ? 'Tempo Testnet Explorer' : 'Tempo Explorer'
+
+	return {
+		'@context': 'https://schema.org',
+		'@id': `${origin}/#application`,
+		'@type': 'WebApplication',
+		applicationCategory: 'DeveloperApplication',
+		description:
+			'Explore and analyze blocks, transactions, contracts, and tokens on Tempo.',
+		isPartOf: { '@id': 'https://tempo.xyz/#website' },
+		name,
+		operatingSystem: 'Web',
+		provider: { '@id': EXPLORER_ORGANIZATION_ID },
+		url: `${origin}/`,
+	}
+}

--- a/apps/explorer/src/routes/__root.tsx
+++ b/apps/explorer/src/routes/__root.tsx
@@ -16,6 +16,11 @@ import { BreadcrumbsProvider } from '#comps/Breadcrumbs'
 import { ErrorBoundary } from '#comps/ErrorBoundary'
 import { IntroSeenProvider } from '#comps/Intro'
 import { TokenListMembershipProvider } from '#comps/TokenListMembership'
+import {
+	getCanonicalExplorerUrl,
+	getExplorerWebApplication,
+} from '#lib/explorer-indexing'
+import { getRequestURL, getTempoEnv } from '#lib/env'
 import { OG_BASE_URL } from '#lib/og'
 import { ProgressLine } from '#comps/ProgressLine'
 import { defaultThemeMode, themeBootScript } from '#lib/theme'
@@ -30,6 +35,37 @@ import {
 import { initDatadogRum } from '#lib/telemetry/datadog'
 import { getWagmiConfig, getWagmiStateSSR } from '#wagmi.config.ts'
 import css from './styles.css?url'
+
+function getCurrentCanonicalExplorerUrl(): string | undefined {
+	const pathname =
+		typeof window === 'undefined'
+			? getRequestURL().pathname
+			: window.location.pathname
+	return getCanonicalExplorerUrl(getTempoEnv(), pathname)
+}
+
+function getExplorerCanonicalLinks() {
+	const href = getCurrentCanonicalExplorerUrl()
+	return href ? [{ rel: 'canonical', href }] : []
+}
+
+function getExplorerRobotsMeta() {
+	return getCurrentCanonicalExplorerUrl()
+		? []
+		: [{ name: 'robots', content: 'noindex, nofollow' }]
+}
+
+function getExplorerWebApplicationScripts() {
+	const webApplication = getExplorerWebApplication(getTempoEnv())
+	return webApplication
+		? [
+				{
+					children: JSON.stringify(webApplication),
+					type: 'application/ld+json',
+				},
+			]
+		: []
+}
 
 export const Route = createRootRouteWithContext<{
 	queryClient: QueryClient
@@ -88,8 +124,10 @@ export const Route = createRootRouteWithContext<{
 				name: 'twitter:image',
 				content: `${OG_BASE_URL}/explorer`,
 			},
+			...getExplorerRobotsMeta(),
 		],
 		links: [
+			...getExplorerCanonicalLinks(),
 			{
 				rel: 'preload',
 				href: '/fonts/satoshi/Satoshi-Variable.woff2',
@@ -154,6 +192,7 @@ export const Route = createRootRouteWithContext<{
 				href: '/favicon-light.png',
 			},
 		],
+		scripts: getExplorerWebApplicationScripts(),
 	}),
 	scripts: async () => {
 		const scripts: Array<{ children: string; type: string }> = []

--- a/apps/explorer/test/explorer-indexing.node.test.ts
+++ b/apps/explorer/test/explorer-indexing.node.test.ts
@@ -16,9 +16,7 @@ describe('Explorer host consolidation', () => {
 		['explore.42431.tempo.xyz', 'explore.testnet.tempo.xyz'],
 		['explore.moderato.tempo.xyz', 'explore.testnet.tempo.xyz'],
 	])('redirects %s to %s while preserving the resource URL', (from, to) => {
-		expect(
-			getExplorerHostPolicy(`https://${from}/tx/0x123?page=2`),
-		).toEqual({
+		expect(getExplorerHostPolicy(`https://${from}/tx/0x123?page=2`)).toEqual({
 			type: 'redirect',
 			location: `https://${to}/tx/0x123?page=2`,
 		})
@@ -29,12 +27,6 @@ describe('Explorer host consolidation', () => {
 		expect(
 			getExplorerHostPolicy('https://explore.testnet.tempo.xyz/'),
 		).toBeUndefined()
-	})
-
-	it('retires Andantino instead of mapping old resource URLs to another chain', () => {
-		expect(
-			getExplorerHostPolicy('https://explore.andantino.tempo.xyz/tx/0x123'),
-		).toEqual({ type: 'retired' })
 	})
 })
 

--- a/apps/explorer/test/explorer-indexing.node.test.ts
+++ b/apps/explorer/test/explorer-indexing.node.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest'
+import {
+	EXPLORER_ORGANIZATION_ID,
+	getCanonicalExplorerUrl,
+	getExplorerHostPolicy,
+	getExplorerWebApplication,
+	isNonIndexableExplorerHost,
+	withExplorerIndexingHeaders,
+} from '#lib/explorer-indexing'
+
+describe('Explorer host consolidation', () => {
+	it.each([
+		['explore.4217.tempo.xyz', 'explore.tempo.xyz'],
+		['explore.mainnet.tempo.xyz', 'explore.tempo.xyz'],
+		['explore.presto.tempo.xyz', 'explore.tempo.xyz'],
+		['explore.42431.tempo.xyz', 'explore.testnet.tempo.xyz'],
+		['explore.moderato.tempo.xyz', 'explore.testnet.tempo.xyz'],
+	])('redirects %s to %s while preserving the resource URL', (from, to) => {
+		expect(
+			getExplorerHostPolicy(`https://${from}/tx/0x123?page=2`),
+		).toEqual({
+			type: 'redirect',
+			location: `https://${to}/tx/0x123?page=2`,
+		})
+	})
+
+	it('does not redirect either canonical host', () => {
+		expect(getExplorerHostPolicy('https://explore.tempo.xyz/')).toBeUndefined()
+		expect(
+			getExplorerHostPolicy('https://explore.testnet.tempo.xyz/'),
+		).toBeUndefined()
+	})
+
+	it('retires Andantino instead of mapping old resource URLs to another chain', () => {
+		expect(
+			getExplorerHostPolicy('https://explore.andantino.tempo.xyz/tx/0x123'),
+		).toEqual({ type: 'retired' })
+	})
+})
+
+describe('Explorer indexing controls', () => {
+	it.each([
+		'explore.31318.tempo.xyz',
+		'explore.devnet.tempo.xyz',
+		'explore.nextfork.devnet.tempo.xyz',
+		'explorer-devnet.example.workers.dev',
+		'explorer-nextfork.example.workers.dev',
+	])('marks %s as non-indexable', (hostname) => {
+		expect(isNonIndexableExplorerHost(hostname)).toBe(true)
+	})
+
+	it.each([
+		'explore.tempo.xyz',
+		'explore.testnet.tempo.xyz',
+	])('keeps %s indexable', (hostname) => {
+		expect(isNonIndexableExplorerHost(hostname)).toBe(false)
+	})
+
+	it('adds an X-Robots-Tag header to devnet responses', async () => {
+		const response = withExplorerIndexingHeaders(
+			'https://explore.devnet.tempo.xyz/blocks',
+			new Response('ok', { headers: { 'Cache-Control': 'public' } }),
+		)
+
+		expect(response.headers.get('X-Robots-Tag')).toBe('noindex, nofollow')
+		expect(response.headers.get('Cache-Control')).toBe('public')
+		expect(await response.text()).toBe('ok')
+	})
+})
+
+describe('Explorer metadata', () => {
+	it('builds path-specific canonical URLs for public networks', () => {
+		expect(getCanonicalExplorerUrl('mainnet', '/tokens')).toBe(
+			'https://explore.tempo.xyz/tokens',
+		)
+		expect(getCanonicalExplorerUrl('testnet', '/token/0x123')).toBe(
+			'https://explore.testnet.tempo.xyz/token/0x123',
+		)
+	})
+
+	it('does not emit a canonical URL for development networks', () => {
+		expect(getCanonicalExplorerUrl('devnet', '/')).toBeUndefined()
+		expect(getCanonicalExplorerUrl('nextfork', '/')).toBeUndefined()
+	})
+
+	it('connects the Explorer application to the canonical Tempo organization', () => {
+		expect(getExplorerWebApplication('mainnet')).toMatchObject({
+			'@id': 'https://explore.tempo.xyz/#application',
+			'@type': 'WebApplication',
+			provider: { '@id': EXPLORER_ORGANIZATION_ID },
+			url: 'https://explore.tempo.xyz/',
+		})
+	})
+})

--- a/apps/explorer/wrangler.json
+++ b/apps/explorer/wrangler.json
@@ -34,6 +34,11 @@
 				{
 					"custom_domain": true,
 					"zone_name": "tempo.xyz",
+					"pattern": "explore.andantino.tempo.xyz"
+				},
+				{
+					"custom_domain": true,
+					"zone_name": "tempo.xyz",
 					"pattern": "explore.42431.tempo.xyz"
 				},
 				{

--- a/apps/explorer/wrangler.json
+++ b/apps/explorer/wrangler.json
@@ -34,11 +34,6 @@
 				{
 					"custom_domain": true,
 					"zone_name": "tempo.xyz",
-					"pattern": "explore.andantino.tempo.xyz"
-				},
-				{
-					"custom_domain": true,
-					"zone_name": "tempo.xyz",
 					"pattern": "explore.42431.tempo.xyz"
 				},
 				{


### PR DESCRIPTION
## What changed

- Permanently redirects five equivalent mainnet and testnet aliases to the canonical Explorer hosts while preserving the path and query.
- Adds `X-Robots-Tag: noindex, nofollow` and matching HTML metadata to devnet and nextfork.
- Adds path-specific canonical links on mainnet and testnet.
- Adds a `WebApplication` entity that identifies `https://tempo.xyz/#organization` as the provider.
- Adds focused coverage for host policies, indexing headers, canonical URLs, and structured data.

## Why

The Explorer currently serves identical indexable responses on multiple public hostnames. It also exposes development networks without noindex controls and does not emit canonical links or an entity relationship back to Tempo. These changes consolidate duplicate signals without changing chain selection or application routing on canonical hosts.

This PR does not change `explore.andantino.tempo.xyz` or any other historical network host.

## Behavior

| Current host | Result |
| --- | --- |
| `explore.4217.tempo.xyz`, `explore.mainnet.tempo.xyz`, `explore.presto.tempo.xyz` | 308 to `explore.tempo.xyz` |
| `explore.42431.tempo.xyz`, `explore.moderato.tempo.xyz` | 308 to `explore.testnet.tempo.xyz` |
| Devnet and nextfork hosts | Existing app response with `noindex, nofollow` |

## Validation

- `pnpm --filter explorer check`
- `pnpm --filter explorer test -- --run`
- 98 Explorer tests passed
- Production builds passed for mainnet, testnet, devnet, and nextfork
- `pnpm gen:types && pnpm check`
- `pnpm lint:tempo`
- `pnpm precommit`
- Live-like Host header smoke tests confirmed the 308 redirects, noindex header, canonical tag, and JSON-LD output
- Testnet `wrangler deploy --dry-run` passed and retains only the existing testnet custom domains

No visual UI changes.