### PR TITLE
fix(explorer): use canonical Zone Portal ABI

### DIFF
--- a/apps/explorer/src/lib/abis.ts
+++ b/apps/explorer/src/lib/abis.ts
@@ -1,5 +1,6 @@
 import { parseAbi } from 'viem'
 import { Abis as ViemTempoAbis, Channel as ViemTempoChannel } from 'viem/tempo'
+import { Abis as ViemZoneAbis } from 'viem/tempo/zones'
 
 export const tip20ChannelReserveAbi = ViemTempoAbis.tip20ChannelReserve
 export const tip20ChannelReserveAddress = ViemTempoChannel.address
@@ -238,7 +239,7 @@ export const Abis = {
 	receivePolicyGuard: receivePolicyGuardAbi,
 	stablecoinDex: stablecoinDexAbi,
 	streamChannel: streamChannelAbi,
-	zonePortal: zonePortalAbi,
+	zonePortal: [...ViemZoneAbis.zonePortal, ...zonePortalAbi],
 	zoneFactory: zoneFactoryAbi,
 } as const
 

--- a/apps/explorer/src/lib/domain/contracts.ts
+++ b/apps/explorer/src/lib/domain/contracts.ts
@@ -21,6 +21,7 @@ import { getWagmiConfig } from '#wagmi.config.ts'
 
 const validatorConfigV2Address =
 	'0xcccccccc00000000000000000000000000000001' as const
+const zonePortalAddressPrefix = '0x5ad000000000000000000000'
 
 /**
  * Registry of known contract addresses to their ABIs and metadata.
@@ -396,6 +397,20 @@ export function getContractInfo(
 	const lowerAddress = address.toLowerCase() as Address.Address
 	const registered = contractRegistry.get(lowerAddress)
 	if (registered) return registered
+
+	// TIP-1091 assigns each Zone Portal a deterministic address whose low eight
+	// bytes contain the zone ID. Use the canonical ABI instead of attempting to
+	// recover an incomplete interface from the portal's minimal-proxy bytecode.
+	if (lowerAddress.startsWith(zonePortalAddressPrefix))
+		return {
+			address,
+			name: 'Zone Portal',
+			code: '0xef',
+			description: 'Bridge assets between Tempo and a Tempo Zone',
+			abi: Abis.zonePortal,
+			category: 'system',
+			docsUrl: 'https://tips.sh/1091',
+		}
 
 	// Dynamic TIP-20 token detection
 	if (isTip20Address(address))

--- a/apps/explorer/test/contracts.node.test.ts
+++ b/apps/explorer/test/contracts.node.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest'
 import type { Abi } from 'viem'
-import { getReadFunctions, getWriteFunctions } from '#lib/domain/contracts'
+import {
+	getContractInfo,
+	getReadFunctions,
+	getWriteFunctions,
+} from '#lib/domain/contracts'
 
 const proxyImplementationAbi = [
 	{
@@ -88,5 +92,19 @@ describe('contract function classification', () => {
 				'setMinterAllowance',
 			])
 		}
+	})
+
+	it('uses the canonical ABI for deterministic Zone Portal addresses', () => {
+		const info = getContractInfo('0x5Ad0000000000000000000000000000000000002')
+
+		expect(info?.name).toBe('Zone Portal')
+		expect(getWriteFunctions(info?.abi ?? []).map((fn) => fn.name)).toEqual([
+			'deposit',
+			'depositEncrypted',
+		])
+		expect(getReadFunctions(info?.abi ?? []).map((fn) => fn.name)).toEqual([
+			'sequencerEncryptionKey',
+			'encryptionKeyCount',
+		])
 	})
 })


### PR DESCRIPTION
## Summary

- recognize deterministic TIP-1091 Zone Portal addresses
- use the canonical viem Zone Portal ABI instead of incomplete bytecode inference
- cover the rendered Read and Write function classification with a regression test

## Screenshots

| Before | After |
|---|---|
| `0xf6087442()` is misclassified as a read and reverts | `deposit` and `depositEncrypted` appear under Write; canonical getters return successfully |

## Validation

- `pnpm --filter explorer check`
- `pnpm --filter explorer test` (13 files, 63 tests)
- `pnpm precommit`
- browser verification against the mainnet Zone Portal page (zero request errors)
- monorepo `pnpm check` reaches unrelated existing generated Cloudflare binding errors in `contract-verification`

Prompted by: @snario
