### PR TITLE
feat(explorer): register Zone E portal

### DIFF
--- a/apps/explorer/src/lib/domain/known-events.ts
+++ b/apps/explorer/src/lib/domain/known-events.ts
@@ -39,6 +39,10 @@ const KNOWN_ZONES: ReadonlyMap<Address.Address, { name: string }> = new Map([
 		Address.from('0x3F5296303400B56271b476F5A0B9cBF74350D6Ac'),
 		{ name: 'Zone B' },
 	],
+	[
+		Address.from('0x59831A17340EE14FE136d751EfbeA8b630470fD2'),
+		{ name: 'Zone E' },
+	],
 ])
 
 const ZONE_PORTAL_EVENT_NAMES = new Set([

--- a/apps/explorer/test/known-events.test.ts
+++ b/apps/explorer/test/known-events.test.ts
@@ -15,6 +15,7 @@ import {
 import { parseKnownEvents } from '#lib/domain/known-events'
 
 const ZONE_5_PORTAL = '0x7069DeC4E64Fd07334A0933eDe836C17259c9B23' as const
+const ZONE_E_PORTAL = '0x59831A17340EE14FE136d751EfbeA8b630470fD2' as const
 const UNKNOWN_ZONE_PORTAL = `0x${'8'.repeat(40)}` as const
 
 const bounceBackAbi = [
@@ -173,6 +174,35 @@ describe('parseKnownEvents', () => {
 
 		expect(knownEvents).toHaveLength(1)
 		expect(knownEvents[0]?.type).toBe('approval')
+	})
+
+	it('labels Zone E deposits', () => {
+		const hash = `0x${'3'.repeat(64)}` as const
+		const amount = 500_000n
+		const logs = [
+			mockLog(
+				{
+					address: userTokenAddress,
+					topics: encodeEventTopics({
+						abi: Abis.tip20,
+						eventName: 'Transfer',
+						args: { from: accountAddress, to: ZONE_E_PORTAL },
+					}) as [Hex.Hex, ...Hex.Hex[]],
+					data: encodeAbiParameters([{ type: 'uint256' }], [amount]),
+				},
+				hash,
+			),
+		]
+
+		const receipt = mockReceipt(logs, accountAddress, hash)
+		const knownEvents = parseKnownEvents(receipt, { getTokenMetadata })
+
+		expect(knownEvents).toHaveLength(1)
+		expect(knownEvents[0]?.type).toBe('zone deposit')
+		expect(knownEvents[0]?.parts[0]).toEqual({
+			type: 'action',
+			value: 'Deposit to Zone E',
+		})
 	})
 
 	it('labels virtual address outgoing transfers as forwarded', () => {


### PR DESCRIPTION
## Summary

- register the current Moderato Zone E portal in explorer known events
- label matching deposits and withdrawals as Zone E
- add regression coverage for the Zone E deposit label

## Validation

- `pnpm --filter explorer test -- known-events.test.ts` (49 tests passed)
- `pnpm --filter explorer check:types`
- `pnpm --filter explorer check:biome`
- repository-wide typecheck is blocked by pre-existing generated Cloudflare binding errors in `apps/contract-verification`
- precommit is blocked because the sandbox cannot authenticate while cloning the gitleaks hook

## Screenshots

| Before | After |
|--------|-------|
| Current Zone E activity renders with the generic `Zone` label | Current Zone E activity renders as `Zone E` |

Prompted by: @Zygimantass