### PR TITLE
fix(explorer): count address history on first page

### DIFF
--- a/apps/explorer/src/lib/server/address-history.ts
+++ b/apps/explorer/src/lib/server/address-history.ts
@@ -97,17 +97,19 @@ function historyFilters(
 	}
 }
 
-function getAddressHistoryTotal(params: {
-	address: Address.Address
-	chainId: number
-	searchParams: HistoryRequestParameters
-}): Promise<HistoryTotal | undefined> {
-	const filters = historyFilters(params.address, params.searchParams)
-	const key = JSON.stringify([params.chainId, filters])
+function getCachedHistoryTotal(
+	key: string,
+): Promise<HistoryTotal | undefined> | undefined {
 	const cached = historyTotalCache.get(key)
 	if (cached && Date.now() - cached.timestamp < HISTORY_TOTAL_CACHE_TTL)
 		return cached.promise
+	if (cached) historyTotalCache.delete(key)
+}
 
+function cacheHistoryTotal(
+	key: string,
+	promise: Promise<HistoryTotal | undefined>,
+) {
 	if (
 		!historyTotalCache.has(key) &&
 		historyTotalCache.size >= HISTORY_TOTAL_CACHE_MAX_ENTRIES
@@ -116,32 +118,11 @@ function getAddressHistoryTotal(params: {
 		if (oldestKey) historyTotalCache.delete(oldestKey)
 	}
 
-	const promise = parseResponse(
-		api.v1.transactions.$get({
-			query: {
-				chainId: String(params.chainId),
-				...filters,
-				include: 'totalCount',
-				limit: '1',
-			},
-		}),
-	)
-		.then((result) =>
-			result.meta?.totalCount === undefined
-				? undefined
-				: {
-						totalCount: result.meta.totalCount,
-						totalCountCapped: result.meta.totalCountCapped ?? false,
-					},
-		)
-		.catch(() => undefined)
-
 	historyTotalCache.set(key, { promise, timestamp: Date.now() })
 	void promise.then((total) => {
 		if (total === undefined && historyTotalCache.get(key)?.promise === promise)
 			historyTotalCache.delete(key)
 	})
-	return promise
 }
 
 function serializeBigInts<T>(value: T): T {
@@ -303,20 +284,40 @@ export async function fetchAddressHistoryData(params: {
 	if (page * limit > HISTORY_COUNT_MAX) return emptyResponse
 
 	const filters = historyFilters(address, searchParams)
+	const totalKey = JSON.stringify([chainId, filters])
+	const cachedTotal = getCachedHistoryTotal(totalKey)
+	// Direct deep-page requests use the capped fallback until page one warms the
+	// cache; only page one refreshes the exact total.
+	const includeTotal = page === 1 && cachedTotal === undefined
+	const resultPromise = parseResponse(
+		api.v1.transactions.$get({
+			query: {
+				chainId: String(chainId),
+				...filters,
+				order: searchParams.sort,
+				limit: String(limit),
+				...(page > 1 ? { page: String(page) } : {}),
+				include: includeTotal ? 'receipt,totalCount' : 'receipt',
+			},
+		}),
+	)
+	const requestedTotal = includeTotal
+		? resultPromise
+				.then((result) =>
+					result.meta?.totalCount === undefined
+						? undefined
+						: {
+								totalCount: result.meta.totalCount,
+								totalCountCapped: result.meta.totalCountCapped ?? false,
+							},
+				)
+				.catch(() => undefined)
+		: undefined
+	if (requestedTotal) cacheHistoryTotal(totalKey, requestedTotal)
+
 	const [result, exactTotal] = await Promise.all([
-		parseResponse(
-			api.v1.transactions.$get({
-				query: {
-					chainId: String(chainId),
-					...filters,
-					order: searchParams.sort,
-					limit: String(limit),
-					...(page > 1 ? { page: String(page) } : {}),
-					include: 'receipt',
-				},
-			}),
-		),
-		getAddressHistoryTotal({ address, chainId, searchParams }),
+		resultPromise,
+		cachedTotal ?? requestedTotal,
 	])
 
 	const getTokenMetadata = includeKnownEvents

--- a/apps/explorer/test/address-history.node.test.ts
+++ b/apps/explorer/test/address-history.node.test.ts
@@ -107,12 +107,12 @@ describe('toEnrichedTransaction', () => {
 })
 
 describe('fetchAddressHistoryData', () => {
-	it('reuses one total count across transaction pages', async () => {
+	it('requests and reuses the total count from the first page', async () => {
 		getTransactions.mockImplementation((options) => {
 			const { include } = (options as { query: { include: string } }).query
 			return Promise.resolve(
 				Response.json(
-					include === 'totalCount'
+					include.includes('totalCount')
 						? {
 								data: [],
 								meta: { totalCount: 1_750, totalCountCapped: false },
@@ -153,12 +153,12 @@ describe('fetchAddressHistoryData', () => {
 			})
 		}
 
-		expect(getTransactions).toHaveBeenCalledTimes(19)
+		expect(getTransactions).toHaveBeenCalledTimes(18)
 		expect(getTransactions).toHaveBeenNthCalledWith(1, {
 			query: {
 				address: params.address,
 				chainId: '4217',
-				include: 'receipt',
+				include: 'receipt,totalCount',
 				limit: '100',
 				order: 'desc',
 			},
@@ -167,8 +167,10 @@ describe('fetchAddressHistoryData', () => {
 			query: {
 				address: params.address,
 				chainId: '4217',
-				include: 'totalCount',
-				limit: '1',
+				include: 'receipt',
+				limit: '100',
+				order: 'desc',
+				page: '2',
 			},
 		})
 		expect(getTransactions).toHaveBeenLastCalledWith({
@@ -182,11 +184,47 @@ describe('fetchAddressHistoryData', () => {
 			},
 		})
 		expect(
-			getTransactions.mock.calls.filter(
-				([options]) =>
-					(options as { query: { include: string } }).query.include ===
+			getTransactions.mock.calls.filter(([options]) =>
+				(options as { query: { include: string } }).query.include.includes(
 					'totalCount',
+				),
 			),
 		).toHaveLength(1)
+	})
+
+	it('does not request a total when opened on a later page', async () => {
+		getTransactions.mockResolvedValue(
+			Response.json({ data: [], nextCursor: 'next' }),
+		)
+
+		await expect(
+			fetchAddressHistoryData({
+				address: '0x2222222222222222222222222222222222222222',
+				chainId: 4217,
+				includeKnownEvents: false,
+				searchParams: {
+					include: 'all',
+					limit: 100,
+					page: 6,
+					sort: 'desc',
+				},
+			}),
+		).resolves.toMatchObject({
+			countCapped: true,
+			page: 6,
+			total: 10_000,
+		})
+
+		expect(getTransactions).toHaveBeenCalledOnce()
+		expect(getTransactions).toHaveBeenCalledWith({
+			query: {
+				address: '0x2222222222222222222222222222222222222222',
+				chainId: '4217',
+				include: 'receipt',
+				limit: '100',
+				order: 'desc',
+				page: '6',
+			},
+		})
 	})
 })


### PR DESCRIPTION
Request transaction totals with the first address-history page and reuse the cached result. Later pages avoid invalid count-only requests and use the existing capped fallback when needed.