### PR TITLE
fix(explorer): describe Zone and Earn activity

### DIFF
--- a/apps/explorer/src/lib/domain/transaction-activities.ts
+++ b/apps/explorer/src/lib/domain/transaction-activities.ts
@@ -35,13 +35,13 @@ export function activitiesToKnownEvents(
 	activities: readonly TransactionActivity[],
 	options: { portal?: Address.Address | null } = {},
 ): KnownEvent[] {
-	return activities.map((activity) => {
+	return activities.flatMap((activity) => {
 		const privateZone = PRIVATE_ZONE_ACTIONS[activity.type]
 		if (privateZone) {
 			const [action, amountKey, tokenKey] = privateZone
 			const amount = amountPart(activity.data, amountKey, tokenKey)
 			const portal = activityAddress(options.portal ?? undefined)
-			return {
+			const zoneEvent: KnownEvent = {
 				type: activity.type,
 				parts: [
 					{ type: 'action', value: action },
@@ -54,7 +54,12 @@ export function activitiesToKnownEvents(
 						: []),
 				],
 			}
+			const vaultEvent = vaultActivityEvent(activity)
+			return vaultEvent ? [zoneEvent, vaultEvent] : [zoneEvent]
 		}
+
+		const vaultEvent = vaultActivityEvent(activity)
+		if (vaultEvent) return [vaultEvent]
 
 		const parts = activityParts(activity)
 		const representedFields = new Set([
@@ -66,27 +71,69 @@ export function activitiesToKnownEvents(
 			'sender',
 			'spender',
 		])
-		return {
-			type: activity.type,
-			parts,
-			...(activity.type === 'transfer'
-				? {
-						meta: {
-							from: activityAddress(activity.data.sender),
-							to: activityAddress(activity.data.recipient),
-						},
-					}
-				: {}),
-			note: Object.entries(activity.data).flatMap(([key, value]) => {
-				if (HIDDEN_FIELDS.has(key) || value == null) return []
-				if (representedFields.has(key)) return []
-				const part = activityValueToPart(value)
-				return part
-					? [[formatLabel(key), part] as [string, KnownEventPart]]
-					: []
-			}),
-		}
+		return [
+			{
+				type: activity.type,
+				parts,
+				...(activity.type === 'transfer'
+					? {
+							meta: {
+								from: activityAddress(activity.data.sender),
+								to: activityAddress(activity.data.recipient),
+							},
+						}
+					: {}),
+				note: Object.entries(activity.data).flatMap(([key, value]) => {
+					if (HIDDEN_FIELDS.has(key) || value == null) return []
+					if (representedFields.has(key)) return []
+					const part = activityValueToPart(value)
+					return part
+						? [[formatLabel(key), part] as [string, KnownEventPart]]
+						: []
+				}),
+			},
+		]
 	})
+}
+
+function vaultActivityEvent(activity: TransactionActivity): KnownEvent | null {
+	const isDeposit = ['assets-deposited', 'private-assets-deposited'].includes(
+		activity.type,
+	)
+	const isWithdrawal = [
+		'assets-withdrawn',
+		'private-shares-redeemed',
+		'shares-redeemed',
+	].includes(activity.type)
+	if (!isDeposit && !isWithdrawal) return null
+	const [sourceAmount, sourceToken, destinationAmount, destinationToken] =
+		isDeposit
+			? ['assets', 'assetToken', 'shares', 'shareToken']
+			: [
+					activity.type === 'assets-withdrawn' ? 'sharesBurned' : 'shares',
+					'shareToken',
+					'assets',
+					'assetToken',
+				]
+	const source = amountPart(activity.data, sourceAmount, sourceToken)
+	const destination = amountPart(
+		activity.data,
+		destinationAmount,
+		destinationToken,
+	)
+	if (!source || !destination) return null
+	return {
+		type: activity.type,
+		parts: [
+			{
+				type: 'action',
+				value: isDeposit ? 'Vault Deposit' : 'Vault Withdrawal',
+			},
+			source,
+			{ type: 'text', value: 'for' },
+			destination,
+		],
+	}
 }
 
 function activityAddress(

--- a/apps/explorer/src/lib/server/transaction-activities.ts
+++ b/apps/explorer/src/lib/server/transaction-activities.ts
@@ -1,5 +1,6 @@
 import { createServerFn } from '@tanstack/react-start'
 import { parseResponse } from 'hono/client'
+import { parseAbi } from 'viem'
 import * as z from 'zod/mini'
 import type {
 	ActivityDataValue,
@@ -7,14 +8,16 @@ import type {
 } from '#lib/domain/transaction-activities'
 import { api } from '#lib/server/tempo-api'
 import { zHash } from '#lib/zod'
-import { getTempoChain } from '#wagmi.config.ts'
+import { getBatchedClient, getTempoChain } from '#wagmi.config.ts'
 
 const InputSchema = z.object({ hash: zHash() })
 
 export const fetchTransactionActivities = createServerFn({ method: 'GET' })
 	.inputValidator((input) => InputSchema.parse(input))
 	.handler(async ({ data }): Promise<TransactionActivity[]> => {
-		return getTransactionActivities(data.hash, getTempoChain().id)
+		return enrichVaultTokens(
+			await getTransactionActivities(data.hash, getTempoChain().id),
+		)
 	})
 
 export async function getTransactionActivities(
@@ -40,6 +43,69 @@ export async function getTransactionActivities(
 		console.error('Failed to fetch transaction activities:', error)
 		return []
 	}
+}
+
+const vaultAbi = parseAbi([
+	'function asset() view returns (address)',
+	'function earnShare() view returns (address)',
+])
+
+async function enrichVaultTokens(
+	activities: TransactionActivity[],
+): Promise<TransactionActivity[]> {
+	const vaults = [
+		...new Set(
+			activities.flatMap((activity) => {
+				const vault = activity.data.vault
+				return typeof vault === 'string' && /^0x[\da-f]{40}$/i.test(vault)
+					? [vault as `0x${string}`]
+					: []
+			}),
+		),
+	]
+	if (vaults.length === 0) return activities
+
+	const client = getBatchedClient()
+	const tokens = new Map(
+		await Promise.all(
+			vaults.map(async (vault) => {
+				const [asset, share] = await Promise.allSettled([
+					client.readContract({
+						address: vault,
+						abi: vaultAbi,
+						functionName: 'asset',
+					}),
+					client.readContract({
+						address: vault,
+						abi: vaultAbi,
+						functionName: 'earnShare',
+					}),
+				])
+				return [
+					vault.toLowerCase(),
+					{
+						asset: asset.status === 'fulfilled' ? asset.value : undefined,
+						share: share.status === 'fulfilled' ? share.value : vault,
+					},
+				] as const
+			}),
+		),
+	)
+
+	return activities.map((activity) => {
+		const vault = activity.data.vault
+		if (typeof vault !== 'string') return activity
+		const token = tokens.get(vault.toLowerCase())
+		if (!token?.asset) return activity
+		return {
+			...activity,
+			data: {
+				...activity.data,
+				assetToken: token.asset,
+				shareToken: token.share,
+			},
+		}
+	})
 }
 
 function normalizeActivityData(

--- a/apps/explorer/test/transaction-activities.test.ts
+++ b/apps/explorer/test/transaction-activities.test.ts
@@ -53,7 +53,7 @@ describe('activitiesToKnownEvents', () => {
 		])
 	})
 
-	test('maps an Earn activity into a receipt event', () => {
+	test('maps an Earn redemption into a Vault Withdrawal', () => {
 		expect(
 			activitiesToKnownEvents([
 				{
@@ -63,6 +63,8 @@ describe('activitiesToKnownEvents', () => {
 					data: {
 						assets: '49999',
 						shares: '49999',
+						assetToken: '0x20c0000000000000000000000000000000000001',
+						shareToken: '0x20c0000000000000000000000000000000000002',
 						status: 'completed',
 						signer: 'self',
 						vault: '0x10c063b3bbc396d7e4a0d4d48212d901e2943663',
@@ -72,17 +74,23 @@ describe('activitiesToKnownEvents', () => {
 		).toEqual([
 			{
 				type: 'shares-redeemed',
-				parts: [{ type: 'action', value: 'Shares redeemed' }],
-				note: [
-					['Assets', { type: 'number', value: 49999n }],
-					['Shares', { type: 'number', value: 49999n }],
-					[
-						'Vault',
-						{
-							type: 'account',
-							value: '0x10c063b3bbc396d7e4a0d4d48212d901e2943663',
+				parts: [
+					{ type: 'action', value: 'Vault Withdrawal' },
+					{
+						type: 'amount',
+						value: {
+							value: 49999n,
+							token: '0x20c0000000000000000000000000000000000002',
 						},
-					],
+					},
+					{ type: 'text', value: 'for' },
+					{
+						type: 'amount',
+						value: {
+							value: 49999n,
+							token: '0x20c0000000000000000000000000000000000001',
+						},
+					},
 				],
 			},
 		])
@@ -115,6 +123,10 @@ describe('activitiesToKnownEvents', () => {
 							actionId: `0x${'1'.repeat(64)}`,
 							[amountKey]: '1000000',
 							[tokenKey]: token,
+							assets: '1000000',
+							shares: '500000',
+							assetToken: '0x20c0000000000000000000000000000000000002',
+							shareToken: '0x20c0000000000000000000000000000000000003',
 						},
 					},
 				],
@@ -128,6 +140,39 @@ describe('activitiesToKnownEvents', () => {
 					{ type: 'amount', value: { value: 1000000n, token } },
 					{ type: 'text', value: 'to' },
 					{ type: 'account', value: portal },
+				],
+			},
+			{
+				type,
+				parts: [
+					{
+						type: 'action',
+						value:
+							type === 'private-assets-deposited'
+								? 'Vault Deposit'
+								: 'Vault Withdrawal',
+					},
+					{
+						type: 'amount',
+						value: {
+							value: type === 'private-assets-deposited' ? 1000000n : 500000n,
+							token:
+								type === 'private-assets-deposited'
+									? '0x20c0000000000000000000000000000000000002'
+									: '0x20c0000000000000000000000000000000000003',
+						},
+					},
+					{ type: 'text', value: 'for' },
+					{
+						type: 'amount',
+						value: {
+							value: type === 'private-assets-deposited' ? 500000n : 1000000n,
+							token:
+								type === 'private-assets-deposited'
+									? '0x20c0000000000000000000000000000000000003'
+									: '0x20c0000000000000000000000000000000000002',
+						},
+					},
 				],
 			},
 		])


### PR DESCRIPTION
## Summary

- show the private Zone leg and the independent vault deposit/withdrawal leg
- resolve the vault asset and share tokens so amounts use their real symbols and logos

## Screenshots

| Before | After |
|---|---|
| Generic private activity with raw vault fields | `Private Zone Deposit` + `Vault Deposit` with token amounts |

## Validation

- Explorer checks passed
- Explorer tests: 63 passed
- `pnpm precommit` passed

Prompted by: @snario
