### PR TITLE
fix(explorer): filter null bytes from memos

### DIFF
--- a/apps/explorer/src/lib/domain/memo.ts
+++ b/apps/explorer/src/lib/domain/memo.ts
@@ -22,18 +22,13 @@ export function decodeMemoForDisplay(memo: Hex.Hex): string | undefined {
 	if (isMppAttributionMemo(memo)) return undefined
 
 	const bytes = OxHex.toBytes(memo)
+	const displayBytes = bytes.filter((byte) => byte !== 0)
 
-	let start = 0
-	let end = bytes.length
-
-	while (start < end && bytes[start] === 0) start += 1
-	while (end > start && bytes[end - 1] === 0) end -= 1
-
-	if (start === end) return undefined
+	if (displayBytes.length === 0) return undefined
 
 	let decoded: string
 	try {
-		decoded = decoder.decode(bytes.subarray(start, end))
+		decoded = decoder.decode(displayBytes)
 	} catch {
 		return undefined
 	}

--- a/apps/explorer/test/memo.test.ts
+++ b/apps/explorer/test/memo.test.ts
@@ -27,6 +27,17 @@ const providedReceiptToken =
 const providedReceiptMemo =
 	'0xef1ed71201c62939e7f7496e1106ef00000000000000000000a166aee7e294f6' as Hex.Hex
 
+describe('memo display', () => {
+	it('filters null bytes from text memos', () => {
+		expect(
+			decodeMemoForDisplay(
+				'0x67616d6573000000000000000000000000000000000000000000000000000000',
+			),
+		).toBe('games')
+		expect(decodeMemoForDisplay('0x67616d006573')).toBe('games')
+	})
+})
+
 describe('MPP attribution memos', () => {
 	it('identifies and hides MPP attribution memos from generic memo display', () => {
 		expect({


### PR DESCRIPTION
## Summary

- remove null bytes from memo payloads before UTF-8 decoding
- cover padded and embedded null bytes, including the reported `games` memo

## Screenshots

| Before | After |
| --- | --- |
| `games` followed by null replacement symbols | `games` |

## Tests

- `pnpm test` in `apps/explorer` (13 files, 61 tests)
- `pnpm check`
- `pnpm precommit`

Prompted by: @Zygimantass