### PR TITLE
fix(explorer): cap address history pages

### DIFF
--- a/apps/explorer/src/lib/server/address-history.ts
+++ b/apps/explorer/src/lib/server/address-history.ts
@@ -24,7 +24,7 @@ import { resolveTotal } from '#lib/server/token'
 import { parseTimestamp } from '#lib/timestamp'
 import { getWagmiConfig } from '#wagmi.config'
 
-export const [MAX_LIMIT, DEFAULT_LIMIT] = [100, 10]
+export const [MAX_LIMIT, DEFAULT_LIMIT] = [10, 10]
 /** The API's positional-pagination window: `page × limit` must stay within. */
 const HISTORY_COUNT_MAX = 10_000
 const CSV_EXPORT_LIMIT = HISTORY_COUNT_MAX

--- a/apps/explorer/src/routes/_layout/address/$address.tsx
+++ b/apps/explorer/src/routes/_layout/address/$address.tsx
@@ -166,7 +166,7 @@ export const Route = createFileRoute('/_layout/address/$address')({
 		limit: z.prefault(
 			z.pipe(
 				z.number(),
-				z.transform((val) => Math.min(100, Math.max(5, val))),
+				z.transform((val) => Math.min(10, Math.max(5, val))),
 			),
 			defaultSearchValues.limit,
 		),

--- a/apps/explorer/test/address-history.node.test.ts
+++ b/apps/explorer/test/address-history.node.test.ts
@@ -107,6 +107,23 @@ describe('toEnrichedTransaction', () => {
 })
 
 describe('fetchAddressHistoryData', () => {
+	it('rejects page sizes above 10', async () => {
+		await expect(
+			fetchAddressHistoryData({
+				address: '0x1111111111111111111111111111111111111111',
+				chainId: 4217,
+				includeKnownEvents: false,
+				searchParams: {
+					include: 'all',
+					limit: 11,
+					page: 1,
+					sort: 'desc',
+				},
+			}),
+		).rejects.toThrowError('Limit is too high')
+		expect(getTransactions).not.toHaveBeenCalled()
+	})
+
 	it('requests and reuses the total count from the first page', async () => {
 		getTransactions.mockImplementation((options) => {
 			const { include } = (options as { query: { include: string } }).query
@@ -129,7 +146,7 @@ describe('fetchAddressHistoryData', () => {
 			includeKnownEvents: false,
 			searchParams: {
 				include: 'all' as const,
-				limit: 100,
+				limit: 10,
 				page: 1,
 				sort: 'desc' as const,
 			},
@@ -159,7 +176,7 @@ describe('fetchAddressHistoryData', () => {
 				address: params.address,
 				chainId: '4217',
 				include: 'receipt,totalCount',
-				limit: '100',
+				limit: '10',
 				order: 'desc',
 			},
 		})
@@ -168,7 +185,7 @@ describe('fetchAddressHistoryData', () => {
 				address: params.address,
 				chainId: '4217',
 				include: 'receipt',
-				limit: '100',
+				limit: '10',
 				order: 'desc',
 				page: '2',
 			},
@@ -178,7 +195,7 @@ describe('fetchAddressHistoryData', () => {
 				address: params.address,
 				chainId: '4217',
 				include: 'receipt',
-				limit: '100',
+				limit: '10',
 				order: 'desc',
 				page: '18',
 			},
@@ -204,7 +221,7 @@ describe('fetchAddressHistoryData', () => {
 				includeKnownEvents: false,
 				searchParams: {
 					include: 'all',
-					limit: 100,
+					limit: 10,
 					page: 6,
 					sort: 'desc',
 				},
@@ -221,7 +238,7 @@ describe('fetchAddressHistoryData', () => {
 				address: '0x2222222222222222222222222222222222222222',
 				chainId: '4217',
 				include: 'receipt',
-				limit: '100',
+				limit: '10',
 				order: 'desc',
 				page: '6',
 			},


### PR DESCRIPTION
Caps Explorer address-history pages at 10 rows in URL parsing and server validation, reducing oversized requests while preserving pagination and CSV exports.