### PR TITLE
fix(fee-payer): enable logpush observability export to Datadog

### DIFF
--- a/apps/fee-payer/wrangler.json
+++ b/apps/fee-payer/wrangler.json
@@ -14,6 +14,7 @@
 	],
 	"preview_urls": true,
 	"keep_vars": true,
+	"logpush": true,
 	"kv_namespaces": [
 		{
 			"binding": "SponsorApiKeyStore",
@@ -26,7 +27,12 @@
 			"enabled": true,
 			"head_sampling_rate": 1,
 			"invocation_logs": true,
-			"persist": true
+			"persist": true,
+			"destinations": ["internal-logs"]
+		},
+		"traces": {
+			"enabled": true,
+			"destinations": ["internal-traces"]
 		}
 	},
 	"env": {


### PR DESCRIPTION
## Problem

#1142 added metric tagging to fee-payer, but metrics still aren't reaching Datadog. `cloudflare-worker-metrics` alone doesn't ship anything — the Worker's Cloudflare observability/log export config must also be enabled.

## Fix

Aligns `apps/fee-payer/wrangler.json` with the known-good mpp-proxy config:

- `logpush: true`
- `observability.logs.destinations: ["internal-logs"]`
- `observability.traces.enabled: true` with `destinations: ["internal-traces"]`

## Caveat

If fee-payer deploys in a different Cloudflare account than mpp-proxy, the `internal-logs` / `internal-traces` destinations may not exist there and would need to be created first.

## Verification after deploy

Check Datadog for:
- `http_request_count{service:fee-payer}`
- `http_response_count{service:fee-payer}`