### PR TITLE
perf(explorer): defer syntax highlighting

### DIFF
--- a/apps/explorer/src/comps/Contract.tsx
+++ b/apps/explorer/src/comps/Contract.tsx
@@ -146,7 +146,7 @@ export function ContractTabContent(props: {
 					</>
 				}
 			>
-				<AbiViewer abi={abi} />
+				<AbiViewer abi={abi} enabled={abiExpanded} />
 			</CollapsibleSection>
 
 			{/* Bytecode Section - hidden for TIP-20 */}

--- a/apps/explorer/src/comps/ContractAbi.tsx
+++ b/apps/explorer/src/comps/ContractAbi.tsx
@@ -1,14 +1,117 @@
 import * as React from 'react'
 import type { Abi } from 'viem'
 
+type HighlightRequest = {
+	id: number
+	json: string
+}
+
+type HighlightResponse =
+	| { id: number; html: string }
+	| { id: number; error: string }
+
+const HIGHLIGHT_CACHE_SIZE = 20
+const highlightCache = new Map<string, string>()
+const highlightsInFlight = new Map<string, Promise<string>>()
+const pendingWorkerRequests = new Map<
+	number,
+	{
+		resolve: (html: string) => void
+		reject: (error: Error) => void
+	}
+>()
+
+let highlighterWorker: Worker | null = null
+let nextWorkerRequestId = 0
+
+function getHighlighterWorker(): Worker {
+	if (highlighterWorker) return highlighterWorker
+
+	highlighterWorker = new Worker(
+		new URL('../workers/json-highlighter.ts', import.meta.url),
+		{ type: 'module' },
+	)
+	highlighterWorker.addEventListener(
+		'message',
+		(event: MessageEvent<HighlightResponse>) => {
+			const request = pendingWorkerRequests.get(event.data.id)
+			if (!request) return
+
+			pendingWorkerRequests.delete(event.data.id)
+			if ('html' in event.data) request.resolve(event.data.html)
+			else request.reject(new Error(event.data.error))
+		},
+	)
+	highlighterWorker.addEventListener('error', () => {
+		for (const request of pendingWorkerRequests.values()) {
+			request.reject(new Error('Syntax highlighting worker failed'))
+		}
+		pendingWorkerRequests.clear()
+		highlighterWorker?.terminate()
+		highlighterWorker = null
+	})
+
+	return highlighterWorker
+}
+
+function getCachedHighlight(json: string): string | undefined {
+	const html = highlightCache.get(json)
+	if (!html) return undefined
+
+	highlightCache.delete(json)
+	highlightCache.set(json, html)
+	return html
+}
+
+function cacheHighlight(json: string, html: string): void {
+	highlightCache.set(json, html)
+	if (highlightCache.size <= HIGHLIGHT_CACHE_SIZE) return
+
+	const oldestKey = highlightCache.keys().next().value
+	if (oldestKey !== undefined) highlightCache.delete(oldestKey)
+}
+
+function highlightJson(json: string): Promise<string> {
+	const cached = getCachedHighlight(json)
+	if (cached) return Promise.resolve(cached)
+
+	const existing = highlightsInFlight.get(json)
+	if (existing) return existing
+
+	const id = nextWorkerRequestId++
+	const promise = new Promise<string>((resolve, reject) => {
+		pendingWorkerRequests.set(id, { resolve, reject })
+		getHighlighterWorker().postMessage({ id, json } satisfies HighlightRequest)
+	})
+	highlightsInFlight.set(json, promise)
+	void promise.then(
+		(html) => {
+			cacheHighlight(json, html)
+			highlightsInFlight.delete(json)
+		},
+		() => highlightsInFlight.delete(json),
+	)
+	return promise
+}
+
+function scheduleWhenIdle(callback: () => void): () => void {
+	if (typeof window.requestIdleCallback === 'function') {
+		const id = window.requestIdleCallback(callback, { timeout: 1_000 })
+		return () => window.cancelIdleCallback(id)
+	}
+
+	const id = window.setTimeout(callback, 50)
+	return () => window.clearTimeout(id)
+}
+
 // ============================================================================
 // ABI Viewer
 // ============================================================================
 
-export function AbiViewer(props: { abi: Abi }) {
-	const { abi } = props
+export function AbiViewer(props: AbiViewer.Props): React.JSX.Element {
+	const { abi, enabled } = props
 	const json = React.useMemo(() => JSON.stringify(abi, null, 2), [abi])
-	const highlightedHtml = useHighlightedJson(json)
+	const highlightedHtml = useHighlightedJson(json, enabled)
 
 	return (
 		<div className="max-h-[280px] overflow-auto mx-3 mb-2">
@@ -31,43 +134,36 @@ export function AbiViewer(props: { abi: Abi }) {
 	)
 }
 
-function useHighlightedJson(json: string): string | null {
-	const [html, setHtml] = React.useState<string | null>(null)
+export declare namespace AbiViewer {
+	type Props = {
+		abi: Abi
+		enabled: boolean
+	}
+}
+
+function useHighlightedJson(json: string, enabled: boolean): string | null {
+	const [highlighted, setHighlighted] = React.useState<{
+		json: string
+		html: string
+	} | null>(null)
 
 	React.useEffect(() => {
+		if (!enabled) return
+
 		let cancelled = false
-
-		async function highlight() {
-			const { createHighlighterCore } = await import('shiki/core')
-			const { createJavaScriptRegexEngine } = await import(
-				'shiki/engine/javascript'
+		const cancelScheduledHighlight = scheduleWhenIdle(() => {
+			void highlightJson(json).then(
+				(html) => {
+					if (!cancelled) setHighlighted({ json, html })
+				},
+				() => undefined,
 			)
-
-			const highlighter = await createHighlighterCore({
-				themes: [
-					import('@shikijs/themes/github-light'),
-					import('@shikijs/themes/github-dark'),
-				],
-				langs: [import('@shikijs/langs/json')],
-				engine: createJavaScriptRegexEngine({ forgiving: true }),
-			})
-
-			if (cancelled) return
-
-			const result = highlighter.codeToHtml(json, {
-				lang: 'json',
-				themes: { light: 'github-light', dark: 'github-dark' },
-				defaultColor: 'light-dark()',
-			})
-
-			if (!cancelled) setHtml(result)
-		}
-
-		highlight()
+		})
 		return () => {
 			cancelled = true
+			cancelScheduledHighlight()
 		}
-	}, [json])
+	}, [enabled, json])
 
-	return html
+	return highlighted?.json === json ? highlighted.html : null
 }

--- a/apps/explorer/src/lib/domain/contract-source.ts
+++ b/apps/explorer/src/lib/domain/contract-source.ts
@@ -261,15 +261,19 @@ export async function fetchContractSource(params: {
 export function contractSourceQueryOptions(params: {
 	address: Address.Address
 	chainId: number
+	highlight?: boolean
 }) {
-	const { address, chainId } = params
+	const { address, chainId, highlight = true } = params
 	return queryOptions({
 		enabled: isAddress(address) && Boolean(chainId),
-		queryKey: ['contract-source', address, chainId],
-		queryFn: () => fetchContractSource({ address, chainId }),
-		// staleTime: 0 so client refetches with highlighting after SSR seeds unhighlighted data
-		// gcTime keeps the data cached to prevent flashing during refetch
-		staleTime: 0,
+		queryKey: [
+			'contract-source',
+			address,
+			chainId,
+			highlight ? 'highlighted' : 'plain',
+		],
+		queryFn: () => fetchContractSource({ address, chainId, highlight }),
+		staleTime: Number.POSITIVE_INFINITY,
 		gcTime: 1000 * 60 * 60, // 1 hour
 	})
 }
@@ -277,12 +281,14 @@ export function contractSourceQueryOptions(params: {
 export function useContractSourceQueryOptions(params: {
 	address: Address.Address
 	chainId?: number
+	highlight?: boolean
 }) {
-	const { address, chainId } = params
+	const { address, chainId, highlight } = params
 	const defaultChainId = useChainId()
 
 	return contractSourceQueryOptions({
 		address,
 		chainId: chainId ?? defaultChainId,
+		highlight,
 	})
 }

--- a/apps/explorer/src/routes/_layout/address/$address.tsx
+++ b/apps/explorer/src/routes/_layout/address/$address.tsx
@@ -960,17 +960,29 @@ function SectionsWrapper(props: {
 	const isTransactionsTabActive = visibleTabs[activeSection] === 'transactions'
 	const isTransfersTabActive = visibleTabs[activeSection] === 'transfers'
 	const isHoldersTabActive = visibleTabs[activeSection] === 'holders'
+	const isContractTabActive = visibleTabs[activeSection] === 'contract'
 
-	// Contract source query - fetch on demand when contract tab is active
-	// Keeps initial page load light while still enabling ABI/source in the UI
+	// Fetch readable source first so highlighting never delays contract data.
 	const contractSourceQuery = useQuery({
-		...useContractSourceQueryOptions({ address }),
+		...useContractSourceQueryOptions({ address, highlight: false }),
 		initialData: contractSource,
 		enabled: isMounted && isContract,
 	})
+	// Progressively replace plain source with server-highlighted output only when
+	// it is about to be rendered.
+	const highlightedContractSourceQuery = useQuery({
+		...useContractSourceQueryOptions({ address, highlight: true }),
+		enabled:
+			isMounted &&
+			isContract &&
+			isContractTabActive &&
+			Boolean(contractSourceQuery.data),
+	})
 	// Use SSR data until mounted to avoid hydration mismatch, then use query data
 	const resolvedContractSource = isMounted
-		? (contractSourceQuery.data ?? undefined)
+		? (highlightedContractSourceQuery.data ??
+			contractSourceQuery.data ??
+			undefined)
 		: contractSource
 
 	const extractedAbiQuery = useQuery({

--- a/apps/explorer/src/workers/json-highlighter.ts
+++ b/apps/explorer/src/workers/json-highlighter.ts
@@ -1,0 +1,56 @@
+import { createHighlighterCore, type HighlighterCore } from 'shiki/core'
+import { createJavaScriptRegexEngine } from 'shiki/engine/javascript'
+
+type HighlightRequest = {
+	id: number
+	json: string
+}
+
+type HighlightResponse =
+	| { id: number; html: string }
+	| { id: number; error: string }
+
+type WorkerScope = {
+	addEventListener: (
+		type: 'message',
+		listener: (event: MessageEvent<HighlightRequest>) => void,
+	) => void
+	postMessage: (message: HighlightResponse) => void
+}
+
+const workerScope = globalThis as unknown as WorkerScope
+let highlighterPromise: Promise<HighlighterCore> | null = null
+
+function getHighlighter(): Promise<HighlighterCore> {
+	if (!highlighterPromise) {
+		highlighterPromise = createHighlighterCore({
+			themes: [
+				import('@shikijs/themes/github-light'),
+				import('@shikijs/themes/github-dark'),
+			],
+			langs: [import('@shikijs/langs/json')],
+			engine: createJavaScriptRegexEngine({ forgiving: true }),
+		})
+	}
+	return highlighterPromise
+}
+
+workerScope.addEventListener('message', (event) => {
+	const { id, json } = event.data
+	void getHighlighter()
+		.then((highlighter) =>
+			highlighter.codeToHtml(json, {
+				lang: 'json',
+				themes: { light: 'github-light', dark: 'github-dark' },
+				defaultColor: 'light-dark()',
+			}),
+		)
+		.then(
+			(html) => workerScope.postMessage({ id, html }),
+			(error) =>
+				workerScope.postMessage({
+					id,
+					error: error instanceof Error ? error.message : 'Highlighting failed',
+				}),
+		)
+})

--- a/apps/explorer/test/contract-source.test.ts
+++ b/apps/explorer/test/contract-source.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+	contractSourceQueryOptions,
 	normalizeContractSourceResponse,
 	parseContractSource,
 } from '#lib/domain/contract-source.ts'
@@ -91,5 +92,26 @@ describe('contract-source parsing', () => {
 
 		const reparsed = parseContractSource(source)
 		expect(reparsed.kind).toBe('native')
+	})
+})
+
+describe('contract-source queries', () => {
+	it('caches plain and highlighted source separately', () => {
+		const params = {
+			address: '0xcccccccc00000000000000000000000000000000' as const,
+			chainId: 4217,
+		}
+
+		expect(
+			contractSourceQueryOptions({ ...params, highlight: false }).queryKey,
+		).toEqual(['contract-source', params.address, params.chainId, 'plain'])
+		expect(
+			contractSourceQueryOptions({ ...params, highlight: true }).queryKey,
+		).toEqual([
+			'contract-source',
+			params.address,
+			params.chainId,
+			'highlighted',
+		])
 	})
 })


### PR DESCRIPTION
## Summary

- render contract source as plain text before requesting server-highlighted output
- request highlighted source only when the Contract tab is active
- move ABI highlighting into an idle-scheduled Web Worker
- cache ABI highlight results in a bounded LRU and deduplicate in-flight jobs

## Screenshots

| Before | After |
|--------|-------|
| No visual difference once highlighting completes | No visual difference; plain code is readable immediately and syntax colors are progressively applied |

## Validation

- `pnpm check`
- `pnpm check:types`
- `pnpm --filter explorer test -- --run` (48 tests passed)
- `pnpm --filter explorer build`
- `pnpm precommit`