### PR TITLE
fix(explorer): update pathUSD docs link

### DIFF
--- a/apps/explorer/src/lib/domain/contracts.ts
+++ b/apps/explorer/src/lib/domain/contracts.ts
@@ -187,7 +187,7 @@ export const tip20ContractRegistry = new Map<Address.Address, ContractInfo>(<
 			abi: Abis.tip20,
 			code: '0xef',
 			category: 'token',
-			docsUrl: 'https://docs.tempo.xyz/documentation/protocol/exchange/pathUSD',
+			docsUrl: 'https://docs.tempo.xyz/protocol/exchange/quote-tokens#pathusd',
 			address: '0x20c0000000000000000000000000000000000000',
 		},
 	],


### PR DESCRIPTION
## Summary

- Update the explorer’s pathUSD contract metadata to link to the current Quote Tokens documentation.
- Preserve the `#pathusd` anchor so the Docs action opens the relevant section.

## Testing

- `pnpm --filter explorer check` (73 tests passed)
- `pnpm --filter explorer test -- --run` (49 tests passed)
- `pnpm check` (explorer passed; repository-wide type checking is blocked by existing missing `contract-verification` Cloudflare bindings)
- `pnpm precommit` (blocked because gitleaks clone authentication failed)

## Screenshots

| Before | After |
| --- | --- |
| Docs button opens stale `/documentation/protocol/exchange/pathUSD` URL (404) | Docs button opens `/protocol/exchange/quote-tokens#pathusd` |

No visual layout change.

Prompted by: @shekhirin
