### PR TITLE
fix(tokenlist): align OpenAPI schema with proxy responses

### DIFF
--- a/apps/tokenlist/schema/openapi.json
+++ b/apps/tokenlist/schema/openapi.json
@@ -136,9 +136,13 @@
 									"$ref": "#/components/schemas/TokenList"
 								},
 								"example": {
-									"schema": "https://esm.sh/gh/uniswap/token-lists/src/tokenlist.schema.json",
 									"name": "Tempo Testnet",
-									"logo_uri": "https://esm.sh/gh/tempoxyz/tokenlist/data/42431/icon.svg",
+									"timestamp": "2026-08-25T00:00:00Z",
+									"version": {
+										"major": 1,
+										"minor": 0,
+										"patch": 0
+									},
 									"tokens": [
 										{
 											"name": "pathUSD",
@@ -146,7 +150,7 @@
 											"decimals": 6,
 											"chainId": 42431,
 											"address": "0x20c0000000000000000000000000000000000000",
-											"logo_uri": "https://esm.sh/gh/tempoxyz/tokenlist/data/42431/icons/pathusd.svg",
+											"logoURI": "https://esm.sh/gh/tempoxyz/tokenlist/data/42431/icons/pathusd.svg",
 											"extensions": {
 												"chain": "tempo",
 												"label": "pathUSD",
@@ -201,7 +205,7 @@
 									"decimals": 6,
 									"chainId": 42431,
 									"address": "0x20c0000000000000000000000000000000000000",
-									"logo_uri": "https://esm.sh/gh/tempoxyz/tokenlist/data/42431/icons/pathusd.svg",
+									"logoURI": "https://esm.sh/gh/tempoxyz/tokenlist/data/42431/icons/pathusd.svg",
 									"extensions": {
 										"chain": "tempo",
 										"label": "pathUSD"
@@ -230,30 +234,27 @@
 								"schema": {
 									"$ref": "#/components/schemas/AllTokenLists"
 								},
-								"example": {
-									"chains": {
-										"42431": {
-											"schema": "https://esm.sh/gh/uniswap/token-lists/src/tokenlist.schema.json",
-											"name": "Tempo Testnet",
-											"logo_uri": "https://esm.sh/gh/tempoxyz/tokenlist/data/42431/icon.svg",
-											"tokens": [
-												{
-													"name": "pathUSD",
-													"symbol": "pathUSD",
-													"decimals": 6,
-													"chainId": 42431,
-													"address": "0x20c0000000000000000000000000000000000000",
-													"logoURI": "https://esm.sh/gh/tempoxyz/tokenlist/data/42431/icons/pathusd.svg",
-													"extensions": {
-														"chain": "tempo",
-														"label": "pathUSD"
-													}
-												}
-											],
-											"keywords": ["tempo", "testnet"]
-										}
+								"example": [
+									{
+										"name": "Tempo Testnet",
+										"timestamp": "2026-08-25T00:00:00Z",
+										"version": {
+											"major": 1,
+											"minor": 0,
+											"patch": 0
+										},
+										"tokens": [
+											{
+												"name": "pathUSD",
+												"symbol": "pathUSD",
+												"decimals": 6,
+												"chainId": 42431,
+												"address": "0x20c0000000000000000000000000000000000000",
+												"logoURI": "https://esm.sh/gh/tempoxyz/tokenlist/data/42431/icons/pathusd.svg"
+											}
+										]
 									}
-								}
+								]
 							}
 						}
 					}
@@ -298,16 +299,21 @@
 							"application/json": {
 								"schema": {
 									"type": "object",
+									"required": ["timestamp", "source", "rev", "chains"],
 									"properties": {
 										"chains": {
 											"type": "array",
 											"items": {
-												"type": "string"
+												"type": "integer"
 											}
 										},
 										"timestamp": {
+											"type": "integer",
+											"format": "int64"
+										},
+										"source": {
 											"type": "string",
-											"format": "date-time"
+											"format": "uri"
 										},
 										"rev": {
 											"type": "string"
@@ -315,9 +321,10 @@
 									}
 								},
 								"example": {
-									"chains": ["42431"],
-									"timestamp": "2023-04-10T12:34:56Z",
-									"rev": "1.0.0"
+									"chains": [31318, 42431, 4217],
+									"timestamp": 1787613015295,
+									"source": "https://github.com/tempoxyz/tempo-apps",
+									"rev": "e932cab9"
 								}
 							}
 						}
@@ -440,17 +447,10 @@
 				}
 			},
 			"AllTokenLists": {
-				"type": "object",
-				"description": "Collection of token lists keyed by chain ID (e.g., '1', '137').",
-				"required": ["chains"],
-				"properties": {
-					"chains": {
-						"type": "object",
-						"description": "Mapping of chain IDs to their respective token lists",
-						"additionalProperties": {
-							"$ref": "#/components/schemas/TokenList"
-						}
-					}
+				"type": "array",
+				"description": "Token lists for all supported chains that returned successfully.",
+				"items": {
+					"$ref": "#/components/schemas/TokenList"
 				}
 			},
 			"TagsMap": {
@@ -460,27 +460,11 @@
 					"$ref": "#/components/schemas/TagDefinition"
 				}
 			},
-			"TokenMap": {
-				"type": "object",
-				"description": "Mapping of 'chainId_tokenAddress' to token objects",
-				"additionalProperties": {
-					"$ref": "#/components/schemas/TokenInfo"
-				}
-			},
 			"TokenList": {
 				"type": "object",
 				"description": "Token list for a specific blockchain network",
-				"required": ["name", "tokens", "keywords"],
+				"required": ["name", "timestamp", "version", "tokens"],
 				"properties": {
-					"schema": {
-						"type": "string",
-						"format": "url",
-						"description": "JSON Schema reference",
-						"minLength": 1,
-						"maxLength": 500,
-						"pattern": "^https?://.+$",
-						"example": "https://esm.sh/gh/uniswap/token-lists/src/tokenlist.schema.json"
-					},
 					"name": {
 						"type": "string",
 						"description": "Name of the token list",
@@ -499,7 +483,7 @@
 					"version": {
 						"$ref": "#/components/schemas/Version"
 					},
-					"logo_uri": {
+					"logoURI": {
 						"type": "string",
 						"format": "url",
 						"minLength": 1,
@@ -532,9 +516,6 @@
 						"minItems": 1,
 						"maxItems": 10000,
 						"description": "List of tokens included in the list"
-					},
-					"token_map": {
-						"$ref": "#/components/schemas/TokenMap"
 					}
 				}
 			},
@@ -569,16 +550,9 @@
 			"TokenInfo": {
 				"type": "object",
 				"description": "Information about a specific token",
-				"required": [
-					"chain_id",
-					"address",
-					"decimals",
-					"name",
-					"symbol",
-					"tags"
-				],
+				"required": ["chainId", "address", "decimals", "name", "symbol"],
 				"properties": {
-					"chain_id": {
+					"chainId": {
 						"type": "integer",
 						"format": "int32",
 						"minimum": 1,
@@ -618,7 +592,7 @@
 						"description": "Symbol of the token",
 						"example": "USDC.e"
 					},
-					"logo_uri": {
+					"logoURI": {
 						"type": "string",
 						"format": "url",
 						"minLength": 1,

--- a/apps/tokenlist/test/api-contract.test.ts
+++ b/apps/tokenlist/test/api-contract.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { CHAIN_IDS } from '../src/chains.ts'
+import app from '../src/index.tsx'
+import { OpenAPISpec } from '../src/schema.ts'
+
+const tokenListFor = (chainId: number) => ({
+	name: `Tempo ${chainId}`,
+	timestamp: '2026-08-25T00:00:00Z',
+	version: { major: 1, minor: 0, patch: 0 },
+	tokens: [
+		{
+			chainId,
+			address: '0x20c0000000000000000000000000000000000000',
+			decimals: 6,
+			name: 'Path USD',
+			symbol: 'pathUSD',
+			logoURI: 'https://example.com/pathusd.png',
+		},
+	],
+})
+
+function mockTempoApi(options: { unavailableChainId?: number } = {}): void {
+	vi.stubGlobal(
+		'fetch',
+		vi.fn(async (input: string | URL | Request) => {
+			const url = new URL(
+				input instanceof Request ? input.url : input.toString(),
+			)
+			const chainId = Number(url.searchParams.get('chainId'))
+			if (chainId === options.unavailableChainId)
+				return new Response('unavailable', { status: 503 })
+			return Response.json(tokenListFor(chainId))
+		}),
+	)
+}
+
+const request = (path: string) => app.request(path, {}, {} as Cloudflare.Env)
+
+afterEach(() => {
+	vi.unstubAllGlobals()
+})
+
+describe('tokenlist API contract', () => {
+	it('preserves canonical Tempo API token list responses', async () => {
+		mockTempoApi()
+
+		const listResponse = await request('/list/4217')
+		await expect(listResponse.json()).resolves.toEqual(tokenListFor(4217))
+
+		const assetResponse = await request('/asset/4217/pathUSD')
+		await expect(assetResponse.json()).resolves.toEqual(
+			tokenListFor(4217).tokens[0],
+		)
+
+		const allResponse = await request('/lists/all')
+		await expect(allResponse.json()).resolves.toEqual(
+			CHAIN_IDS.map(tokenListFor),
+		)
+	})
+
+	it('omits upstream failures from the all-lists response', async () => {
+		mockTempoApi({ unavailableChainId: 42431 })
+
+		const response = await request('/lists/all')
+		expect(response.status).toBe(200)
+		await expect(response.json()).resolves.toEqual(
+			CHAIN_IDS.filter((chainId) => chainId !== 42431).map(tokenListFor),
+		)
+	})
+
+	it('documents the canonical proxy response shapes in OpenAPI', () => {
+		expect(OpenAPISpec.components.schemas.AllTokenLists).toMatchObject({
+			type: 'array',
+			items: { $ref: '#/components/schemas/TokenList' },
+		})
+
+		expect(OpenAPISpec.components.schemas.TokenList.required).toEqual([
+			'name',
+			'timestamp',
+			'version',
+			'tokens',
+		])
+
+		expect(OpenAPISpec.components.schemas.TokenInfo.required).toEqual([
+			'chainId',
+			'address',
+			'decimals',
+			'name',
+			'symbol',
+		])
+		expect(OpenAPISpec.components.schemas.TokenInfo.properties).toHaveProperty(
+			'chainId',
+		)
+		expect(OpenAPISpec.components.schemas.TokenInfo.properties).toHaveProperty(
+			'logoURI',
+		)
+	})
+
+	it('keeps the version response and OpenAPI schema aligned', async () => {
+		vi.stubGlobal('__BUILD_VERSION__', 'test-rev')
+
+		const response = await request('/version')
+		const version = await response.json()
+		expect(version).toMatchObject({
+			source: 'https://github.com/tempoxyz/tempo-apps',
+			rev: 'test-rev',
+			chains: CHAIN_IDS,
+		})
+		expect(version.timestamp).toEqual(expect.any(Number))
+
+		const versionSchema =
+			OpenAPISpec.paths['/version'].get.responses['200'].content[
+				'application/json'
+			].schema
+		expect(versionSchema).toMatchObject({
+			type: 'object',
+			required: ['timestamp', 'source', 'rev', 'chains'],
+			properties: {
+				timestamp: { type: 'integer', format: 'int64' },
+				source: { type: 'string', format: 'uri' },
+				rev: { type: 'string' },
+				chains: { type: 'array', items: { type: 'integer' } },
+			},
+		})
+	})
+})


### PR DESCRIPTION
## Summary
- align the `TokenList` and `TokenInfo` OpenAPI schemas with the canonical Tempo API response fields
- document `/lists/all` as an array and `/version` with its runtime field types
- add route and schema regression coverage, including the existing partial-upstream-failure behavior

## Root cause
#1122 intentionally switched the tokenlist routes to proxy `/v1/tokenlist` responses, but the static OpenAPI document still described the previous local response shapes. As a result, generated clients could expect a keyed object from `/lists/all`, snake_case token fields, and incorrect `/version` types.

This PR changes only the published API contract and its tests. Runtime response behavior is unchanged.

## Validation
- `corepack pnpm --filter tokenlist gen:types`
- `corepack pnpm --filter tokenlist check`
- `corepack pnpm --filter tokenlist exec vitest run --reporter=verbose` (6 tests passed)
- `corepack pnpm exec biome check .`
- `corepack pnpm precommit`
- `git diff --check`