### PR TITLE
fix(explorer): handle token page loading failures

### DIFF
--- a/apps/explorer/src/comps/Tip20ContractInfo.tsx
+++ b/apps/explorer/src/comps/Tip20ContractInfo.tsx
@@ -45,7 +45,7 @@ export function Tip20TokenTabContent(
 		},
 	})
 
-	const { data: tip20Data } = useQuery<{
+	const { data: tip20Data, refetch: refetchTip20Data } = useQuery<{
 		roles: Array<{
 			role: string
 			roleHash: string
@@ -53,6 +53,7 @@ export function Tip20TokenTabContent(
 			grantedAt?: number
 			grantedTx?: `0x${string}`
 		}>
+		rolesUnavailable: boolean
 		config: {
 			supplyCap: string | null
 			totalSupply: string | null
@@ -72,16 +73,7 @@ export function Tip20TokenTabContent(
 			)
 			const response = await fetch(url)
 			if (!response.ok)
-				return {
-					roles: [],
-					config: {
-						supplyCap: null,
-						totalSupply: null,
-						currency: null,
-						transferPolicyId: null,
-						paused: null,
-					},
-				}
+				throw new Error(`Failed to fetch TIP-20 data: ${response.status}`)
 			return response.json()
 		},
 	})
@@ -186,7 +178,20 @@ export function Tip20TokenTabContent(
 				onToggle={() => setRolesExpanded(!rolesExpanded)}
 			>
 				<div className="px-[18px] py-[12px]">
-					{roles && roles.length > 0 ? (
+					{tip20Data?.rolesUnavailable ? (
+						<div className="flex items-center gap-2 text-[13px]">
+							<span className="text-tertiary">
+								Roles are temporarily unavailable.
+							</span>
+							<button
+								type="button"
+								className="text-accent hover:underline"
+								onClick={() => void refetchTip20Data()}
+							>
+								Try again
+							</button>
+						</div>
+					) : roles && roles.length > 0 ? (
 						<div className="flex flex-col gap-[8px] text-[13px]">
 							{roles.map((r) => {
 								const info = getContractInfo(r.account)

--- a/apps/explorer/src/lib/server/token.ts
+++ b/apps/explorer/src/lib/server/token.ts
@@ -42,8 +42,9 @@ const tokenDetailsCache = new Map<
 
 /**
  * Cached token detail lookup shared by the holders / transfers server fns:
- * exact `holderCount`, `totalSupply`, the `TokenCreated` timestamp, and
- * lifetime `transferStats`.
+ * exact `holderCount`, `totalSupply`, and lifetime `transferStats`.
+ * `createdAt` is intentionally omitted because the creation lookup can add
+ * several seconds and neither paginated view consumes it.
  */
 async function getTokenDetails(
 	chainId: number,
@@ -58,7 +59,7 @@ async function getTokenDetails(
 			param: { token: address },
 			query: {
 				chainId: String(chainId),
-				include: 'createdAt,holderCount,transferStats',
+				include: 'holderCount,transferStats',
 			},
 		}),
 	).catch((error) => {
@@ -357,7 +358,7 @@ export const fetchAccountTransfers = createServerFn({ method: 'POST' })
 			}
 		} catch (error) {
 			console.error('Failed to fetch account transfers:', error)
-			return EMPTY_ACCOUNT_TRANSFERS_RESPONSE
+			throw error
 		}
 	})
 
@@ -409,6 +410,6 @@ export const fetchTransfers = createServerFn({ method: 'POST' })
 			}
 		} catch (error) {
 			console.error('Failed to fetch transfers:', error)
-			return EMPTY_TRANSFERS_RESPONSE
+			throw error
 		}
 	})

--- a/apps/explorer/src/routes/_layout/address/$address.tsx
+++ b/apps/explorer/src/routes/_layout/address/$address.tsx
@@ -630,6 +630,9 @@ function RouteComponent() {
 	const prefetchedRef = React.useRef<string | null>(null)
 	React.useEffect(() => {
 		if (prefetchedRef.current === address) return
+		// Keep the transfers request isolated from slower history/holder queries.
+		// Those tabs fetch normally when the user opens them.
+		if (tab === 'transfers') return
 
 		const after =
 			period === '24h'
@@ -654,7 +657,7 @@ function RouteComponent() {
 					}),
 				)
 
-			if (visibleTabs.includes('transfers') && tab !== 'transfers') {
+			if (visibleTabs.includes('transfers')) {
 				if (isToken)
 					void queryClient.prefetchQuery(
 						transfersQueryOptions({ address, page: 1, limit, account }),
@@ -1102,6 +1105,8 @@ function SectionsWrapper(props: {
 		data: transfersData,
 		isPending: isTransfersPending,
 		isFetching: isTransfersFetching,
+		error: tokenTransfersError,
+		refetch: refetchTransfers,
 	} = useQuery({
 		...transfersQueryOptions({
 			address,
@@ -1118,6 +1123,8 @@ function SectionsWrapper(props: {
 		data: accountTransfersData,
 		isPending: isAccountTransfersPending,
 		isFetching: isAccountTransfersFetching,
+		error: accountTransfersError,
+		refetch: refetchAccountTransfers,
 	} = useQuery({
 		...accountTransfersQueryOptions({
 			account: address,
@@ -1167,9 +1174,16 @@ function SectionsWrapper(props: {
 		isTransactionsTabActive && !error && (isHistoryPending || !historyData)
 	const isTransactionsFetching =
 		isTransactionsTabActive && isHistoryFetching && !isTransactionsLoading
+	const transfersError = isToken ? tokenTransfersError : accountTransfersError
+	const refetchActiveTransfers = isToken
+		? refetchTransfers
+		: refetchAccountTransfers
 	const isTransfersLoading = isToken
-		? isTransfersTabActive && (isTransfersPending || !transfersData)
+		? isTransfersTabActive &&
+			!transfersError &&
+			(isTransfersPending || !transfersData)
 		: isTransfersTabActive &&
+			!transfersError &&
 			(isAccountTransfersPending || !accountTransfersData)
 	const isTransfersFetchingNext = isToken
 		? isTransfersTabActive && isTransfersFetching && !isTransfersLoading
@@ -1608,6 +1622,29 @@ function SectionsWrapper(props: {
 				}
 			}
 			case 'transfers': {
+				if (transfersError) {
+					return {
+						title: 'Transfers',
+						itemsLabel: 'transfers',
+						content: (
+							<div className="rounded-[10px] bg-card-header p-4.5">
+								<p className="text-sm font-medium text-red-400">
+									Transfers are temporarily unavailable
+								</p>
+								<p className="mt-1 text-xs text-tertiary">
+									The Tempo API could not complete this request.
+								</p>
+								<button
+									type="button"
+									className="mt-3 rounded-[6px] bg-distinct px-3 py-1.5 text-xs text-primary transition-colors hover:bg-base-alt"
+									onClick={() => void refetchActiveTransfers()}
+								>
+									Try again
+								</button>
+							</div>
+						),
+					}
+				}
 				if (!isToken) {
 					// Account-scoped view: rows span multiple tokens, so amounts
 					// carry per-row token metadata.

--- a/apps/explorer/src/routes/api/tip20-roles.ts
+++ b/apps/explorer/src/routes/api/tip20-roles.ts
@@ -60,7 +60,11 @@ export type Tip20Config = {
 	symbol: string | null
 }
 
-export type Tip20RolesResponse = { roles: RoleHolder[]; config: Tip20Config }
+export type Tip20RolesResponse = {
+	roles: RoleHolder[]
+	rolesUnavailable: boolean
+	config: Tip20Config
+}
 
 export const Route = createFileRoute('/api/tip20-roles')({
 	server: {
@@ -125,6 +129,7 @@ export const Route = createFileRoute('/api/tip20-roles')({
 					}
 
 					const roles: RoleHolder[] = []
+					let rolesUnavailable = false
 					try {
 						const roleLogs = await tempoQueryBuilder(chainId)
 							.selectFrom('logs')
@@ -196,14 +201,20 @@ export const Route = createFileRoute('/api/tip20-roles')({
 						}
 					} catch (error) {
 						console.error('[tip20-roles] failed to fetch role logs:', error)
-						throw error
+						rolesUnavailable = true
 					}
 
 					return Response.json(
-						{ roles, config: tip20Config } satisfies Tip20RolesResponse,
+						{
+							roles,
+							rolesUnavailable,
+							config: tip20Config,
+						} satisfies Tip20RolesResponse,
 						{
 							headers: {
-								'Cache-Control': 'public, max-age=300',
+								'Cache-Control': rolesUnavailable
+									? 'no-store'
+									: 'public, max-age=300',
 							},
 						},
 					)

--- a/apps/explorer/test/tip20-roles.node.test.ts
+++ b/apps/explorer/test/tip20-roles.node.test.ts
@@ -116,6 +116,7 @@ describe('TIP-20 roles API', () => {
 
 		expect(response.status).toBe(200)
 		expect(await response.json()).toMatchObject({
+			rolesUnavailable: false,
 			roles: [
 				{
 					role: 'PAUSE',
@@ -147,18 +148,25 @@ describe('TIP-20 roles API', () => {
 		expect(limitIndex).toBeGreaterThan(topicFilterIndex)
 	})
 
-	it('returns an uncached server error when the role query fails', async () => {
+	it('returns config without caching when the role query fails', async () => {
 		const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
 		mocks.setQueryResult(new Error('TIDX unavailable'))
 
 		try {
 			const response = await handler({ request: request() })
 
-			expect(response.status).toBe(500)
-			expect(response.headers.has('Cache-Control')).toBe(false)
-			expect(await response.json()).toEqual({
-				data: null,
-				error: 'TIDX unavailable',
+			expect(response.status).toBe(200)
+			expect(response.headers.get('Cache-Control')).toBe('no-store')
+			expect(await response.json()).toMatchObject({
+				roles: [],
+				rolesUnavailable: true,
+				config: {
+					totalSupply: '100 CADD',
+					supplyCap: '1 CADD',
+					currency: 'CAD',
+					transferPolicyId: '1',
+					paused: false,
+				},
 			})
 		} finally {
 			consoleError.mockRestore()


### PR DESCRIPTION
## Summary

- omit the expensive unused `createdAt` aggregate from paginated token holder/transfer details
- stop prefetching history and holder data while the transfers tab is active
- surface transfer failures after the normal bounded retries with a manual retry action
- preserve TIP-20 configuration when the independent role-log query fails, and show roles as temporarily unavailable instead of empty

## Context

The testnet transfer feed itself completes in roughly 600 ms, while the token detail request was gated by a `createdAt` lookup taking roughly 5.6 seconds. The PathUSD token-data endpoint also returned a 500 because a role-log query failed with an upstream 422, discarding configuration that had already loaded successfully.

## Testing

- `pnpm --filter explorer check:biome`
- `pnpm --filter explorer check:types`
- `pnpm --filter explorer check:env` (58 tests)
- `pnpm --filter explorer build`
