### PR TITLE
fix(explorer): hide misleading receipt totals

### DIFF
--- a/apps/explorer/src/comps/Receipt.tsx
+++ b/apps/explorer/src/comps/Receipt.tsx
@@ -8,7 +8,6 @@ import { ReceiptMark } from '#comps/ReceiptMark'
 import { useTokenListMembership } from '#comps/TokenListMembership'
 import { TxEventDescription, TxEventMemoLine } from '#comps/TxEventDescription'
 import type { KnownEvent } from '#lib/domain/known-events'
-import { DEFAULT_KNOWN_EVENT_AMOUNT_DECIMALS } from '#lib/domain/known-event-totals'
 import { DateFormatter, PriceFormatter } from '#lib/formatting'
 import { useCopy } from '#lib/hooks'
 import {
@@ -195,25 +194,6 @@ export function Receipt(props: Receipt.Props) {
 												firstAmountPart?.type === 'amount'
 											? firstAmountPart.value
 											: undefined)
-								const totalAmountBigInt = displayTotalAmount
-									? displayTotalAmount.value
-									: event.type === 'swap' && amountParts.length > 0
-										? firstAmountPart?.type === 'amount'
-											? firstAmountPart.value.value
-											: 0n
-										: amountParts.reduce((sum, part) => {
-												if (part.type === 'amount')
-													return sum + part.value.value
-												return sum
-											}, 0n)
-								const decimals = displayTotalAmount
-									? (displayTotalAmount.decimals ??
-										DEFAULT_KNOWN_EVENT_AMOUNT_DECIMALS)
-									: firstAmountPart?.type === 'amount'
-										? (firstAmountPart.value.decimals ??
-											DEFAULT_KNOWN_EVENT_AMOUNT_DECIMALS)
-										: DEFAULT_KNOWN_EVENT_AMOUNT_DECIMALS
-
 								return (
 									<div
 										key={`${event.type}-${index}`}
@@ -232,14 +212,6 @@ export function Receipt(props: Receipt.Props) {
 															infinite={null}
 															prefix={showUsdPrefix ? '$' : undefined}
 															short
-														/>
-													) : totalAmountBigInt > 0n ? (
-														<Amount.Base
-															decimals={decimals}
-															infinite={null}
-															prefix={showUsdPrefix ? '$' : undefined}
-															short
-															value={totalAmountBigInt}
 														/>
 													) : null}
 												</div>

--- a/apps/explorer/src/routes/_layout/receipt/$hash.tsx
+++ b/apps/explorer/src/routes/_layout/receipt/$hash.tsx
@@ -503,6 +503,13 @@ function Component() {
 	const eventsTotalDisplayValue =
 		eventsTotal > 0n ? Number(Value.format(eventsTotal, 18)) : undefined
 	const eventTotalTokens = getKnownEventAmounts(displayEvents)
+	const hasVaultActivity = displayEvents.some((event) =>
+		event.parts.some(
+			(part) =>
+				part.type === 'action' &&
+				(part.value === 'Vault Deposit' || part.value === 'Vault Withdrawal'),
+		),
+	)
 
 	const total =
 		streamingTotal !== undefined
@@ -549,8 +556,8 @@ function Component() {
 				sender={receipt.from}
 				status={receipt.status}
 				timestamp={block.timestamp}
-				total={total}
-				totalDisplay={totalDisplay}
+				total={hasVaultActivity ? undefined : total}
+				totalDisplay={hasVaultActivity ? undefined : totalDisplay}
 				exportSearch={location.searchStr}
 			/>
 		</div>


### PR DESCRIPTION
## Summary

- omit side totals for multi-token activity rows
- omit the receipt total when vault activity has no meaningful single total

## Screenshots

| Before | After |
|---|---|
| Misleading `0` and `Total 2.5` | Neither value is shown |

## Validation

- Explorer checks passed
- Explorer tests: 63 passed
- `pnpm precommit` passed

Prompted by: @snario
