### PR TITLE
fix(explorer): widen receipt UI

### DIFF
--- a/apps/explorer/src/comps/Receipt.tsx
+++ b/apps/explorer/src/comps/Receipt.tsx
@@ -83,7 +83,7 @@ export function Receipt(props: Receipt.Props) {
 		<>
 			<div
 				data-receipt
-				className="flex w-[360px] flex-col bg-base-alt border border-base-border border-b-0 shadow-[0px_4px_44px_rgba(0,0,0,0.25)] rounded-[10px] rounded-br-none rounded-bl-none text-base-content"
+				className="flex w-[min(414px,calc(100vw-32px))] flex-col bg-base-alt border border-base-border border-b-0 shadow-[0px_4px_44px_rgba(0,0,0,0.25)] rounded-[10px] rounded-br-none rounded-bl-none text-base-content"
 			>
 				<div className="flex items-start gap-[40px] px-[20px] pt-[24px] pb-[16px]">
 					<div className="shrink-0">
@@ -393,7 +393,7 @@ export function Receipt(props: Receipt.Props) {
 			</div>
 
 			<div className="flex flex-col items-center -mt-8 w-full print:hidden">
-				<div className="max-w-[360px] w-full">
+				<div className="w-[min(414px,calc(100vw-32px))]">
 					<div className="grid grid-cols-4 border border-base-border bg-base-plane-interactive text-[12px] text-tertiary">
 						<button
 							type="button"


### PR DESCRIPTION
## Summary

- widen the explorer receipt and action bar from 360px to 414px (15%)
- preserve 16px mobile gutters to prevent horizontal overflow

## Screenshots

| Before | After |
|--------|-------|
| [360px receipt](https://tempoxyz.enterprise.slack.com/files/U0ANX3AM5RR/F0BTDKV5LCQ/demo-receipt-before.png) | [414px receipt](https://tempoxyz.enterprise.slack.com/files/U0ANX3AM5RR/F0BSFBLQJ5B/demo-receipt-after.png) |

## Validation

- `pnpm --filter explorer check:biome`
- `pnpm --filter explorer check:types`
- `pnpm test -- --run` (13 files, 63 tests)
- `pnpm precommit`
- browser measurements at desktop and mobile widths

The monorepo-wide `pnpm check` reaches unrelated existing `contract-verification` type errors because its locally generated Cloudflare `Env` is missing bindings.

Prompted by: @snario
