### PR TITLE
fix(explorer): show private Zone portal recipient

### DIFF
--- a/apps/explorer/src/lib/domain/transaction-activities.ts
+++ b/apps/explorer/src/lib/domain/transaction-activities.ts
@@ -33,15 +33,26 @@ const PRIVATE_ZONE_ACTIONS: Record<string, [string, string, string]> = {
 
 export function activitiesToKnownEvents(
 	activities: readonly TransactionActivity[],
+	options: { portal?: Address.Address | null } = {},
 ): KnownEvent[] {
 	return activities.map((activity) => {
 		const privateZone = PRIVATE_ZONE_ACTIONS[activity.type]
 		if (privateZone) {
 			const [action, amountKey, tokenKey] = privateZone
 			const amount = amountPart(activity.data, amountKey, tokenKey)
+			const portal = activityAddress(options.portal ?? undefined)
 			return {
 				type: activity.type,
-				parts: [{ type: 'action', value: action }, ...(amount ? [amount] : [])],
+				parts: [
+					{ type: 'action', value: action },
+					...(amount ? [amount] : []),
+					...(portal
+						? [
+								{ type: 'text' as const, value: 'to' },
+								{ type: 'account' as const, value: portal },
+							]
+						: []),
+				],
 			}
 		}
 

--- a/apps/explorer/src/routes/_layout/receipt/$hash.tsx
+++ b/apps/explorer/src/routes/_layout/receipt/$hash.tsx
@@ -119,7 +119,9 @@ async function fetchReceiptData(params: { hash: Hex.Hex; rpcUrl?: string }) {
 	const fallbackEvents = knownCall
 		? [knownCall, ...parsedEvents.filter((e) => e.type !== 'fee')]
 		: parsedEvents
-	const activityEvents = activitiesToKnownEvents(activities)
+	const activityEvents = activitiesToKnownEvents(activities, {
+		portal: receipt.to,
+	})
 	const knownEvents =
 		activityEvents.length > 0 ? activityEvents : fallbackEvents
 

--- a/apps/explorer/src/routes/_layout/tx/$hash.tsx
+++ b/apps/explorer/src/routes/_layout/tx/$hash.tsx
@@ -124,7 +124,9 @@ export const Route = createFileRoute('/_layout/tx/$hash')({
 						fetchTransactionActivities({ data: { hash } }),
 					])
 
-				const activityEvents = activitiesToKnownEvents(activities)
+				const activityEvents = activitiesToKnownEvents(activities, {
+					portal: txData.receipt.to,
+				})
 				return { ...txData, balanceChangesData, traceData, activityEvents }
 			} catch (error) {
 				console.error(error)

--- a/apps/explorer/test/transaction-activities.test.ts
+++ b/apps/explorer/test/transaction-activities.test.ts
@@ -103,25 +103,31 @@ describe('activitiesToKnownEvents', () => {
 		],
 	])('simplifies %s', (type, action, amountKey, tokenKey) => {
 		const token = '0x20c0000000000000000000000000000000000001'
+		const portal = '0x5ad0000000000000000000000000000000000001'
 		expect(
-			activitiesToKnownEvents([
-				{
-					id: 'activity-1',
-					title: 'Low-level private activity',
-					type,
-					data: {
-						actionId: `0x${'1'.repeat(64)}`,
-						[amountKey]: '1000000',
-						[tokenKey]: token,
+			activitiesToKnownEvents(
+				[
+					{
+						id: 'activity-1',
+						title: 'Low-level private activity',
+						type,
+						data: {
+							actionId: `0x${'1'.repeat(64)}`,
+							[amountKey]: '1000000',
+							[tokenKey]: token,
+						},
 					},
-				},
-			]),
+				],
+				{ portal },
+			),
 		).toEqual([
 			{
 				type,
 				parts: [
 					{ type: 'action', value: action },
 					{ type: 'amount', value: { value: 1000000n, token } },
+					{ type: 'text', value: 'to' },
+					{ type: 'account', value: portal },
 				],
 			},
 		])


### PR DESCRIPTION
## Summary

- show the private Zone asset amount followed by the transaction's Zone portal address

## Validation

- Explorer checks passed
- Explorer tests: 63 passed
- `pnpm precommit` passed

## Screenshots

| Before | After |
|---|---|
| `1 DLUSD` | `1 DLUSD to 0x5ad0…0001` |

Prompted by: @snario
