### PR TITLE
fix(contract-verification): generate worker types on postinstall

### DIFF
--- a/apps/contract-verification/package.json
+++ b/apps/contract-verification/package.json
@@ -27,7 +27,8 @@
 		"db:seed": "node ./scripts/precompile-seed/index.ts",
 		"db:seed:local": "pnpm db:prepare:local && pnpm db:seed",
 		"db:seed:remote": "pnpm db:prepare:remote && pnpm db:seed",
-		"gen:types": "wrangler types --env-interface='CloudflareBindings' --env-file='.env.example'"
+		"gen:types": "wrangler types --env-interface='CloudflareBindings' --env-file='.env.example'",
+		"postinstall": "pnpm gen:types"
 	},
 	"dependencies": {
 		"@cloudflare/containers": "^0.2.3",


### PR DESCRIPTION
## Problem

On a fresh clone, `pnpm install && pnpm check:types` fails with exit code 2. All 78 errors come from `apps/contract-verification`, and every one is the same shape:

    src/route.verify.ts(221,33): error TS2339: Property 'CONTRACTS_DB' does not exist on type 'Env'.

`AGENTS.md` states type checking must produce zero errors before every commit, so this blocks the documented workflow for any new contributor.

## Reproduction

    git clone https://github.com/tempoxyz/tempo-apps.git
    cd tempo-apps
    pnpm install
    pnpm check:types

Result: exit 2, 78 errors in `apps/contract-verification`.

## Root cause

`worker-configuration.d.ts` is gitignored (`.gitignore:13`), so it has to be generated locally. `apps/contract-verification` defines a `gen:types` script but nothing ever invokes it, leaving `Env` empty after install.

Every other Worker app already handles this:

| App | Mechanism |
| --- | --- |
| `explorer` | `postinstall: pnpm gen:types` |
| `fee-payer` | `postinstall: pnpm gen:types` |
| `key-manager` | `postinstall: pnpm gen:types` |
| `og` | `postinstall: pnpm gen:types` |
| `tokenlist` | `postinstall: pnpm gen:types` |
| `reth-snapshots-viewer` | `postinstall: pnpm gen:types` |
| `tempo-snapshots-viewer` | `postinstall: pnpm gen:types` |
| `mcp-docs-indexer` | `check:types` runs `gen:types` first |
| `contract-verification` | none |

## Fix

Adds the `postinstall` hook used by the other seven apps. Placed as the last key directly after `gen:types`, matching the layout in `og`, `tokenlist`, `fee-payer`, and both snapshot viewers.

## Verification

| Step | Result |
| --- | --- |
| Delete `worker-configuration.d.ts`, run `check:types` | fails, 78 x TS2339 |
| Apply fix, `pnpm install --filter contracts` | postinstall runs, types written |
| `pnpm --filter contracts check:types` | exit 0 |
| `pnpm --filter contracts test` | 17 files, 224 tests passed |
| `biome check` on the changed file (no `--write`) | clean |

`pnpm check` was intentionally not run since it carries `--write --unsafe` and would touch unrelated files.

One file changed, one line added.
