### PR TITLE
feat(explorer): add TIP-403 policy detail page

### DIFF
--- a/apps/explorer/public/llms-full.txt
+++ b/apps/explorer/public/llms-full.txt
@@ -2,7 +2,7 @@
 
 > Comprehensive reference for agents and AI systems using Tempo Explorer.
 
-Tempo Explorer is a blockchain explorer for the Tempo network. It helps users inspect blocks, transactions, receipts, addresses, contracts, tokens, balances, Fee AMM pools, and on-chain events.
+Tempo Explorer is a blockchain explorer for the Tempo network. It helps users inspect blocks, transactions, receipts, addresses, contracts, tokens, TIP-403 policies, balances, Fee AMM pools, and on-chain events.
 
 For a shorter overview, see [`/llms.txt`](/llms.txt).
 

--- a/apps/explorer/public/llms.txt
+++ b/apps/explorer/public/llms.txt
@@ -1,6 +1,6 @@
 # Tempo Explorer
 
-> The official block explorer for the Tempo blockchain. View blocks, transactions, receipts, addresses, contracts, tokens, Fee AMM pools, and network activity.
+> The official block explorer for the Tempo blockchain. View blocks, transactions, receipts, addresses, contracts, tokens, TIP-403 policies, Fee AMM pools, and network activity.
 
 For a full reference, see [`/llms-full.txt`](/llms-full.txt).
 
@@ -11,6 +11,7 @@ For a full reference, see [`/llms-full.txt`](/llms-full.txt).
 - Browse recent blocks and inspect a block's transactions.
 - Inspect addresses, balances, transaction history, contracts, and token activity.
 - View TIP20 token metadata, transfers, and holders.
+- View TIP-403 policy types, administrators, members, composed policies, and policy events.
 - Read verified contracts and interact with contract functions when an ABI is available.
 - Browse Fee AMM pools, reserves, liquidity, and routes.
 - Export address transactions and balances as CSV.
@@ -34,6 +35,9 @@ For a full reference, see [`/llms-full.txt`](/llms-full.txt).
 - Block countdown: `/block/countdown/{targetBlock}`
 - Tokens list: `/tokens`
 - Fee AMM: `/fee-amm`
+- TIP-403 policy: `/policy/{policyId}`
+  - Member search: `?q={address}`
+  - Member pagination: `?page={number}&limit={number}`
 
 ## Networks
 

