### PR TITLE
fix(explorer): order private vault settlement activity

### DIFF
--- a/apps/explorer/src/lib/domain/transaction-activities.ts
+++ b/apps/explorer/src/lib/domain/transaction-activities.ts
@@ -19,13 +19,9 @@ export type ActivityDataValue =
 
 const HIDDEN_FIELDS = new Set(['signer', 'status'])
 const PRIVATE_ZONE_ACTIONS: Record<string, [string, string, string]> = {
-	'private-assets-deposited': [
-		'Private Zone Deposit',
-		'inputAmount',
-		'inputToken',
-	],
+	'private-assets-deposited': ['Private Zone Deposit', 'shares', 'shareToken'],
 	'private-shares-redeemed': [
-		'Private Zone Withdrawal',
+		'Private Zone Deposit',
 		'outputAmount',
 		'outputToken',
 	],
@@ -55,7 +51,7 @@ export function activitiesToKnownEvents(
 				],
 			}
 			const vaultEvent = vaultActivityEvent(activity)
-			return vaultEvent ? [zoneEvent, vaultEvent] : [zoneEvent]
+			return vaultEvent ? [vaultEvent, zoneEvent] : [zoneEvent]
 		}
 
 		const vaultEvent = vaultActivityEvent(activity)

--- a/apps/explorer/test/transaction-activities.test.ts
+++ b/apps/explorer/test/transaction-activities.test.ts
@@ -100,12 +100,12 @@ describe('activitiesToKnownEvents', () => {
 		[
 			'private-assets-deposited',
 			'Private Zone Deposit',
-			'inputAmount',
-			'inputToken',
+			'shares',
+			'shareToken',
 		],
 		[
 			'private-shares-redeemed',
-			'Private Zone Withdrawal',
+			'Private Zone Deposit',
 			'outputAmount',
 			'outputToken',
 		],
@@ -133,15 +133,6 @@ describe('activitiesToKnownEvents', () => {
 				{ portal },
 			),
 		).toEqual([
-			{
-				type,
-				parts: [
-					{ type: 'action', value: action },
-					{ type: 'amount', value: { value: 1000000n, token } },
-					{ type: 'text', value: 'to' },
-					{ type: 'account', value: portal },
-				],
-			},
 			{
 				type,
 				parts: [
@@ -173,6 +164,24 @@ describe('activitiesToKnownEvents', () => {
 									: '0x20c0000000000000000000000000000000000002',
 						},
 					},
+				],
+			},
+			{
+				type,
+				parts: [
+					{ type: 'action', value: action },
+					{
+						type: 'amount',
+						value: {
+							value: type === 'private-assets-deposited' ? 500000n : 1000000n,
+							token:
+								type === 'private-assets-deposited'
+									? '0x20c0000000000000000000000000000000000003'
+									: token,
+						},
+					},
+					{ type: 'text', value: 'to' },
+					{ type: 'account', value: portal },
 				],
 			},
 		])


### PR DESCRIPTION
## Summary

- show the vault action before the resulting private Zone deposit
- show the asset actually returned to the Zone portal

## Screenshots

| Before | After |
|---|---|
| Private Zone action before vault action | Vault action followed by the returned private asset |

## Validation

- Explorer checks passed
- Explorer tests: 63 passed
- `pnpm precommit` passed

Prompted by: @snario
