### PR TITLE
fix(explorer): use Tempo API for address metadata

### DIFF
--- a/apps/explorer/src/lib/server/address-metadata.ts
+++ b/apps/explorer/src/lib/server/address-metadata.ts
@@ -5,16 +5,8 @@ import { VirtualAddress } from 'ox/tempo'
 import { getCode } from 'viem/actions'
 import { type AccountType, getAccountType } from '#lib/account'
 import { isTip20Address } from '#lib/domain/tip20'
-import {
-	type ContractCreationData,
-	fetchContractCreationData,
-} from '#lib/server/contract-creation'
 import { api } from '#lib/server/tempo-api'
 import {
-	type ContractCreationReceiptRow,
-	fetchAddressOldestTx,
-	fetchAddressTxStats,
-	fetchContractCreationReceipt,
 	fetchTokenTransferBoundaries,
 	fetchVirtualAddressTransferStats,
 } from '#lib/server/tempo-queries'
@@ -59,27 +51,15 @@ type AddressTxAggregate = {
 export function pickTip20CreatedTimestamp(params: {
 	tokenCreatedTimestamp: unknown
 	firstTransferTimestamp: unknown
-	contractCreationTimestamp?: unknown
 }): number | undefined {
 	const tokenCreatedTimestamp = parseTimestamp(params.tokenCreatedTimestamp)
 	const firstTransferTimestamp = parseTimestamp(params.firstTransferTimestamp)
-	const contractCreationTimestamp = parseTimestamp(
-		params.contractCreationTimestamp,
-	)
 
 	if (tokenCreatedTimestamp != null) return tokenCreatedTimestamp
-
-	return contractCreationTimestamp != null &&
-		(firstTransferTimestamp == null ||
-			contractCreationTimestamp < firstTransferTimestamp)
-		? contractCreationTimestamp
-		: firstTransferTimestamp
+	return firstTransferTimestamp
 }
 
-export function buildAddressTxMetadata(
-	aggregate: AddressTxAggregate,
-	creation: ContractCreationReceiptRow | ContractCreationData | undefined,
-): {
+export function buildAddressTxMetadata(aggregate: AddressTxAggregate): {
 	txCount: number
 	lastActivityTimestamp?: number
 	createdTimestamp?: number
@@ -87,32 +67,53 @@ export function buildAddressTxMetadata(
 	createdBy?: string
 } {
 	const oldestTimestamp = parseTimestamp(aggregate.oldestTxsBlockTimestamp)
-	const creationTimestamp = parseTimestamp(
-		creation && 'block_timestamp' in creation
-			? creation.block_timestamp
-			: creation?.timestamp,
-	)
-	const useCreation =
-		creationTimestamp != null &&
-		(oldestTimestamp == null || creationTimestamp <= oldestTimestamp)
 
 	return {
-		txCount: (aggregate.count ?? 0) + (creation ? 1 : 0),
+		txCount: aggregate.count ?? 0,
 		lastActivityTimestamp: parseTimestamp(aggregate.latestTxsBlockTimestamp),
-		createdTimestamp:
-			useCreation && creationTimestamp != null
-				? creationTimestamp
-				: oldestTimestamp,
-		createdTxHash:
-			useCreation && creation
-				? 'tx_hash' in creation
-					? creation.tx_hash
-					: (creation.hash ?? undefined)
-				: aggregate.oldestTxHash,
-		createdBy:
-			useCreation && creation
-				? (creation.from ?? undefined)
-				: aggregate.oldestTxFrom,
+		createdTimestamp: oldestTimestamp,
+		createdTxHash: aggregate.oldestTxHash,
+		createdBy: aggregate.oldestTxFrom,
+	}
+}
+
+/** Address activity boundaries and count from structured Tempo API pages. */
+export async function fetchAddressTxMetadata(
+	chainId: number,
+	address: Address.Address,
+): Promise<AddressTxAggregate> {
+	const [oldestPage, latestPage] = await Promise.all([
+		parseResponse(
+			api.v1.transactions.$get({
+				query: {
+					address,
+					chainId: String(chainId),
+					include: 'totalCount',
+					limit: '5',
+					order: 'asc',
+				},
+			}),
+		),
+		parseResponse(
+			api.v1.transactions.$get({
+				query: {
+					address,
+					chainId: String(chainId),
+					limit: '5',
+					order: 'desc',
+				},
+			}),
+		),
+	])
+	const oldest = oldestPage.data[0]
+	const latest = latestPage.data[0]
+
+	return {
+		count: oldestPage.meta?.totalCount,
+		latestTxsBlockTimestamp: latest?.timestamp,
+		oldestTxsBlockTimestamp: oldest?.timestamp,
+		oldestTxHash: oldest?.hash,
+		oldestTxFrom: oldest?.sender,
 	}
 }
 
@@ -211,11 +212,6 @@ async function loadAddressMetadata(
 				latestTimestamp: undefined,
 			})),
 		])