--- a/apps/explorer/src/comps/Breadcrumbs.tsx
+++ b/apps/explorer/src/comps/Breadcrumbs.tsx
@@ -11,7 +11,15 @@ const MAX_CRUMBS = 3
 export interface Crumb {
 	path: string
 	label: string
-	type: 'home' | 'tx' | 'receipt' | 'address' | 'token' | 'block' | 'other'
+	type:
+		| 'home'
+		| 'tx'
+		| 'receipt'
+		| 'address'
+		| 'token'
+		| 'block'
+		| 'policy'
+		| 'other'
 }
 
 function truncateHash(hash: string, prefixLen = 6, suffixLen = 4): string {
@@ -53,6 +61,11 @@ function getLabelForPath(pathname: string): {
 	const blockMatch = pathname.match(/^\/block\/(\d+|latest)$/)
 	if (blockMatch) {
 		return { label: `Block ${blockMatch[1]}`, type: 'block' }
+	}
+
+	const policyMatch = pathname.match(/^\/policy\/(\d+)$/)
+	if (policyMatch) {
+		return { label: `Policy #${policyMatch[1]}`, type: 'policy' }
 	}
 
 	if (pathname === '/blocks') {

--- a/apps/explorer/src/lib/domain/tip403.ts
+++ b/apps/explorer/src/lib/domain/tip403.ts
@@ -1,0 +1,30 @@
+import type * as Address from 'ox/Address'
+
+export type Tip403PolicyType = 'whitelist' | 'blacklist' | 'compound'
+
+export function parseTip403PolicyId(value: string): string | undefined {
+	if (!/^\d+$/.test(value)) return undefined
+	try {
+		const id = BigInt(value)
+		if (id < 0n || id > 2n ** 64n - 1n) return undefined
+		return id.toString()
+	} catch {
+		return undefined
+	}
+}
+
+export function parseTip403PolicyType(value: number): Tip403PolicyType {
+	if (value === 0) return 'whitelist'
+	if (value === 1) return 'blacklist'
+	return 'compound'
+}
+
+export function updateTip403Member(
+	members: Map<string, Address.Address>,
+	account: Address.Address,
+	active: boolean,
+) {
+	const key = account.toLowerCase()
+	if (active) members.set(key, account)
+	else members.delete(key)
+}

--- a/apps/explorer/src/lib/server/tip403-log-utils.ts
+++ b/apps/explorer/src/lib/server/tip403-log-utils.ts
@@ -1,0 +1,55 @@
+export type PolicyLogIdentity = {
+	tx_hash?: string | null
+	log_idx?: unknown
+}
+
+function policyLogKey(log: PolicyLogIdentity): string | undefined {
+	if (!log.tx_hash || log.log_idx == null) return undefined
+	return `${log.tx_hash.toLowerCase()}:${String(log.log_idx)}`
+}
+
+export function dedupePolicyLogs<log extends PolicyLogIdentity>(
+	logs: readonly log[],
+): log[] {
+	const seen = new Set<string>()
+	return logs.filter((log) => {
+		const key = policyLogKey(log)
+		if (!key) return true
+		if (seen.has(key)) return false
+		seen.add(key)
+		return true
+	})
+}
+
+export async function fetchAllPolicyLogPages<log extends PolicyLogIdentity>(
+	fetchPage: (limit: number, offset: number) => Promise<log[]>,
+	pageSize: number,
+): Promise<log[]> {
+	const logs: log[] = []
+	let offset = 0
+	while (true) {
+		const page = await fetchPage(pageSize, offset)
+		logs.push(...page)
+		if (page.length < pageSize) return dedupePolicyLogs(logs)
+		offset += page.length
+	}
+}
+
+export async function fetchRecentUniquePolicyLogs<
+	log extends PolicyLogIdentity,
+>(
+	fetchPage: (limit: number, offset: number) => Promise<log[]>,
+	uniqueLimit: number,
+): Promise<log[]> {
+	const logs: log[] = []
+	let offset = 0
+	const pageSize = uniqueLimit + 1
+	while (true) {
+		const page = await fetchPage(pageSize, offset)
+		logs.push(...page)
+		const unique = dedupePolicyLogs(logs)
+		if (unique.length >= uniqueLimit || page.length < pageSize)
+			return unique.slice(0, uniqueLimit)
+		offset += page.length
+	}
+}

--- a/apps/explorer/src/lib/server/tip403.ts
+++ b/apps/explorer/src/lib/server/tip403.ts
@@ -12,10 +12,16 @@ import {
 	type Tip403PolicyType,
 } from '#lib/domain/tip403'
 import { tempoQueryBuilder } from '#lib/server/tempo-queries-provider'
+import {
+	dedupePolicyLogs,
+	fetchAllPolicyLogPages,
+	fetchRecentUniquePolicyLogs,
+} from '#lib/server/tip403-log-utils'
 import { getWagmiConfig } from '#wagmi.config'
 import * as z from 'zod/mini'
 
-const POLICY_LOG_SCAN_LIMIT = 10_000
+const POLICY_LOG_PAGE_SIZE = 10_000
+const RECENT_ACTIVITY_LIMIT = 20
 const registryAddress =
 	Addresses.tip403Registry.toLowerCase() as Address.Address
 
@@ -51,6 +57,7 @@ export type Tip403PolicyEvent = {
 	blockNumber: string
 	timestamp: number | null
 	txHash: Hex.Hex
+	logIndex: string
 	updater?: Address.Address
 	admin?: Address.Address
 	account?: Address.Address
@@ -189,7 +196,12 @@ export const fetchTip403Policy = createServerFn({ method: 'POST' })
 				? ([...results[2].result].map(String) as [string, string, string])
 				: undefined
 
-		const fetchLogs = async (selector: Hex.Hex) => {
+		const fetchLogsPage = async (
+			selector: Hex.Hex,
+			direction: 'asc' | 'desc',
+			limit: number,
+			offset: number,
+		) => {
 			return (await tempoQueryBuilder(chainId, { engine: 'clickhouse' })
 				.selectFrom('logs')
 				.select([
@@ -206,30 +218,50 @@ export const fetchTip403Policy = createServerFn({ method: 'POST' })
 				.where('address', '=', registryAddress)
 				.where('selector', '=', selector)
 				.where('topic1', '=', policyTopic)
-				.orderBy('block_num', 'asc')
-				.orderBy('log_idx', 'asc')
-				.limit(POLICY_LOG_SCAN_LIMIT)
+				.orderBy('block_num', direction)
+				.orderBy('log_idx', direction)
+				.limit(limit)
+				.offset(offset)
 				.execute()) as PolicyLog[]
 		}
 
+		const fetchAllLogs = async (selector: Hex.Hex) => {
+			return fetchAllPolicyLogPages(
+				(limit, offset) => fetchLogsPage(selector, 'asc', limit, offset),
+				POLICY_LOG_PAGE_SIZE,
+			)
+		}
+
+		const fetchRecentLogs = async (selector: Hex.Hex) => {
+			return fetchRecentUniquePolicyLogs(
+				(limit, offset) => fetchLogsPage(selector, 'desc', limit, offset),
+				RECENT_ACTIVITY_LIMIT + 1,
+			)
+		}
+
+		const [whitelistUpdated, blacklistUpdated, recentByType] =
+			await Promise.all([
+				fetchAllLogs(eventSelectors.whitelistUpdated),
+				fetchAllLogs(eventSelectors.blacklistUpdated),
+				Promise.all([
+					fetchRecentLogs(eventSelectors.created),
+					fetchRecentLogs(eventSelectors.adminUpdated),
+					fetchRecentLogs(eventSelectors.whitelistUpdated),
+					fetchRecentLogs(eventSelectors.blacklistUpdated),
+					fetchRecentLogs(eventSelectors.compoundCreated),
+				]),
+			])
+
 		const [
 			created,
-			adminUpdated,
-			whitelistUpdated,
-			blacklistUpdated,
+			recentAdminUpdated,
+			recentWhitelistUpdated,
+			recentBlacklistUpdated,
 			compoundCreated,
-		] = await Promise.all([
-			fetchLogs(eventSelectors.created),
-			fetchLogs(eventSelectors.adminUpdated),
-			fetchLogs(eventSelectors.whitelistUpdated),
-			fetchLogs(eventSelectors.blacklistUpdated),
-			fetchLogs(eventSelectors.compoundCreated),
-		])
+		] = recentByType
 
-		const events = sortLogs(
+		const membershipEvents = sortLogs(
 			[
-				...created.map((log) => ({ log, type: 'created' as const })),
-				...adminUpdated.map((log) => ({ log, type: 'admin updated' as const })),
 				...whitelistUpdated.map((log) => ({
 					log,
 					type: 'whitelist updated' as const,
@@ -238,33 +270,51 @@ export const fetchTip403Policy = createServerFn({ method: 'POST' })
 					log,
 					type: 'blacklist updated' as const,
 				})),
-				...compoundCreated.map((log) => ({
-					log,
-					type: 'compound created' as const,
-				})),
 			].map(({ log, type }) => ({ ...log, eventType: type })),
 		)
 
+		const recentEvents = sortLogs(
+			dedupePolicyLogs([
+				...created,
+				...recentAdminUpdated,
+				...recentWhitelistUpdated,
+				...recentBlacklistUpdated,
+				...compoundCreated,
+			]).map((log) => ({
+				...log,
+				eventType:
+					log.selector === eventSelectors.created
+						? 'created'
+						: log.selector === eventSelectors.adminUpdated
+							? 'admin updated'
+							: log.selector === eventSelectors.whitelistUpdated
+								? 'whitelist updated'
+								: log.selector === eventSelectors.blacklistUpdated
+									? 'blacklist updated'
+									: 'compound created',
+			})),
+		).reverse()
+
 		const members = new Map<string, Address.Address>()
+		for (const event of membershipEvents) {
+			const account = parseAddress(event.topic3)
+			if (!account) continue
+			updateTip403Member(members, account, parseBool(event.data))
+		}
+
 		const activity: Tip403PolicyEvent[] = []
-		for (const event of events) {
+		for (const event of recentEvents.slice(0, RECENT_ACTIVITY_LIMIT)) {
 			const account = parseAddress(event.topic3)
 			const updater = parseAddress(event.topic2)
 			const txHash = event.tx_hash as Hex.Hex | null
-			if (!txHash) continue
-
-			if (event.eventType === 'whitelist updated' && account) {
-				updateTip403Member(members, account, parseBool(event.data))
-			}
-			if (event.eventType === 'blacklist updated' && account) {
-				updateTip403Member(members, account, parseBool(event.data))
-			}
+			if (!txHash || event.log_idx == null) continue
 
 			activity.push({
 				type: event.eventType,
 				blockNumber: String(event.block_num ?? 0),
 				timestamp: parseTimestamp(event.block_timestamp),
 				txHash,
+				logIndex: String(event.log_idx),
 				updater,
 				admin:
 					event.eventType === 'admin updated'
@@ -300,7 +350,7 @@ export const fetchTip403Policy = createServerFn({ method: 'POST' })
 			componentPolicies,
 			members: allMembers.slice(offset, offset + data.limit),
 			membersTotal: allMembers.length,
-			activity: activity.reverse().slice(0, 20),
-			activityTruncated: events.length > 20,
+			activity,
+			activityTruncated: recentEvents.length > RECENT_ACTIVITY_LIMIT,
 		}
 	})

--- a/apps/explorer/src/lib/server/tip403.ts
+++ b/apps/explorer/src/lib/server/tip403.ts
@@ -1,0 +1,306 @@
+import { createServerFn } from '@tanstack/react-start'
+import * as Address from 'ox/Address'
+import * as Hash from 'ox/Hash'
+import * as Hex from 'ox/Hex'
+import { decodeAbiParameters, toHex } from 'viem'
+import { Addresses } from 'viem/tempo'
+import { getChainId, readContracts } from 'wagmi/actions'
+import { Abis } from '#lib/abis'
+import {
+	parseTip403PolicyType,
+	updateTip403Member,
+	type Tip403PolicyType,
+} from '#lib/domain/tip403'
+import { tempoQueryBuilder } from '#lib/server/tempo-queries-provider'
+import { getWagmiConfig } from '#wagmi.config'
+import * as z from 'zod/mini'
+
+const POLICY_LOG_SCAN_LIMIT = 10_000
+const registryAddress =
+	Addresses.tip403Registry.toLowerCase() as Address.Address
+
+const eventSelectors = {
+	created: Hash.keccak256(
+		Hex.fromString('PolicyCreated(uint64,address,uint8)'),
+	),
+	adminUpdated: Hash.keccak256(
+		Hex.fromString('PolicyAdminUpdated(uint64,address,address)'),
+	),
+	whitelistUpdated: Hash.keccak256(
+		Hex.fromString('WhitelistUpdated(uint64,address,address,bool)'),
+	),
+	blacklistUpdated: Hash.keccak256(
+		Hex.fromString('BlacklistUpdated(uint64,address,address,bool)'),
+	),
+	compoundCreated: Hash.keccak256(
+		Hex.fromString(
+			'CompoundPolicyCreated(uint64,address,uint64,uint64,uint64)',
+		),
+	),
+} as const
+
+type PolicyType = Tip403PolicyType
+
+export type Tip403PolicyEvent = {
+	type:
+		| 'created'
+		| 'admin updated'
+		| 'whitelist updated'
+		| 'blacklist updated'
+		| 'compound created'
+	blockNumber: string
+	timestamp: number | null
+	txHash: Hex.Hex
+	updater?: Address.Address
+	admin?: Address.Address
+	account?: Address.Address
+	allowed?: boolean
+	componentPolicies?: [string, string, string]
+}
+
+export type Tip403PolicyResponse = {
+	policyId: string
+	type: PolicyType
+	admin: Address.Address
+	componentPolicies?: [string, string, string]
+	members: Address.Address[]
+	membersTotal: number
+	activity: Tip403PolicyEvent[]
+	activityTruncated: boolean
+}
+
+type PolicyLog = {
+	selector?: string | null
+	topic1?: string | null
+	topic2?: string | null
+	topic3?: string | null
+	data?: string | null
+	block_num?: unknown
+	block_timestamp?: unknown
+	tx_hash?: string | null
+	log_idx?: unknown
+}
+
+type PolicyEventType = Tip403PolicyEvent['type']
+type TaggedPolicyLog = PolicyLog & { eventType: PolicyEventType }
+
+function parseTimestamp(value: unknown): number | null {
+	if (typeof value === 'number' && Number.isFinite(value)) return value
+	if (typeof value === 'bigint') return Number(value)
+	if (typeof value === 'string') {
+		const numeric = Number(value)
+		if (Number.isFinite(numeric)) return numeric
+		const date = Date.parse(value)
+		if (Number.isFinite(date)) return Math.floor(date / 1000)
+	}
+	return null
+}
+
+function parseAddress(
+	topic: string | null | undefined,
+): Address.Address | undefined {
+	if (!topic || topic.length < 40) return undefined
+	try {
+		return Address.checksum(`0x${topic.slice(-40)}` as Address.Address)
+	} catch {
+		return undefined
+	}
+}
+
+function parseBool(data: string | null | undefined): boolean {
+	if (!data) return false
+	try {
+		return Hex.toBigInt(data as Hex.Hex) !== 0n
+	} catch {
+		return false
+	}
+}
+
+function sortLogs(logs: TaggedPolicyLog[]): TaggedPolicyLog[] {
+	return [...logs].sort((a, b) => {
+		const blockA = BigInt(String(a.block_num ?? 0))
+		const blockB = BigInt(String(b.block_num ?? 0))
+		if (blockA !== blockB) return blockA < blockB ? -1 : 1
+		return Number(a.log_idx ?? 0) - Number(b.log_idx ?? 0)
+	})
+}
+
+function decodeCompoundPolicies(data: string | null | undefined) {
+	if (!data) return undefined
+	try {
+		const [sender, recipient, mintRecipient] = decodeAbiParameters(
+			[{ type: 'uint64' }, { type: 'uint64' }, { type: 'uint64' }],
+			data as Hex.Hex,
+		)
+		return [
+			sender.toString(),
+			recipient.toString(),
+			mintRecipient.toString(),
+		] as [string, string, string]
+	} catch {
+		return undefined
+	}
+}
+
+export const fetchTip403Policy = createServerFn({ method: 'POST' })
+	.inputValidator(
+		z.object({
+			policyId: z.string(),
+			page: z.number(),
+			limit: z.number(),
+			query: z.string(),
+		}),
+	)
+	.handler(async ({ data }): Promise<Tip403PolicyResponse | null> => {
+		const policyId = BigInt(data.policyId)
+		const policyTopic = toHex(policyId, { size: 32 })
+		const config = getWagmiConfig()
+		const chainId = getChainId(config)
+		const results = await readContracts(config, {
+			contracts: [
+				{
+					address: Addresses.tip403Registry,
+					abi: Abis.tip403Registry,
+					functionName: 'policyExists',
+					args: [policyId],
+				},
+				{
+					address: Addresses.tip403Registry,
+					abi: Abis.tip403Registry,
+					functionName: 'policyData',
+					args: [policyId],
+				},
+				{
+					address: Addresses.tip403Registry,
+					abi: Abis.tip403Registry,
+					functionName: 'compoundPolicyData',
+					args: [policyId],
+				},
+			],
+		})
+
+		if (results[0].status !== 'success' || !results[0].result) return null
+		if (results[1].status !== 'success') return null
+
+		const [rawType, admin] = results[1].result as [number, Address.Address]
+		const type = parseTip403PolicyType(Number(rawType))
+		const componentPolicies =
+			type === 'compound' && results[2].status === 'success'
+				? ([...results[2].result].map(String) as [string, string, string])
+				: undefined
+
+		const fetchLogs = async (selector: Hex.Hex) => {
+			return (await tempoQueryBuilder(chainId, { engine: 'clickhouse' })
+				.selectFrom('logs')
+				.select([
+					'selector',
+					'topic1',
+					'topic2',
+					'topic3',
+					'data',
+					'block_num',
+					'block_timestamp',
+					'tx_hash',
+					'log_idx',
+				])
+				.where('address', '=', registryAddress)
+				.where('selector', '=', selector)
+				.where('topic1', '=', policyTopic)
+				.orderBy('block_num', 'asc')
+				.orderBy('log_idx', 'asc')
+				.limit(POLICY_LOG_SCAN_LIMIT)
+				.execute()) as PolicyLog[]
+		}
+
+		const [
+			created,
+			adminUpdated,
+			whitelistUpdated,
+			blacklistUpdated,
+			compoundCreated,
+		] = await Promise.all([
+			fetchLogs(eventSelectors.created),
+			fetchLogs(eventSelectors.adminUpdated),
+			fetchLogs(eventSelectors.whitelistUpdated),
+			fetchLogs(eventSelectors.blacklistUpdated),
+			fetchLogs(eventSelectors.compoundCreated),
+		])
+
+		const events = sortLogs(
+			[
+				...created.map((log) => ({ log, type: 'created' as const })),
+				...adminUpdated.map((log) => ({ log, type: 'admin updated' as const })),
+				...whitelistUpdated.map((log) => ({
+					log,
+					type: 'whitelist updated' as const,
+				})),
+				...blacklistUpdated.map((log) => ({
+					log,
+					type: 'blacklist updated' as const,
+				})),
+				...compoundCreated.map((log) => ({
+					log,
+					type: 'compound created' as const,
+				})),
+			].map(({ log, type }) => ({ ...log, eventType: type })),
+		)
+
+		const members = new Map<string, Address.Address>()
+		const activity: Tip403PolicyEvent[] = []
+		for (const event of events) {
+			const account = parseAddress(event.topic3)
+			const updater = parseAddress(event.topic2)
+			const txHash = event.tx_hash as Hex.Hex | null
+			if (!txHash) continue
+
+			if (event.eventType === 'whitelist updated' && account) {
+				updateTip403Member(members, account, parseBool(event.data))
+			}
+			if (event.eventType === 'blacklist updated' && account) {
+				updateTip403Member(members, account, parseBool(event.data))
+			}
+
+			activity.push({
+				type: event.eventType,
+				blockNumber: String(event.block_num ?? 0),
+				timestamp: parseTimestamp(event.block_timestamp),
+				txHash,
+				updater,
+				admin:
+					event.eventType === 'admin updated'
+						? parseAddress(event.topic3)
+						: undefined,
+				account:
+					event.eventType === 'whitelist updated' ||
+					event.eventType === 'blacklist updated'
+						? account
+						: undefined,
+				allowed:
+					event.eventType === 'whitelist updated' ||
+					event.eventType === 'blacklist updated'
+						? parseBool(event.data)
+						: undefined,
+				componentPolicies:
+					event.eventType === 'compound created'
+						? decodeCompoundPolicies(event.data)
+						: undefined,
+			})
+		}
+
+		const normalizedQuery = data.query.trim().toLowerCase()
+		const allMembers = [...members.values()].filter((member) =>
+			!normalizedQuery ? true : member.toLowerCase().includes(normalizedQuery),
+		)
+		const offset = (data.page - 1) * data.limit
+
+		return {
+			policyId: data.policyId,
+			type,
+			admin,
+			componentPolicies,
+			members: allMembers.slice(offset, offset + data.limit),
+			membersTotal: allMembers.length,
+			activity: activity.reverse().slice(0, 20),
+			activityTruncated: events.length > 20,
+		}
+	})

--- a/apps/explorer/src/routeTree.gen.ts
+++ b/apps/explorer/src/routeTree.gen.ts
@@ -25,6 +25,7 @@ import { Route as ApiAbiBatchRouteImport } from './routes/api/abi/batch'
 import { Route as LayoutTxHashRouteImport } from './routes/_layout/tx/$hash'
 import { Route as LayoutTokenAddressRouteImport } from './routes/_layout/token/$address'
 import { Route as LayoutReceiptHashRouteImport } from './routes/_layout/receipt/$hash'
+import { Route as LayoutPolicyIdRouteImport } from './routes/_layout/policy/$id'
 import { Route as LayoutDemoTxRouteImport } from './routes/_layout/demo/tx'
 import { Route as LayoutDemoPaginationRouteImport } from './routes/_layout/demo/pagination'
 import { Route as LayoutDemoEmptyStateRouteImport } from './routes/_layout/demo/empty-state'
@@ -117,6 +118,11 @@ const LayoutTokenAddressRoute = LayoutTokenAddressRouteImport.update({
 const LayoutReceiptHashRoute = LayoutReceiptHashRouteImport.update({
   id: '/receipt/$hash',
   path: '/receipt/$hash',
+  getParentRoute: () => LayoutRoute,
+} as any)
+const LayoutPolicyIdRoute = LayoutPolicyIdRouteImport.update({
+  id: '/policy/$id',
+  path: '/policy/$id',
   getParentRoute: () => LayoutRoute,
 } as any)
 const LayoutDemoTxRoute = LayoutDemoTxRouteImport.update({
@@ -212,6 +218,7 @@ export interface FileRoutesByFullPath {
   '/demo/empty-state': typeof LayoutDemoEmptyStateRoute
   '/demo/pagination': typeof LayoutDemoPaginationRoute
   '/demo/tx': typeof LayoutDemoTxRoute
+  '/policy/$id': typeof LayoutPolicyIdRoute
   '/receipt/$hash': typeof LayoutReceiptHashRoute
   '/token/$address': typeof LayoutTokenAddressRoute
   '/tx/$hash': typeof LayoutTxHashRoute
@@ -243,6 +250,7 @@ export interface FileRoutesByTo {
   '/demo/empty-state': typeof LayoutDemoEmptyStateRoute
   '/demo/pagination': typeof LayoutDemoPaginationRoute
   '/demo/tx': typeof LayoutDemoTxRoute
+  '/policy/$id': typeof LayoutPolicyIdRoute
   '/receipt/$hash': typeof LayoutReceiptHashRoute
   '/token/$address': typeof LayoutTokenAddressRoute
   '/tx/$hash': typeof LayoutTxHashRoute
@@ -276,6 +284,7 @@ export interface FileRoutesById {
   '/_layout/demo/empty-state': typeof LayoutDemoEmptyStateRoute
   '/_layout/demo/pagination': typeof LayoutDemoPaginationRoute
   '/_layout/demo/tx': typeof LayoutDemoTxRoute
+  '/_layout/policy/$id': typeof LayoutPolicyIdRoute
   '/_layout/receipt/$hash': typeof LayoutReceiptHashRoute
   '/_layout/token/$address': typeof LayoutTokenAddressRoute
   '/_layout/tx/$hash': typeof LayoutTxHashRoute
@@ -309,6 +318,7 @@ export interface FileRouteTypes {
     | '/demo/empty-state'
     | '/demo/pagination'
     | '/demo/tx'
+    | '/policy/$id'
     | '/receipt/$hash'
     | '/token/$address'
     | '/tx/$hash'
@@ -340,6 +350,7 @@ export interface FileRouteTypes {
     | '/demo/empty-state'
     | '/demo/pagination'
     | '/demo/tx'
+    | '/policy/$id'
     | '/receipt/$hash'
     | '/token/$address'
     | '/tx/$hash'
@@ -372,6 +383,7 @@ export interface FileRouteTypes {
     | '/_layout/demo/empty-state'
     | '/_layout/demo/pagination'
     | '/_layout/demo/tx'
+    | '/_layout/policy/$id'
     | '/_layout/receipt/$hash'
     | '/_layout/token/$address'
     | '/_layout/tx/$hash'
@@ -519,6 +531,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof LayoutReceiptHashRouteImport
       parentRoute: typeof LayoutRoute
     }
+    '/_layout/policy/$id': {
+      id: '/_layout/policy/$id'
+      path: '/policy/$id'
+      fullPath: '/policy/$id'
+      preLoaderRoute: typeof LayoutPolicyIdRouteImport
+      parentRoute: typeof LayoutRoute
+    }
     '/_layout/demo/tx': {
       id: '/_layout/demo/tx'
       path: '/demo/tx'
@@ -631,6 +650,7 @@ interface LayoutRouteChildren {
   LayoutDemoEmptyStateRoute: typeof LayoutDemoEmptyStateRoute
   LayoutDemoPaginationRoute: typeof LayoutDemoPaginationRoute
   LayoutDemoTxRoute: typeof LayoutDemoTxRoute
+  LayoutPolicyIdRoute: typeof LayoutPolicyIdRoute
   LayoutReceiptHashRoute: typeof LayoutReceiptHashRoute
   LayoutTokenAddressRoute: typeof LayoutTokenAddressRoute
   LayoutTxHashRoute: typeof LayoutTxHashRoute
@@ -649,6 +669,7 @@ const LayoutRouteChildren: LayoutRouteChildren = {
   LayoutDemoEmptyStateRoute: LayoutDemoEmptyStateRoute,
   LayoutDemoPaginationRoute: LayoutDemoPaginationRoute,
   LayoutDemoTxRoute: LayoutDemoTxRoute,
+  LayoutPolicyIdRoute: LayoutPolicyIdRoute,
   LayoutReceiptHashRoute: LayoutReceiptHashRoute,
   LayoutTokenAddressRoute: LayoutTokenAddressRoute,
   LayoutTxHashRoute: LayoutTxHashRoute,

--- a/apps/explorer/src/routes/_layout/policy/$id.tsx
+++ b/apps/explorer/src/routes/_layout/policy/$id.tsx
@@ -5,6 +5,7 @@ import {
 	stripSearchParams,
 	useNavigate,
 } from '@tanstack/react-router'
+import * as React from 'react'
 import { Addresses } from 'viem/tempo'
 import * as z from 'zod/mini'
 import { Address as AddressLink } from '#comps/Address'
@@ -87,6 +88,7 @@ function RouteComponent() {
 	const { page, limit, q } = Route.useSearch()
 	const isMobile = useMediaQuery('(max-width: 799px)')
 	const mode = isMobile ? 'stacked' : 'tabs'
+	const [activeSection, setActiveSection] = React.useState(0)
 
 	return (
 		<div className="max-[800px]:flex max-[800px]:flex-col max-[800px]:pt-10 max-[800px]:pb-8 grid w-full grid-cols-[auto_1fr] gap-[14px] px-4 pt-20 pb-16 min-w-0 min-[1240px]:max-w-[1280px]">
@@ -94,6 +96,8 @@ function RouteComponent() {
 			<PolicyCard policy={policy} />
 			<Sections
 				mode={mode}
+				activeSection={activeSection}
+				onSectionChange={setActiveSection}
 				sections={[
 					{
 						title: 'Members',

--- a/apps/explorer/src/routes/_layout/policy/$id.tsx
+++ b/apps/explorer/src/routes/_layout/policy/$id.tsx
@@ -1,0 +1,377 @@
+import {
+	createFileRoute,
+	Link,
+	notFound,
+	stripSearchParams,
+	useNavigate,
+} from '@tanstack/react-router'
+import { Addresses } from 'viem/tempo'
+import * as z from 'zod/mini'
+import { Address as AddressLink } from '#comps/Address'
+import { BreadcrumbsSlot } from '#comps/Breadcrumbs'
+import { CopyButton } from '#comps/CopyButton'
+import { DataGrid } from '#comps/DataGrid'
+import { InfoCard } from '#comps/InfoCard'
+import { Sections } from '#comps/Sections'
+import { TimeColumnHeader, useTimeFormat } from '#comps/TimeFormat'
+import { TimestampCell } from '#comps/TimestampCell'
+import { TransactionCell } from '#comps/TransactionCell'
+import { cx } from '#lib/css'
+import { parseTip403PolicyId } from '#lib/domain/tip403'
+import type {
+	Tip403PolicyResponse,
+	Tip403PolicyEvent,
+} from '#lib/server/tip403'
+import { fetchTip403Policy } from '#lib/server/tip403'
+import { withLoaderTiming } from '#lib/profiling'
+import { useMediaQuery } from '#lib/hooks'
+
+const defaultSearchValues = { page: 1, limit: 10, q: '' } as const
+
+export const Route = createFileRoute('/_layout/policy/$id')({
+	component: RouteComponent,
+	notFoundComponent: ({ data }) => (
+		<div className="flex flex-1 items-center justify-center px-4 pt-20">
+			<div className="text-center">
+				<h1 className="text-[32px] font-medium text-primary">
+					Policy Not Found
+				</h1>
+				<p className="mt-2 text-[15px] text-secondary">
+					The TIP-403 policy does not exist or could not be loaded.
+				</p>
+				{data ? <span className="sr-only">{String(data)}</span> : null}
+			</div>
+		</div>
+	),
+	validateSearch: z.object({
+		page: z.prefault(z.coerce.number(), defaultSearchValues.page),
+		limit: z.prefault(
+			z.pipe(
+				z.coerce.number(),
+				z.transform((value) => Math.min(100, Math.max(5, value))),
+			),
+			defaultSearchValues.limit,
+		),
+		q: z.prefault(z.string(), defaultSearchValues.q),
+	}),
+	search: { middlewares: [stripSearchParams(defaultSearchValues)] },
+	loaderDeps: ({ search: { page, limit, q } }) => ({ page, limit, q }),
+	loader: ({ params, deps }) =>
+		withLoaderTiming('/_layout/policy/$id', async () => {
+			const policyId = parseTip403PolicyId(params.id)
+			if (!policyId) throw notFound()
+			const policy = await fetchTip403Policy({
+				data: { policyId, page: deps.page, limit: deps.limit, query: deps.q },
+			})
+			if (!policy) throw notFound()
+			return policy
+		}),
+	head: ({ params, loaderData }) => {
+		const policyId = loaderData?.policyId ?? params.id
+		const title = `TIP-403 Policy #${policyId} ⋅ Tempo Explorer`
+		return {
+			title,
+			meta: [
+				{ title },
+				{
+					name: 'description',
+					content: `View TIP-403 transfer policy ${policyId} on Tempo.`,
+				},
+			],
+		}
+	},
+})
+
+function RouteComponent() {
+	const policy = Route.useLoaderData()
+	const { page, limit, q } = Route.useSearch()
+	const isMobile = useMediaQuery('(max-width: 799px)')
+	const mode = isMobile ? 'stacked' : 'tabs'
+
+	return (
+		<div className="max-[800px]:flex max-[800px]:flex-col max-[800px]:pt-10 max-[800px]:pb-8 grid w-full grid-cols-[auto_1fr] gap-[14px] px-4 pt-20 pb-16 min-w-0 min-[1240px]:max-w-[1280px]">
+			<BreadcrumbsSlot className="col-span-full" />
+			<PolicyCard policy={policy} />
+			<Sections
+				mode={mode}
+				sections={[
+					{
+						title: 'Members',
+						totalItems: policy.membersTotal,
+						autoCollapse: false,
+						contextual: <MembersSearch query={q} />,
+						content: <MembersGrid policy={policy} page={page} limit={limit} />,
+					},
+					{
+						title: 'Activity',
+						totalItems: policy.activity.length,
+						autoCollapse: false,
+						content: <ActivityGrid policy={policy} />,
+					},
+				]}
+			/>
+		</div>
+	)
+}
+
+function PolicyCard(props: { policy: Tip403PolicyResponse }) {
+	const { policy } = props
+	const builtIn =
+		policy.policyId === '0'
+			? 'Always reject'
+			: policy.policyId === '1'
+				? 'Always allow'
+				: undefined
+
+	return (
+		<InfoCard
+			title={<InfoCard.Title>TIP-403 Policy</InfoCard.Title>}
+			className="self-start max-[800px]:w-full"
+			sections={[
+				{ label: 'Policy ID', value: <span>#{policy.policyId}</span> },
+				{
+					label: 'Type',
+					value: (
+						<span className="flex items-center gap-2">
+							<PolicyTypeBadge type={policy.type} />
+							{builtIn ? (
+								<span className="text-tertiary">{builtIn}</span>
+							) : null}
+						</span>
+					),
+				},
+				{
+					label: 'Admin',
+					value: <AddressLink address={policy.admin} chars={4} />,
+				},
+				{
+					label: 'Registry',
+					value: <AddressLink address={Addresses.tip403Registry} chars={4} />,
+				},
+				...(policy.type === 'compound' && policy.componentPolicies
+					? [
+							{
+								label: 'Sender policy',
+								value: (
+									<Link
+										to="/policy/$id"
+										params={{ id: policy.componentPolicies[0] }}
+										className="text-accent hover:underline"
+									>
+										#{policy.componentPolicies[0]}
+									</Link>
+								),
+							},
+							{
+								label: 'Recipient policy',
+								value: (
+									<Link
+										to="/policy/$id"
+										params={{ id: policy.componentPolicies[1] }}
+										className="text-accent hover:underline"
+									>
+										#{policy.componentPolicies[1]}
+									</Link>
+								),
+							},
+							{
+								label: 'Mint recipient',
+								value: (
+									<Link
+										to="/policy/$id"
+										params={{ id: policy.componentPolicies[2] }}
+										className="text-accent hover:underline"
+									>
+										#{policy.componentPolicies[2]}
+									</Link>
+								),
+							},
+						]
+					: []),
+			]}
+		/>
+	)
+}
+
+function PolicyTypeBadge(props: { type: Tip403PolicyResponse['type'] }) {
+	return (
+		<span
+			className={cx(
+				'rounded-[4px] px-1.5 py-0.5 text-[11px] font-medium capitalize',
+				props.type === 'whitelist'
+					? 'bg-positive/10 text-positive'
+					: props.type === 'blacklist'
+						? 'bg-negative/10 text-negative'
+						: 'bg-accent/10 text-accent',
+			)}
+		>
+			{props.type}
+		</span>
+	)
+}
+
+function MembersSearch(props: { query: string }) {
+	const navigate = useNavigate()
+	return (
+		<form
+			className="flex items-center gap-2"
+			onSubmit={(event) => {
+				event.preventDefault()
+				const query =
+					new FormData(event.currentTarget).get('query')?.toString() ?? ''
+				void navigate({
+					to: '.',
+					search: (previous) => ({
+						...previous,
+						page: 1,
+						q: query || undefined,
+					}),
+				})
+			}}
+		>
+			<input
+				name="query"
+				defaultValue={props.query}
+				placeholder="Search addresses"
+				aria-label="Search policy members"
+				className="h-7 w-[220px] rounded-[4px] border border-base-border bg-base px-2 text-[12px] font-mono text-primary outline-none placeholder:text-tertiary focus:border-accent"
+			/>
+			<button
+				type="submit"
+				className="h-7 rounded-[4px] border border-base-border px-2 text-[12px] text-secondary hover:bg-base-alt press-down"
+			>
+				Search
+			</button>
+		</form>
+	)
+}
+
+function MembersGrid(props: {
+	policy: Tip403PolicyResponse
+	page: number
+	limit: number
+}) {
+	const { policy, page, limit } = props
+	const pages = Math.max(1, Math.ceil(policy.membersTotal / limit))
+	const status = policy.type === 'whitelist' ? 'Authorized' : 'Restricted'
+
+	return (
+		<DataGrid
+			columns={{
+				stacked: [
+					{ label: 'Address', width: '1fr', minWidth: 220 },
+					{ label: 'Status', width: '1fr', minWidth: 110 },
+				],
+				tabs: [
+					{ label: 'Address', width: '1fr', minWidth: 220 },
+					{ label: 'Status', width: '1fr', minWidth: 110 },
+				],
+			}}
+			items={() =>
+				policy.members.map((address) => ({
+					key: address,
+					cells: [
+						<AddressLink key="address" address={address} chars={5} />,
+						<span
+							key="status"
+							className={
+								policy.type === 'whitelist' ? 'text-positive' : 'text-negative'
+							}
+						>
+							{status}
+						</span>,
+					],
+				}))
+			}
+			totalItems={policy.membersTotal}
+			page={page}
+			pages={pages}
+			itemsPerPage={limit}
+			itemsLabel="members"
+			emptyState="This policy has no current members."
+		/>
+	)
+}
+
+function ActivityGrid(props: { policy: Tip403PolicyResponse }) {
+	const { policy } = props
+	const { formatLabel, cycleTimeFormat, timeFormat } = useTimeFormat()
+	const timeColumn = (
+		<TimeColumnHeader
+			label="Time"
+			formatLabel={formatLabel}
+			onCycle={cycleTimeFormat}
+		/>
+	)
+
+	return (
+		<DataGrid
+			columns={{
+				stacked: [
+					{ label: 'Event', width: '2fr', minWidth: 150 },
+					{ label: 'Account', width: '2fr', minWidth: 200 },
+					{ label: timeColumn, width: '1fr', minWidth: 90 },
+					{ label: 'Transaction', width: '2fr', minWidth: 150 },
+				],
+				tabs: [
+					{ label: 'Event', width: '2fr', minWidth: 150 },
+					{ label: 'Account', width: '2fr', minWidth: 200 },
+					{ label: timeColumn, width: '1fr', minWidth: 90 },
+					{ label: 'Transaction', width: '2fr', minWidth: 150 },
+				],
+			}}
+			items={() =>
+				policy.activity.map((event) => activityRow(event, timeFormat))
+			}
+			totalItems={policy.activity.length}
+			page={1}
+			itemsPerPage={20}
+			itemsLabel="events"
+			pagination="simple"
+			showSimpleCount={false}
+			emptyState="No policy events found."
+		/>
+	)
+}
+
+function activityRow(
+	event: Tip403PolicyEvent,
+	timeFormat: ReturnType<typeof useTimeFormat>['timeFormat'],
+): DataGrid.Row {
+	const account = event.account ?? event.admin ?? event.updater
+	const eventLabel =
+		event.type === 'whitelist updated' || event.type === 'blacklist updated'
+			? `${event.type === 'whitelist updated' ? 'Whitelist' : 'Blacklist'} ${event.allowed ? 'updated' : 'removed'}`
+			: event.type === 'admin updated'
+				? 'Admin updated'
+				: event.type === 'compound created'
+					? 'Compound policy created'
+					: 'Policy created'
+
+	return {
+		key: `${event.txHash}-${event.blockNumber}`,
+		cells: [
+			<span key="event" className="text-primary">
+				{eventLabel}
+			</span>,
+			account ? (
+				<AddressLink key="account" address={account} chars={4} />
+			) : (
+				<span key="account">—</span>
+			),
+			event.timestamp != null ? (
+				<TimestampCell
+					key="time"
+					timestamp={BigInt(event.timestamp)}
+					format={timeFormat}
+				/>
+			) : (
+				<span key="time">—</span>
+			),
+			<div key="transaction" className="flex items-center gap-1">
+				<TransactionCell hash={event.txHash} />
+				<CopyButton value={event.txHash} ariaLabel="Copy transaction hash" />
+			</div>,
+		],
+	}
+}

--- a/apps/explorer/src/routes/_layout/policy/$id.tsx
+++ b/apps/explorer/src/routes/_layout/policy/$id.tsx
@@ -353,7 +353,7 @@ function activityRow(
 					: 'Policy created'
 
 	return {
-		key: `${event.txHash}-${event.blockNumber}`,
+		key: `${event.txHash}-${event.logIndex}`,
 		cells: [
 			<span key="event" className="text-primary">
 				{eventLabel}

--- a/apps/explorer/test/tip403-log-utils.test.ts
+++ b/apps/explorer/test/tip403-log-utils.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import {
+	dedupePolicyLogs,
+	fetchAllPolicyLogPages,
+	fetchRecentUniquePolicyLogs,
+} from '#lib/server/tip403-log-utils'
+
+type Log = { tx_hash: string; log_idx: number }
+
+const logs: Log[] = [
+	{ tx_hash: '0xaaa', log_idx: 0 },
+	{ tx_hash: '0xaaa', log_idx: 0 },
+	{ tx_hash: '0xbbb', log_idx: 1 },
+	{ tx_hash: '0xccc', log_idx: 2 },
+	{ tx_hash: '0xddd', log_idx: 3 },
+]
+
+describe('TIP-403 policy log helpers', () => {
+	it('deduplicates logs by transaction hash and log index', () => {
+		expect(dedupePolicyLogs(logs)).toEqual([logs[0], logs[2], logs[3], logs[4]])
+	})
+
+	it('reads every page before reconstructing policy state', async () => {
+		const offsets: number[] = []
+		const result = await fetchAllPolicyLogPages(async (limit, offset) => {
+			offsets.push(offset)
+			return logs.slice(offset, offset + limit)
+		}, 2)
+
+		expect(offsets).toEqual([0, 2, 4])
+		expect(result).toEqual([logs[0], logs[2], logs[3], logs[4]])
+	})
+
+	it('continues past duplicate rows to fill recent activity', async () => {
+		const result = await fetchRecentUniquePolicyLogs(
+			async (limit, offset) => logs.slice(offset, offset + limit),
+			3,
+		)
+
+		expect(result).toEqual([logs[0], logs[2], logs[3]])
+	})
+})

--- a/apps/explorer/test/tip403-policy.test.ts
+++ b/apps/explorer/test/tip403-policy.test.ts
@@ -1,0 +1,33 @@
+import * as Address from 'ox/Address'
+import { describe, expect, it } from 'vitest'
+import {
+	parseTip403PolicyId,
+	parseTip403PolicyType,
+	updateTip403Member,
+} from '#lib/domain/tip403'
+
+const account = Address.from('0x0000000000000000000000000000000000000001')
+
+describe('TIP-403 policy helpers', () => {
+	it('normalizes valid uint64 policy IDs and rejects invalid IDs', () => {
+		expect(parseTip403PolicyId('0002')).toBe('2')
+		expect(parseTip403PolicyId('18446744073709551615')).toBe(
+			'18446744073709551615',
+		)
+		expect(parseTip403PolicyId('-1')).toBeUndefined()
+		expect(parseTip403PolicyId('18446744073709551616')).toBeUndefined()
+	})
+
+	it('maps the registry policy enum, including compound policies', () => {
+		expect(parseTip403PolicyType(0)).toBe('whitelist')
+		expect(parseTip403PolicyType(1)).toBe('blacklist')
+		expect(parseTip403PolicyType(2)).toBe('compound')
+	})
+
+	it('replays membership updates case-insensitively', () => {
+		const members = new Map<string, typeof account>()
+		updateTip403Member(members, account, true)
+		updateTip403Member(members, account.toUpperCase() as typeof account, false)
+		expect(members).toHaveLength(0)
+	})
+})


### PR DESCRIPTION
## Summary

Adds a `/policy/:id` detail route for TIP-403 policies in the Explorer.

- Shows policy ID, type, built-in labels, admin, registry, and compound policy links.
- Reconstructs current whitelist/blacklist members from indexed events with search and pagination.
- Shows recent policy activity with linked transactions and timestamps.
- Adds breadcrumb and LLM route metadata.

## Screenshots

| Before | After |
|--------|-------|
| No TIP-403 policy detail route; policy data was only visible through contract interaction. | `/policy/{policyId}` provides a dedicated metadata, members, and activity view. |

## Validation

- `pnpm --filter explorer check:biome`
- `pnpm --filter explorer check:types`
- `pnpm --filter explorer test --run` (10 files, 52 tests)
- `pnpm --filter explorer build`

The repository-wide type check is currently blocked by pre-existing missing Cloudflare `Env` bindings in `apps/contract-verification`.

Prompted by: @deodad