### PR TITLE
Fix `test:testnet` to use the testnet environment

### DIFF
--- a/apps/fee-payer/package.json
+++ b/apps/fee-payer/package.json
@@ -23,7 +23,7 @@
 		"test": "vitest --run",
 		"test:watch": "vitest",
 		"test:moderato": "TEMPO_ENV=moderato vitest --run",
-		"test:testnet": "TEMPO_ENV=moderato vitest --run",
+		"test:testnet": "TEMPO_ENV=testnet vitest --run",
 		"postinstall": "pnpm gen:types"
 	},
 	"dependencies": {


### PR DESCRIPTION
Update `apps/fee-payer/package.json` so `test:testnet` sets `TEMPO_ENV=testnet` instead of `moderato`.

[`src/lib/chain.ts`](https://github.com/tempoxyz/tempo-apps/blob/main/apps/fee-payer/src/lib/chain.ts) explicitly supports `testnet` as a backwards-compatible alias for `moderato`. The previous script used `TEMPO_ENV=moderato`, making `test:testnet` run the same environment as `test:moderato` and bypassing the `testnet` alias handling.