### PR TITLE
feat(fee-payer): tag emitted metrics

### DIFF
--- a/apps/fee-payer/README.md
+++ b/apps/fee-payer/README.md
@@ -30,3 +30,21 @@ Environment variables:
 |--------|-------|--------|
 | GET | `/usage` | - optional: `blockTimestampFrom` (epoch seconds)<br>- optional: `blockTimestampTo` (epoch seconds) |
 | POST | `*` | JSON-RPC request body for fee sponsorship<br>Supported sponsorship methods: `eth_signRawTransaction`, `eth_sendRawTransactionSync` (other JSON-RPC methods may be proxied, e.g. `eth_chainId`) |
+
+## Metrics
+
+Metrics are emitted through `cloudflare-worker-metrics` with these global tags:
+
+- `service:fee-payer`
+- `tempo_env` from `TEMPO_ENV`
+- `build_version`
+
+| Metric | Type | Tags |
+| --- | --- | --- |
+| `http_request_count` | counter | `method`, `route` |
+| `http_response_count` | counter | `method`, `route`, `status`, optional `error_type` |
+| `http_response_duration_ms` | histogram | `method`, `route` |
+| `fee_payer_rpc_request_count` | counter | `rpc_method`, `keyed_route`, `chain_id` |
+| `fee_payer_sponsorship_response_count` | counter | `rpc_method`, `keyed_route`, `chain_id`, `status` (`success` or `error`) |
+
+Routes are normalized and metrics never include API keys, addresses, origins, or transaction hashes.

--- a/apps/fee-payer/src/lib/observability/metrics.ts
+++ b/apps/fee-payer/src/lib/observability/metrics.ts
@@ -1,3 +1,4 @@
+import { env } from 'cloudflare:workers'
 import { createMetrics } from 'cloudflare-worker-metrics'
 import type { MetricRegistry } from './metric-registry.js'
 
@@ -20,12 +21,18 @@ function getBuildVersion(): string {
 	return typeof __BUILD_VERSION__ === 'string' ? __BUILD_VERSION__ : 'dev'
 }
 
+function getTempoEnvironment(): string {
+	return env.TEMPO_ENV
+}
+
 function createFeePayerMetrics(): FeePayerMetrics {
 	if (!metricsEnabled()) return noop
 
 	const instance = createMetrics<MetricRegistry>({
 		globalTags: {
 			build_version: getBuildVersion(),
+			service: 'fee-payer',
+			tempo_env: getTempoEnvironment(),
 		},
 	})
 


### PR DESCRIPTION
## Motivation

Make fee-payer metrics consistently identifiable across deployments.

## Summary

- Tag emitted metrics with the canonical service and Tempo environment.
- Document metric names, types, dimensions, and privacy boundaries.

## Key design considerations

- Uses only low-cardinality operational tags; excludes customer and transaction identifiers.