### PR TITLE
Explorer: make Validator Config V2 the primary search result

### DIFF
--- a/apps/explorer/src/lib/account.ts
+++ b/apps/explorer/src/lib/account.ts
@@ -46,7 +46,7 @@ const taggedAccounts: Record<Address.Address, AccountTag> = {
 	},
 	'0xcccccccc00000000000000000000000000000000': {
 		id: 'system:validator-config',
-		label: 'Validator Contract V1 (legacy)',
+		label: 'Validator Config V1 (legacy)',
 	},
 	'0x4e4f4e4345000000000000000000000000000000': {
 		id: 'system:nonce-manager',

--- a/apps/explorer/src/lib/account.ts
+++ b/apps/explorer/src/lib/account.ts
@@ -46,7 +46,7 @@ const taggedAccounts: Record<Address.Address, AccountTag> = {
 	},
 	'0xcccccccc00000000000000000000000000000000': {
 		id: 'system:validator-config',
-		label: 'Validator Config',
+		label: 'Validator Contract V1 (legacy)',
 	},
 	'0x4e4f4e4345000000000000000000000000000000': {
 		id: 'system:nonce-manager',

--- a/apps/explorer/src/lib/domain/contracts.ts
+++ b/apps/explorer/src/lib/domain/contracts.ts
@@ -286,7 +286,7 @@ export const systemContractRegistry = new Map<Address.Address, ContractInfo>(<
 	[
 		Addresses.validator,
 		{
-			name: 'Validator Contract V1 (legacy)',
+			name: 'Validator Config V1 (legacy)',
 			code: '0xef',
 			description: 'Manage validator set and configuration',
 			abi: Abis.validatorConfig,
@@ -298,7 +298,7 @@ export const systemContractRegistry = new Map<Address.Address, ContractInfo>(<
 	[
 		validatorConfigV2Address,
 		{
-			name: 'Validator Contract',
+			name: 'Validator Config',
 			code: '0xef',
 			description: 'Manage validator set and configuration',
 			abi: Abis.validatorConfigV2,

--- a/apps/explorer/src/lib/domain/contracts.ts
+++ b/apps/explorer/src/lib/domain/contracts.ts
@@ -19,6 +19,9 @@ import { getChainId, getPublicClient } from 'wagmi/actions'
 import { isTip20Address } from '#lib/domain/tip20.ts'
 import { getWagmiConfig } from '#wagmi.config.ts'
 
+const validatorConfigV2Address =
+	'0xcccccccc00000000000000000000000000000001' as const
+
 /**
  * Registry of known contract addresses to their ABIs and metadata.
  * This enables the explorer to render contract interfaces for any precompile.
@@ -283,13 +286,25 @@ export const systemContractRegistry = new Map<Address.Address, ContractInfo>(<
 	[
 		Addresses.validator,
 		{
-			name: 'Validator Config',
+			name: 'Validator Contract V1 (legacy)',
 			code: '0xef',
 			description: 'Manage validator set and configuration',
 			abi: Abis.validatorConfig,
 			category: 'system',
 			docsUrl: 'https://docs.tempo.xyz/documentation/protocol/validators',
 			address: Addresses.validator,
+		},
+	],
+	[
+		validatorConfigV2Address,
+		{
+			name: 'Validator Contract',
+			code: '0xef',
+			description: 'Manage validator set and configuration',
+			abi: Abis.validatorConfigV2,
+			category: 'system',
+			docsUrl: 'https://tips.sh/1017',
+			address: validatorConfigV2Address,
 		},
 	],
 	[

--- a/apps/explorer/src/routes/api/search.ts
+++ b/apps/explorer/src/routes/api/search.ts
@@ -102,7 +102,7 @@ function buildAddressResult(address: Address.Address): AddressSearchResult {
 	}
 }
 
-function searchKnownContracts(query: string): AddressSearchResult[] {
+export function searchKnownContracts(query: string): AddressSearchResult[] {
 	const normalizedQuery = query.toLowerCase()
 	if (normalizedQuery.length < 2) return []
 

--- a/apps/explorer/test/search-tokens.node.test.ts
+++ b/apps/explorer/test/search-tokens.node.test.ts
@@ -3,11 +3,11 @@ import { searchKnownContracts, searchTokens } from '../src/routes/api/search.ts'
 
 describe('searchKnownContracts', () => {
 	it('ranks the V2 validator contract before the legacy V1 contract', () => {
-		const results = searchKnownContracts('validator contract')
+		const results = searchKnownContracts('validator config')
 
 		expect(results.slice(0, 2).map(({ label }) => label)).toEqual([
-			'Validator Contract',
-			'Validator Contract V1 (legacy)',
+			'Validator Config',
+			'Validator Config V1 (legacy)',
 		])
 	})
 })

--- a/apps/explorer/test/search-tokens.node.test.ts
+++ b/apps/explorer/test/search-tokens.node.test.ts
@@ -1,5 +1,16 @@
 import { describe, expect, it } from 'vitest'
-import { searchTokens } from '../src/routes/api/search.ts'
+import { searchKnownContracts, searchTokens } from '../src/routes/api/search.ts'
+
+describe('searchKnownContracts', () => {
+	it('ranks the V2 validator contract before the legacy V1 contract', () => {
+		const results = searchKnownContracts('validator contract')
+
+		expect(results.slice(0, 2).map(({ label }) => label)).toEqual([
+			'Validator Contract',
+			'Validator Contract V1 (legacy)',
+		])
+	})
+})
 
 describe('searchTokens', () => {
 	it('finds verified tokens missing from the static index by symbol', () => {


### PR DESCRIPTION
## Summary
- relabel the V1 entry as `Validator Config V1 (legacy)`
- register Validator Config V2 as `Validator Config` with its V2 ABI and TIP-1017 docs
- rank V2 first when searching `validator config`

## Validation
- `pnpm --dir apps/explorer check:types`
- `pnpm --dir apps/explorer test --run` (48 tests)
- focused search-order regression test
- `pnpm check` reached unrelated pre-existing contract-verification generated type errors
- `pnpm precommit` blocked because the sandbox could not authenticate to clone the external gitleaks hook

## Screenshots

| Before | After |
|---|---|
| Search exposes only `Validator Config` (V1) | Search exposes `Validator Config` (V2) first and `Validator Config V1 (legacy)` second |

Prompted by: @alexrisch