### PR TITLE
fix(contract-verification): restore RPC auth

### DIFF
--- a/apps/contract-verification/.env.example
+++ b/apps/contract-verification/.env.example
@@ -15,3 +15,7 @@ WRANGLER_SEND_METRICS=false
 # Dynamic chain registry (optional)
 # CHAINS_CONFIG_URL="https://example.com/chains"
 # CHAINS_CONFIG_AUTH_TOKEN is a Cloudflare Secrets Store binding (see wrangler.json secrets_store_secrets)
+
+# Tempo RPC Basic Auth credentials (configure production values as Cloudflare secrets)
+TEMPO_MAINNET_RPC_AUTH=""
+TEMPO_TESTNET_RPC_AUTH=""

--- a/apps/contract-verification/env.d.ts
+++ b/apps/contract-verification/env.d.ts
@@ -24,6 +24,10 @@ interface EnvironmentVariables {
 	readonly CHAINS_CONFIG_URL?: string
 	/** Bearer token for authenticating with the chain config endpoint (optional). */
 	readonly CHAINS_CONFIG_AUTH_TOKEN?: string
+
+	/** Basic Auth credentials (`client_id:api_key`) for Tempo RPCs (optional). */
+	readonly TEMPO_MAINNET_RPC_AUTH?: string
+	readonly TEMPO_TESTNET_RPC_AUTH?: string
 }
 
 // Node.js `process.env` auto-completion

--- a/apps/contract-verification/src/lib/rpc.ts
+++ b/apps/contract-verification/src/lib/rpc.ts
@@ -1,0 +1,36 @@
+import { tempo, tempoModerato } from '@wagmi/core/chains'
+import { http } from 'viem'
+
+interface RpcAuthEnv {
+	readonly TEMPO_MAINNET_RPC_AUTH?: string
+	readonly TEMPO_TESTNET_RPC_AUTH?: string
+}
+
+export function getRpcAuthorizationHeader(
+	chainId: number,
+	env: RpcAuthEnv,
+): string | undefined {
+	const credentials =
+		chainId === tempo.id
+			? env.TEMPO_MAINNET_RPC_AUTH
+			: chainId === tempoModerato.id
+				? env.TEMPO_TESTNET_RPC_AUTH
+				: undefined
+
+	return credentials ? `Basic ${btoa(credentials)}` : undefined
+}
+
+export function createRpcTransport(
+	rpcUrl: string | undefined,
+	chainId: number,
+	env: RpcAuthEnv,
+) {
+	const authorization = getRpcAuthorizationHeader(chainId, env)
+
+	return http(
+		rpcUrl,
+		authorization
+			? { fetchOptions: { headers: { Authorization: authorization } } }
+			: undefined,
+	)
+}

--- a/apps/contract-verification/src/route.verify-legacy.ts
+++ b/apps/contract-verification/src/route.verify-legacy.ts
@@ -3,7 +3,7 @@ import * as z from 'zod/mini'
 import { Address, Hex } from 'ox'
 import { and, eq, or } from 'drizzle-orm'
 import { getRandom } from '@cloudflare/containers'
-import { createPublicClient, http, keccak256 } from 'viem'
+import { createPublicClient, keccak256 } from 'viem'
 
 import {
 	getDb,
@@ -34,6 +34,7 @@ import {
 } from '#lib/bytecode-matching.ts'
 import type { AppEnv } from '#index.tsx'
 import { getLogger } from '#lib/logger.ts'
+import { createRpcTransport } from '#lib/rpc.ts'
 
 const logger = getLogger(['tempo'])
 
@@ -188,7 +189,7 @@ legacyVerifyRoute.post('/vyper', async (context) => {
 		const rpcUrl = chainConfig.rpcUrls.default.http.at(0)
 		const client = createPublicClient({
 			chain: chainConfig,
-			transport: http(rpcUrl),
+			transport: createRpcTransport(rpcUrl, chainConfig.id, context.env),
 		})
 
 		const creationTransactionMetadata = body.creatorTxHash

--- a/apps/contract-verification/src/route.verify.ts
+++ b/apps/contract-verification/src/route.verify.ts
@@ -5,7 +5,7 @@ import { and, eq, isNull, or } from 'drizzle-orm'
 import type { BatchItem } from 'drizzle-orm/batch'
 
 import { getRandom } from '@cloudflare/containers'
-import { createPublicClient, http, keccak256 } from 'viem'
+import { createPublicClient, type http, keccak256 } from 'viem'
 
 import {
 	getDb,
@@ -37,6 +37,7 @@ import {
 import type { AppEnv } from '#index.tsx'
 import type { ChainRegistry } from '#lib/chain-registry.ts'
 import { getLogger } from '#lib/logger.ts'
+import { createRpcTransport } from '#lib/rpc.ts'
 import {
 	type CompileOutput,
 	getValidationCustomCode,
@@ -688,7 +689,7 @@ async function runVerificationJob(
 		const createClient = deps?.createPublicClient ?? createPublicClient
 		const client = createClient({
 			chain,
-			transport: http(rpcUrl),
+			transport: createRpcTransport(rpcUrl, chain.id, env),
 		})
 
 		const creationTransactionMetadata = sanitizedBody.creationTransactionHash

--- a/apps/contract-verification/test/unit/rpc.test.ts
+++ b/apps/contract-verification/test/unit/rpc.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from 'vitest'
+import { tempo, tempoDevnet, tempoModerato } from '@wagmi/core/chains'
+
+import { getRpcAuthorizationHeader } from '#lib/rpc.ts'
+
+const env = {
+	TEMPO_MAINNET_RPC_AUTH: 'mainnet-client:mainnet-key',
+	TEMPO_TESTNET_RPC_AUTH: 'testnet-client:testnet-key',
+}
+
+describe('getRpcAuthorizationHeader', () => {
+	test('uses the mainnet credentials for Tempo mainnet', () => {
+		expect(getRpcAuthorizationHeader(tempo.id, env)).toBe(
+			`Basic ${btoa(env.TEMPO_MAINNET_RPC_AUTH)}`,
+		)
+	})
+
+	test('uses the testnet credentials for Tempo Moderato', () => {
+		expect(getRpcAuthorizationHeader(tempoModerato.id, env)).toBe(
+			`Basic ${btoa(env.TEMPO_TESTNET_RPC_AUTH)}`,
+		)
+	})
+
+	test('does not authenticate other chains', () => {
+		expect(getRpcAuthorizationHeader(tempoDevnet.id, env)).toBeUndefined()
+	})
+
+	test('does not authenticate when the credential is missing', () => {
+		expect(getRpcAuthorizationHeader(tempo.id, {})).toBeUndefined()
+	})
+})


### PR DESCRIPTION
## Summary

- send secret-backed Basic Auth headers for Tempo mainnet and Moderato RPC calls
- keep anonymous RPC access as a fallback when credentials are not configured
- cover mainnet, testnet, unsupported-chain, and missing-secret behavior

## Deployment follow-up

Provision `TEMPO_MAINNET_RPC_AUTH` and `TEMPO_TESTNET_RPC_AUTH` as Cloudflare Worker secrets in `client_id:api_key` format.

## Validation

- `pnpm check`
- `pnpm check:types`
- `pnpm precommit`
- `pnpm --filter contracts exec vitest --run test/unit/rpc.test.ts`
- full verifier suite: 223 passed; 5 existing `job-runner-do` tests timed out in the sandbox

Prompted by: @grandizzy