### PR TITLE
fix(explorer): reuse transaction history totals

### DIFF
--- a/apps/explorer/src/lib/server/address-history.ts
+++ b/apps/explorer/src/lib/server/address-history.ts
@@ -23,6 +23,8 @@ export const [MAX_LIMIT, DEFAULT_LIMIT] = [100, 10]
 /** The API's positional-pagination window: `page × limit` must stay within. */
 const HISTORY_COUNT_MAX = 10_000
 const CSV_EXPORT_LIMIT = HISTORY_COUNT_MAX
+const HISTORY_TOTAL_CACHE_TTL = 60_000
+const HISTORY_TOTAL_CACHE_MAX_ENTRIES = 50
 
 export type EnrichedTransaction = {
 	hash: `0x${string}`
@@ -62,6 +64,85 @@ type TransactionRow = InferResponseType<
 	typeof api.v1.transactions.$get,
 	200
 >['data'][number]
+
+type HistoryTotal = {
+	totalCount: number
+	totalCountCapped: boolean
+}
+
+const historyTotalCache = new Map<
+	string,
+	{ promise: Promise<HistoryTotal | undefined>; timestamp: number }
+>()
+
+function historyFilters(
+	address: Address.Address,
+	searchParams: HistoryRequestParameters,
+) {
+	const sideFilter =
+		searchParams.include === 'sent'
+			? { sender: address }
+			: searchParams.include === 'received'
+				? { recipient: address }
+				: { address }
+
+	return {
+		...sideFilter,
+		...(searchParams.status ? { status: searchParams.status } : {}),
+		...(searchParams.after
+			? {
+					'timestamp.from': new Date(searchParams.after * 1000).toISOString(),
+				}
+			: {}),
+	}
+}
+
+function getAddressHistoryTotal(params: {
+	address: Address.Address
+	chainId: number
+	searchParams: HistoryRequestParameters
+}): Promise<HistoryTotal | undefined> {
+	const filters = historyFilters(params.address, params.searchParams)
+	const key = JSON.stringify([params.chainId, filters])
+	const cached = historyTotalCache.get(key)
+	if (cached && Date.now() - cached.timestamp < HISTORY_TOTAL_CACHE_TTL)
+		return cached.promise
+
+	if (
+		!historyTotalCache.has(key) &&
+		historyTotalCache.size >= HISTORY_TOTAL_CACHE_MAX_ENTRIES
+	) {
+		const oldestKey = historyTotalCache.keys().next().value
+		if (oldestKey) historyTotalCache.delete(oldestKey)
+	}
+
+	const promise = parseResponse(
+		api.v1.transactions.$get({
+			query: {
+				chainId: String(params.chainId),
+				...filters,
+				include: 'totalCount',
+				limit: '1',
+			},
+		}),
+	)
+		.then((result) =>
+			result.meta?.totalCount === undefined
+				? undefined
+				: {
+						totalCount: result.meta.totalCount,
+						totalCountCapped: result.meta.totalCountCapped ?? false,
+					},
+		)
+		.catch(() => undefined)
+
+	historyTotalCache.set(key, { promise, timestamp: Date.now() })
+	void promise.then((total) => {
+		if (total === undefined && historyTotalCache.get(key)?.promise === promise)
+			historyTotalCache.delete(key)
+	})
+	return promise
+}
 
 function serializeBigInts<T>(value: T): T {
 	if (typeof value === 'bigint') {
@@ -221,34 +302,22 @@ export async function fetchAddressHistoryData(params: {
 	// (totals are clamped page-aligned below), but guard direct requests.
 	if (page * limit > HISTORY_COUNT_MAX) return emptyResponse
 
-	// `include=sent|received` narrows the side; `all` matches either side.
-	const sideFilter =
-		searchParams.include === 'sent'
-			? { sender: address }
-			: searchParams.include === 'received'
-				? { recipient: address }
-				: { address }
-
-	const result = await parseResponse(
-		api.v1.transactions.$get({
-			query: {
-				chainId: String(chainId),
-				...sideFilter,
-				...(searchParams.status ? { status: searchParams.status } : {}),
-				...(searchParams.after
-					? {
-							'timestamp.from': new Date(
-								searchParams.after * 1000,
-							).toISOString(),
-						}
-					: {}),
-				order: searchParams.sort,
-				limit: String(limit),
-				...(page > 1 ? { page: String(page) } : {}),
-				include: 'receipt,totalCount',
-			},
-		}),
-	)
+	const filters = historyFilters(address, searchParams)
+	const [result, exactTotal] = await Promise.all([
+		parseResponse(
+			api.v1.transactions.$get({
+				query: {
+					chainId: String(chainId),
+					...filters,
+					order: searchParams.sort,
+					limit: String(limit),
+					...(page > 1 ? { page: String(page) } : {}),
+					include: 'receipt',
+				},
+			}),
+		),
+		getAddressHistoryTotal({ address, chainId, searchParams }),
+	])
 
 	const getTokenMetadata = includeKnownEvents
 		? await buildTokenMetadataLookup(result.data)
@@ -259,8 +328,8 @@ export async function fetchAddressHistoryData(params: {
 	)
 
 	const { total, totalCapped } = resolveTotal({
-		exactCount: result.meta?.totalCount,
-		exactCountCapped: result.meta?.totalCountCapped,
+		exactCount: exactTotal?.totalCount,
+		exactCountCapped: exactTotal?.totalCountCapped,
 		page,
 		limit,
 		rows: transactions.length,

--- a/apps/explorer/test/address-history.node.test.ts
+++ b/apps/explorer/test/address-history.node.test.ts
@@ -1,5 +1,20 @@
-import { describe, expect, it } from 'vitest'
-import { toEnrichedTransaction } from '#lib/server/address-history'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+	fetchAddressHistoryData,
+	toEnrichedTransaction,
+} from '#lib/server/address-history'
+
+const { getTransactions } = vi.hoisted(() => ({
+	getTransactions: vi.fn(),
+}))
+
+vi.mock('#lib/server/tempo-api', () => ({
+	api: { v1: { transactions: { $get: getTransactions } } },
+}))
+
+beforeEach(() => {
+	getTransactions.mockReset()
+})
 
 const SENDER = '0x286ad6cfc7279c8a6d86d15dcefcb77a65aa7e92'
 const RECIPIENT = '0x20c0000000000000000000000000000000000003'
@@ -88,5 +103,90 @@ describe('toEnrichedTransaction', () => {
 		)
 
 		expect(result.status).toBe('reverted')
+	})
+})
+
+describe('fetchAddressHistoryData', () => {
+	it('reuses one total count across transaction pages', async () => {
+		getTransactions.mockImplementation((options) => {
+			const { include } = (options as { query: { include: string } }).query
+			return Promise.resolve(
+				Response.json(
+					include === 'totalCount'
+						? {
+								data: [],
+								meta: { totalCount: 1_750, totalCountCapped: false },
+								nextCursor: null,
+							}
+						: { data: [], nextCursor: 'next' },
+				),
+			)
+		})
+
+		const params = {
+			address: '0x1111111111111111111111111111111111111111' as const,
+			chainId: 4217,
+			includeKnownEvents: false,
+			searchParams: {
+				include: 'all' as const,
+				limit: 100,
+				page: 1,
+				sort: 'desc' as const,
+			},
+		}
+
+		await expect(fetchAddressHistoryData(params)).resolves.toMatchObject({
+			countCapped: false,
+			page: 1,
+			total: 1_750,
+		})
+		for (let page = 2; page <= 18; page++) {
+			await expect(
+				fetchAddressHistoryData({
+					...params,
+					searchParams: { ...params.searchParams, page },
+				}),
+			).resolves.toMatchObject({
+				countCapped: false,
+				page,
+				total: 1_750,
+			})
+		}
+
+		expect(getTransactions).toHaveBeenCalledTimes(19)
+		expect(getTransactions).toHaveBeenNthCalledWith(1, {
+			query: {
+				address: params.address,
+				chainId: '4217',
+				include: 'receipt',
+				limit: '100',
+				order: 'desc',
+			},
+		})
+		expect(getTransactions).toHaveBeenNthCalledWith(2, {
+			query: {
+				address: params.address,
+				chainId: '4217',
+				include: 'totalCount',
+				limit: '1',
+			},
+		})
+		expect(getTransactions).toHaveBeenLastCalledWith({
+			query: {
+				address: params.address,
+				chainId: '4217',
+				include: 'receipt',
+				limit: '100',
+				order: 'desc',
+				page: '18',
+			},
+		})
+		expect(
+			getTransactions.mock.calls.filter(
+				([options]) =>
+					(options as { query: { include: string } }).query.include ===
+					'totalCount',
+			),
+		).toHaveLength(1)
 	})
 })


### PR DESCRIPTION
Fetch transaction receipts per page while reusing one cached total-count request for matching address-history filters, reducing repeated expensive API counts during deep Explorer pagination.