### PR TITLE
fix(explorer): deduplicate blocked transfer totals

### DIFF
--- a/apps/explorer/src/lib/domain/known-events.ts
+++ b/apps/explorer/src/lib/domain/known-events.ts
@@ -1497,16 +1497,11 @@ export function parseKnownEvents(
 	const blockedTransferKeys = new Set<string>()
 	for (const event of events) {
 		if (event.eventName !== 'TransferBlocked') continue
-		const { token, amount, receipt } = event.args as {
+		const { token, amount } = event.args as {
 			token: Address.Address
 			amount: bigint
-			receipt: Hex.Hex
 		}
-		const decodedReceipt = decodeClaimReceiptV1(receipt)
-		if (!decodedReceipt) continue
-		blockedTransferKeys.add(
-			`${Address.from(token)}:${Address.from(decodedReceipt.originator)}:${amount.toString()}`,
-		)
+		blockedTransferKeys.add(`${token.toLowerCase()}:${amount.toString()}`)
 	}
 
 	const preferenceMap = new Map<string, string>()
@@ -1679,7 +1674,7 @@ export function parseKnownEvents(
 				if (
 					Address.isEqual(to, RECEIVE_POLICY_GUARD) &&
 					blockedTransferKeys.has(
-						`${Address.from(event.address)}:${Address.from(from)}:${amount.toString()}`,
+						`${event.address.toLowerCase()}:${amount.toString()}`,
 					)
 				) {
 					include = false
@@ -1753,7 +1748,7 @@ export function parseKnownEvents(
 				if (
 					Address.isEqual(to, RECEIVE_POLICY_GUARD) &&
 					blockedTransferKeys.has(
-						`${Address.from(event.address)}:${Address.from(from)}:${amount.toString()}`,
+						`${event.address.toLowerCase()}:${amount.toString()}`,
 					)
 				) {
 					include = false

--- a/apps/explorer/test/known-events.test.ts
+++ b/apps/explorer/test/known-events.test.ts
@@ -17,6 +17,8 @@ import { parseKnownEvents } from '#lib/domain/known-events'
 const ZONE_5_PORTAL = '0x7069DeC4E64Fd07334A0933eDe836C17259c9B23' as const
 const ZONE_E_PORTAL = '0x59831A17340EE14FE136d751EfbeA8b630470fD2' as const
 const UNKNOWN_ZONE_PORTAL = `0x${'8'.repeat(40)}` as const
+const RECEIVE_POLICY_GUARD =
+	'0xB10C000000000000000000000000000000000000' as const
 
 const bounceBackAbi = [
 	{
@@ -58,6 +60,49 @@ const depositMadeAbi = [
 ] as const
 
 describe('parseKnownEvents', () => {
+	it('deduplicates policy guard transfers when the receipt version is unknown', () => {
+		const hash = `0x${'9'.repeat(64)}` as const
+		const amount = 35_000_000n
+		const logs = [
+			mockLog(
+				{
+					address: userTokenAddress,
+					topics: encodeEventTopics({
+						abi: Abis.tip20,
+						eventName: 'Transfer',
+						args: { from: accountAddress, to: RECEIVE_POLICY_GUARD },
+					}) as [Hex.Hex, ...Hex.Hex[]],
+					data: encodeAbiParameters([{ type: 'uint256' }], [amount]),
+				},
+				hash,
+			),
+			mockLog(
+				{
+					address: RECEIVE_POLICY_GUARD,
+					topics: encodeEventTopics({
+						abi: Abis.receivePolicyGuard,
+						eventName: 'TransferBlocked',
+						args: {
+							token: userTokenAddress,
+							receiver: recipientAddress,
+							blockedNonce: 1n,
+						},
+					}) as [Hex.Hex, ...Hex.Hex[]],
+					data: encodeAbiParameters(
+						[{ type: 'uint256' }, { type: 'uint8' }, { type: 'bytes' }],
+						[amount, 2, '0x'],
+					),
+				},
+				hash,
+			),
+		]
+
+		const receipt = mockReceipt(logs, accountAddress, hash)
+		const knownEvents = parseKnownEvents(receipt, { getTokenMetadata })
+
+		expect(knownEvents.map((event) => event.type)).toEqual(['transfer blocked'])
+	})
+
 	it('decodes stablecoin DEX OrderFlipped buy and sell events', () => {
 		const hash = `0x${'6'.repeat(64)}` as const
 		const amount = 1_000_000n


### PR DESCRIPTION
## Summary

- deduplicate the mechanical TIP-20 transfer to ReceivePolicyGuard from the user-facing TransferBlocked event
- match blocked transfers independently of receipt version so v2 receipts do not double totals
- add regression coverage for an unknown receipt version

## Validation

- `pnpm --filter explorer exec vitest run test/known-events.test.ts`
- `pnpm --filter explorer check:types`
- `pnpm exec biome check apps/explorer/src/lib/domain/known-events.ts apps/explorer/test/known-events.test.ts`

Prompted by: @jxom