### PR TITLE
fix(fee-payer): authenticate downstream RPC requests

### DIFF
--- a/apps/fee-payer/.env.example
+++ b/apps/fee-payer/.env.example
@@ -2,6 +2,8 @@ ALLOWED_ORIGINS=*
 # testnet | devnet
 TEMPO_ENV=testnet
 TEMPO_RPC_URL=https://rpc.moderato.tempo.xyz
+# Configure production values as a Cloudflare secret.
+TEMPO_RPC_AUTH=
 SPONSOR_PRIVATE_KEY=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
 
 # for /usage endpoint

--- a/apps/fee-payer/README.md
+++ b/apps/fee-payer/README.md
@@ -23,6 +23,13 @@ Tests use Cloudflare's [vitest-pool-workers](https://developers.cloudflare.com/w
 Environment variables:
 - `TEMPO_ENV` - `localnet` (default), `moderato`, or `devnet` (`testnet` is accepted as a backwards-compatible alias of `moderato`)
 - `TEMPO_TAG` - Docker image tag for localnet (default: `latest`)
+- `TEMPO_RPC_AUTH` - optional Tempo RPC Basic Auth credentials in `client_id:api_key` format; configure production values as a Cloudflare secret
+
+Configure authenticated Moderato RPC access with:
+
+```bash
+pnpm wrangler secret put TEMPO_RPC_AUTH --env moderato
+```
 
 ## API
 

--- a/apps/fee-payer/env.d.ts
+++ b/apps/fee-payer/env.d.ts
@@ -1,6 +1,8 @@
 interface EnvironmentVariables {
 	readonly TEMPO_ENV: 'testnet' | 'devnet' | 'moderato' | 'localnet' | 'mainnet'
 	readonly TEMPO_RPC_URL: string
+	/** Basic Auth credentials (`client_id:api_key`) for the Tempo RPC. */
+	readonly TEMPO_RPC_AUTH?: string
 	readonly ALLOWED_ORIGINS: string
 	readonly POSTHOG_API_KEY?: string
 	readonly ADMIN_SECRET?: string

--- a/apps/fee-payer/src/index.ts
+++ b/apps/fee-payer/src/index.ts
@@ -5,7 +5,6 @@ import { type Context, Hono } from 'hono'
 import { cache } from 'hono/cache'
 import { cors } from 'hono/cors'
 import { HTTPException } from 'hono/http-exception'
-import { http } from 'viem'
 import { privateKeyToAccount } from 'viem/accounts'
 import * as z from 'zod'
 import { admin } from './lib/admin.js'
@@ -21,6 +20,7 @@ import {
 	getRequestContext,
 } from './lib/posthog.js'
 import { rateLimitMiddleware } from './lib/rate-limit.js'
+import { createRpcTransport } from './lib/rpc.js'
 import { getUsage } from './lib/usage.js'
 
 const USAGE_CACHE_TTL = 60
@@ -114,8 +114,10 @@ const relayHandler = Handler.relay({
 		url: 'https://sponsor.tempo.xyz',
 	},
 	transports: {
-		[tempoChain.id]: http(
-			env.TEMPO_RPC_URL ?? tempoChain.rpcUrls.default.http[0],
+		[tempoChain.id]: createRpcTransport(
+			env.TEMPO_RPC_URL,
+			tempoChain.rpcUrls.default.http[0],
+			env,
 		),
 	},
 })

--- a/apps/fee-payer/src/lib/rpc.ts
+++ b/apps/fee-payer/src/lib/rpc.ts
@@ -1,0 +1,24 @@
+import { http } from 'viem'
+
+interface RpcAuthEnv {
+	readonly TEMPO_RPC_AUTH?: string
+}
+
+export function getRpcAuthorizationHeader(env: RpcAuthEnv): string | undefined {
+	return env.TEMPO_RPC_AUTH ? `Basic ${btoa(env.TEMPO_RPC_AUTH)}` : undefined
+}
+
+export function createRpcTransport(
+	rpcUrl: string | undefined,
+	fallbackRpcUrl: string,
+	env: RpcAuthEnv,
+) {
+	const authorization = getRpcAuthorizationHeader(env)
+
+	return http(
+		rpcUrl ?? fallbackRpcUrl,
+		authorization
+			? { fetchOptions: { headers: { Authorization: authorization } } }
+			: undefined,
+	)
+}

--- a/apps/fee-payer/src/lib/usage.ts
+++ b/apps/fee-payer/src/lib/usage.ts
@@ -2,10 +2,11 @@ import { env } from 'cloudflare:workers'
 import * as IDX from 'idxs'
 import { sql } from 'kysely'
 import type { Address } from 'ox'
-import { createPublicClient, formatUnits, http } from 'viem'
+import { createPublicClient, formatUnits } from 'viem'
 import { Actions, Addresses } from 'viem/tempo'
 import { tempoChain } from './chain.js'
 import { pathUsd } from './consts.js'
+import { createRpcTransport } from './rpc.js'
 
 const IS = IDX.IndexSupply.create({
 	apiKey: env.INDEXSUPPLY_API_KEY,
@@ -67,8 +68,10 @@ export async function getUsage(
 		cachedFeeTokenMetadata = await Actions.token.getMetadata(
 			createPublicClient({
 				chain: tempoChain,
-				transport: http(
-					env.TEMPO_RPC_URL ?? tempoChain.rpcUrls.default.http[0],
+				transport: createRpcTransport(
+					env.TEMPO_RPC_URL,
+					tempoChain.rpcUrls.default.http[0],
+					env,
 				),
 			}),
 			{ token: pathUsd },

--- a/apps/fee-payer/test/rpc.test.ts
+++ b/apps/fee-payer/test/rpc.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from 'vitest'
+import { getRpcAuthorizationHeader } from '../src/lib/rpc.js'
+
+describe('getRpcAuthorizationHeader', () => {
+	test('encodes configured RPC credentials as Basic Auth', () => {
+		const credentials = 'fee-payer:test-api-key'
+
+		expect(getRpcAuthorizationHeader({ TEMPO_RPC_AUTH: credentials })).toBe(
+			`Basic ${btoa(credentials)}`,
+		)
+	})
+
+	test('does not authenticate when credentials are missing', () => {
+		expect(getRpcAuthorizationHeader({})).toBeUndefined()
+	})
+})


### PR DESCRIPTION
## Summary

- send secret-backed Basic Auth credentials on fee-payer downstream RPC requests
- reuse the authenticated transport for relay and usage lookups
- document the `TEMPO_RPC_AUTH` Cloudflare secret setup

## Deployment follow-up

- [stg-infra#1142](https://github.com/tempoxyz/stg-infra/pull/1142) provisioned and deployed the dedicated `fee-payer` Orchestra client
- set `TEMPO_RPC_AUTH` on `fee-payer-moderato` to `fee-payer:<api_key>` before deploying this change

## Validation

- `pnpm precommit`
- `pnpm check:types` in `apps/fee-payer`
- `pnpm build` in `apps/fee-payer`
- focused RPC auth tests: 2 passed
- live authenticated `eth_chainId` request to Moderato returned chain ID `42431`
- full fee-payer integration suite attempted; blocked because Docker/local Tempo is unavailable in the sandbox

Prompted by: @struong
