### PR TITLE
feat(explorer): show transaction activities

### DIFF
--- a/apps/explorer/src/comps/TxTransactionRow.tsx
+++ b/apps/explorer/src/comps/TxTransactionRow.tsx
@@ -89,7 +89,7 @@ export function getPerspectiveEvent(
 	accountAddress?: Address.Address,
 ) {
 	if (!accountAddress) return event
-	if (event.type !== 'send') return event
+	if (event.type !== 'send' && event.type !== 'transfer') return event
 	const toMatches =
 		event.meta?.to && Address.isEqual(event.meta.to, accountAddress)
 	const fromMatches =

--- a/apps/explorer/src/lib/domain/transaction-activities.ts
+++ b/apps/explorer/src/lib/domain/transaction-activities.ts
@@ -6,26 +6,144 @@ export type TransactionActivity = {
 	id: string
 	title: string
 	type: string
-	data: Record<string, string | number | boolean>
+	data: Record<string, ActivityDataValue>
 }
+
+export type ActivityDataValue =
+	| string
+	| number
+	| boolean
+	| null
+	| ActivityDataValue[]
+	| { [key: string]: ActivityDataValue }
 
 const HIDDEN_FIELDS = new Set(['signer', 'status'])
 
 export function activitiesToKnownEvents(
 	activities: readonly TransactionActivity[],
 ): KnownEvent[] {
-	return activities.map((activity) => ({
-		type: activity.type,
-		parts: [{ type: 'action', value: activity.title }],
-		note: Object.entries(activity.data).flatMap(([key, value]) => {
-			if (HIDDEN_FIELDS.has(key) || value == null) return []
-			const part = activityValueToPart(value)
-			return part ? [[formatLabel(key), part] as [string, KnownEventPart]] : []
-		}),
-	}))
+	return activities.map((activity) => {
+		const parts = activityParts(activity)
+		const representedFields = new Set([
+			'sourceAmount',
+			'sourceToken',
+			'destinationAmount',
+			'destinationToken',
+			'recipient',
+			'sender',
+			'spender',
+		])
+		return {
+			type: activity.type,
+			parts,
+			...(activity.type === 'transfer'
+				? {
+						meta: {
+							from: activityAddress(activity.data.sender),
+							to: activityAddress(activity.data.recipient),
+						},
+					}
+				: {}),
+			note: Object.entries(activity.data).flatMap(([key, value]) => {
+				if (HIDDEN_FIELDS.has(key) || value == null) return []
+				if (representedFields.has(key)) return []
+				const part = activityValueToPart(value)
+				return part
+					? [[formatLabel(key), part] as [string, KnownEventPart]]
+					: []
+			}),
+		}
+	})
 }
 
-function activityValueToPart(value: unknown): KnownEventPart | null {
+function activityAddress(
+	value: ActivityDataValue | undefined,
+): Address.Address | undefined {
+	return typeof value === 'string' && Address.validate(value)
+		? value
+		: undefined
+}
+
+function activityParts(activity: TransactionActivity): KnownEventPart[] {
+	const parts: KnownEventPart[] = [{ type: 'action', value: activity.title }]
+	const source = amountPart(activity.data, 'sourceAmount', 'sourceToken')
+	const destination = amountPart(
+		activity.data,
+		'destinationAmount',
+		'destinationToken',
+	)
+	if (source) parts.push(source)
+
+	if (activity.type === 'swap' && destination) {
+		parts.push({ type: 'text', value: 'for' }, destination)
+	} else if (activity.type === 'approval') {
+		pushAccount(parts, 'for spender', activity.data.spender)
+	} else if (activity.type === 'mint') {
+		pushAccount(parts, 'to', activity.data.recipient)
+	} else if (activity.type === 'burn') {
+		pushAccount(parts, 'from', activity.data.sender)
+	} else if (activity.type === 'transfer') {
+		const direction = activity.data.direction
+		pushAccount(
+			parts,
+			direction === 'in' ? 'from' : 'to',
+			direction === 'in' ? activity.data.sender : activity.data.recipient,
+		)
+	}
+	return parts
+}
+
+function amountPart(
+	data: TransactionActivity['data'],
+	amountKey: string,
+	tokenKey: string,
+): KnownEventPart | null {
+	const amount = asRecord(data[amountKey])
+	const token = asRecord(data[tokenKey])
+	if (!amount || !token) return null
+	const baseUnits = amount.baseUnits
+	const decimals = amount.decimals
+	const address = token.address
+	if (
+		typeof baseUnits !== 'string' ||
+		!/^\d+$/.test(baseUnits) ||
+		typeof decimals !== 'number' ||
+		typeof address !== 'string' ||
+		!Address.validate(address)
+	)
+		return null
+	return {
+		type: 'amount',
+		value: {
+			value: BigInt(baseUnits),
+			decimals,
+			token: address,
+			...(typeof token.symbol === 'string' ? { symbol: token.symbol } : {}),
+			...(typeof amount.currency === 'string'
+				? { currency: amount.currency }
+				: {}),
+		},
+	}
+}
+
+function pushAccount(
+	parts: KnownEventPart[],
+	label: string,
+	value: ActivityDataValue | undefined,
+): void {
+	if (typeof value !== 'string' || !Address.validate(value)) return
+	parts.push({ type: 'text', value: label }, { type: 'account', value })
+}
+
+function asRecord(
+	value: ActivityDataValue | undefined,
+): Record<string, ActivityDataValue> | null {
+	return value !== null && typeof value === 'object' && !Array.isArray(value)
+		? value
+		: null
+}
+
+function activityValueToPart(value: ActivityDataValue): KnownEventPart | null {
 	if (typeof value === 'number' && Number.isFinite(value)) {
 		return { type: 'number', value }
 	}

--- a/apps/explorer/src/lib/domain/transaction-activities.ts
+++ b/apps/explorer/src/lib/domain/transaction-activities.ts
@@ -1,0 +1,43 @@
+import * as Address from 'ox/Address'
+import * as Hex from 'ox/Hex'
+import type { KnownEvent, KnownEventPart } from './known-events'
+
+export type TransactionActivity = {
+	id: string
+	title: string
+	type: string
+	data: Record<string, string | number | boolean>
+}
+
+const HIDDEN_FIELDS = new Set(['signer', 'status'])
+
+export function activitiesToKnownEvents(
+	activities: readonly TransactionActivity[],
+): KnownEvent[] {
+	return activities.map((activity) => ({
+		type: activity.type,
+		parts: [{ type: 'action', value: activity.title }],
+		note: Object.entries(activity.data).flatMap(([key, value]) => {
+			if (HIDDEN_FIELDS.has(key) || value == null) return []
+			const part = activityValueToPart(value)
+			return part ? [[formatLabel(key), part] as [string, KnownEventPart]] : []
+		}),
+	}))
+}
+
+function activityValueToPart(value: unknown): KnownEventPart | null {
+	if (typeof value === 'number' && Number.isFinite(value)) {
+		return { type: 'number', value }
+	}
+	if (typeof value !== 'string') return null
+	if (Address.validate(value)) return { type: 'account', value }
+	if (Hex.validate(value)) return { type: 'hex', value }
+	if (/^\d+$/.test(value)) return { type: 'number', value: BigInt(value) }
+	return { type: 'text', value }
+}
+
+function formatLabel(value: string): string {
+	return value
+		.replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+		.replace(/^./, (character) => character.toUpperCase())
+}

--- a/apps/explorer/src/lib/server/address-history.ts
+++ b/apps/explorer/src/lib/server/address-history.ts
@@ -9,11 +9,16 @@ import * as z from 'zod/mini'
 import { type KnownEvent, parseKnownEvents } from '#lib/domain/known-events'
 import { isTip20Address, type Metadata } from '#lib/domain/tip20'
 import {
+	activitiesToKnownEvents,
+	type TransactionActivity,
+} from '#lib/domain/transaction-activities'
+import {
 	buildCsv,
 	createCsvDownloadResponse,
 	createTimestampedCsvFilename,
 } from '#lib/server/csv'
 import { api } from '#lib/server/tempo-api'
+import { getTransactionActivities } from '#lib/server/transaction-activities'
 import { fetchAddressTxExportRows } from '#lib/server/tempo-queries'
 import { resolveTotal } from '#lib/server/token'
 import { parseTimestamp } from '#lib/timestamp'
@@ -199,6 +204,7 @@ export function toEnrichedTransaction(
 	options: {
 		includeKnownEvents: boolean
 		getTokenMetadata: (address: Address.Address) => Metadata | undefined
+		activities?: TransactionActivity[] | undefined
 	},
 ): EnrichedTransaction {
 	const receipt = row.meta?.receipt
@@ -207,6 +213,8 @@ export function toEnrichedTransaction(
 
 	const knownEvents = (() => {
 		if (!options.includeKnownEvents || !receipt) return []
+		const activityEvents = activitiesToKnownEvents(options.activities ?? [])
+		if (activityEvents.length > 0) return activityEvents
 		try {
 			return parseKnownEvents(
 				{
@@ -320,12 +328,23 @@ export async function fetchAddressHistoryData(params: {
 		cachedTotal ?? requestedTotal,
 	])
 
-	const getTokenMetadata = includeKnownEvents
-		? await buildTokenMetadataLookup(result.data)
-		: () => undefined
+	const [getTokenMetadata, activities] = await Promise.all([
+		includeKnownEvents
+			? buildTokenMetadataLookup(result.data)
+			: Promise.resolve(() => undefined),
+		includeKnownEvents
+			? Promise.all(
+					result.data.map((row) => getTransactionActivities(row.hash, chainId)),
+				)
+			: Promise.resolve([]),
+	])
 
-	const transactions = result.data.map((row) =>
-		toEnrichedTransaction(row, { includeKnownEvents, getTokenMetadata }),
+	const transactions = result.data.map((row, index) =>
+		toEnrichedTransaction(row, {
+			includeKnownEvents,
+			getTokenMetadata,
+			activities: activities[index],
+		}),
 	)
 
 	const { total, totalCapped } = resolveTotal({

--- a/apps/explorer/src/lib/server/transaction-activities.ts
+++ b/apps/explorer/src/lib/server/transaction-activities.ts
@@ -1,0 +1,38 @@
+import { createServerFn } from '@tanstack/react-start'
+import { parseResponse } from 'hono/client'
+import * as z from 'zod/mini'
+import type { TransactionActivity } from '#lib/domain/transaction-activities'
+import { api } from '#lib/server/tempo-api'
+import { zHash } from '#lib/zod'
+import { getTempoChain } from '#wagmi.config.ts'
+
+const InputSchema = z.object({ hash: zHash() })
+
+export const fetchTransactionActivities = createServerFn({ method: 'GET' })
+	.inputValidator((input) => InputSchema.parse(input))
+	.handler(async ({ data }): Promise<TransactionActivity[]> => {
+		try {
+			const upstream = await api.v1.transactions[
+				':transactionHash'
+			].activities.$get({
+				param: { transactionHash: data.hash },
+				query: { chainId: String(getTempoChain().id) },
+			})
+			if (upstream.status === 404) return []
+			const response = await parseResponse(Promise.resolve(upstream))
+			return response.data.map((activity) => ({
+				id: activity.id,
+				title: activity.title,
+				type: activity.type,
+				data: Object.fromEntries(
+					Object.entries(activity.data).filter(
+						(entry): entry is [string, string | number | boolean] =>
+							['string', 'number', 'boolean'].includes(typeof entry[1]),
+					),
+				),
+			}))
+		} catch (error) {
+			console.error('Failed to fetch transaction activities:', error)
+			return []
+		}
+	})

--- a/apps/explorer/src/lib/server/transaction-activities.ts
+++ b/apps/explorer/src/lib/server/transaction-activities.ts
@@ -1,7 +1,10 @@
 import { createServerFn } from '@tanstack/react-start'
 import { parseResponse } from 'hono/client'
 import * as z from 'zod/mini'
-import type { TransactionActivity } from '#lib/domain/transaction-activities'
+import type {
+	ActivityDataValue,
+	TransactionActivity,
+} from '#lib/domain/transaction-activities'
 import { api } from '#lib/server/tempo-api'
 import { zHash } from '#lib/zod'
 import { getTempoChain } from '#wagmi.config.ts'
@@ -11,28 +14,54 @@ const InputSchema = z.object({ hash: zHash() })
 export const fetchTransactionActivities = createServerFn({ method: 'GET' })
 	.inputValidator((input) => InputSchema.parse(input))
 	.handler(async ({ data }): Promise<TransactionActivity[]> => {
-		try {
-			const upstream = await api.v1.transactions[
-				':transactionHash'
-			].activities.$get({
-				param: { transactionHash: data.hash },
-				query: { chainId: String(getTempoChain().id) },
-			})
-			if (upstream.status === 404) return []
-			const response = await parseResponse(Promise.resolve(upstream))
-			return response.data.map((activity) => ({
-				id: activity.id,
-				title: activity.title,
-				type: activity.type,
-				data: Object.fromEntries(
-					Object.entries(activity.data).filter(
-						(entry): entry is [string, string | number | boolean] =>
-							['string', 'number', 'boolean'].includes(typeof entry[1]),
-					),
-				),
-			}))
-		} catch (error) {
-			console.error('Failed to fetch transaction activities:', error)
-			return []
-		}
+		return getTransactionActivities(data.hash, getTempoChain().id)
 	})
+
+export async function getTransactionActivities(
+	hash: `0x${string}`,
+	chainId: number,
+): Promise<TransactionActivity[]> {
+	try {
+		const upstream = await api.v1.transactions[
+			':transactionHash'
+		].activities.$get({
+			param: { transactionHash: hash },
+			query: { chainId: String(chainId) },
+		})
+		if (upstream.status === 404) return []
+		const response = await parseResponse(Promise.resolve(upstream))
+		return response.data.map((activity) => ({
+			id: activity.id,
+			title: activity.title,
+			type: activity.type,
+			data: normalizeActivityData(activity.data),
+		}))
+	} catch (error) {
+		console.error('Failed to fetch transaction activities:', error)
+		return []
+	}
+}
+
+function normalizeActivityData(
+	value: object,
+): Record<string, ActivityDataValue> {
+	return Object.fromEntries(
+		Object.entries(value).flatMap(([key, nested]) => {
+			const normalized = normalizeActivityValue(nested)
+			return normalized === undefined ? [] : [[key, normalized]]
+		}),
+	)
+}
+
+function normalizeActivityValue(value: unknown): ActivityDataValue | undefined {
+	if (value === null) return null
+	if (['string', 'number', 'boolean'].includes(typeof value))
+		return value as string | number | boolean
+	if (Array.isArray(value)) {
+		return value.flatMap((item) => {
+			const normalized = normalizeActivityValue(item)
+			return normalized === undefined ? [] : [normalized]
+		})
+	}
+	if (typeof value === 'object') return normalizeActivityData(value)
+}

--- a/apps/explorer/src/routes/_layout/receipt/$hash.tsx
+++ b/apps/explorer/src/routes/_layout/receipt/$hash.tsx
@@ -27,6 +27,7 @@ import { calculateKnownEventsTotal } from '#lib/domain/known-event-totals'
 import { getFeeBreakdown, LineItems } from '#lib/domain/receipt'
 import { buildTxSummary } from '#lib/domain/tx-summary'
 import * as Tip20 from '#lib/domain/tip20'
+import { activitiesToKnownEvents } from '#lib/domain/transaction-activities'
 import { DateFormatter, PriceFormatter } from '#lib/formatting'
 import { useKeyboardShortcut } from '#lib/hooks'
 import {
@@ -37,6 +38,7 @@ import {
 import { areUsdPricedTokens, hasTokenAmount } from '#lib/pricing'
 import { withLoaderTiming } from '#lib/profiling'
 import { getFeeTokenForChain } from '#lib/fee-token'
+import { fetchTransactionActivities } from '#lib/server/transaction-activities'
 import { getTempoChain, getWagmiConfig } from '#wagmi.config.ts'
 
 const TEMPO_CHAIN_ID = getTempoChain().id
@@ -90,10 +92,11 @@ async function fetchReceiptData(params: { hash: Hex.Hex; rpcUrl?: string }) {
 		hash: params.hash,
 	})
 	// TODO: investigate & consider batch/multicall
-	const [block, transaction, getTokenMetadata] = await Promise.all([
+	const [block, transaction, getTokenMetadata, activities] = await Promise.all([
 		client.getBlock({ blockHash: receipt.blockHash }),
 		client.getTransaction({ hash: receipt.transactionHash }),
 		Tip20.metadataFromLogs(receipt.logs),
+		fetchTransactionActivities({ data: { hash: receipt.transactionHash } }),
 	])
 	const timestampFormatted = DateFormatter.format(block.timestamp)
 
@@ -113,9 +116,12 @@ async function fetchReceiptData(params: { hash: Hex.Hex; rpcUrl?: string }) {
 			? decodeKnownCall(transaction.to, transaction.input)
 			: null
 
-	const knownEvents = knownCall
+	const fallbackEvents = knownCall
 		? [knownCall, ...parsedEvents.filter((e) => e.type !== 'fee')]
 		: parsedEvents
+	const activityEvents = activitiesToKnownEvents(activities)
+	const knownEvents =
+		activityEvents.length > 0 ? activityEvents : fallbackEvents
 
 	return {
 		block,

--- a/apps/explorer/src/routes/_layout/tx/$hash.tsx
+++ b/apps/explorer/src/routes/_layout/tx/$hash.tsx
@@ -43,6 +43,7 @@ import {
 } from '#lib/domain/tx-event-groups'
 import type { FeeBreakdownItem } from '#lib/domain/receipt'
 import { isTip20Address } from '#lib/domain/tip20'
+import { activitiesToKnownEvents } from '#lib/domain/transaction-activities'
 import { PriceFormatter } from '#lib/formatting'
 import { useKeyboardShortcut, useMediaQuery } from '#lib/hooks'
 import { buildOgImageUrl, buildTxDescription, OG_BASE_URL } from '#lib/og'
@@ -62,6 +63,7 @@ import {
 import { withLoaderTiming } from '#lib/profiling'
 import { zHash } from '#lib/zod'
 import { fetchBalanceChanges } from '#routes/api/tx/balance-changes/$hash'
+import { fetchTransactionActivities } from '#lib/server/transaction-activities'
 import ChevronDownIcon from '~icons/lucide/chevron-down'
 
 const defaultSearchValues = {
@@ -108,19 +110,22 @@ export const Route = createFileRoute('/_layout/tx/$hash')({
 			try {
 				const offset = (page - 1) * LIMIT
 
-				const [txData, balanceChangesData, traceData] = await Promise.all([
-					context.queryClient.ensureQueryData(txQueryOptions({ hash })),
-					fetchBalanceChanges({ hash, limit: LIMIT, offset }).catch(() => ({
-						changes: [],
-						tokenMetadata: {},
-						total: 0,
-					})),
-					context.queryClient
-						.ensureQueryData(traceQueryOptions({ hash }))
-						.catch(() => ({ trace: null, prestate: null })),
-				])
+				const [txData, balanceChangesData, traceData, activities] =
+					await Promise.all([
+						context.queryClient.ensureQueryData(txQueryOptions({ hash })),
+						fetchBalanceChanges({ hash, limit: LIMIT, offset }).catch(() => ({
+							changes: [],
+							tokenMetadata: {},
+							total: 0,
+						})),
+						context.queryClient
+							.ensureQueryData(traceQueryOptions({ hash }))
+							.catch(() => ({ trace: null, prestate: null })),
+						fetchTransactionActivities({ data: { hash } }),
+					])
 
-				return { ...txData, balanceChangesData, traceData }
+				const activityEvents = activitiesToKnownEvents(activities)
+				return { ...txData, balanceChangesData, traceData, activityEvents }
 			} catch (error) {
 				console.error(error)
 				throw notFound({
@@ -141,7 +146,10 @@ export const Route = createFileRoute('/_layout/tx/$hash')({
 			? buildTxDescription({
 					timestamp: Number(loaderData.block.timestamp) * 1000,
 					from: loaderData.receipt.from,
-					events: loaderData.knownEvents ?? [],
+					events:
+						loaderData.activityEvents.length > 0
+							? loaderData.activityEvents
+							: (loaderData.knownEvents ?? []),
 				})
 			: 'View transaction details on Tempo Explorer.'
 
@@ -168,6 +176,7 @@ function RouteComponent() {
 	const { tab, page } = Route.useSearch()
 	const {
 		balanceChangesData,
+		activityEvents,
 		traceData,
 		block,
 		feeBreakdown,
@@ -189,6 +198,8 @@ function RouteComponent() {
 			!event.meta?.to ||
 			!OxAddressUtil.isEqual(event.meta.to, RECEIVE_POLICY_GUARD),
 	)
+	const descriptionEvents =
+		activityEvents.length > 0 ? activityEvents : displayKnownEvents
 
 	useKeyboardShortcut({
 		t: () =>
@@ -212,11 +223,18 @@ function RouteComponent() {
 			buildTxSummary({
 				receipt,
 				transaction,
-				knownEvents,
+				knownEvents: activityEvents.length > 0 ? activityEvents : knownEvents,
 				trace: traceData.trace,
 				balanceChangesData,
 			}),
-		[receipt, knownEvents, traceData.trace, balanceChangesData, transaction],
+		[
+			receipt,
+			knownEvents,
+			activityEvents,
+			traceData.trace,
+			balanceChangesData,
+			transaction,
+		],
 	)
 
 	const setActiveSection = (newIndex: number) => {
@@ -240,7 +258,7 @@ function RouteComponent() {
 				receipt={receipt}
 				transaction={transaction}
 				block={block}
-				knownEvents={displayKnownEvents}
+				knownEvents={descriptionEvents}
 				feeBreakdown={feeBreakdown}
 				balanceChangesData={balanceChangesData}
 			/>

--- a/apps/explorer/test/transaction-activities.test.ts
+++ b/apps/explorer/test/transaction-activities.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, test } from 'vitest'
+import { activitiesToKnownEvents } from '#lib/domain/transaction-activities'
+
+describe('activitiesToKnownEvents', () => {
+	test('maps an Earn activity into a receipt event', () => {
+		expect(
+			activitiesToKnownEvents([
+				{
+					id: 'activity-1',
+					title: 'Shares redeemed',
+					type: 'shares-redeemed',
+					data: {
+						assets: '49999',
+						shares: '49999',
+						status: 'completed',
+						signer: 'self',
+						vault: '0x10c063b3bbc396d7e4a0d4d48212d901e2943663',
+					},
+				},
+			]),
+		).toEqual([
+			{
+				type: 'shares-redeemed',
+				parts: [{ type: 'action', value: 'Shares redeemed' }],
+				note: [
+					['Assets', { type: 'number', value: 49999n }],
+					['Shares', { type: 'number', value: 49999n }],
+					[
+						'Vault',
+						{
+							type: 'account',
+							value: '0x10c063b3bbc396d7e4a0d4d48212d901e2943663',
+						},
+					],
+				],
+			},
+		])
+	})
+})

--- a/apps/explorer/test/transaction-activities.test.ts
+++ b/apps/explorer/test/transaction-activities.test.ts
@@ -2,6 +2,57 @@ import { describe, expect, test } from 'vitest'
 import { activitiesToKnownEvents } from '#lib/domain/transaction-activities'
 
 describe('activitiesToKnownEvents', () => {
+	test('preserves token amounts and perspective for transfers', () => {
+		expect(
+			activitiesToKnownEvents([
+				{
+					id: 'activity-1',
+					title: 'Token transferred',
+					type: 'transfer',
+					data: {
+						direction: 'in',
+						sender: '0x0000000000000000000000000000000000000001',
+						recipient: '0x0000000000000000000000000000000000000002',
+						sourceAmount: {
+							baseUnits: '1230000',
+							currency: 'USD',
+							decimals: 6,
+							formatted: '1.23',
+						},
+						sourceToken: {
+							address: '0x20c0000000000000000000000000000000000001',
+							symbol: 'USD',
+						},
+					},
+				},
+			]),
+		).toMatchObject([
+			{
+				type: 'transfer',
+				meta: {
+					from: '0x0000000000000000000000000000000000000001',
+					to: '0x0000000000000000000000000000000000000002',
+				},
+				parts: [
+					{ type: 'action', value: 'Token transferred' },
+					{
+						type: 'amount',
+						value: {
+							value: 1230000n,
+							decimals: 6,
+							symbol: 'USD',
+						},
+					},
+					{ type: 'text', value: 'from' },
+					{
+						type: 'account',
+						value: '0x0000000000000000000000000000000000000001',
+					},
+				],
+			},
+		])
+	})
+
 	test('maps an Earn activity into a receipt event', () => {
 		expect(
 			activitiesToKnownEvents([


### PR DESCRIPTION
## Summary

- fetch classified transaction activities from the Tempo API
- use activity titles and structured fields in transaction descriptions, receipt line items, and account transaction history
- preserve token amounts and account-relative transfer direction in the history table
- fall back to the explorer's local event decoder when activities are unavailable

## Testing

- `pnpm --filter explorer check`
- `pnpm --filter explorer test`
- `pnpm --filter explorer build`
- `pnpm precommit`

The monorepo-wide type check remains blocked by pre-existing missing Cloudflare binding types in `apps/contract-verification`; the explorer type check passes.

## Screenshots

| Before | After |
|---|---|
| Locally decoded event descriptions | Tempo API activity titles and structured fields in transaction, receipt, and account-history views |

Prompted by: @jxom