-		const contractCreation =
-			stats?.createdAt == null
-				? await fetchContractCreationData(address).catch(() => null)
-				: null
-
 		response = {
 			address,
 			chainId,
@@ -225,36 +221,17 @@ async function loadAddressMetadata(
 			createdTimestamp: pickTip20CreatedTimestamp({
 				tokenCreatedTimestamp: stats?.createdAt,
 				firstTransferTimestamp: boundaries.oldestTimestamp,
-				contractCreationTimestamp: contractCreation?.timestamp,
 			}),
 		}
 	} else {
-		// One aggregate (exact distinct count + boundaries) + the oldest
-		// tx row for the "created by" stat. Creation receipt stays on
-		// the SQL lane (D4.1) with the existing RPC bisection fallback.
-		const [bytecode, stats, oldestTx, indexedCreation] = await Promise.all([
+		// Structured Tempo API pages provide the first and latest indexed activity
+		// without the historical RPC binary search previously used for contracts.
+		const [bytecode, stats] = await Promise.all([
 			bytecodePromise,
-			fetchAddressTxStats(address, chainId),
-			fetchAddressOldestTx(address, chainId).catch(() => undefined),
-			fetchContractCreationReceipt(address, chainId).catch(() => undefined),
+			fetchAddressTxMetadata(chainId, address),
 		])
 		const accountType = getAccountType(bytecode)
-		const creation =
-			indexedCreation ??
-			(accountType === 'contract'
-				? await fetchContractCreationData(address).catch(() => null)
-				: undefined) ??
-			undefined
-		const metadata = buildAddressTxMetadata(
-			{
-				count: stats.count,
-				latestTxsBlockTimestamp: stats.latestTimestamp,
-				oldestTxsBlockTimestamp: stats.oldestTimestamp,
-				oldestTxHash: oldestTx?.hash,
-				oldestTxFrom: oldestTx?.from,
-			},
-			creation,
-		)
+		const metadata = buildAddressTxMetadata(stats)
 
 		response = {
 			address,

--- a/apps/explorer/src/routes/_layout/address/$address.tsx
+++ b/apps/explorer/src/routes/_layout/address/$address.tsx
@@ -630,65 +630,6 @@ function addressMetadataQueryOptions(address: Address.Address) {
 	}
 }
 
-type ContractCreationResponse = {
-	creation: {
-		blockNumber: string
-		timestamp: string
-		hash: Hex.Hex | null
-		from: Address.Address | null
-		to: Address.Address | null
-		value: string | null
-		status: 'success' | 'reverted' | null
-		gasUsed: string | null
-		effectiveGasPrice: string | null
-	} | null
-	error: string | null
-}
-
-async function fetchContractCreation(
-	address: Address.Address,
-): Promise<ContractCreationResponse> {
-	const response = await fetch(`/api/contract/creation/${address}`)
-	return response.json() as Promise<ContractCreationResponse>
-}
-
-function buildContractCreationTransaction(params: {
-	address: Address.Address
-	creation: NonNullable<ContractCreationResponse['creation']>
-}): EnrichedTransaction | null {
-	const { address, creation } = params
-
-	if (!creation.hash || !creation.from) return null
-
-	const blockNumber = parseOptionalBigInt(creation.blockNumber) ?? 0n
-	const timestamp = parseOptionalBigInt(creation.timestamp) ?? 0n
-	const value = parseOptionalBigInt(creation.value) ?? 0n
-	const gasUsed = parseOptionalBigInt(creation.gasUsed) ?? 0n
-	const effectiveGasPrice =
-		parseOptionalBigInt(creation.effectiveGasPrice) ?? 0n
-
-	return {
-		hash: creation.hash,
-		blockNumber: Hex.fromNumber(blockNumber),
-		timestamp: Number(timestamp),
-		from: Address.checksum(creation.from),
-		to: creation.to ? Address.checksum(creation.to) : null,
-		value: Hex.fromNumber(value),
-		status: creation.status ?? 'success',
-		gasUsed: Hex.fromNumber(gasUsed),
-		effectiveGasPrice: Hex.fromNumber(effectiveGasPrice),
-		knownEvents: [
-			{
-				type: 'contract creation',
-				parts: [
-					{ type: 'action', value: 'Deploy Contract' },
-					{ type: 'account', value: Address.checksum(address) },
-				],
-			},
-		],
-	}
-}
-
 function AccountCardWithTimestamps(props: {
 	address: Address.Address
 	assetsData: AssetData[]
@@ -709,34 +650,11 @@ function AccountCardWithTimestamps(props: {
 	} = props
 
 	const resolvedAccountType = addressMetadata?.accountType ?? initialAccountType
-	const isContract = resolvedAccountType === 'contract'
-	const missingCreated = addressMetadata?.createdTimestamp == null
 	const isTip20 = Tip20.isTip20Address(address)
-
-	// Fall back to binary-search contract creation lookup when metadata has no
-	// timestamp, and cross-check TIP-20 tokens whose first transfer can be later
-	// than their creation block.
-	const { data: contractCreation } = useQuery({
-		queryKey: ['contract-creation', address],
-		queryFn: () => fetchContractCreation(address),
-		enabled: isContract && (missingCreated || isTip20),
-		staleTime: 60_000,
-	})
-
-	const metadataCreatedTimestamp =
+	const createdTimestamp =
 		addressMetadata?.createdTimestamp != null
 			? BigInt(addressMetadata.createdTimestamp)
 			: undefined
-	const contractCreatedTimestamp =
-		contractCreation?.creation?.timestamp != null
-			? BigInt(contractCreation.creation.timestamp)
-			: undefined
-	const createdTimestamp =
-		metadataCreatedTimestamp != null && contractCreatedTimestamp != null
-			? metadataCreatedTimestamp <= contractCreatedTimestamp
-				? metadataCreatedTimestamp
-				: contractCreatedTimestamp
-			: (metadataCreatedTimestamp ?? contractCreatedTimestamp)
 
 	const virtualAddressParts = getVirtualAddressParts(address)
 	const { isTokenListed } = useTokenListMembership()
@@ -927,59 +845,10 @@ function SectionsWrapper(props: {
 		: page === 1
 			? initialData
 			: historyQueryData
-	const baseTransactions = historyData?.transactions ?? []
+	const transactions = historyData?.transactions ?? []
 	const hasMore = historyData?.hasMore ?? false
 	const total = historyData?.total
 	const countCapped = historyData?.countCapped ?? false
-	const shouldFetchContractCreation =
-		isMounted &&
-		isContract &&
-		isTransactionsTabActive &&
-		historyData !== undefined &&
-		!hasMore
-
-	const { data: contractCreationData } = useQuery({
-		queryKey: ['contract-creation', address],
-		queryFn: () => fetchContractCreation(address),
-		enabled: shouldFetchContractCreation,
-		staleTime: 60_000,
-	})
-
-	const transactions = React.useMemo(() => {
-		if (!isTransactionsTabActive || !isContract) return baseTransactions
-		if (hasMore) return baseTransactions
-
-		const creation = contractCreationData?.creation
-		if (!creation) return baseTransactions
-
-		const creationTransaction = buildContractCreationTransaction({
-			address,
-			creation,
-		})
-		if (!creationTransaction) return baseTransactions
-
-		// Don't append if it doesn't match the active status filter
-		if (status && creationTransaction.status !== status) return baseTransactions
-
-		if (
-			baseTransactions.some(
-				(transaction) =>
-					transaction.hash.toLowerCase() ===
-					creationTransaction.hash.toLowerCase(),
-			)
-		)
-			return baseTransactions
-
-		return [...baseTransactions, creationTransaction]
-	}, [
-		address,
-		baseTransactions,
-		contractCreationData?.creation,
-		hasMore,
-		isContract,
-		isTransactionsTabActive,
-		status,
-	])
 
 	// Token transfers query
 	const transfersPage = isTransfersTabActive ? page : 1

--- a/apps/explorer/test/address-metadata.node.test.ts
+++ b/apps/explorer/test/address-metadata.node.test.ts
@@ -1,73 +1,101 @@
-import type { Address, Hex } from 'ox'
-import { describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
 	buildAddressTxMetadata,
+	fetchAddressTxMetadata,
 	pickTip20CreatedTimestamp,
 } from '#lib/server/address-metadata'
-import type { ContractCreationData } from '#lib/server/contract-creation'
+
+const { getTransactions } = vi.hoisted(() => ({
+	getTransactions: vi.fn(),
+}))
+
+vi.mock('#lib/server/tempo-api', () => ({
+	api: { v1: { transactions: { $get: getTransactions } } },
+}))
+
+beforeEach(() => {
+	getTransactions.mockReset()
+})
 
 describe('address metadata', () => {
-	it('uses RPC contract creation fallback when indexed receipts miss creation', () => {
-		const creation = {
-			blockNumber: 10n,
-			timestamp: 100n,
-			hash: '0xcreate' as Hex.Hex,
-			from: '0xdeployer' as Address.Address,
-			to: null,
-			value: 0n,
-			status: 'success',
-			gasUsed: 21_000n,
-			effectiveGasPrice: 1n,
-		} satisfies ContractCreationData
-
+	it('uses the first indexed address activity as creation metadata', () => {
 		expect(
-			buildAddressTxMetadata(
-				{
-					count: 0,
-					latestTxsBlockTimestamp: undefined,
-					oldestTxsBlockTimestamp: undefined,
-				},
-				creation,
-			),
+			buildAddressTxMetadata({
+				count: 3,
+				latestTxsBlockTimestamp: 300,
+				oldestTxsBlockTimestamp: 100,
+				oldestTxHash: '0xoldest',
+				oldestTxFrom: '0xsender',
+			}),
 		).toEqual({
-			txCount: 1,
-			lastActivityTimestamp: undefined,
+			txCount: 3,
+			lastActivityTimestamp: 300,
 			createdTimestamp: 100,
-			createdTxHash: '0xcreate',
-			createdBy: '0xdeployer',
+			createdTxHash: '0xoldest',
+			createdBy: '0xsender',
 		})
 	})
 
-	it('keeps older direct address activity as the created timestamp', () => {
-		const creation = {
-			blockNumber: 20n,
-			timestamp: 200n,
-			hash: '0xcreate' as Hex.Hex,
-			from: '0xdeployer' as Address.Address,
-			to: null,
-			value: 0n,
-			status: 'success',
-			gasUsed: 21_000n,
-			effectiveGasPrice: 1n,
-		} satisfies ContractCreationData
+	it('returns empty activity metadata for a new address', () => {
+		expect(buildAddressTxMetadata({ count: 0 })).toEqual({
+			txCount: 0,
+			lastActivityTimestamp: undefined,
+			createdTimestamp: undefined,
+			createdTxHash: undefined,
+			createdBy: undefined,
+		})
+	})
 
-		expect(
-			buildAddressTxMetadata(
-				{
-					count: 3,
-					latestTxsBlockTimestamp: 300,
-					oldestTxsBlockTimestamp: 100,
-					oldestTxHash: '0xold',
-					oldestTxFrom: '0xsender',
-				},
-				creation,
+	it('loads activity boundaries and count from Tempo API transaction pages', async () => {
+		getTransactions
+			.mockResolvedValueOnce(
+				Response.json({
+					data: [
+						{
+							hash: '0xoldest',
+							sender: '0xsender',
+							timestamp: '2026-01-01T00:00:00.000Z',
+						},
+					],
+					meta: { totalCount: 3 },
+					nextCursor: null,
+				}),
+			)
+			.mockResolvedValueOnce(
+				Response.json({
+					data: [{ timestamp: '2026-01-03T00:00:00.000Z' }],
+					nextCursor: null,
+				}),
+			)
+
+		await expect(
+			fetchAddressTxMetadata(
+				4217,
+				'0x1111111111111111111111111111111111111111',
 			),
-		).toEqual({
-			txCount: 4,
-			lastActivityTimestamp: 300,
-			createdTimestamp: 100,
-			createdTxHash: '0xold',
-			createdBy: '0xsender',
+		).resolves.toEqual({
+			count: 3,
+			latestTxsBlockTimestamp: '2026-01-03T00:00:00.000Z',
+			oldestTxsBlockTimestamp: '2026-01-01T00:00:00.000Z',
+			oldestTxHash: '0xoldest',
+			oldestTxFrom: '0xsender',
+		})
+		expect(getTransactions).toHaveBeenNthCalledWith(1, {
+			query: {
+				address: '0x1111111111111111111111111111111111111111',
+				chainId: '4217',
+				include: 'totalCount',
+				limit: '5',
+				order: 'asc',
+			},
+		})
+		expect(getTransactions).toHaveBeenNthCalledWith(2, {
+			query: {
+				address: '0x1111111111111111111111111111111111111111',
+				chainId: '4217',
+				limit: '5',
+				order: 'desc',
+			},
 		})
 	})
 })
@@ -78,19 +106,8 @@ describe('pickTip20CreatedTimestamp', () => {
 			pickTip20CreatedTimestamp({
 				tokenCreatedTimestamp: '2026-01-02T00:00:00.000Z',
 				firstTransferTimestamp: '2026-01-01T00:00:00.000Z',
-				contractCreationTimestamp: 100,
 			}),
 		).toBe(Date.parse('2026-01-02T00:00:00.000Z') / 1000)
-	})
-
-	it('uses the contract creation when older than the first transfer', () => {
-		expect(
-			pickTip20CreatedTimestamp({
-				tokenCreatedTimestamp: undefined,
-				firstTransferTimestamp: 200,
-				contractCreationTimestamp: 100,
-			}),
-		).toBe(100)
 	})
 
 	it('falls back to the first transfer timestamp', () => {
@@ -98,7 +115,6 @@ describe('pickTip20CreatedTimestamp', () => {
 			pickTip20CreatedTimestamp({
 				tokenCreatedTimestamp: undefined,
 				firstTransferTimestamp: 200,
-				contractCreationTimestamp: undefined,
 			}),
 		).toBe(200)
 		expect(


### PR DESCRIPTION
Uses parallel Tempo API transaction lookups for address metadata, removing the cold contract-creation RPC search. Transaction history now reflects indexed activity instead of synthesizing a deployment row.

## Screenshots

No layout changes.