### PR TITLE
fix(explorer): show private Zone asset amounts

### DIFF
--- a/apps/explorer/src/lib/domain/transaction-activities.ts
+++ b/apps/explorer/src/lib/domain/transaction-activities.ts
@@ -20,7 +20,7 @@ export type ActivityDataValue =
 const HIDDEN_FIELDS = new Set(['signer', 'status'])
 const PRIVATE_ZONE_ACTIONS: Record<string, string> = {
 	'private-assets-deposited': 'Private Zone Deposit',
-	'private-assets-redeemed': 'Private Zone Withdrawal',
+	'private-shares-redeemed': 'Private Zone Withdrawal',
 }
 
 export function activitiesToKnownEvents(

--- a/apps/explorer/src/lib/domain/transaction-activities.ts
+++ b/apps/explorer/src/lib/domain/transaction-activities.ts
@@ -18,21 +18,32 @@ export type ActivityDataValue =
 	| { [key: string]: ActivityDataValue }
 
 const HIDDEN_FIELDS = new Set(['signer', 'status'])
-const PRIVATE_ZONE_ACTIONS: Record<string, string> = {
-	'private-assets-deposited': 'Private Zone Deposit',
-	'private-shares-redeemed': 'Private Zone Withdrawal',
+const PRIVATE_ZONE_ACTIONS: Record<string, [string, string, string]> = {
+	'private-assets-deposited': [
+		'Private Zone Deposit',
+		'inputAmount',
+		'inputToken',
+	],
+	'private-shares-redeemed': [
+		'Private Zone Withdrawal',
+		'outputAmount',
+		'outputToken',
+	],
 }
 
 export function activitiesToKnownEvents(
 	activities: readonly TransactionActivity[],
 ): KnownEvent[] {
 	return activities.map((activity) => {
-		const privateZoneAction = PRIVATE_ZONE_ACTIONS[activity.type]
-		if (privateZoneAction)
+		const privateZone = PRIVATE_ZONE_ACTIONS[activity.type]
+		if (privateZone) {
+			const [action, amountKey, tokenKey] = privateZone
+			const amount = amountPart(activity.data, amountKey, tokenKey)
 			return {
 				type: activity.type,
-				parts: [{ type: 'action', value: privateZoneAction }],
+				parts: [{ type: 'action', value: action }, ...(amount ? [amount] : [])],
 			}
+		}
 
 		const parts = activityParts(activity)
 		const representedFields = new Set([
@@ -109,8 +120,21 @@ function amountPart(
 	amountKey: string,
 	tokenKey: string,
 ): KnownEventPart | null {
-	const amount = asRecord(data[amountKey])
-	const token = asRecord(data[tokenKey])
+	const rawAmount = data[amountKey]
+	const rawToken = data[tokenKey]
+	if (
+		typeof rawAmount === 'string' &&
+		/^\d+$/.test(rawAmount) &&
+		typeof rawToken === 'string' &&
+		Address.validate(rawToken)
+	)
+		return {
+			type: 'amount',
+			value: { value: BigInt(rawAmount), token: rawToken },
+		}
+
+	const amount = asRecord(rawAmount)
+	const token = asRecord(rawToken)
 	if (!amount || !token) return null
 	const baseUnits = amount.baseUnits
 	const decimals = amount.decimals

--- a/apps/explorer/test/transaction-activities.test.ts
+++ b/apps/explorer/test/transaction-activities.test.ts
@@ -89,18 +89,41 @@ describe('activitiesToKnownEvents', () => {
 	})
 
 	test.each([
-		['private-assets-deposited', 'Private Zone Deposit'],
-		['private-shares-redeemed', 'Private Zone Withdrawal'],
-	])('simplifies %s', (type, action) => {
+		[
+			'private-assets-deposited',
+			'Private Zone Deposit',
+			'inputAmount',
+			'inputToken',
+		],
+		[
+			'private-shares-redeemed',
+			'Private Zone Withdrawal',
+			'outputAmount',
+			'outputToken',
+		],
+	])('simplifies %s', (type, action, amountKey, tokenKey) => {
+		const token = '0x20c0000000000000000000000000000000000001'
 		expect(
 			activitiesToKnownEvents([
 				{
 					id: 'activity-1',
 					title: 'Low-level private activity',
 					type,
-					data: { actionId: `0x${'1'.repeat(64)}` },
+					data: {
+						actionId: `0x${'1'.repeat(64)}`,
+						[amountKey]: '1000000',
+						[tokenKey]: token,
+					},
 				},
 			]),
-		).toEqual([{ type, parts: [{ type: 'action', value: action }] }])
+		).toEqual([
+			{
+				type,
+				parts: [
+					{ type: 'action', value: action },
+					{ type: 'amount', value: { value: 1000000n, token } },
+				],
+			},
+		])
 	})
 })

--- a/apps/explorer/test/transaction-activities.test.ts
+++ b/apps/explorer/test/transaction-activities.test.ts
@@ -90,7 +90,7 @@ describe('activitiesToKnownEvents', () => {
 
 	test.each([
 		['private-assets-deposited', 'Private Zone Deposit'],
-		['private-assets-redeemed', 'Private Zone Withdrawal'],
+		['private-shares-redeemed', 'Private Zone Withdrawal'],
 	])('simplifies %s', (type, action) => {
 		expect(
 			activitiesToKnownEvents([


### PR DESCRIPTION
## Summary

- match the canonical `private-shares-redeemed` activity type
- show the deposited input asset and withdrawn output asset
- keep the dark private labels while hiding low-level metadata

## Validation

- Explorer Biome and type checks passed
- Explorer tests: 63 passed
- `pnpm precommit` passed

## Screenshots

| Before | After |
|---|---|
| Action ID, vault, shares, and deposit hash | [`Private Zone Deposit`](https://a91a0db2-explorer-mainnet.porto.workers.dev/receipt/0x8159f2df9d1d93d76ffedde60c731000a9f7b17a928a5476aa36539079591bd0) / [`Private Zone Withdrawal`](https://a91a0db2-explorer-mainnet.porto.workers.dev/receipt/0x65c9a4bb30faee66eb4667e6274b29501e283ff4bc40e27daee51459207ffc13) with asset amount |

Prompted by: @snario
