### PR TITLE
feat(explorer): label Tempo API fee payer

### DIFF
--- a/apps/explorer/src/comps/FeePayer.tsx
+++ b/apps/explorer/src/comps/FeePayer.tsx
@@ -1,0 +1,70 @@
+import { Link } from '@tanstack/react-router'
+import type { Address } from 'ox'
+import * as AddressUtil from 'ox/Address'
+import * as React from 'react'
+import { Midcut } from '#comps/Midcut'
+
+const TEMPO_API_FEE_PAYER = AddressUtil.from(
+	'0x58aa7ce42e1d13b2919e2ac7e006c4fbc171442c',
+)
+
+export function FeePayer(props: FeePayer.Props): React.JSX.Element {
+	const { address } = props
+	const tooltipId = React.useId()
+
+	if (!AddressUtil.isEqual(address, TEMPO_API_FEE_PAYER)) {
+		return (
+			<Link
+				to="/address/$address"
+				params={{ address }}
+				className="text-[13px] text-accent hover:underline press-down w-full font-mono max-w-[50ch]"
+				title={address}
+			>
+				<Midcut value={address} prefix="0x" min={4} align="end" />
+			</Link>
+		)
+	}
+
+	return (
+		<span className="group relative inline-flex">
+			<button
+				type="button"
+				aria-describedby={tooltipId}
+				className="inline-flex cursor-default items-center gap-[6px] rounded-full border border-accent/25 bg-accent/10 px-[9px] py-[3px] text-[12px] font-medium text-accent transition-colors group-hover:border-accent/40 group-hover:bg-accent/15 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+			>
+				<span
+					className="grid size-[10px] grid-cols-2 gap-px"
+					aria-hidden="true"
+				>
+					<span className="rounded-[1px] bg-current" />
+					<span className="rounded-[1px] bg-current" />
+					<span className="rounded-[1px] bg-current" />
+					<span className="rounded-[1px] bg-current" />
+				</span>
+				Tempo API
+			</button>
+			<span
+				id={tooltipId}
+				role="tooltip"
+				className="absolute bottom-[calc(100%+8px)] left-1/2 z-50 hidden w-[224px] -translate-x-1/2 rounded-[8px] border border-base-border bg-base-background px-[10px] py-[8px] text-center text-[12px] leading-[17px] text-secondary shadow-[0_8px_24px_rgba(0,0,0,0.3)] before:absolute before:-bottom-[8px] before:left-0 before:h-[8px] before:w-full before:content-[''] group-hover:block group-focus-within:block"
+			>
+				Build faster with sponsored transactions from{' '}
+				<a
+					href="https://api.tempo.xyz"
+					target="_blank"
+					rel="noopener noreferrer"
+					className="text-accent hover:underline focus-visible:outline-none focus-visible:underline"
+				>
+					Tempo API
+				</a>
+				.
+			</span>
+		</span>
+	)
+}
+
+export declare namespace FeePayer {
+	type Props = {
+		address: Address.Address
+	}
+}

--- a/apps/explorer/src/comps/FeePayer.tsx
+++ b/apps/explorer/src/comps/FeePayer.tsx
@@ -1,7 +1,7 @@
 import { Link } from '@tanstack/react-router'
 import type { Address } from 'ox'
 import * as AddressUtil from 'ox/Address'
