### PR TITLE
fix(mcp-docs-indexer): mark docs tools read-only

### DIFF
--- a/apps/mcp-docs-indexer/src/lib/mcp.test.ts
+++ b/apps/mcp-docs-indexer/src/lib/mcp.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { Executor } from '@cloudflare/codemode'
+import type { Tool } from '@modelcontextprotocol/sdk/types.js'
 import { handleMcp } from './mcp.js'
 import { captureMcpAnalytics, parseJsonRpcRequest } from './posthog-mcp.js'
 import type { Source } from './sources.js'
@@ -53,6 +54,14 @@ describe('handleMcp', () => {
 		expect(res).toBeDefined()
 		const body = await res?.json()
 		expect(body.result.tools).toHaveLength(3)
+		expect(body.result.tools.map((tool: Tool) => tool.annotations)).toEqual(
+			Array.from({ length: 3 }, () => ({
+				destructiveHint: false,
+				idempotentHint: true,
+				openWorldHint: true,
+				readOnlyHint: true,
+			})),
+		)
 		expect(body.result.tools[0].name).toBe('search')
 		expect(body.result.tools[0].inputSchema.properties.source.enum).toEqual([
 			'viem',

--- a/apps/mcp-docs-indexer/src/lib/mcp.ts
+++ b/apps/mcp-docs-indexer/src/lib/mcp.ts
@@ -97,6 +97,12 @@ const SOURCE_INDEX_CACHE_MAX_ENTRIES = 64
 const DEFAULT_MAX_PAGE_CHARS = 12_000
 const RESOURCE_INDEX_MAX_ENTRIES = 50
 const SOURCES_RESOURCE_URI = 'tempo-docs://sources'
+const READ_ONLY_TOOL_ANNOTATIONS = {
+	destructiveHint: false,
+	idempotentHint: true,
+	openWorldHint: true,
+	readOnlyHint: true,
+} as const
 
 type SearchResultChunk = AiSearchSearchResponse['chunks'][number]
 const sourceFilterFallbackUntil = new Map<string, number>()
@@ -1439,6 +1445,7 @@ function toolSchemas(sources: Source[]): Tool[] {
 		{
 			name: 'search',
 			description: 'Search Tempo, viem, wagmi, MPP, Vocs, and Regen docs.',
+			annotations: READ_ONLY_TOOL_ANNOTATIONS,
 			inputSchema: {
 				type: 'object',
 				properties: {
@@ -1499,6 +1506,7 @@ function toolSchemas(sources: Source[]): Tool[] {
 		{
 			name: 'find_pages',
 			description: 'Find page URLs from a source index.',
+			annotations: READ_ONLY_TOOL_ANNOTATIONS,
 			inputSchema: {
 				type: 'object',
 				properties: {
@@ -1530,6 +1538,7 @@ function toolSchemas(sources: Source[]): Tool[] {
 		{
 			name: 'read_page',
 			description: 'Read one cleaned docs page.',
+			annotations: READ_ONLY_TOOL_ANNOTATIONS,
 			inputSchema: {
 				type: 'object',
 				properties: {


### PR DESCRIPTION
Mark documentation search and page tools as read-only in MCP metadata. This lets progressive clients call `docs_search` through the read gate instead of treating it as an unclassified write.