### PR TITLE
fix(explorer): query TIP-20 roles with ClickHouse

### DIFF
--- a/apps/explorer/src/lib/server/tempo-queries-provider.ts
+++ b/apps/explorer/src/lib/server/tempo-queries-provider.ts
@@ -22,8 +22,11 @@ tidx.on('response', (res) => {
 			)
 })
 
-export function tempoQueryBuilder(chainId: number) {
-	return QB.from({ ...tidx, chainId })
+export function tempoQueryBuilder(
+	chainId: number,
+	options: { engine?: string | undefined } = {},
+) {
+	return QB.from({ ...tidx, chainId, ...options })
 }
 
 export { tidx }

--- a/apps/explorer/src/routes/api/tip20-roles.ts
+++ b/apps/explorer/src/routes/api/tip20-roles.ts
@@ -131,7 +131,9 @@ export const Route = createFileRoute('/api/tip20-roles')({
 					const roles: RoleHolder[] = []
 					let rolesUnavailable = false
 					try {
-						const roleLogs = await tempoQueryBuilder(chainId)
+						const roleLogs = await tempoQueryBuilder(chainId, {
+							engine: 'clickhouse',
+						})
 							.selectFrom('logs')
 							.select([
 								'topic0',
@@ -144,7 +146,7 @@ export const Route = createFileRoute('/api/tip20-roles')({
 								'log_idx',
 							])
 							.where('address', '=', address)
-							.where('topic0', '=', ROLE_MEMBERSHIP_UPDATED_SELECTOR)
+							.where('selector', '=', ROLE_MEMBERSHIP_UPDATED_SELECTOR)
 							.orderBy('block_num', 'asc')
 							.orderBy('log_idx', 'asc')
 							.limit(ROLE_LOG_SCAN_LIMIT)

--- a/apps/explorer/src/routes/api/tip20-roles.ts
+++ b/apps/explorer/src/routes/api/tip20-roles.ts
@@ -132,6 +132,7 @@ export const Route = createFileRoute('/api/tip20-roles')({
 					let rolesUnavailable = false
 					try {
 						const roleLogs = await tempoQueryBuilder(chainId, {
+							// TODO: Switch to TIDX 1.0 once released.
 							engine: 'clickhouse',
 						})
 							.selectFrom('logs')

--- a/apps/explorer/test/tempo-queries-provider.node.test.ts
+++ b/apps/explorer/test/tempo-queries-provider.node.test.ts
@@ -4,10 +4,11 @@ const mocks = vi.hoisted(() => ({
 	create: vi.fn(() => ({
 		on: vi.fn(),
 	})),
+	from: vi.fn(),
 }))
 
 vi.mock('tidx.ts', () => ({
-	QB: { from: vi.fn() },
+	QB: { from: mocks.from },
 	Tidx: { create: mocks.create },
 }))
 
@@ -17,8 +18,10 @@ vi.mock('#lib/server/env', () => ({
 }))
 
 describe('Tempo query provider', () => {
+	let provider: typeof import('#lib/server/tempo-queries-provider')
+
 	beforeAll(async () => {
-		await import('#lib/server/tempo-queries-provider')
+		provider = await import('#lib/server/tempo-queries-provider')
 	})
 
 	it('authenticates indexer requests with the Tempo API key', () => {
@@ -26,5 +29,13 @@ describe('Tempo query provider', () => {
 			baseUrl: 'https://api.tempo.xyz/v1/indexer',
 			headers: { 'tempo-api-key': 'tempo-api-secret' },
 		})
+	})
+
+	it('forwards the query engine', () => {
+		provider.tempoQueryBuilder(4217, { engine: 'clickhouse' })
+
+		expect(mocks.from).toHaveBeenCalledWith(
+			expect.objectContaining({ chainId: 4217, engine: 'clickhouse' }),
+		)
 	})
 })

--- a/apps/explorer/test/tip20-roles.node.test.ts
+++ b/apps/explorer/test/tip20-roles.node.test.ts
@@ -50,6 +50,10 @@ const mocks = vi.hoisted(() => {
 		setQueryResult(result: unknown[] | Error) {
 			queryResult = result
 		},
+		tempoQueryBuilder(...args: unknown[]) {
+			queryCalls.push(['tempoQueryBuilder', ...args])
+			return queryBuilder
+		},
 	}
 })
 
@@ -59,7 +63,7 @@ vi.mock('wagmi/actions', () => ({
 }))
 
 vi.mock('#lib/server/tempo-queries-provider', () => ({
-	tempoQueryBuilder: () => mocks.queryBuilder,
+	tempoQueryBuilder: mocks.tempoQueryBuilder,
 }))
 
 vi.mock('#wagmi.config', () => ({
@@ -97,7 +101,7 @@ describe('TIP-20 roles API', () => {
 		])
 	})
 
-	it('filters role events by topic before applying the scan limit', async () => {
+	it('queries ClickHouse by selector before applying the scan limit', async () => {
 		const pauseRole = Hash.keccak256(Hex.fromString('PAUSE_ROLE'))
 		mocks.setQueryResult([
 			{
@@ -127,10 +131,10 @@ describe('TIP-20 roles API', () => {
 			],
 		})
 
-		const topicFilterIndex = mocks.queryCalls.findIndex(
+		const selectorFilterIndex = mocks.queryCalls.findIndex(
 			(call) =>
 				call[0] === 'where' &&
-				call[1] === 'topic0' &&
+				call[1] === 'selector' &&
 				call[2] === '=' &&
 				call[3] === ROLE_MEMBERSHIP_UPDATED_SELECTOR,
 		)
@@ -139,13 +143,18 @@ describe('TIP-20 roles API', () => {
 		)
 
 		expect(mocks.queryCalls).toContainEqual([
+			'tempoQueryBuilder',
+			4217,
+			{ engine: 'clickhouse' },
+		])
+		expect(mocks.queryCalls).toContainEqual([
 			'where',
 			'address',
 			'=',
 			TOKEN_ADDRESS,
 		])
-		expect(topicFilterIndex).toBeGreaterThan(-1)
-		expect(limitIndex).toBeGreaterThan(topicFilterIndex)
+		expect(selectorFilterIndex).toBeGreaterThan(-1)
+		expect(limitIndex).toBeGreaterThan(selectorFilterIndex)
 	})
 
 	it('returns config without caching when the role query fails', async () => {


### PR DESCRIPTION
Query TIP-20 role history through ClickHouse and filter logs by the indexed `selector` field. This avoids PostgreSQL timeouts when loading token roles after https://github.com/tempoxyz/tempo-apps/pull/1156.