-import * as React from 'react'
+import type * as React from 'react'
 import { Midcut } from '#comps/Midcut'
 
 const TEMPO_API_FEE_PAYER = AddressUtil.from(
@@ -10,7 +10,6 @@ const TEMPO_API_FEE_PAYER = AddressUtil.from(
 
 export function FeePayer(props: FeePayer.Props): React.JSX.Element {
 	const { address } = props
-	const tooltipId = React.useId()
 
 	if (!AddressUtil.isEqual(address, TEMPO_API_FEE_PAYER)) {
 		return (
@@ -26,40 +25,20 @@ export function FeePayer(props: FeePayer.Props): React.JSX.Element {
 	}
 
 	return (
-		<span className="group relative inline-flex">
-			<button
-				type="button"
-				aria-describedby={tooltipId}
-				className="inline-flex cursor-default items-center gap-[6px] rounded-full border border-accent/25 bg-accent/10 px-[9px] py-[3px] text-[12px] font-medium text-accent transition-colors group-hover:border-accent/40 group-hover:bg-accent/15 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
-			>
-				<span
-					className="grid size-[10px] grid-cols-2 gap-px"
-					aria-hidden="true"
-				>
-					<span className="rounded-[1px] bg-current" />
-					<span className="rounded-[1px] bg-current" />
-					<span className="rounded-[1px] bg-current" />
-					<span className="rounded-[1px] bg-current" />
-				</span>
-				Tempo API
-			</button>
-			<span
-				id={tooltipId}
-				role="tooltip"
-				className="absolute bottom-[calc(100%+8px)] left-1/2 z-50 hidden w-[224px] -translate-x-1/2 rounded-[8px] border border-base-border bg-base-background px-[10px] py-[8px] text-center text-[12px] leading-[17px] text-secondary shadow-[0_8px_24px_rgba(0,0,0,0.3)] before:absolute before:-bottom-[8px] before:left-0 before:h-[8px] before:w-full before:content-[''] group-hover:block group-focus-within:block"
-			>
-				Build faster with sponsored transactions from{' '}
-				<a
-					href="https://api.tempo.xyz"
-					target="_blank"
-					rel="noopener noreferrer"
-					className="text-accent hover:underline focus-visible:outline-none focus-visible:underline"
-				>
-					Tempo API
-				</a>
-				.
+		<a
+			href="https://api.tempo.xyz"
+			target="_blank"
+			rel="noopener noreferrer"
+			className="inline-flex items-center gap-[6px] rounded-full border border-accent/25 bg-accent/10 px-[9px] py-[3px] text-[12px] font-medium text-accent transition-colors hover:border-accent/40 hover:bg-accent/15 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+		>
+			<span className="grid size-[10px] grid-cols-2 gap-px" aria-hidden="true">
+				<span className="rounded-[1px] bg-current" />
+				<span className="rounded-[1px] bg-current" />
+				<span className="rounded-[1px] bg-current" />
+				<span className="rounded-[1px] bg-current" />
 			</span>
-		</span>
+			Tempo API
+		</a>
 	)
 }
 

--- a/apps/explorer/src/routes/_layout/tx/$hash.tsx
+++ b/apps/explorer/src/routes/_layout/tx/$hash.tsx
@@ -18,6 +18,7 @@ import * as z from 'zod/mini'
 import { Address } from '#comps/Address'
 import { BreadcrumbsSlot } from '#comps/Breadcrumbs'
 import { DataGrid } from '#comps/DataGrid'
+import { FeePayer } from '#comps/FeePayer'
 import { InfoRow } from '#comps/InfoRow'
 import { Midcut } from '#comps/Midcut'
 import { NotFound } from '#comps/NotFound'
@@ -368,6 +369,12 @@ function OverviewSection(props: {
 	const isExpiringNonce = nonceKey === 2n ** 256n - 1n
 	const positionInBlock = receipt.transactionIndex
 	const input = transaction.input
+	const feePayer =
+		'feePayer' in receipt &&
+		typeof receipt.feePayer === 'string' &&
+		OxAddressUtil.validate(receipt.feePayer)
+			? receipt.feePayer
+			: undefined
 
 	const memos = knownEvents
 		.map((event) => event.note)
@@ -428,6 +435,11 @@ function OverviewSection(props: {
 					</span>
 				)}
 			</InfoRow>
+			{feePayer && (
+				<InfoRow label="Fee Payer">
+					<FeePayer address={feePayer} />
+				</InfoRow>
+			)}
 			<InfoRow label="Gas Used">
 				<span className="text-primary">
 					{gasUsed.toLocaleString()} / {gasLimit.toLocaleString()}{' '}


### PR DESCRIPTION
## Summary

- show a branded Tempo API badge for transactions sponsored by the Tempo API fee payer
- expose an accessible hover/focus tooltip with a CTA to https://api.tempo.xyz
- preserve the normal linked address treatment for all other fee payers

## Screenshots

| Before | After |
| --- | --- |
| Fee payer shown as `0x58aa…442c` | `Tempo API` badge with a hover/focus CTA linking to `api.tempo.xyz` |

## Validation

- `pnpm --filter explorer check`
- `pnpm --filter explorer test -- --run` (48 tests)
- `pnpm --filter explorer build`
- visually checked badge and keyboard-focused tooltip against explorer styles
- repository-wide `pnpm check` remains blocked by pre-existing generated Cloudflare binding errors in `apps/contract-verification`

Prompted by: @tmm