### PR TITLE
feat(explorer): add contract dependency discovery

### DIFF
--- a/apps/explorer/src/lib/domain/contract-discovery.ts
+++ b/apps/explorer/src/lib/domain/contract-discovery.ts
@@ -6,6 +6,53 @@ export type DiscoveryNode = {
 	kind: 'contract' | 'native' | 'account'
 	depth: number
 	isRoot: boolean
+	details: DiscoveryNodeDetails
+}
+
+export type DiscoveryNodeDetails = {
+	bytecode: {
+		status: 'available' | 'empty' | 'unavailable' | 'precompile'
+		bytes?: number
+	}
+	abi?: DiscoveryAbiSummary
+	source?: DiscoverySourceSummary
+	proxy?: {
+		implementation?: Address
+		admin?: Address
+	}
+}
+
+export type DiscoveryAbiSummary = {
+	functionCount: number
+	readFunctionCount: number
+	writeFunctionCount: number
+	eventCount: number
+	errorCount: number
+	functions: Array<{
+		name: string
+		stateMutability: string
+		inputs: number
+		outputs: number
+	}>
+	truncated: boolean
+}
+
+export type DiscoverySourceSummary = {
+	kind: 'verified' | 'native'
+	name: string
+	language: string
+	compiler?: string
+	compilerVersion?: string
+	fullyQualifiedName?: string
+	verifiedAt?: string | null
+	match?: string | null
+	runtimeMatch?: string | null
+	sourceFileCount: number
+	docsUrl?: string
+	repository?: string
+	commit?: string
+	commitUrl?: string | null
+	entrypoints?: string[]
 }
 
 export type DiscoveryEdge = {
@@ -17,6 +64,7 @@ export type DiscoveryEdge = {
 
 export type ContractDiscovery = {
 	root: Address
+	chainId: number
 	nodes: DiscoveryNode[]
 	edges: DiscoveryEdge[]
 	truncated: boolean

--- a/apps/explorer/src/lib/domain/contract-discovery.ts
+++ b/apps/explorer/src/lib/domain/contract-discovery.ts
@@ -58,6 +58,7 @@ export type DiscoverySourceSummary = {
 export type DiscoveryEdge = {
 	from: Address
 	to: Address
+	action: string
 	label: string
 	kind: 'getter' | 'proxy' | 'role'
 }

--- a/apps/explorer/src/lib/domain/contract-discovery.ts
+++ b/apps/explorer/src/lib/domain/contract-discovery.ts
@@ -1,0 +1,33 @@
+import type { Address } from 'viem'
+
+export type DiscoveryNode = {
+	id: Address
+	name: string
+	kind: 'contract' | 'native' | 'account'
+	depth: number
+	isRoot: boolean
+}
+
+export type DiscoveryEdge = {
+	from: Address
+	to: Address
+	label: string
+	kind: 'getter' | 'proxy' | 'role'
+}
+
+export type ContractDiscovery = {
+	root: Address
+	nodes: DiscoveryNode[]
+	edges: DiscoveryEdge[]
+	truncated: boolean
+}
+
+export async function fetchContractDiscovery(
+	address: Address,
+): Promise<ContractDiscovery> {
+	const response = await fetch(
+		`/api/contract-discovery?address=${encodeURIComponent(address)}`,
+	)
+	if (!response.ok) throw new Error('Contract discovery failed')
+	return response.json() as Promise<ContractDiscovery>
+}

--- a/apps/explorer/src/lib/server/contract-discovery.ts
+++ b/apps/explorer/src/lib/server/contract-discovery.ts
@@ -1,0 +1,363 @@
+import * as Address from 'ox/Address'
+import * as Hash from 'ox/Hash'
+import * as Hex from 'ox/Hex'
+import {
+	type Abi,
+	type AbiFunction,
+	type Chain,
+	createPublicClient,
+	http,
+	parseAbiItem,
+	type PublicClient,
+	type Transport,
+	zeroAddress,
+} from 'viem'
+import { Abis } from '#lib/abis'
+import type {
+	ContractDiscovery,
+	DiscoveryEdge,
+	DiscoveryNode,
+} from '#lib/domain/contract-discovery'
+import { fetchContractSourceDirect } from '#lib/domain/contract-source'
+import * as Tip20 from '#lib/domain/tip20'
+import { tempoQueryBuilder } from '#lib/server/tempo-queries-provider'
+import { getTempoChain } from '#wagmi.config'
+
+const MAX_NODES = 32
+const MAX_DEPTH = 4
+const MAX_GETTERS_PER_CONTRACT = 80
+const ROLE_LOG_SCAN_LIMIT = 10_000
+const ROLE_EVENT = Hash.keccak256(
+	Hex.fromString('RoleMembershipUpdated(bytes32,address,address,bool)'),
+)
+const ISSUER_ROLE = Hash.keccak256(Hex.fromString('ISSUER_ROLE'))
+const ROLE_EVENT_ABI = parseAbiItem(
+	'event RoleMembershipUpdated(bytes32 indexed role, address indexed account, address indexed sender, bool hasRole)',
+)
+const IMPLEMENTATION_SLOT =
+	'0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc'
+const ADMIN_SLOT =
+	'0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103'
+
+type QueueItem = { address: Address.Address; depth: number }
+
+export async function discoverContractGraph(
+	root: Address.Address,
+): Promise<ContractDiscovery> {
+	const chain = getTempoChain()
+	const client = createPublicClient({
+		chain,
+		transport: http(chain.rpcUrls.default.http[0]),
+	})
+	const queue: QueueItem[] = [{ address: Address.checksum(root), depth: 0 }]
+	const seen = new Set<string>()
+	const queued = new Set([root.toLowerCase()])
+	const nodes: DiscoveryNode[] = []
+	const edges: DiscoveryEdge[] = []
+	const deadline = Date.now() + 25_000
+	let incomplete = false
+
+	while (
+		queue.length > 0 &&
+		nodes.length < MAX_NODES &&
+		Date.now() < deadline
+	) {
+		const current = queue.shift()
+		if (!current) break
+		const key = current.address.toLowerCase()
+		if (seen.has(key)) continue
+		seen.add(key)
+
+		const isNative = Tip20.isTip20Address(current.address)
+		let abi: Abi | undefined
+		let name: string | undefined
+		let hasVerifiedSource = false
+
+		if (isNative) {
+			abi = Abis.tip20
+		} else {
+			try {
+				const source = await withTimeout(
+					fetchContractSourceDirect({
+						address: current.address,
+						chainId: chain.id,
+					}),
+					3_000,
+				)
+				abi = source.abi as Abi
+				name = source.kind === 'native' ? source.name : source.compilation.name
+				hasVerifiedSource = true
+			} catch {
+				// Fall through to bytecode classification for unverified addresses.
+			}
+		}
+		const bytecode = hasVerifiedSource
+			? undefined
+			: await withTimeout(
+					client.getCode({ address: current.address }),
+					3_000,
+				).catch(() => undefined)
+		const isContract =
+			isNative ||
+			hasVerifiedSource ||
+			(bytecode !== undefined && bytecode !== '0x')
+
+		nodes.push({
+			id: current.address,
+			name: name ?? fallbackName(current.address, isNative, isContract),
+			kind: isNative ? 'native' : isContract ? 'contract' : 'account',
+			depth: current.depth,
+			isRoot: current.depth === 0,
+		})
+
+		if (!isContract || current.depth >= MAX_DEPTH) continue
+
+		const found: DiscoveryEdge[] = []
+		if (isNative) {
+			const roleResult = await currentTip20Issuers(
+				current.address,
+				chain.id,
+				client,
+			)
+			if (!roleResult.complete) incomplete = true
+			for (const issuer of roleResult.issuers) {
+				found.push({
+					from: current.address,
+					to: issuer,
+					label: 'ISSUER_ROLE',
+					kind: 'role',
+				})
+			}
+		}
+
+		if (abi) {
+			const getters = abi
+				.filter(isAddressGetter)
+				.slice(0, MAX_GETTERS_PER_CONTRACT)
+			const results = await Promise.all(
+				getters.map((getter) =>
+					withTimeout(
+						client.readContract({
+							address: current.address,
+							abi: [getter],
+							functionName: getter.name,
+						}),
+						3_000,
+					).then(
+						(result) => ({ getter, result }),
+						() => undefined,
+					),
+				),
+			)
+			for (const entry of results) {
+				if (!entry) continue
+				const { getter, result } = entry
+				for (const target of extractAddresses(result)) {
+					found.push({
+						from: current.address,
+						to: target,
+						label: getter.name,
+						kind: 'getter',
+					})
+				}
+			}
+		}
+
+		if (!isNative) {
+			for (const [label, slot] of [
+				['$implementation', IMPLEMENTATION_SLOT],
+				['$admin', ADMIN_SLOT],
+			] as const) {
+				try {
+					const value = await withTimeout(
+						client.getStorageAt({ address: current.address, slot }),
+						3_000,
+					)
+					const target = storageAddress(value)
+					if (target)
+						found.push({
+							from: current.address,
+							to: target,
+							label,
+							kind: 'proxy',
+						})
+				} catch {
+					// Some RPC transports do not expose storage reads.
+				}
+			}
+		}
+
+		for (const edge of dedupeEdges(found)) {
+			edges.push(edge)
+			const targetKey = edge.to.toLowerCase()
+			if (!seen.has(targetKey) && !queued.has(targetKey)) {
+				queued.add(targetKey)
+				queue.push({ address: edge.to, depth: current.depth + 1 })
+			}
+		}
+	}
+
+	return {
+		root: Address.checksum(root),
+		nodes,
+		edges: edges.filter(
+			(edge) =>
+				nodes.some(
+					(node) => node.id.toLowerCase() === edge.from.toLowerCase(),
+				) &&
+				nodes.some((node) => node.id.toLowerCase() === edge.to.toLowerCase()),
+		),
+		truncated: incomplete || queue.length > 0,
+	}
+}
+
+function isAddressGetter(item: Abi[number]): item is AbiFunction {
+	return (
+		item.type === 'function' &&
+		(item.stateMutability === 'view' || item.stateMutability === 'pure') &&
+		item.inputs.length === 0 &&
+		item.outputs.length === 1 &&
+		(item.outputs[0]?.type === 'address' ||
+			item.outputs[0]?.type === 'address[]')
+	)
+}
+
+function extractAddresses(value: unknown): Address.Address[] {
+	const values = Array.isArray(value) ? value : [value]
+	return values.flatMap((candidate) => {
+		if (typeof candidate !== 'string' || !Address.validate(candidate)) return []
+		if (candidate.toLowerCase() === zeroAddress) return []
+		return [Address.checksum(candidate)]
+	})
+}
+
+function storageAddress(
+	value: Hex.Hex | undefined,
+): Address.Address | undefined {
+	if (!value || value === '0x') return undefined
+	const candidate = `0x${value.slice(-40)}`
+	if (!Address.validate(candidate) || candidate.toLowerCase() === zeroAddress)
+		return undefined
+	return Address.checksum(candidate)
+}
+
+async function currentTip20Issuers<
+	TTransport extends Transport,
+	TChain extends Chain | undefined,
+>(
+	address: Address.Address,
+	chainId: number,
+	client: PublicClient<TTransport, TChain>,
+): Promise<{ issuers: Address.Address[]; complete: boolean }> {
+	try {
+		const query = tempoQueryBuilder(chainId, { engine: 'clickhouse' })
+			.selectFrom('logs')
+			.select(['topic1', 'topic2', 'data', 'block_num', 'log_idx'])
+			.where('address', '=', address.toLowerCase() as Address.Address)
+			.where('selector', '=', ROLE_EVENT)
+			.orderBy('block_num', 'asc')
+			.orderBy('log_idx', 'asc')
+			.limit(ROLE_LOG_SCAN_LIMIT)
+			.execute()
+		const logs = await withTimeout(query, 4_000)
+		const current = new Map<Address.Address, boolean>()
+		for (const log of logs) {
+			if (log.topic1?.toLowerCase() !== ISSUER_ROLE.toLowerCase()) continue
+			if (!log.topic2 || !log.data) continue
+			const account = Address.checksum(`0x${log.topic2.slice(-40)}`)
+			current.set(account, Hex.toBigInt(log.data) !== 0n)
+		}
+		return {
+			issuers: [...current]
+				.filter(([, active]) => active)
+				.map(([account]) => account),
+			complete: true,
+		}
+	} catch {
+		return currentTip20IssuersFromRpc(address, client)
+	}
+}
+
+async function currentTip20IssuersFromRpc<
+	TTransport extends Transport,
+	TChain extends Chain | undefined,
+>(
+	address: Address.Address,
+	client: PublicClient<TTransport, TChain>,
+): Promise<{ issuers: Address.Address[]; complete: boolean }> {
+	try {
+		const latest = await withTimeout(client.getBlockNumber(), 3_000)
+		const first = latest > 1_000_000n ? latest - 1_000_000n : 0n
+		const ranges: { fromBlock: bigint; toBlock: bigint }[] = []
+		for (let fromBlock = first; fromBlock <= latest; fromBlock += 100_000n) {
+			ranges.push({
+				fromBlock,
+				toBlock: fromBlock + 99_999n < latest ? fromBlock + 99_999n : latest,
+			})
+		}
+		const logs = (
+			await withTimeout(
+				Promise.all(
+					ranges.map((range) =>
+						client.getLogs({ address, event: ROLE_EVENT_ABI, ...range }),
+					),
+				),
+				8_000,
+			)
+		).flat()
+		const current = new Map<Address.Address, boolean>()
+		for (const log of logs) {
+			if (log.args.role?.toLowerCase() !== ISSUER_ROLE.toLowerCase()) continue
+			if (!log.args.account || log.args.hasRole === undefined) continue
+			current.set(Address.checksum(log.args.account), log.args.hasRole)
+		}
+		return {
+			issuers: [...current]
+				.filter(([, active]) => active)
+				.map(([account]) => account),
+			complete: true,
+		}
+	} catch {
+		return { issuers: [], complete: false }
+	}
+}
+
+async function withTimeout<T>(
+	promise: Promise<T>,
+	timeoutMs: number,
+): Promise<T> {
+	let timeout: ReturnType<typeof setTimeout> | undefined
+	try {
+		return await Promise.race([
+			promise,
+			new Promise<never>((_, reject) => {
+				timeout = setTimeout(() => reject(new Error('Timed out')), timeoutMs)
+			}),
+		])
+	} finally {
+		if (timeout) clearTimeout(timeout)
+	}
+}
+
+function fallbackName(
+	address: Address.Address,
+	isNative: boolean,
+	isContract: boolean,
+): string {
+	const short = `${address.slice(0, 8)}…${address.slice(-6)}`
+	return isNative
+		? `Native token ${short}`
+		: isContract
+			? `Contract ${short}`
+			: `Account ${short}`
+}
+
+function dedupeEdges(edges: DiscoveryEdge[]): DiscoveryEdge[] {
+	const seen = new Set<string>()
+	return edges.filter((edge) => {
+		const key = `${edge.from.toLowerCase()}:${edge.to.toLowerCase()}:${edge.label}`
+		if (seen.has(key)) return false
+		seen.add(key)
+		return edge.from.toLowerCase() !== edge.to.toLowerCase()
+	})
+}

--- a/apps/explorer/src/lib/server/contract-discovery.ts
+++ b/apps/explorer/src/lib/server/contract-discovery.ts
@@ -18,6 +18,7 @@ import type {
 	DiscoveryEdge,
 	DiscoveryNode,
 } from '#lib/domain/contract-discovery'
+import type { ContractSource } from '#lib/domain/contract-source'
 import { fetchContractSourceDirect } from '#lib/domain/contract-source'
 import * as Tip20 from '#lib/domain/tip20'
 import { tempoQueryBuilder } from '#lib/server/tempo-queries-provider'
@@ -71,46 +72,56 @@ export async function discoverContractGraph(
 		const isNative = Tip20.isTip20Address(current.address)
 		let abi: Abi | undefined
 		let name: string | undefined
-		let hasVerifiedSource = false
 
 		if (isNative) {
 			abi = Abis.tip20
-		} else {
-			try {
-				const source = await withTimeout(
-					fetchContractSourceDirect({
-						address: current.address,
-						chainId: chain.id,
-					}),
-					3_000,
-				)
-				abi = source.abi as Abi
-				name = source.kind === 'native' ? source.name : source.compilation.name
-				hasVerifiedSource = true
-			} catch {
-				// Fall through to bytecode classification for unverified addresses.
-			}
 		}
-		const bytecode = hasVerifiedSource
-			? undefined
-			: await withTimeout(
-					client.getCode({ address: current.address }),
-					3_000,
-				).catch(() => undefined)
+
+		const [source, bytecode] = await Promise.all([
+			isNative
+				? Promise.resolve(undefined)
+				: withTimeout(
+						fetchContractSourceDirect({
+							address: current.address,
+							chainId: chain.id,
+						}),
+						3_000,
+					).catch(() => undefined),
+			isNative
+				? Promise.resolve(undefined)
+				: withTimeout(
+						client.getCode({ address: current.address }),
+						3_000,
+					).catch(() => undefined),
+		])
+		if (source) {
+			abi = source.abi as Abi
+			name = source.kind === 'native' ? source.name : source.compilation.name
+		}
+		const hasVerifiedSource = source !== undefined
 		const isContract =
 			isNative ||
 			hasVerifiedSource ||
 			(bytecode !== undefined && bytecode !== '0x')
 
-		nodes.push({
+		const node: DiscoveryNode = {
 			id: current.address,
 			name: name ?? fallbackName(current.address, isNative, isContract),
 			kind: isNative ? 'native' : isContract ? 'contract' : 'account',
 			depth: current.depth,
 			isRoot: current.depth === 0,
-		})
+			details: buildNodeDetails({
+				abi,
+				bytecode,
+				isNative,
+				source,
+			}),
+		}
 
-		if (!isContract || current.depth >= MAX_DEPTH) continue
+		if (!isContract || current.depth >= MAX_DEPTH) {
+			nodes.push(node)
+			continue
+		}
 
 		const found: DiscoveryEdge[] = []
 		if (isNative) {
@@ -174,18 +185,24 @@ export async function discoverContractGraph(
 						3_000,
 					)
 					const target = storageAddress(value)
-					if (target)
+					if (target) {
+						const proxy = node.details.proxy ?? {}
+						proxy[label === '$implementation' ? 'implementation' : 'admin'] =
+							target
+						node.details.proxy = proxy
 						found.push({
 							from: current.address,
 							to: target,
 							label,
 							kind: 'proxy',
 						})
+					}
 				} catch {
 					// Some RPC transports do not expose storage reads.
 				}
 			}
 		}
+		nodes.push(node)
 
 		for (const edge of dedupeEdges(found)) {
 			edges.push(edge)
@@ -199,6 +216,7 @@ export async function discoverContractGraph(
 
 	return {
 		root: Address.checksum(root),
+		chainId: chain.id,
 		nodes,
 		edges: edges.filter(
 			(edge) =>
@@ -208,6 +226,94 @@ export async function discoverContractGraph(
 				nodes.some((node) => node.id.toLowerCase() === edge.to.toLowerCase()),
 		),
 		truncated: incomplete || queue.length > 0,
+	}
+}
+
+function buildNodeDetails(props: {
+	abi?: Abi
+	bytecode?: Hex.Hex
+	isNative: boolean
+	source?: ContractSource
+}): DiscoveryNode['details'] {
+	const { abi, bytecode, isNative, source } = props
+	return {
+		bytecode: {
+			status: isNative
+				? 'precompile'
+				: bytecode === undefined
+					? 'unavailable'
+					: bytecode === '0x'
+						? 'empty'
+						: 'available',
+			...(bytecode && bytecode !== '0x'
+				? { bytes: (bytecode.length - 2) / 2 }
+				: {}),
+		},
+		...(abi ? { abi: summarizeAbi(abi) } : {}),
+		...(source ? { source: summarizeSource(source) } : {}),
+	}
+}
+
+function summarizeAbi(abi: Abi) {
+	const functions = abi.filter(
+		(item): item is AbiFunction => item.type === 'function',
+	)
+	const reads = functions.filter(
+		(item) =>
+			item.stateMutability === 'view' || item.stateMutability === 'pure',
+	)
+	const writes = functions.filter(
+		(item) =>
+			item.stateMutability === 'nonpayable' ||
+			item.stateMutability === 'payable',
+	)
+	const maxFunctions = 100
+
+	return {
+		functionCount: functions.length,
+		readFunctionCount: reads.length,
+		writeFunctionCount: writes.length,
+		eventCount: abi.filter((item) => item.type === 'event').length,
+		errorCount: abi.filter((item) => item.type === 'error').length,
+		functions: functions.slice(0, maxFunctions).map((item) => ({
+			name: item.name,
+			stateMutability: item.stateMutability,
+			inputs: item.inputs.length,
+			outputs: item.outputs.length,
+		})),
+		truncated: functions.length > maxFunctions,
+	}
+}
+
+function summarizeSource(source: ContractSource) {
+	if (source.kind === 'native') {
+		return {
+			kind: source.kind,
+			name: source.name,
+			language: source.nativeSource.language,
+			verifiedAt: source.verifiedAt,
+			match: source.match,
+			runtimeMatch: source.runtimeMatch,
+			sourceFileCount: Object.keys(source.sources).length,
+			...(source.docsUrl ? { docsUrl: source.docsUrl } : {}),
+			repository: source.nativeSource.repository,
+			commit: source.nativeSource.commit,
+			commitUrl: source.nativeSource.commitUrl,
+			entrypoints: source.nativeSource.entrypoints,
+		}
+	}
+
+	return {
+		kind: source.kind,
+		name: source.compilation.name,
+		language: source.compilation.language,
+		compiler: source.compilation.compiler,
+		compilerVersion: source.compilation.compilerVersion,
+		fullyQualifiedName: source.compilation.fullyQualifiedName,
+		verifiedAt: source.verifiedAt,
+		match: source.match,
+		runtimeMatch: source.runtimeMatch,
+		sourceFileCount: Object.keys(source.stdJsonInput.sources).length,
 	}
 }
 

--- a/apps/explorer/src/lib/server/contract-discovery.ts
+++ b/apps/explorer/src/lib/server/contract-discovery.ts
@@ -135,6 +135,7 @@ export async function discoverContractGraph(
 				found.push({
 					from: current.address,
 					to: issuer,
+					action: 'needs approval from',
 					label: 'ISSUER_ROLE',
 					kind: 'role',
 				})
@@ -167,6 +168,7 @@ export async function discoverContractGraph(
 					found.push({
 						from: current.address,
 						to: target,
+						action: describeGetterAction(getter.name),
 						label: getter.name,
 						kind: 'getter',
 					})
@@ -193,6 +195,10 @@ export async function discoverContractGraph(
 						found.push({
 							from: current.address,
 							to: target,
+							action:
+								label === '$implementation'
+									? 'runs code from'
+									: 'is controlled by',
 							label,
 							kind: 'proxy',
 						})
@@ -452,10 +458,32 @@ function fallbackName(
 ): string {
 	const short = `${address.slice(0, 8)}…${address.slice(-6)}`
 	return isNative
-		? `Native token ${short}`
+		? `Tempo system contract ${short}`
 		: isContract
-			? `Contract ${short}`
-			: `Account ${short}`
+			? `Unverified contract ${short}`
+			: `Wallet / account ${short}`
+}
+
+function describeGetterAction(name: string): string {
+	const normalized = name.replaceAll('_', '').toLowerCase()
+	if (normalized.includes('implementation')) return 'runs code from'
+	if (
+		normalized.includes('admin') ||
+		normalized.includes('owner') ||
+		normalized.includes('manager') ||
+		normalized.includes('authority')
+	)
+		return 'is controlled by'
+	if (normalized.includes('issuer')) return 'gets its issuer from'
+	if (normalized.includes('feetoken') || normalized.includes('feecurrency'))
+		return 'pays fees with'
+	if (normalized.includes('registry')) return 'checks with'
+	if (normalized.includes('policy')) return 'follows rules from'
+	if (normalized.includes('factory')) return 'was created by'
+	if (normalized.includes('validator')) return 'uses validator settings from'
+	if (normalized.includes('recipient')) return 'sends to'
+	if (normalized.includes('token')) return 'uses token from'
+	return 'looks up an address from'
 }
 
 function dedupeEdges(edges: DiscoveryEdge[]): DiscoveryEdge[] {

--- a/apps/explorer/src/routeTree.gen.ts
+++ b/apps/explorer/src/routeTree.gen.ts
@@ -17,6 +17,7 @@ import { Route as ApiTip20RolesRouteImport } from './routes/api/tip20-roles'
 import { Route as ApiSimulateRouteImport } from './routes/api/simulate'
 import { Route as ApiSearchRouteImport } from './routes/api/search'
 import { Route as ApiHealthRouteImport } from './routes/api/health'
+import { Route as ApiContractDiscoveryRouteImport } from './routes/api/contract-discovery'
 import { Route as ApiCodeRouteImport } from './routes/api/code'
 import { Route as LayoutTokensRouteImport } from './routes/_layout/tokens'
 import { Route as LayoutSimulateRouteImport } from './routes/_layout/simulate'
@@ -28,6 +29,7 @@ import { Route as LayoutTxHashRouteImport } from './routes/_layout/tx/$hash'
 import { Route as LayoutTokenAddressRouteImport } from './routes/_layout/token/$address'
 import { Route as LayoutReceiptHashRouteImport } from './routes/_layout/receipt/$hash'
 import { Route as LayoutPolicyIdRouteImport } from './routes/_layout/policy/$id'
+import { Route as LayoutDiscoverAddressRouteImport } from './routes/_layout/discover/$address'
 import { Route as LayoutDemoTxRouteImport } from './routes/_layout/demo/tx'
 import { Route as LayoutDemoPaginationRouteImport } from './routes/_layout/demo/pagination'
 import { Route as LayoutDemoEmptyStateRouteImport } from './routes/_layout/demo/empty-state'
@@ -80,6 +82,11 @@ const ApiSearchRoute = ApiSearchRouteImport.update({
 const ApiHealthRoute = ApiHealthRouteImport.update({
   id: '/api/health',
   path: '/api/health',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiContractDiscoveryRoute = ApiContractDiscoveryRouteImport.update({
+  id: '/api/contract-discovery',
+  path: '/api/contract-discovery',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ApiCodeRoute = ApiCodeRouteImport.update({
@@ -135,6 +142,11 @@ const LayoutReceiptHashRoute = LayoutReceiptHashRouteImport.update({
 const LayoutPolicyIdRoute = LayoutPolicyIdRouteImport.update({
   id: '/policy/$id',
   path: '/policy/$id',
+  getParentRoute: () => LayoutRoute,
+} as any)
+const LayoutDiscoverAddressRoute = LayoutDiscoverAddressRouteImport.update({
+  id: '/discover/$address',
+  path: '/discover/$address',
   getParentRoute: () => LayoutRoute,
 } as any)
 const LayoutDemoTxRoute = LayoutDemoTxRouteImport.update({
@@ -221,6 +233,7 @@ export interface FileRoutesByFullPath {
   '/simulate': typeof LayoutSimulateRoute
   '/tokens': typeof LayoutTokensRoute
   '/api/code': typeof ApiCodeRoute
+  '/api/contract-discovery': typeof ApiContractDiscoveryRoute
   '/api/health': typeof ApiHealthRoute
   '/api/search': typeof ApiSearchRoute
   '/api/simulate': typeof ApiSimulateRoute
@@ -232,6 +245,7 @@ export interface FileRoutesByFullPath {
   '/demo/empty-state': typeof LayoutDemoEmptyStateRoute
   '/demo/pagination': typeof LayoutDemoPaginationRoute
   '/demo/tx': typeof LayoutDemoTxRoute
+  '/discover/$address': typeof LayoutDiscoverAddressRoute
   '/policy/$id': typeof LayoutPolicyIdRoute
   '/receipt/$hash': typeof LayoutReceiptHashRoute
   '/token/$address': typeof LayoutTokenAddressRoute
@@ -254,6 +268,7 @@ export interface FileRoutesByTo {
   '/simulate': typeof LayoutSimulateRoute
   '/tokens': typeof LayoutTokensRoute
   '/api/code': typeof ApiCodeRoute
+  '/api/contract-discovery': typeof ApiContractDiscoveryRoute
   '/api/health': typeof ApiHealthRoute
   '/api/search': typeof ApiSearchRoute
   '/api/simulate': typeof ApiSimulateRoute
@@ -266,6 +281,7 @@ export interface FileRoutesByTo {
   '/demo/empty-state': typeof LayoutDemoEmptyStateRoute
   '/demo/pagination': typeof LayoutDemoPaginationRoute
   '/demo/tx': typeof LayoutDemoTxRoute
+  '/discover/$address': typeof LayoutDiscoverAddressRoute
   '/policy/$id': typeof LayoutPolicyIdRoute
   '/receipt/$hash': typeof LayoutReceiptHashRoute
   '/token/$address': typeof LayoutTokenAddressRoute
@@ -290,6 +306,7 @@ export interface FileRoutesById {
   '/_layout/simulate': typeof LayoutSimulateRoute
   '/_layout/tokens': typeof LayoutTokensRoute
   '/api/code': typeof ApiCodeRoute
+  '/api/contract-discovery': typeof ApiContractDiscoveryRoute
   '/api/health': typeof ApiHealthRoute
   '/api/search': typeof ApiSearchRoute
   '/api/simulate': typeof ApiSimulateRoute
@@ -302,6 +319,7 @@ export interface FileRoutesById {
   '/_layout/demo/empty-state': typeof LayoutDemoEmptyStateRoute
   '/_layout/demo/pagination': typeof LayoutDemoPaginationRoute
   '/_layout/demo/tx': typeof LayoutDemoTxRoute
+  '/_layout/discover/$address': typeof LayoutDiscoverAddressRoute
   '/_layout/policy/$id': typeof LayoutPolicyIdRoute
   '/_layout/receipt/$hash': typeof LayoutReceiptHashRoute
   '/_layout/token/$address': typeof LayoutTokenAddressRoute
@@ -327,6 +345,7 @@ export interface FileRouteTypes {
     | '/simulate'
     | '/tokens'
     | '/api/code'
+    | '/api/contract-discovery'
     | '/api/health'
     | '/api/search'
     | '/api/simulate'
@@ -338,6 +357,7 @@ export interface FileRouteTypes {
     | '/demo/empty-state'
     | '/demo/pagination'
     | '/demo/tx'
+    | '/discover/$address'
     | '/policy/$id'
     | '/receipt/$hash'
     | '/token/$address'
@@ -360,6 +380,7 @@ export interface FileRouteTypes {
     | '/simulate'
     | '/tokens'
     | '/api/code'
+    | '/api/contract-discovery'
     | '/api/health'
     | '/api/search'
     | '/api/simulate'
@@ -372,6 +393,7 @@ export interface FileRouteTypes {
     | '/demo/empty-state'
     | '/demo/pagination'
     | '/demo/tx'
+    | '/discover/$address'
     | '/policy/$id'
     | '/receipt/$hash'
     | '/token/$address'
@@ -395,6 +417,7 @@ export interface FileRouteTypes {
     | '/_layout/simulate'
     | '/_layout/tokens'
     | '/api/code'
+    | '/api/contract-discovery'
     | '/api/health'
     | '/api/search'
     | '/api/simulate'
@@ -407,6 +430,7 @@ export interface FileRouteTypes {
     | '/_layout/demo/empty-state'
     | '/_layout/demo/pagination'
     | '/_layout/demo/tx'
+    | '/_layout/discover/$address'
     | '/_layout/policy/$id'
     | '/_layout/receipt/$hash'
     | '/_layout/token/$address'
@@ -427,6 +451,7 @@ export interface RootRouteChildren {
   LayoutRoute: typeof LayoutRouteWithChildren
   SearchRoute: typeof SearchRoute
   ApiCodeRoute: typeof ApiCodeRoute
+  ApiContractDiscoveryRoute: typeof ApiContractDiscoveryRoute
   ApiHealthRoute: typeof ApiHealthRoute
   ApiSearchRoute: typeof ApiSearchRoute
   ApiSimulateRoute: typeof ApiSimulateRoute
@@ -498,6 +523,13 @@ declare module '@tanstack/react-router' {
       path: '/api/health'
       fullPath: '/api/health'
       preLoaderRoute: typeof ApiHealthRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/contract-discovery': {
+      id: '/api/contract-discovery'
+      path: '/api/contract-discovery'
+      fullPath: '/api/contract-discovery'
+      preLoaderRoute: typeof ApiContractDiscoveryRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/code': {
@@ -575,6 +607,13 @@ declare module '@tanstack/react-router' {
       path: '/policy/$id'
       fullPath: '/policy/$id'
       preLoaderRoute: typeof LayoutPolicyIdRouteImport
+      parentRoute: typeof LayoutRoute
+    }
+    '/_layout/discover/$address': {
+      id: '/_layout/discover/$address'
+      path: '/discover/$address'
+      fullPath: '/discover/$address'
+      preLoaderRoute: typeof LayoutDiscoverAddressRouteImport
       parentRoute: typeof LayoutRoute
     }
     '/_layout/demo/tx': {
@@ -690,6 +729,7 @@ interface LayoutRouteChildren {
   LayoutDemoEmptyStateRoute: typeof LayoutDemoEmptyStateRoute
   LayoutDemoPaginationRoute: typeof LayoutDemoPaginationRoute
   LayoutDemoTxRoute: typeof LayoutDemoTxRoute
+  LayoutDiscoverAddressRoute: typeof LayoutDiscoverAddressRoute
   LayoutPolicyIdRoute: typeof LayoutPolicyIdRoute
   LayoutReceiptHashRoute: typeof LayoutReceiptHashRoute
   LayoutTokenAddressRoute: typeof LayoutTokenAddressRoute
@@ -710,6 +750,7 @@ const LayoutRouteChildren: LayoutRouteChildren = {
   LayoutDemoEmptyStateRoute: LayoutDemoEmptyStateRoute,
   LayoutDemoPaginationRoute: LayoutDemoPaginationRoute,
   LayoutDemoTxRoute: LayoutDemoTxRoute,
+  LayoutDiscoverAddressRoute: LayoutDiscoverAddressRoute,
   LayoutPolicyIdRoute: LayoutPolicyIdRoute,
   LayoutReceiptHashRoute: LayoutReceiptHashRoute,
   LayoutTokenAddressRoute: LayoutTokenAddressRoute,
@@ -725,6 +766,7 @@ const rootRouteChildren: RootRouteChildren = {
   LayoutRoute: LayoutRouteWithChildren,
   SearchRoute: SearchRoute,
   ApiCodeRoute: ApiCodeRoute,
+  ApiContractDiscoveryRoute: ApiContractDiscoveryRoute,
   ApiHealthRoute: ApiHealthRoute,
   ApiSearchRoute: ApiSearchRoute,
   ApiSimulateRoute: ApiSimulateRoute,

--- a/apps/explorer/src/routes/_layout/address/$address.tsx
+++ b/apps/explorer/src/routes/_layout/address/$address.tsx
@@ -124,6 +124,7 @@ const allTabs = [
 	'holders',
 	'token',
 	'contract',
+	'dependencies',
 	'interact',
 ] as const
 
@@ -458,7 +459,7 @@ function RouteComponent() {
 			tabs.push('token')
 		}
 		if (isContract) {
-			tabs.push('contract', 'interact')
+			tabs.push('contract', 'dependencies', 'interact')
 		}
 		return tabs
 	}, [isToken, isTip20, isContract])
@@ -1691,6 +1692,32 @@ function SectionsWrapper(props: {
 							}
 							isLoadingContractInfo={isLoadingContractInfo}
 						/>
+					),
+				}
+			case 'dependencies':
+				return {
+					title: 'Dependencies',
+					totalItems: 0,
+					itemsLabel: 'relationships',
+					content: (
+						<div className="flex min-h-64 flex-col items-center justify-center gap-4 rounded-lg border border-border bg-surface-secondary/40 p-8 text-center">
+							<div>
+								<h3 className="text-base font-semibold">
+									Contract dependency graph
+								</h3>
+								<p className="mt-1 max-w-xl text-sm text-secondary">
+									Trace verified address getters, proxy implementations, and
+									native TIP-20 roles from this address.
+								</p>
+							</div>
+							<Link
+								className="rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground"
+								params={{ address }}
+								to="/discover/$address"
+							>
+								Open discovery graph
+							</Link>
+						</div>
 					),
 				}
 			default:

--- a/apps/explorer/src/routes/_layout/address/$address.tsx
+++ b/apps/explorer/src/routes/_layout/address/$address.tsx
@@ -25,6 +25,7 @@ import { AddressCell } from '#comps/AddressCell'
 import { BalanceCell, TransferAmountCell } from '#comps/AmountCell'
 import { BreadcrumbsSlot } from '#comps/Breadcrumbs'
 import { ContractTabContent, InteractTabContent } from '#comps/Contract'
+import { ContractFeatureCard } from '#comps/ContractFeatureCard'
 import { Tip20TokenTabContent } from '#comps/Tip20ContractInfo'
 import { DataGrid } from '#comps/DataGrid'
 import { Pagination } from '#comps/Pagination'
@@ -1699,26 +1700,7 @@ function SectionsWrapper(props: {
 					title: 'Dependencies',
 					totalItems: 0,
 					itemsLabel: 'relationships',
-					content: (
-						<div className="flex min-h-64 flex-col items-center justify-center gap-4 rounded-lg border border-border bg-surface-secondary/40 p-8 text-center">
-							<div>
-								<h3 className="text-base font-semibold">
-									Contract dependency graph
-								</h3>
-								<p className="mt-1 max-w-xl text-sm text-secondary">
-									Trace verified address getters, proxy implementations, and
-									native TIP-20 roles from this address.
-								</p>
-							</div>
-							<Link
-								className="rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground"
-								params={{ address }}
-								to="/discover/$address"
-							>
-								Open discovery graph
-							</Link>
-						</div>
-					),
+					content: <DependenciesTabContent address={address} />,
 				}
 			default:
 				return {
@@ -1737,6 +1719,50 @@ function SectionsWrapper(props: {
 			activeSection={activeSection}
 			onSectionChange={onSectionChange}
 		/>
+	)
+}
+
+function DependenciesTabContent(props: {
+	address: Address.Address
+}): React.JSX.Element {
+	return (
+		<ContractFeatureCard
+			actions={
+				<Link
+					className="rounded-[6px] bg-primary px-[10px] py-[6px] text-[12px] font-medium text-content-inverse press-down hover:opacity-90"
+					params={{ address: props.address }}
+					to="/discover/$address"
+				>
+					Open graph
+				</Link>
+			}
+			description="Trace verified getters, proxy slots, and native TIP-20 roles."
+			rightSideDescription="Mainnet"
+			rightSideTitle="Live discovery"
+			title="Contract dependency graph"
+		>
+			<div className="flex min-h-[220px] items-center justify-center rounded-[6px] border border-dashed border-distinct bg-base-alt px-[18px] py-[24px] text-center">
+				<div className="flex max-w-[520px] flex-col items-center gap-3">
+					<div className="flex items-center gap-2 text-[13px] font-medium text-primary">
+						<span className="grid size-[24px] place-items-center rounded-[6px] bg-accent/10 text-accent">
+							<span className="size-[7px] rounded-full bg-accent" />
+						</span>
+						<span>Explore the relationships behind this contract</span>
+					</div>
+					<p className="max-w-[440px] text-[12px] leading-[18px] text-secondary">
+						Open the discovery graph to inspect connected contracts,
+						implementations, roles, ABI summaries, and verification metadata.
+					</p>
+					<Link
+						className="inline-flex items-center rounded-[6px] border border-card-border bg-card px-[10px] py-[6px] text-[12px] font-medium text-primary press-down hover:bg-surface"
+						params={{ address: props.address }}
+						to="/discover/$address"
+					>
+						View dependencies
+					</Link>
+				</div>
+			</div>
+		</ContractFeatureCard>
 	)
 }
 

--- a/apps/explorer/src/routes/_layout/discover/$address.tsx
+++ b/apps/explorer/src/routes/_layout/discover/$address.tsx
@@ -7,6 +7,8 @@ import type {
 	DiscoveryEdge,
 	DiscoveryNode,
 } from '#lib/domain/contract-discovery'
+import { CopyButton } from '#comps/CopyButton'
+import { cx } from '#lib/css'
 import { fetchContractDiscovery } from '#lib/domain/contract-discovery'
 import { zAddress } from '#lib/zod'
 import MinusIcon from '~icons/lucide/minus'
@@ -14,7 +16,7 @@ import PlusIcon from '~icons/lucide/plus'
 import RefreshCwIcon from '~icons/lucide/refresh-cw'
 
 const CARD_WIDTH = 248
-const CARD_HEIGHT = 92
+const CARD_HEIGHT = 108
 const COLUMN_GAP = 150
 const ROW_GAP = 44
 const PADDING = 56
@@ -40,6 +42,11 @@ function DiscoveryPage(): React.JSX.Element {
 	const navigate = useNavigate()
 	const [input, setInput] = React.useState<string>(address)
 	const [zoom, setZoom] = React.useState(1)
+	const [selectedNodeId, setSelectedNodeId] = React.useState<string>(address)
+
+	React.useEffect(() => {
+		setSelectedNodeId(address)
+	}, [address])
 
 	const submit = (event: React.FormEvent) => {
 		event.preventDefault()
@@ -82,44 +89,84 @@ function DiscoveryPage(): React.JSX.Element {
 				</form>
 			</header>
 
+			{query.isPending ? (
+				<section className="relative min-h-[680px] overflow-hidden rounded-xl border border-border bg-surface">
+					<GraphLoading />
+				</section>
+			) : query.isError ? (
+				<section className="grid min-h-[680px] place-items-center rounded-xl border border-border bg-surface text-sm text-negative">
+					{query.error.message}
+				</section>
+			) : (
+				<DiscoveryWorkspace
+					graph={query.data}
+					selectedNodeId={selectedNodeId}
+					setSelectedNodeId={setSelectedNodeId}
+					zoom={zoom}
+					setZoom={setZoom}
+				/>
+			)}
+		</main>
+	)
+}
+
+function DiscoveryWorkspace(props: {
+	graph: ContractDiscovery
+	selectedNodeId: string
+	setSelectedNodeId: React.Dispatch<React.SetStateAction<string>>
+	zoom: number
+	setZoom: React.Dispatch<React.SetStateAction<number>>
+}): React.JSX.Element {
+	const selectedNode =
+		props.graph.nodes.find(
+			(node) => node.id.toLowerCase() === props.selectedNodeId.toLowerCase(),
+		) ?? props.graph.nodes[0]
+
+	if (!selectedNode) return <GraphLoading />
+
+	return (
+		<div className="grid items-start gap-4 lg:grid-cols-[minmax(0,1fr)_360px]">
 			<section className="relative min-h-[680px] overflow-hidden rounded-xl border border-border bg-surface">
 				<div className="absolute top-3 right-3 z-20 flex items-center gap-1 rounded-lg border border-border bg-surface/95 p-1 shadow-sm backdrop-blur">
 					<IconButton
 						label="Zoom out"
-						onClick={() => setZoom((z) => Math.max(0.5, z - 0.1))}
+						onClick={() => props.setZoom((z) => Math.max(0.5, z - 0.1))}
 					>
 						<MinusIcon />
 					</IconButton>
 					<span className="w-12 text-center text-xs tabular-nums text-secondary">
-						{Math.round(zoom * 100)}%
+						{Math.round(props.zoom * 100)}%
 					</span>
 					<IconButton
 						label="Zoom in"
-						onClick={() => setZoom((z) => Math.min(1.5, z + 0.1))}
+						onClick={() => props.setZoom((z) => Math.min(1.5, z + 0.1))}
 					>
 						<PlusIcon />
 					</IconButton>
-					<IconButton label="Reset zoom" onClick={() => setZoom(1)}>
+					<IconButton label="Reset zoom" onClick={() => props.setZoom(1)}>
 						<RefreshCwIcon />
 					</IconButton>
 				</div>
-
-				{query.isPending ? (
-					<GraphLoading />
-				) : query.isError ? (
-					<div className="grid min-h-[680px] place-items-center text-sm text-negative">
-						{query.error.message}
-					</div>
-				) : (
-					<DependencyGraph graph={query.data} zoom={zoom} />
-				)}
+				<DependencyGraph
+					graph={props.graph}
+					selectedNodeId={selectedNode.id}
+					onSelect={(node) => props.setSelectedNodeId(node.id)}
+					zoom={props.zoom}
+				/>
 			</section>
-		</main>
+			<DiscoveryInspector
+				graph={props.graph}
+				node={selectedNode}
+				onSelect={(node) => props.setSelectedNodeId(node.id)}
+			/>
+		</div>
 	)
 }
 
 function DependencyGraph(props: {
 	graph: ContractDiscovery
+	selectedNodeId: string
+	onSelect: (node: DiscoveryNode) => void
 	zoom: number
 }): React.JSX.Element {
 	const markerId = React.useId()
@@ -163,12 +210,22 @@ function DependencyGraph(props: {
 							from={positionById.get(edge.from.toLowerCase())}
 							key={`${edge.from}:${edge.to}:${edge.label}`}
 							markerId={markerId}
+							selectedNodeId={props.selectedNodeId}
 							to={positionById.get(edge.to.toLowerCase())}
 						/>
 					))}
 				</svg>
 				{layout.nodes.map(({ node, x, y }) => (
-					<GraphNode key={node.id} node={node} x={x} y={y} />
+					<GraphNode
+						key={node.id}
+						node={node}
+						onSelect={props.onSelect}
+						selected={
+							node.id.toLowerCase() === props.selectedNodeId.toLowerCase()
+						}
+						x={x}
+						y={y}
+					/>
 				))}
 				{props.graph.truncated && (
 					<div className="absolute bottom-4 left-4 rounded-md border border-border bg-surface px-3 py-2 text-xs text-secondary shadow-sm">
@@ -181,6 +238,11 @@ function DependencyGraph(props: {
 }
 
 type PositionedNode = { node: DiscoveryNode; x: number; y: number }
+
+type GraphNodeProps = PositionedNode & {
+	onSelect: (node: DiscoveryNode) => void
+	selected: boolean
+}
 
 function buildLayout(nodes: DiscoveryNode[]): {
 	nodes: PositionedNode[]
@@ -216,14 +278,21 @@ function buildLayout(nodes: DiscoveryNode[]): {
 	}
 }
 
-function GraphNode(props: PositionedNode): React.JSX.Element {
-	const { node, x, y } = props
+function GraphNode(props: GraphNodeProps): React.JSX.Element {
+	const { node, onSelect, selected, x, y } = props
 	return (
-		<Link
-			className={`absolute rounded-xl border bg-surface p-4 shadow-sm transition hover:-translate-y-0.5 hover:border-accent hover:shadow-md ${node.isRoot ? 'border-accent ring-2 ring-accent/15' : 'border-border'}`}
-			params={{ address: node.id }}
+		<button
+			aria-label={`Inspect ${node.name}`}
+			aria-pressed={selected}
+			className={cx(
+				'absolute rounded-xl border bg-surface p-4 text-left shadow-sm transition hover:-translate-y-0.5 hover:border-accent hover:shadow-md',
+				selected || node.isRoot
+					? 'border-accent ring-2 ring-accent/15'
+					: 'border-border',
+			)}
+			onClick={() => onSelect(node)}
 			style={{ left: x, top: y, width: CARD_WIDTH, height: CARD_HEIGHT }}
-			to="/address/$address"
+			type="button"
 		>
 			<div className="mb-2 flex items-center justify-between gap-2">
 				<div className="truncate text-sm font-semibold">{node.name}</div>
@@ -237,7 +306,15 @@ function GraphNode(props: PositionedNode): React.JSX.Element {
 			>
 				{node.id}
 			</div>
-		</Link>
+			<div className="mt-2 flex items-center justify-between gap-2 text-[10px] text-tertiary">
+				<span>
+					{node.details.source
+						? 'verified source'
+						: node.details.bytecode.status}
+				</span>
+				<span>depth {node.depth}</span>
+			</div>
+		</button>
 	)
 }
 
@@ -245,6 +322,7 @@ function GraphEdgeLine(props: {
 	edge: DiscoveryEdge
 	from?: PositionedNode
 	markerId: string
+	selectedNodeId: string
 	to?: PositionedNode
 }): React.JSX.Element | null {
 	if (!props.from || !props.to) return null
@@ -256,16 +334,34 @@ function GraphEdgeLine(props: {
 	const path = `M ${x1} ${y1} C ${x1 + bend} ${y1}, ${x2 - bend} ${y2}, ${x2} ${y2}`
 	const labelX = (x1 + x2) / 2
 	const labelY = (y1 + y2) / 2 - 7
+	const isActive =
+		props.edge.from.toLowerCase() === props.selectedNodeId.toLowerCase() ||
+		props.edge.to.toLowerCase() === props.selectedNodeId.toLowerCase()
+	const labelWidth = Math.max(58, props.edge.label.length * 7 + 18)
 	return (
 		<g>
 			<path
 				d={path}
-				className="fill-none stroke-border-strong"
+				className={cx(
+					'fill-none transition-colors',
+					isActive ? 'stroke-accent' : 'stroke-border-strong',
+				)}
 				markerEnd={`url(#${props.markerId})`}
-				strokeWidth="1.5"
+				strokeWidth={isActive ? '2' : '1.5'}
+			/>
+			<rect
+				className="fill-surface stroke-border"
+				height="20"
+				rx="10"
+				width={labelWidth}
+				x={labelX - labelWidth / 2}
+				y={labelY - 14}
 			/>
 			<text
-				className="fill-secondary text-[11px]"
+				className={cx(
+					'text-[11px]',
+					isActive ? 'fill-accent' : 'fill-secondary',
+				)}
 				textAnchor="middle"
 				x={labelX}
 				y={labelY}
@@ -274,6 +370,391 @@ function GraphEdgeLine(props: {
 			</text>
 		</g>
 	)
+}
+
+type DiscoveryInspectorProps = {
+	graph: ContractDiscovery
+	node: DiscoveryNode
+	onSelect: (node: DiscoveryNode) => void
+}
+
+function DiscoveryInspector(props: DiscoveryInspectorProps): React.JSX.Element {
+	const { graph, node, onSelect } = props
+	const source = node.details.source
+	const abi = node.details.abi
+	const outgoing = graph.edges.filter(
+		(edge) => edge.from.toLowerCase() === node.id.toLowerCase(),
+	)
+	const incoming = graph.edges.filter(
+		(edge) => edge.to.toLowerCase() === node.id.toLowerCase(),
+	)
+
+	return (
+		<aside className="flex max-h-[680px] min-h-[680px] flex-col overflow-y-auto rounded-xl border border-border bg-surface">
+			<div className="border-b border-border px-5 py-4">
+				<div className="mb-2 flex items-center justify-between gap-3">
+					<span className="text-xs font-medium tracking-[0.16em] text-secondary uppercase">
+						Node inspector
+					</span>
+					<span className="rounded-full bg-surface-secondary px-2 py-0.5 text-[10px] font-medium text-secondary uppercase">
+						{node.kind}
+					</span>
+				</div>
+				<h2 className="truncate text-lg font-semibold" title={node.name}>
+					{node.name}
+				</h2>
+				<div className="mt-2 flex items-start gap-2">
+					<code className="min-w-0 flex-1 break-all text-xs text-secondary">
+						{node.id}
+					</code>
+					<CopyButton value={node.id} ariaLabel="Copy node address" />
+				</div>
+				<div className="mt-4 flex flex-wrap gap-2">
+					<Link
+						className="rounded-md bg-primary px-3 py-2 text-xs font-medium text-primary-foreground hover:opacity-90"
+						params={{ address: node.id }}
+						search={{
+							tab: node.kind === 'account' ? 'transactions' : 'contract',
+						}}
+						to="/address/$address"
+					>
+						Open address details
+					</Link>
+					<span className="rounded-md border border-border px-3 py-2 text-xs text-secondary">
+						{node.isRoot ? 'Root node' : `Depth ${node.depth}`}
+					</span>
+				</div>
+			</div>
+
+			<InspectorSection title="Identity">
+				<DetailRow label="Network">Tempo · chain {graph.chainId}</DetailRow>
+				<DetailRow label="Classification">
+					{node.kind === 'native'
+						? 'Native TIP-20 precompile'
+						: node.kind === 'contract'
+							? 'Smart contract'
+							: 'Externally owned account'}
+				</DetailRow>
+				<DetailRow label="Bytecode">
+					{formatBytecode(node.details.bytecode)}
+				</DetailRow>
+			</InspectorSection>
+
+			<InspectorSection title="Source & verification">
+				{source ? (
+					<SourceDetails source={source} />
+				) : (
+					<p className="px-4 py-3 text-xs text-secondary">
+						{node.kind === 'account'
+							? 'No deployed bytecode or verified source was found.'
+							: 'No source metadata was returned for this node.'}
+					</p>
+				)}
+			</InspectorSection>
+
+			<InspectorSection title="Interface">
+				{abi ? (
+					<>
+						<div className="grid grid-cols-2 gap-px border-b border-border bg-border">
+							<Stat label="Functions" value={abi.functionCount} />
+							<Stat label="Read" value={abi.readFunctionCount} />
+							<Stat label="Write" value={abi.writeFunctionCount} />
+							<Stat label="Events" value={abi.eventCount} />
+							<Stat label="Errors" value={abi.errorCount} />
+						</div>
+						<details className="group px-4 py-3">
+							<summary className="cursor-pointer list-none text-xs font-medium text-primary marker:hidden">
+								Show functions
+								<span className="ml-1 text-secondary">
+									({abi.functionCount})
+								</span>
+							</summary>
+							<div className="mt-3 divide-y divide-border rounded-md border border-border">
+								{abi.functions.map((item) => (
+									<div
+										className="flex items-center justify-between gap-3 px-3 py-2"
+										key={`${item.name}-${item.stateMutability}`}
+									>
+										<code className="min-w-0 truncate text-[11px] text-primary">
+											{item.name}({item.inputs}) → {item.outputs}
+										</code>
+										<span className="shrink-0 text-[10px] text-secondary">
+											{item.stateMutability}
+										</span>
+									</div>
+								))}
+							</div>
+							{abi.truncated && (
+								<p className="mt-2 text-[11px] text-secondary">
+									Showing the first 100 functions. Open the address for the full
+									ABI.
+								</p>
+							)}
+						</details>
+					</>
+				) : (
+					<p className="px-4 py-3 text-xs text-secondary">
+						No ABI was available for this node.
+					</p>
+				)}
+			</InspectorSection>
+
+			{node.details.proxy && (
+				<InspectorSection title="Proxy slots">
+					{node.details.proxy.implementation && (
+						<ProxyAddressRow
+							address={node.details.proxy.implementation}
+							label="Implementation"
+							node={findNode(graph, node.details.proxy.implementation)}
+							onSelect={onSelect}
+						/>
+					)}
+					{node.details.proxy.admin && (
+						<ProxyAddressRow
+							address={node.details.proxy.admin}
+							label="Admin"
+							node={findNode(graph, node.details.proxy.admin)}
+							onSelect={onSelect}
+						/>
+					)}
+				</InspectorSection>
+			)}
+
+			<InspectorSection
+				title={`Connections (${outgoing.length + incoming.length})`}
+			>
+				{outgoing.length > 0 && (
+					<ConnectionGroup
+						edges={outgoing}
+						graph={graph}
+						onSelect={onSelect}
+						title="Points to"
+					/>
+				)}
+				{incoming.length > 0 && (
+					<ConnectionGroup
+						edges={incoming}
+						graph={graph}
+						onSelect={onSelect}
+						title="Referenced by"
+					/>
+				)}
+				{outgoing.length === 0 && incoming.length === 0 && (
+					<p className="px-4 py-3 text-xs text-secondary">
+						No resolved relationships at this depth.
+					</p>
+				)}
+			</InspectorSection>
+		</aside>
+	)
+}
+
+function InspectorSection(props: {
+	title: string
+	children: React.ReactNode
+}): React.JSX.Element {
+	return (
+		<section className="border-b border-border">
+			<h3 className="px-4 pt-4 text-xs font-semibold tracking-wide text-secondary uppercase">
+				{props.title}
+			</h3>
+			<div className="pb-3">{props.children}</div>
+		</section>
+	)
+}
+
+function DetailRow(props: {
+	label: string
+	children: React.ReactNode
+}): React.JSX.Element {
+	return (
+		<div className="flex items-start justify-between gap-4 px-4 pt-3 text-xs">
+			<span className="shrink-0 text-secondary">{props.label}</span>
+			<span className="min-w-0 text-right text-primary">{props.children}</span>
+		</div>
+	)
+}
+
+function Stat(props: { label: string; value: number }): React.JSX.Element {
+	return (
+		<div className="bg-surface px-4 py-3">
+			<div className="text-lg font-semibold tabular-nums">{props.value}</div>
+			<div className="text-[10px] text-secondary uppercase">{props.label}</div>
+		</div>
+	)
+}
+
+function SourceDetails(props: {
+	source: NonNullable<DiscoveryNode['details']['source']>
+}): React.JSX.Element {
+	const { source } = props
+	return (
+		<div>
+			<DetailRow label="Status">
+				<span className="text-positive">
+					{source.kind === 'native' ? 'Native source' : 'Verified source'}
+				</span>
+			</DetailRow>
+			<DetailRow label="Contract">{source.name}</DetailRow>
+			<DetailRow label="Language">{source.language}</DetailRow>
+			<DetailRow label="Source files">{source.sourceFileCount}</DetailRow>
+			{source.compilerVersion && (
+				<DetailRow label="Compiler">
+					{source.compiler} {source.compilerVersion}
+				</DetailRow>
+			)}
+			{source.fullyQualifiedName && (
+				<DetailRow label="FQN">
+					<code className="break-all text-[11px]">
+						{source.fullyQualifiedName}
+					</code>
+				</DetailRow>
+			)}
+			{source.repository && (
+				<DetailRow label="Repository">
+					<a
+						className="text-accent hover:underline"
+						href={source.commitUrl ?? source.repository}
+						rel="noreferrer"
+						target="_blank"
+					>
+						{source.repository}
+					</a>
+				</DetailRow>
+			)}
+			{source.docsUrl && (
+				<DetailRow label="Docs">
+					<a
+						className="text-accent hover:underline"
+						href={source.docsUrl}
+						rel="noreferrer"
+						target="_blank"
+					>
+						Open documentation
+					</a>
+				</DetailRow>
+			)}
+		</div>
+	)
+}
+
+function ProxyAddressRow(props: {
+	address: DiscoveryNode['id']
+	label: string
+	node?: DiscoveryNode
+	onSelect: (node: DiscoveryNode) => void
+}): React.JSX.Element {
+	return (
+		<div className="flex items-center justify-between gap-3 px-4 pt-3 text-xs">
+			<span className="text-secondary">{props.label}</span>
+			<div className="flex min-w-0 items-center gap-2">
+				{props.node ? (
+					<button
+						className="truncate text-accent hover:underline"
+						onClick={() => props.node && props.onSelect(props.node)}
+						type="button"
+					>
+						{props.node.name}
+					</button>
+				) : (
+					<span className="truncate text-primary">
+						{shortenAddress(props.address)}
+					</span>
+				)}
+				<Link
+					className="shrink-0 font-mono text-[10px] text-secondary hover:text-primary"
+					params={{ address: props.address }}
+					to="/address/$address"
+				>
+					{shortenAddress(props.address)}
+				</Link>
+			</div>
+		</div>
+	)
+}
+
+function ConnectionGroup(props: {
+	edges: DiscoveryEdge[]
+	graph: ContractDiscovery
+	onSelect: (node: DiscoveryNode) => void
+	title: string
+}): React.JSX.Element {
+	return (
+		<div className="px-4 pt-3">
+			<div className="mb-2 text-[11px] font-medium text-secondary">
+				{props.title}
+			</div>
+			<div className="space-y-2">
+				{props.edges.map((edge) => {
+					const address = props.title === 'Points to' ? edge.to : edge.from
+					const node = findNode(props.graph, address)
+					return (
+						<div
+							className="rounded-md border border-border px-3 py-2"
+							key={`${edge.from}:${edge.to}:${edge.label}`}
+						>
+							<div className="mb-1 flex items-center justify-between gap-2">
+								<span className="rounded bg-surface-secondary px-1.5 py-0.5 text-[10px] text-secondary">
+									{edge.kind}
+								</span>
+								<code className="text-[10px] text-tertiary">{edge.label}</code>
+							</div>
+							<div className="flex items-center justify-between gap-2">
+								{node ? (
+									<button
+										className="min-w-0 truncate text-left text-xs font-medium text-accent hover:underline"
+										onClick={() => props.onSelect(node)}
+										type="button"
+									>
+										{node.name}
+									</button>
+								) : (
+									<span className="truncate text-xs text-primary">
+										{shortenAddress(address)}
+									</span>
+								)}
+								<Link
+									className="shrink-0 font-mono text-[10px] text-secondary hover:text-primary"
+									params={{ address }}
+									to="/address/$address"
+								>
+									{shortenAddress(address)}
+								</Link>
+							</div>
+						</div>
+					)
+				})}
+			</div>
+		</div>
+	)
+}
+
+function findNode(
+	graph: ContractDiscovery,
+	address: DiscoveryNode['id'],
+): DiscoveryNode | undefined {
+	return graph.nodes.find(
+		(node) => node.id.toLowerCase() === address.toLowerCase(),
+	)
+}
+
+function shortenAddress(address: string): string {
+	return `${address.slice(0, 8)}…${address.slice(-6)}`
+}
+
+function formatBytecode(
+	bytecode: DiscoveryNode['details']['bytecode'],
+): string {
+	if (bytecode.status === 'precompile') return 'Native precompile'
+	if (bytecode.status === 'unavailable') return 'RPC unavailable'
+	if (bytecode.status === 'empty') return 'No deployed bytecode'
+	return `${formatBytes(bytecode.bytes)} deployed`
+}
+
+function formatBytes(value: number | undefined): string {
+	if (value === undefined) return 'Unknown size'
+	if (value < 1_024) return `${value} B`
+	return `${(value / 1_024).toFixed(value < 10_240 ? 1 : 0)} KB`
 }
 
 function IconButton(props: {

--- a/apps/explorer/src/routes/_layout/discover/$address.tsx
+++ b/apps/explorer/src/routes/_layout/discover/$address.tsx
@@ -11,6 +11,7 @@ import { CopyButton } from '#comps/CopyButton'
 import { cx } from '#lib/css'
 import { fetchContractDiscovery } from '#lib/domain/contract-discovery'
 import { zAddress } from '#lib/zod'
+import ArrowRightIcon from '~icons/lucide/arrow-right'
 import MinusIcon from '~icons/lucide/minus'
 import PlusIcon from '~icons/lucide/plus'
 import RefreshCwIcon from '~icons/lucide/refresh-cw'
@@ -58,43 +59,46 @@ function DiscoveryPage(): React.JSX.Element {
 	}
 
 	return (
-		<main className="mx-auto flex w-full max-w-[1800px] flex-col gap-5 px-4 py-6 sm:px-6">
-			<header className="flex flex-col gap-4 xl:flex-row xl:items-end xl:justify-between">
+		<main className="mx-auto flex w-full min-w-0 max-w-7xl flex-col gap-6 px-4 pt-20 pb-16 sm:px-6">
+			<header className="flex flex-col gap-6 xl:flex-row xl:items-end xl:justify-between">
 				<div>
-					<div className="mb-1 text-xs font-medium tracking-[0.18em] text-secondary uppercase">
+					<div className="mb-2 text-[11px] font-medium tracking-[0.16em] text-tertiary uppercase">
 						Tempo Discovery
 					</div>
-					<h1 className="text-2xl font-semibold tracking-tight">
+					<h1 className="text-[32px] leading-none font-semibold tracking-[-0.02em] text-primary">
 						Contract dependency graph
 					</h1>
-					<p className="mt-1 max-w-3xl text-sm text-secondary">
+					<p className="mt-2 max-w-[720px] text-[14px] text-secondary">
 						Live relationships from verified getters, proxy slots, and native
 						TIP-20 roles.
 					</p>
 				</div>
-				<form className="flex w-full max-w-2xl gap-2" onSubmit={submit}>
-					<input
-						aria-label="Root contract address"
-						className="min-w-0 flex-1 rounded-lg border border-border bg-surface px-3 py-2 font-mono text-sm outline-none focus:border-accent"
-						value={input}
-						onChange={(event) => setInput(event.target.value)}
-					/>
-					<button
-						className="rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground disabled:opacity-50"
-						disabled={!Address.validate(input)}
-						type="submit"
-					>
-						Discover
-					</button>
+				<form className="w-full max-w-[640px]" onSubmit={submit}>
+					<div className="relative">
+						<input
+							aria-label="Root contract address"
+							className="h-[42px] w-full rounded-[10px] border border-base-border bg-surface px-[16px] pr-[52px] font-mono text-[13px] text-primary outline-none placeholder:text-tertiary focus-visible:border-focus"
+							value={input}
+							onChange={(event) => setInput(event.target.value)}
+						/>
+						<button
+							aria-label="Discover contract"
+							className="absolute top-1/2 right-[6px] grid size-[30px] -translate-y-1/2 place-items-center rounded-[10px]! border border-base-border bg-base-background/90 text-primary press-down transition-colors hover:bg-surface disabled:cursor-default disabled:text-tertiary"
+							disabled={!Address.validate(input)}
+							type="submit"
+						>
+							<ArrowRightIcon className="size-[14px]" />
+						</button>
+					</div>
 				</form>
 			</header>
 
 			{query.isPending ? (
-				<section className="relative min-h-[680px] overflow-hidden rounded-xl border border-border bg-surface">
+				<section className="relative min-h-[680px] overflow-hidden rounded-[10px] border border-card-border bg-card-header">
 					<GraphLoading />
 				</section>
 			) : query.isError ? (
-				<section className="grid min-h-[680px] place-items-center rounded-xl border border-border bg-surface text-sm text-negative">
+				<section className="grid min-h-[680px] place-items-center rounded-[10px] border border-card-border bg-card-header text-[13px] text-negative">
 					{query.error.message}
 				</section>
 			) : (
@@ -125,16 +129,16 @@ function DiscoveryWorkspace(props: {
 	if (!selectedNode) return <GraphLoading />
 
 	return (
-		<div className="grid items-start gap-4 lg:grid-cols-[minmax(0,1fr)_360px]">
-			<section className="relative min-h-[680px] overflow-hidden rounded-xl border border-border bg-surface">
-				<div className="absolute top-3 right-3 z-20 flex items-center gap-1 rounded-lg border border-border bg-surface/95 p-1 shadow-sm backdrop-blur">
+		<div className="grid items-start gap-3.5 lg:grid-cols-[minmax(0,1fr)_360px]">
+			<section className="relative min-h-[680px] min-w-0 overflow-hidden rounded-[10px] border border-card-border bg-card-header">
+				<div className="absolute top-3 right-3 z-20 flex items-center gap-[2px] rounded-[7px] border border-card-border bg-card-header/95 p-[2px] shadow-[0_4px_20px_rgba(0,0,0,0.05)] backdrop-blur">
 					<IconButton
 						label="Zoom out"
 						onClick={() => props.setZoom((z) => Math.max(0.5, z - 0.1))}
 					>
 						<MinusIcon />
 					</IconButton>
-					<span className="w-12 text-center text-xs tabular-nums text-secondary">
+					<span className="w-12 text-center text-[11px] tabular-nums text-tertiary">
 						{Math.round(props.zoom * 100)}%
 					</span>
 					<IconButton
@@ -179,7 +183,7 @@ function DependencyGraph(props: {
 	)
 
 	return (
-		<div className="h-[680px] overflow-auto">
+		<div className="h-[680px] overflow-auto bg-card">
 			<div
 				className="relative origin-top-left transition-transform duration-150"
 				style={{
@@ -201,7 +205,7 @@ function DependencyGraph(props: {
 							refX="7"
 							refY="4"
 						>
-							<path d="M0,0 L8,4 L0,8 Z" className="fill-border-strong" />
+							<path d="M0,0 L8,4 L0,8 Z" className="fill-card-border" />
 						</marker>
 					</defs>
 					{props.graph.edges.map((edge) => (
@@ -228,7 +232,7 @@ function DependencyGraph(props: {
 					/>
 				))}
 				{props.graph.truncated && (
-					<div className="absolute bottom-4 left-4 rounded-md border border-border bg-surface px-3 py-2 text-xs text-secondary shadow-sm">
+					<div className="absolute bottom-4 left-4 rounded-[6px] border border-card-border bg-card-header px-3 py-2 text-[11px] text-secondary shadow-[0_4px_20px_rgba(0,0,0,0.05)]">
 						Partial graph: a source timed out or the 32-node limit was reached.
 					</div>
 				)}
@@ -285,28 +289,30 @@ function GraphNode(props: GraphNodeProps): React.JSX.Element {
 			aria-label={`Inspect ${node.name}`}
 			aria-pressed={selected}
 			className={cx(
-				'absolute rounded-xl border bg-surface p-4 text-left shadow-sm transition hover:-translate-y-0.5 hover:border-accent hover:shadow-md',
+				'absolute rounded-[10px] border bg-card-header p-[14px] text-left shadow-[0_1px_2px_rgba(0,0,0,0.04)] transition-colors hover:border-accent hover:bg-surface',
 				selected || node.isRoot
-					? 'border-accent ring-2 ring-accent/15'
-					: 'border-border',
+					? 'border-accent bg-accent/[0.04] ring-1 ring-accent/30'
+					: 'border-card-border',
 			)}
 			onClick={() => onSelect(node)}
 			style={{ left: x, top: y, width: CARD_WIDTH, height: CARD_HEIGHT }}
 			type="button"
 		>
 			<div className="mb-2 flex items-center justify-between gap-2">
-				<div className="truncate text-sm font-semibold">{node.name}</div>
-				<span className="shrink-0 rounded-full bg-surface-secondary px-2 py-0.5 text-[10px] font-medium text-secondary uppercase">
+				<div className="truncate text-[13px] font-medium text-primary">
+					{node.name}
+				</div>
+				<span className="shrink-0 rounded-[5px] border border-card-border bg-base-alt px-[6px] py-[2px] text-[10px] font-medium leading-none text-tertiary uppercase">
 					{node.kind}
 				</span>
 			</div>
 			<div
-				className="truncate font-mono text-xs text-secondary"
+				className="truncate font-mono text-[11px] text-secondary"
 				title={node.id}
 			>
 				{node.id}
 			</div>
-			<div className="mt-2 flex items-center justify-between gap-2 text-[10px] text-tertiary">
+			<div className="mt-2 flex items-center justify-between gap-2 text-[11px] text-tertiary">
 				<span>
 					{node.details.source
 						? 'verified source'
@@ -344,13 +350,13 @@ function GraphEdgeLine(props: {
 				d={path}
 				className={cx(
 					'fill-none transition-colors',
-					isActive ? 'stroke-accent' : 'stroke-border-strong',
+					isActive ? 'stroke-accent' : 'stroke-card-border',
 				)}
 				markerEnd={`url(#${props.markerId})`}
 				strokeWidth={isActive ? '2' : '1.5'}
 			/>
 			<rect
-				className="fill-surface stroke-border"
+				className="fill-card-header stroke-card-border"
 				height="20"
 				rx="10"
 				width={labelWidth}
@@ -390,28 +396,31 @@ function DiscoveryInspector(props: DiscoveryInspectorProps): React.JSX.Element {
 	)
 
 	return (
-		<aside className="flex max-h-[680px] min-h-[680px] flex-col overflow-y-auto rounded-xl border border-border bg-surface">
-			<div className="border-b border-border px-5 py-4">
+		<aside className="flex min-h-0 max-h-none flex-col overflow-y-auto rounded-[10px] border border-card-border bg-card-header lg:max-h-[680px] lg:min-h-[680px]">
+			<div className="border-b border-dashed border-card-border px-[16px] py-[14px]">
 				<div className="mb-2 flex items-center justify-between gap-3">
-					<span className="text-xs font-medium tracking-[0.16em] text-secondary uppercase">
+					<span className="text-[11px] font-medium tracking-[0.14em] text-tertiary uppercase">
 						Node inspector
 					</span>
-					<span className="rounded-full bg-surface-secondary px-2 py-0.5 text-[10px] font-medium text-secondary uppercase">
+					<span className="rounded-[5px] border border-card-border bg-base-alt px-[6px] py-[2px] text-[10px] font-medium leading-none text-tertiary uppercase">
 						{node.kind}
 					</span>
 				</div>
-				<h2 className="truncate text-lg font-semibold" title={node.name}>
+				<h2
+					className="truncate text-[18px] font-medium text-primary"
+					title={node.name}
+				>
 					{node.name}
 				</h2>
 				<div className="mt-2 flex items-start gap-2">
-					<code className="min-w-0 flex-1 break-all text-xs text-secondary">
+					<code className="min-w-0 flex-1 break-all font-mono text-[12px] text-secondary">
 						{node.id}
 					</code>
 					<CopyButton value={node.id} ariaLabel="Copy node address" />
 				</div>
-				<div className="mt-4 flex flex-wrap gap-2">
+				<div className="mt-3 flex flex-wrap gap-2">
 					<Link
-						className="rounded-md bg-primary px-3 py-2 text-xs font-medium text-primary-foreground hover:opacity-90"
+						className="rounded-[6px] bg-primary px-[10px] py-[7px] text-[12px] font-medium text-content-inverse press-down hover:opacity-90"
 						params={{ address: node.id }}
 						search={{
 							tab: node.kind === 'account' ? 'transactions' : 'contract',
@@ -420,7 +429,7 @@ function DiscoveryInspector(props: DiscoveryInspectorProps): React.JSX.Element {
 					>
 						Open address details
 					</Link>
-					<span className="rounded-md border border-border px-3 py-2 text-xs text-secondary">
+					<span className="rounded-[6px] border border-card-border bg-base-alt px-[10px] py-[7px] text-[12px] text-secondary">
 						{node.isRoot ? 'Root node' : `Depth ${node.depth}`}
 					</span>
 				</div>
@@ -444,7 +453,7 @@ function DiscoveryInspector(props: DiscoveryInspectorProps): React.JSX.Element {
 				{source ? (
 					<SourceDetails source={source} />
 				) : (
-					<p className="px-4 py-3 text-xs text-secondary">
+					<p className="px-[16px] py-[10px] text-[12px] text-tertiary">
 						{node.kind === 'account'
 							? 'No deployed bytecode or verified source was found.'
 							: 'No source metadata was returned for this node.'}
@@ -455,37 +464,37 @@ function DiscoveryInspector(props: DiscoveryInspectorProps): React.JSX.Element {
 			<InspectorSection title="Interface">
 				{abi ? (
 					<>
-						<div className="grid grid-cols-2 gap-px border-b border-border bg-border">
+						<div className="grid grid-cols-2 gap-px border-b border-card-border bg-card-border">
 							<Stat label="Functions" value={abi.functionCount} />
 							<Stat label="Read" value={abi.readFunctionCount} />
 							<Stat label="Write" value={abi.writeFunctionCount} />
 							<Stat label="Events" value={abi.eventCount} />
 							<Stat label="Errors" value={abi.errorCount} />
 						</div>
-						<details className="group px-4 py-3">
-							<summary className="cursor-pointer list-none text-xs font-medium text-primary marker:hidden">
+						<details className="group px-[16px] py-[10px]">
+							<summary className="cursor-pointer list-none text-[12px] font-medium text-primary marker:hidden">
 								Show functions
 								<span className="ml-1 text-secondary">
 									({abi.functionCount})
 								</span>
 							</summary>
-							<div className="mt-3 divide-y divide-border rounded-md border border-border">
+							<div className="mt-3 divide-y divide-card-border overflow-hidden rounded-[6px] border border-card-border bg-card">
 								{abi.functions.map((item) => (
 									<div
-										className="flex items-center justify-between gap-3 px-3 py-2"
+										className="flex items-center justify-between gap-3 border-b border-card-border px-[10px] py-[8px] last:border-b-0"
 										key={`${item.name}-${item.stateMutability}`}
 									>
-										<code className="min-w-0 truncate text-[11px] text-primary">
+										<code className="min-w-0 truncate font-mono text-[11px] text-primary">
 											{item.name}({item.inputs}) → {item.outputs}
 										</code>
-										<span className="shrink-0 text-[10px] text-secondary">
+										<span className="shrink-0 rounded-[4px] bg-base-alt px-[5px] py-[2px] text-[10px] text-tertiary">
 											{item.stateMutability}
 										</span>
 									</div>
 								))}
 							</div>
 							{abi.truncated && (
-								<p className="mt-2 text-[11px] text-secondary">
+								<p className="mt-2 text-[11px] text-tertiary">
 									Showing the first 100 functions. Open the address for the full
 									ABI.
 								</p>
@@ -493,7 +502,7 @@ function DiscoveryInspector(props: DiscoveryInspectorProps): React.JSX.Element {
 						</details>
 					</>
 				) : (
-					<p className="px-4 py-3 text-xs text-secondary">
+					<p className="px-[16px] py-[10px] text-[12px] text-tertiary">
 						No ABI was available for this node.
 					</p>
 				)}
@@ -540,7 +549,7 @@ function DiscoveryInspector(props: DiscoveryInspectorProps): React.JSX.Element {
 					/>
 				)}
 				{outgoing.length === 0 && incoming.length === 0 && (
-					<p className="px-4 py-3 text-xs text-secondary">
+					<p className="px-[16px] py-[10px] text-[12px] text-tertiary">
 						No resolved relationships at this depth.
 					</p>
 				)}
@@ -554,11 +563,11 @@ function InspectorSection(props: {
 	children: React.ReactNode
 }): React.JSX.Element {
 	return (
-		<section className="border-b border-border">
-			<h3 className="px-4 pt-4 text-xs font-semibold tracking-wide text-secondary uppercase">
+		<section className="border-b border-dashed border-card-border">
+			<h3 className="px-[16px] pt-[12px] text-[11px] font-medium tracking-[0.08em] text-tertiary uppercase">
 				{props.title}
 			</h3>
-			<div className="pb-3">{props.children}</div>
+			<div className="pb-[6px]">{props.children}</div>
 		</section>
 	)
 }
@@ -568,8 +577,8 @@ function DetailRow(props: {
 	children: React.ReactNode
 }): React.JSX.Element {
 	return (
-		<div className="flex items-start justify-between gap-4 px-4 pt-3 text-xs">
-			<span className="shrink-0 text-secondary">{props.label}</span>
+		<div className="flex items-start justify-between gap-4 px-[16px] py-[7px] text-[12px]">
+			<span className="min-w-[84px] shrink-0 text-tertiary">{props.label}</span>
 			<span className="min-w-0 text-right text-primary">{props.children}</span>
 		</div>
 	)
@@ -577,9 +586,11 @@ function DetailRow(props: {
 
 function Stat(props: { label: string; value: number }): React.JSX.Element {
 	return (
-		<div className="bg-surface px-4 py-3">
-			<div className="text-lg font-semibold tabular-nums">{props.value}</div>
-			<div className="text-[10px] text-secondary uppercase">{props.label}</div>
+		<div className="bg-card px-[16px] py-[10px]">
+			<div className="text-[18px] font-medium tabular-nums text-primary">
+				{props.value}
+			</div>
+			<div className="text-[10px] text-tertiary uppercase">{props.label}</div>
 		</div>
 	)
 }
@@ -645,7 +656,7 @@ function ProxyAddressRow(props: {
 	onSelect: (node: DiscoveryNode) => void
 }): React.JSX.Element {
 	return (
-		<div className="flex items-center justify-between gap-3 px-4 pt-3 text-xs">
+		<div className="flex items-center justify-between gap-3 px-[16px] py-[7px] text-[12px]">
 			<span className="text-secondary">{props.label}</span>
 			<div className="flex min-w-0 items-center gap-2">
 				{props.node ? (
@@ -680,36 +691,38 @@ function ConnectionGroup(props: {
 	title: string
 }): React.JSX.Element {
 	return (
-		<div className="px-4 pt-3">
-			<div className="mb-2 text-[11px] font-medium text-secondary">
+		<div className="px-[16px] pt-[10px]">
+			<div className="mb-2 text-[11px] font-medium text-tertiary">
 				{props.title}
 			</div>
-			<div className="space-y-2">
+			<div className="flex flex-col gap-2">
 				{props.edges.map((edge) => {
 					const address = props.title === 'Points to' ? edge.to : edge.from
 					const node = findNode(props.graph, address)
 					return (
 						<div
-							className="rounded-md border border-border px-3 py-2"
+							className="rounded-[6px] border border-card-border bg-card px-[10px] py-[9px]"
 							key={`${edge.from}:${edge.to}:${edge.label}`}
 						>
 							<div className="mb-1 flex items-center justify-between gap-2">
-								<span className="rounded bg-surface-secondary px-1.5 py-0.5 text-[10px] text-secondary">
+								<span className="rounded-[4px] bg-base-alt px-[5px] py-[2px] text-[10px] text-tertiary">
 									{edge.kind}
 								</span>
-								<code className="text-[10px] text-tertiary">{edge.label}</code>
+								<code className="font-mono text-[10px] text-tertiary">
+									{edge.label}
+								</code>
 							</div>
 							<div className="flex items-center justify-between gap-2">
 								{node ? (
 									<button
-										className="min-w-0 truncate text-left text-xs font-medium text-accent hover:underline"
+										className="min-w-0 truncate text-left text-[12px] font-medium text-accent press-down hover:underline"
 										onClick={() => props.onSelect(node)}
 										type="button"
 									>
 										{node.name}
 									</button>
 								) : (
-									<span className="truncate text-xs text-primary">
+									<span className="truncate text-[12px] text-primary">
 										{shortenAddress(address)}
 									</span>
 								)}
@@ -765,7 +778,7 @@ function IconButton(props: {
 	return (
 		<button
 			aria-label={props.label}
-			className="grid size-8 place-items-center rounded-md text-secondary hover:bg-surface-secondary hover:text-primary [&>svg]:size-4"
+			className="grid size-[24px] place-items-center rounded-[6px] text-tertiary press-down hover:bg-base-alt hover:text-primary [&>svg]:size-[14px]"
 			onClick={props.onClick}
 			type="button"
 		>
@@ -777,8 +790,8 @@ function IconButton(props: {
 function GraphLoading(): React.JSX.Element {
 	return (
 		<div className="grid min-h-[680px] place-items-center">
-			<div className="flex items-center gap-3 text-sm text-secondary">
-				<div className="size-4 animate-spin rounded-full border-2 border-border border-t-accent" />
+			<div className="flex items-center gap-3 text-[13px] text-tertiary">
+				<div className="size-4 animate-spin rounded-full border-2 border-card-border border-t-accent" />
 				Reading live contract relationships…
 			</div>
 		</div>

--- a/apps/explorer/src/routes/_layout/discover/$address.tsx
+++ b/apps/explorer/src/routes/_layout/discover/$address.tsx
@@ -69,8 +69,8 @@ function DiscoveryPage(): React.JSX.Element {
 						Contract dependency graph
 					</h1>
 					<p className="mt-2 max-w-[720px] text-[14px] text-secondary">
-						Live relationships from verified getters, proxy slots, and native
-						TIP-20 roles.
+						See what this contract depends on, who controls it, and which system
+						contracts it uses.
 					</p>
 				</div>
 				<form className="w-full max-w-[640px]" onSubmit={submit}>
@@ -236,6 +236,10 @@ function DependencyGraph(props: {
 						Partial graph: a source timed out or the 32-node limit was reached.
 					</div>
 				)}
+				<div className="absolute right-4 bottom-4 rounded-[6px] border border-card-border bg-card-header px-3 py-2 text-[11px] text-tertiary shadow-[0_4px_20px_rgba(0,0,0,0.05)]">
+					Arrows read left to right: the item on the left relies on, reads, or
+					is controlled by the item on the right.
+				</div>
 			</div>
 		</div>
 	)
@@ -302,8 +306,8 @@ function GraphNode(props: GraphNodeProps): React.JSX.Element {
 				<div className="truncate text-[13px] font-medium text-primary">
 					{node.name}
 				</div>
-				<span className="shrink-0 rounded-[5px] border border-card-border bg-base-alt px-[6px] py-[2px] text-[10px] font-medium leading-none text-tertiary uppercase">
-					{node.kind}
+				<span className="shrink-0 rounded-[5px] border border-card-border bg-base-alt px-[6px] py-[2px] text-[10px] font-medium leading-none text-tertiary">
+					{nodeKindLabel(node.kind)}
 				</span>
 			</div>
 			<div
@@ -314,11 +318,9 @@ function GraphNode(props: GraphNodeProps): React.JSX.Element {
 			</div>
 			<div className="mt-2 flex items-center justify-between gap-2 text-[11px] text-tertiary">
 				<span>
-					{node.details.source
-						? 'verified source'
-						: node.details.bytecode.status}
+					{node.details.source ? 'Verified source' : nodeStatusLabel(node)}
 				</span>
-				<span>depth {node.depth}</span>
+				<span>Level {node.depth + 1}</span>
 			</div>
 		</button>
 	)
@@ -343,9 +345,13 @@ function GraphEdgeLine(props: {
 	const isActive =
 		props.edge.from.toLowerCase() === props.selectedNodeId.toLowerCase() ||
 		props.edge.to.toLowerCase() === props.selectedNodeId.toLowerCase()
-	const labelWidth = Math.max(58, props.edge.label.length * 7 + 18)
+	const label = props.edge.action
+	const labelWidth = Math.min(176, Math.max(82, label.length * 6.4 + 22))
 	return (
 		<g>
+			<title>
+				{props.from.node.name} {props.edge.action} {props.to.node.name}
+			</title>
 			<path
 				d={path}
 				className={cx(
@@ -372,7 +378,7 @@ function GraphEdgeLine(props: {
 				x={labelX}
 				y={labelY}
 			>
-				{props.edge.label}
+				{label}
 			</text>
 		</g>
 	)
@@ -402,8 +408,8 @@ function DiscoveryInspector(props: DiscoveryInspectorProps): React.JSX.Element {
 					<span className="text-[11px] font-medium tracking-[0.14em] text-tertiary uppercase">
 						Node inspector
 					</span>
-					<span className="rounded-[5px] border border-card-border bg-base-alt px-[6px] py-[2px] text-[10px] font-medium leading-none text-tertiary uppercase">
-						{node.kind}
+					<span className="rounded-[5px] border border-card-border bg-base-alt px-[6px] py-[2px] text-[10px] font-medium leading-none text-tertiary">
+						{nodeKindLabel(node.kind)}
 					</span>
 				</div>
 				<h2
@@ -509,11 +515,11 @@ function DiscoveryInspector(props: DiscoveryInspectorProps): React.JSX.Element {
 			</InspectorSection>
 
 			{node.details.proxy && (
-				<InspectorSection title="Proxy slots">
+				<InspectorSection title="How this contract is set up">
 					{node.details.proxy.implementation && (
 						<ProxyAddressRow
 							address={node.details.proxy.implementation}
-							label="Implementation"
+							label="Runs code from"
 							node={findNode(graph, node.details.proxy.implementation)}
 							onSelect={onSelect}
 						/>
@@ -521,7 +527,7 @@ function DiscoveryInspector(props: DiscoveryInspectorProps): React.JSX.Element {
 					{node.details.proxy.admin && (
 						<ProxyAddressRow
 							address={node.details.proxy.admin}
-							label="Admin"
+							label="Controlled by"
 							node={findNode(graph, node.details.proxy.admin)}
 							onSelect={onSelect}
 						/>
@@ -530,14 +536,14 @@ function DiscoveryInspector(props: DiscoveryInspectorProps): React.JSX.Element {
 			)}
 
 			<InspectorSection
-				title={`Connections (${outgoing.length + incoming.length})`}
+				title={`How it connects (${outgoing.length + incoming.length})`}
 			>
 				{outgoing.length > 0 && (
 					<ConnectionGroup
 						edges={outgoing}
 						graph={graph}
 						onSelect={onSelect}
-						title="Points to"
+						title="Needs from"
 					/>
 				)}
 				{incoming.length > 0 && (
@@ -545,7 +551,7 @@ function DiscoveryInspector(props: DiscoveryInspectorProps): React.JSX.Element {
 						edges={incoming}
 						graph={graph}
 						onSelect={onSelect}
-						title="Referenced by"
+						title="Used by"
 					/>
 				)}
 				{outgoing.length === 0 && incoming.length === 0 && (
@@ -697,7 +703,7 @@ function ConnectionGroup(props: {
 			</div>
 			<div className="flex flex-col gap-2">
 				{props.edges.map((edge) => {
-					const address = props.title === 'Points to' ? edge.to : edge.from
+					const address = props.title === 'Needs from' ? edge.to : edge.from
 					const node = findNode(props.graph, address)
 					return (
 						<div
@@ -705,12 +711,12 @@ function ConnectionGroup(props: {
 							key={`${edge.from}:${edge.to}:${edge.label}`}
 						>
 							<div className="mb-1 flex items-center justify-between gap-2">
-								<span className="rounded-[4px] bg-base-alt px-[5px] py-[2px] text-[10px] text-tertiary">
-									{edge.kind}
+								<span className="text-[12px] font-medium text-primary">
+									{edge.action}
 								</span>
-								<code className="font-mono text-[10px] text-tertiary">
-									{edge.label}
-								</code>
+								<span className="rounded-[4px] bg-base-alt px-[5px] py-[2px] text-[10px] text-tertiary">
+									{connectionKindLabel(edge.kind)}
+								</span>
 							</div>
 							<div className="flex items-center justify-between gap-2">
 								{node ? (
@@ -734,6 +740,12 @@ function ConnectionGroup(props: {
 									{shortenAddress(address)}
 								</Link>
 							</div>
+							<div
+								className="mt-1 truncate font-mono text-[10px] text-tertiary"
+								title={edge.label}
+							>
+								Technical source: {edge.label}
+							</div>
 						</div>
 					)
 				})}
@@ -753,6 +765,25 @@ function findNode(
 
 function shortenAddress(address: string): string {
 	return `${address.slice(0, 8)}…${address.slice(-6)}`
+}
+
+function nodeKindLabel(kind: DiscoveryNode['kind']): string {
+	if (kind === 'native') return 'System contract'
+	if (kind === 'account') return 'Wallet / account'
+	return 'Contract'
+}
+
+function nodeStatusLabel(node: DiscoveryNode): string {
+	if (node.details.bytecode.status === 'precompile') return 'Tempo system code'
+	if (node.details.bytecode.status === 'available') return 'On-chain code'
+	if (node.details.bytecode.status === 'empty') return 'No code found'
+	return 'Code unavailable'
+}
+
+function connectionKindLabel(kind: DiscoveryEdge['kind']): string {
+	if (kind === 'role') return 'Permission'
+	if (kind === 'proxy') return 'Contract setup'
+	return 'Contract lookup'
 }
 
 function formatBytecode(

--- a/apps/explorer/src/routes/_layout/discover/$address.tsx
+++ b/apps/explorer/src/routes/_layout/discover/$address.tsx
@@ -1,0 +1,305 @@
+import { queryOptions, useQuery } from '@tanstack/react-query'
+import { createFileRoute, Link, useNavigate } from '@tanstack/react-router'
+import * as Address from 'ox/Address'
+import * as React from 'react'
+import type {
+	ContractDiscovery,
+	DiscoveryEdge,
+	DiscoveryNode,
+} from '#lib/domain/contract-discovery'
+import { fetchContractDiscovery } from '#lib/domain/contract-discovery'
+import { zAddress } from '#lib/zod'
+import MinusIcon from '~icons/lucide/minus'
+import PlusIcon from '~icons/lucide/plus'
+import RefreshCwIcon from '~icons/lucide/refresh-cw'
+
+const CARD_WIDTH = 248
+const CARD_HEIGHT = 92
+const COLUMN_GAP = 150
+const ROW_GAP = 44
+const PADDING = 56
+
+const discoveryQueryOptions = (address: Address.Address) =>
+	queryOptions({
+		queryKey: ['contract-discovery', address],
+		queryFn: () => fetchContractDiscovery(address),
+		staleTime: 5 * 60_000,
+	})
+
+export const Route = createFileRoute('/_layout/discover/$address')({
+	component: DiscoveryPage,
+})
+
+function DiscoveryPage(): React.JSX.Element {
+	const params = Route.useParams()
+	const address = zAddress().parse(params.address)
+	const query = useQuery({
+		...discoveryQueryOptions(address),
+		enabled: typeof window !== 'undefined',
+	})
+	const navigate = useNavigate()
+	const [input, setInput] = React.useState<string>(address)
+	const [zoom, setZoom] = React.useState(1)
+
+	const submit = (event: React.FormEvent) => {
+		event.preventDefault()
+		if (!Address.validate(input)) return
+		void navigate({
+			to: '/discover/$address',
+			params: { address: Address.checksum(input) },
+		})
+	}
+
+	return (
+		<main className="mx-auto flex w-full max-w-[1800px] flex-col gap-5 px-4 py-6 sm:px-6">
+			<header className="flex flex-col gap-4 xl:flex-row xl:items-end xl:justify-between">
+				<div>
+					<div className="mb-1 text-xs font-medium tracking-[0.18em] text-secondary uppercase">
+						Tempo Discovery
+					</div>
+					<h1 className="text-2xl font-semibold tracking-tight">
+						Contract dependency graph
+					</h1>
+					<p className="mt-1 max-w-3xl text-sm text-secondary">
+						Live relationships from verified getters, proxy slots, and native
+						TIP-20 roles.
+					</p>
+				</div>
+				<form className="flex w-full max-w-2xl gap-2" onSubmit={submit}>
+					<input
+						aria-label="Root contract address"
+						className="min-w-0 flex-1 rounded-lg border border-border bg-surface px-3 py-2 font-mono text-sm outline-none focus:border-accent"
+						value={input}
+						onChange={(event) => setInput(event.target.value)}
+					/>
+					<button
+						className="rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground disabled:opacity-50"
+						disabled={!Address.validate(input)}
+						type="submit"
+					>
+						Discover
+					</button>
+				</form>
+			</header>
+
+			<section className="relative min-h-[680px] overflow-hidden rounded-xl border border-border bg-surface">
+				<div className="absolute top-3 right-3 z-20 flex items-center gap-1 rounded-lg border border-border bg-surface/95 p-1 shadow-sm backdrop-blur">
+					<IconButton
+						label="Zoom out"
+						onClick={() => setZoom((z) => Math.max(0.5, z - 0.1))}
+					>
+						<MinusIcon />
+					</IconButton>
+					<span className="w-12 text-center text-xs tabular-nums text-secondary">
+						{Math.round(zoom * 100)}%
+					</span>
+					<IconButton
+						label="Zoom in"
+						onClick={() => setZoom((z) => Math.min(1.5, z + 0.1))}
+					>
+						<PlusIcon />
+					</IconButton>
+					<IconButton label="Reset zoom" onClick={() => setZoom(1)}>
+						<RefreshCwIcon />
+					</IconButton>
+				</div>
+
+				{query.isPending ? (
+					<GraphLoading />
+				) : query.isError ? (
+					<div className="grid min-h-[680px] place-items-center text-sm text-negative">
+						{query.error.message}
+					</div>
+				) : (
+					<DependencyGraph graph={query.data} zoom={zoom} />
+				)}
+			</section>
+		</main>
+	)
+}
+
+function DependencyGraph(props: {
+	graph: ContractDiscovery
+	zoom: number
+}): React.JSX.Element {
+	const markerId = React.useId()
+	const layout = React.useMemo(
+		() => buildLayout(props.graph.nodes),
+		[props.graph.nodes],
+	)
+	const positionById = new Map(
+		layout.nodes.map((item) => [item.node.id.toLowerCase(), item]),
+	)
+
+	return (
+		<div className="h-[680px] overflow-auto">
+			<div
+				className="relative origin-top-left transition-transform duration-150"
+				style={{
+					width: layout.width,
+					height: layout.height,
+					transform: `scale(${props.zoom})`,
+				}}
+			>
+				<svg
+					aria-hidden="true"
+					className="pointer-events-none absolute inset-0 h-full w-full overflow-visible"
+				>
+					<defs>
+						<marker
+							id={markerId}
+							markerHeight="8"
+							markerWidth="8"
+							orient="auto"
+							refX="7"
+							refY="4"
+						>
+							<path d="M0,0 L8,4 L0,8 Z" className="fill-border-strong" />
+						</marker>
+					</defs>
+					{props.graph.edges.map((edge) => (
+						<GraphEdgeLine
+							edge={edge}
+							from={positionById.get(edge.from.toLowerCase())}
+							key={`${edge.from}:${edge.to}:${edge.label}`}
+							markerId={markerId}
+							to={positionById.get(edge.to.toLowerCase())}
+						/>
+					))}
+				</svg>
+				{layout.nodes.map(({ node, x, y }) => (
+					<GraphNode key={node.id} node={node} x={x} y={y} />
+				))}
+				{props.graph.truncated && (
+					<div className="absolute bottom-4 left-4 rounded-md border border-border bg-surface px-3 py-2 text-xs text-secondary shadow-sm">
+						Partial graph: a source timed out or the 32-node limit was reached.
+					</div>
+				)}
+			</div>
+		</div>
+	)
+}
+
+type PositionedNode = { node: DiscoveryNode; x: number; y: number }
+
+function buildLayout(nodes: DiscoveryNode[]): {
+	nodes: PositionedNode[]
+	width: number
+	height: number
+} {
+	const byDepth = new Map<number, DiscoveryNode[]>()
+	for (const node of nodes) {
+		const column = byDepth.get(node.depth) ?? []
+		column.push(node)
+		byDepth.set(node.depth, column)
+	}
+	const maxRows = Math.max(
+		1,
+		...[...byDepth.values()].map((items) => items.length),
+	)
+	const height = Math.max(680, PADDING * 2 + maxRows * (CARD_HEIGHT + ROW_GAP))
+	const positioned = [...byDepth.entries()].flatMap(([depth, column]) => {
+		const columnHeight =
+			column.length * CARD_HEIGHT + (column.length - 1) * ROW_GAP
+		const startY = Math.max(PADDING, (height - columnHeight) / 2)
+		return column.map((node, index) => ({
+			node,
+			x: PADDING + depth * (CARD_WIDTH + COLUMN_GAP),
+			y: startY + index * (CARD_HEIGHT + ROW_GAP),
+		}))
+	})
+	const maxDepth = Math.max(0, ...nodes.map((node) => node.depth))
+	return {
+		nodes: positioned,
+		width: PADDING * 2 + (maxDepth + 1) * CARD_WIDTH + maxDepth * COLUMN_GAP,
+		height,
+	}
+}
+
+function GraphNode(props: PositionedNode): React.JSX.Element {
+	const { node, x, y } = props
+	return (
+		<Link
+			className={`absolute rounded-xl border bg-surface p-4 shadow-sm transition hover:-translate-y-0.5 hover:border-accent hover:shadow-md ${node.isRoot ? 'border-accent ring-2 ring-accent/15' : 'border-border'}`}
+			params={{ address: node.id }}
+			style={{ left: x, top: y, width: CARD_WIDTH, height: CARD_HEIGHT }}
+			to="/address/$address"
+		>
+			<div className="mb-2 flex items-center justify-between gap-2">
+				<div className="truncate text-sm font-semibold">{node.name}</div>
+				<span className="shrink-0 rounded-full bg-surface-secondary px-2 py-0.5 text-[10px] font-medium text-secondary uppercase">
+					{node.kind}
+				</span>
+			</div>
+			<div
+				className="truncate font-mono text-xs text-secondary"
+				title={node.id}
+			>
+				{node.id}
+			</div>
+		</Link>
+	)
+}
+
+function GraphEdgeLine(props: {
+	edge: DiscoveryEdge
+	from?: PositionedNode
+	markerId: string
+	to?: PositionedNode
+}): React.JSX.Element | null {
+	if (!props.from || !props.to) return null
+	const x1 = props.from.x + CARD_WIDTH
+	const y1 = props.from.y + CARD_HEIGHT / 2
+	const x2 = props.to.x
+	const y2 = props.to.y + CARD_HEIGHT / 2
+	const bend = Math.max(40, (x2 - x1) / 2)
+	const path = `M ${x1} ${y1} C ${x1 + bend} ${y1}, ${x2 - bend} ${y2}, ${x2} ${y2}`
+	const labelX = (x1 + x2) / 2
+	const labelY = (y1 + y2) / 2 - 7
+	return (
+		<g>
+			<path
+				d={path}
+				className="fill-none stroke-border-strong"
+				markerEnd={`url(#${props.markerId})`}
+				strokeWidth="1.5"
+			/>
+			<text
+				className="fill-secondary text-[11px]"
+				textAnchor="middle"
+				x={labelX}
+				y={labelY}
+			>
+				{props.edge.label}
+			</text>
+		</g>
+	)
+}
+
+function IconButton(props: {
+	label: string
+	onClick: () => void
+	children: React.ReactNode
+}): React.JSX.Element {
+	return (
+		<button
+			aria-label={props.label}
+			className="grid size-8 place-items-center rounded-md text-secondary hover:bg-surface-secondary hover:text-primary [&>svg]:size-4"
+			onClick={props.onClick}
+			type="button"
+		>
+			{props.children}
+		</button>
+	)
+}
+
+function GraphLoading(): React.JSX.Element {
+	return (
+		<div className="grid min-h-[680px] place-items-center">
+			<div className="flex items-center gap-3 text-sm text-secondary">
+				<div className="size-4 animate-spin rounded-full border-2 border-border border-t-accent" />
+				Reading live contract relationships…
+			</div>
+		</div>
+	)
+}

--- a/apps/explorer/src/routes/api/contract-discovery.ts
+++ b/apps/explorer/src/routes/api/contract-discovery.ts
@@ -1,0 +1,29 @@
+import { createFileRoute } from '@tanstack/react-router'
+import * as Address from 'ox/Address'
+import { discoverContractGraph } from '#lib/server/contract-discovery'
+import { zAddress } from '#lib/zod'
+
+export const Route = createFileRoute('/api/contract-discovery')({
+	server: {
+		handlers: {
+			GET: async ({ request }) => {
+				try {
+					const url = new URL(request.url)
+					const address = zAddress().parse(url.searchParams.get('address'))
+					const graph = await discoverContractGraph(Address.checksum(address))
+					return Response.json(graph, {
+						headers: { 'Cache-Control': 'public, max-age=300' },
+					})
+				} catch (error) {
+					return Response.json(
+						{
+							error:
+								error instanceof Error ? error.message : 'Discovery failed',
+						},
+						{ status: 400 },
+					)
+				}
+			},
+		},
+	},
+})


### PR DESCRIPTION
## Summary

- add a Tempo-native contract dependency discovery API and graph view
- follow verified zero-argument address getters, EIP-1967 proxy slots, and TIP-20 role history
- link every contract and native token address page to the discovery surface
- bound graph depth, node count, upstream waits, and show partial-result state

The TIP-20 role path is required for the initial Earn Share because native TIP-20 runtime bytecode does not expose the EarnVault dependency through Solidity source analysis. Its live `ISSUER_ROLE` history resolves to the EarnVault before ABI discovery continues through the Earn stack.

## Screenshots

| Before | After |
|---|---|
| No dependency graph surface | New `/discover/$address` graph; local render verified against `0x20c000000000000000000000FcF238CED5ff9c33` (preview deployment will provide the shareable screenshot) |

## Validation

- `pnpm --filter explorer check:biome`
- `pnpm --filter explorer check:types`
- `pnpm --filter explorer test` (58 passed)
- `pnpm --filter explorer build`
- `pnpm precommit`
- local mainnet render at the requested Earn Share address

Prompted by: @letstokenize
