### PR TITLE
feat(explorer): add Zone Portal activity views

### DIFF
--- a/apps/explorer/src/lib/abis.ts
+++ b/apps/explorer/src/lib/abis.ts
@@ -240,6 +240,21 @@ const zonePortalCurrentAbi = parseAbi([
 	'function submitBatch(uint64 tempoBlockNumber, uint64 recentTempoBlockNumber, (bytes32 prevBlockHash, bytes32 nextBlockHash) blockTransition, (bytes32 prevProcessedHash, bytes32 nextProcessedHash, uint64 prevDepositNumber, uint64 nextDepositNumber) depositQueueTransition, bytes32 withdrawalQueueHash, bytes verifierConfig, bytes proof, uint256 zoneHeight, bytes[] signatures)',
 ])
 
+export const zonePortalActivityAbi = parseAbi([
+	'event DepositMade(bytes32 indexed newCurrentDepositQueueHash, address indexed sender, address token, uint128 netAmount, uint128 fee, uint256 keyIndex, bytes32 ephemeralPubkeyX, uint8 ephemeralPubkeyYParity, bytes ciphertext, bytes12 nonce, bytes16 tag, address tempoRefundRecipient, uint64 depositNumber)',
+	'event BatchSubmitted(uint64 indexed withdrawalBatchIndex, uint256 indexed withdrawalQueueIndex, bytes32 nextProcessedDepositQueueHash, bytes32 nextBlockHash, bytes32 withdrawalQueueHash, uint64 lastProcessedDepositNumber)',
+	'event WithdrawalProcessed(address indexed to, bytes32 indexed senderTag, address token, uint128 amount, bool callbackSuccess)',
+])
+
+export const zonePortalReadAbi = parseAbi([
+	'function enabledTokenCount() view returns (uint256)',
+	'function enabledTokenAt(uint256 index) view returns (address)',
+])
+
+export const zoneFactoryRegistryAbi = parseAbi([
+	'function isZonePortal(address portal) view returns (bool)',
+])
+
 export const zoneMessengerAbi = parseAbi([
 	'function relayMessage(uint32 zoneId, address token, bytes32 senderTag, address target, uint128 amount, uint64 gasLimit, bytes data)',
 ])

--- a/apps/explorer/src/lib/domain/known-events.ts
+++ b/apps/explorer/src/lib/domain/known-events.ts
@@ -315,6 +315,10 @@ function createDetectors(
 
 			if (eventName === 'DepositMade') {
 				const zoneName = getZoneName(address)
+				const action =
+					'to' in args ? `Deposit to ${zoneName}` : 'Private Zone Deposit'
+				const memo =
+					'memo' in args ? decodeMemoForDisplay(args.memo) : undefined
 				const note: NonNullable<KnownEvent['note']> = []
 
 				if (args.fee > 0n) {
@@ -323,32 +327,22 @@ function createDetectors(
 						{ type: 'amount', value: createAmount(args.fee, args.token) },
 					])
 				}
-				if (!('to' in args)) {
-					note.push(['Key Index', { type: 'number', value: args.keyIndex }])
-					return {
-						type: 'zone encrypted deposit',
-						parts: [
-							{ type: 'action', value: `Encrypted Deposit to ${zoneName}` },
-							{
-								type: 'amount',
-								value: createAmount(args.netAmount, args.token),
-							},
-						],
-						note,
-						meta: { from: args.sender, to: address },
-					}
-				}
-
-				const memo = decodeMemoForDisplay(args.memo)
 				if (memo) note.push(['Memo', { type: 'text', value: memo }])
+
+				const recipientParts: KnownEvent['parts'] =
+					'to' in args
+						? [
+								{ type: 'text', value: 'for' },
+								{ type: 'account', value: args.to },
+							]
+						: []
 
 				return {
 					type: 'zone deposit',
 					parts: [
-						{ type: 'action', value: `Deposit to ${zoneName}` },
+						{ type: 'action', value: action },
 						{ type: 'amount', value: createAmount(args.netAmount, args.token) },
-						{ type: 'text', value: 'for' },
-						{ type: 'account', value: args.to },
+						...recipientParts,
 					],
 					note: note.length > 0 ? note : undefined,
 					meta: { from: args.sender, to: address },

--- a/apps/explorer/src/lib/domain/transaction-activities.ts
+++ b/apps/explorer/src/lib/domain/transaction-activities.ts
@@ -18,10 +18,17 @@ export type ActivityDataValue =
 	| { [key: string]: ActivityDataValue }
 
 const HIDDEN_FIELDS = new Set(['signer', 'status'])
+const GENERIC_ACTIVITY_TYPES = new Set(['approval', 'burn', 'mint', 'transfer'])
+const ZONE_EVENT_TYPES = new Set([
+	'zone deposit',
+	'zone encrypted deposit',
+	'zone withdrawal',
+	'zone bounce back',
+])
 const PRIVATE_ZONE_ACTIONS: Record<string, [string, string, string]> = {
 	'private-assets-deposited': ['Private Zone Deposit', 'shares', 'shareToken'],
 	'private-shares-redeemed': [
-		'Private Zone Deposit',
+		'Private Zone Withdrawal',
 		'outputAmount',
 		'outputToken',
 	],
@@ -48,7 +55,7 @@ export function activitiesToKnownEvents(
 				parts: [
 					{ type: 'action', value: action },
 					...(amount ? [amount] : []),
-					...(portal
+					...(portal && activity.type === 'private-assets-deposited'
 						? [
 								{ type: 'text' as const, value: 'to' },
 								{ type: 'account' as const, value: portal },
@@ -144,6 +151,20 @@ export function selectTransactionDescriptionEvents(params: {
 	knownCall: KnownEvent | null
 }): KnownEvent[] {
 	if (params.activityEvents.length === 0) return [...params.fallbackEvents]
+
+	const hasDecodedZoneEvent = params.fallbackEvents.some((event) =>
+		ZONE_EVENT_TYPES.has(event.type),
+	)
+	const activitiesAreGeneric = params.activityEvents.every(
+		(event) =>
+			GENERIC_ACTIVITY_TYPES.has(event.type) || isNonceIncrementedEvent(event),
+	)
+	if (hasDecodedZoneEvent && activitiesAreGeneric) {
+		return params.fallbackEvents.filter(
+			(event) => !GENERIC_ACTIVITY_TYPES.has(event.type),
+		)
+	}
+
 	const hasMeaningfulActivity = params.activityEvents.some(
 		(event) => !isNonceIncrementedEvent(event),
 	)
@@ -151,7 +172,10 @@ export function selectTransactionDescriptionEvents(params: {
 		params.knownCall || hasMeaningfulActivity
 			? params.activityEvents.filter((event) => !isNonceIncrementedEvent(event))
 			: params.activityEvents
-	return params.knownCall
+	const hasPrivateZoneActivity = activityEvents.some(
+		(event) => PRIVATE_ZONE_ACTIONS[event.type] !== undefined,
+	)
+	return params.knownCall && !hasPrivateZoneActivity
 		? [params.knownCall, ...activityEvents]
 		: [...activityEvents]
 }

--- a/apps/explorer/src/lib/domain/zones.ts
+++ b/apps/explorer/src/lib/domain/zones.ts
@@ -1,12 +1,123 @@
-import type { Address } from 'ox'
+import type { Address, Hex } from 'ox'
+import {
+	decodeFunctionData,
+	encodeAbiParameters,
+	keccak256,
+	parseAbi,
+	parseAbiParameters,
+} from 'viem'
 
 const zonePortalPrefix = '0x5ad000000000000000000000' as const
+const maxZoneId = 0xffff_ffffn
+
+const processWithdrawalsAbi = parseAbi([
+	'function processWithdrawals((address token, bytes32 senderTag, address to, uint128 amount, bytes32 memo, uint64 gasLimit, uint64 fallbackNonce, bytes callbackData, bytes encryptedSender)[] withdrawals, bytes32 remainingQueue)',
+])
+
+const withdrawalQueueHashParameters = parseAbiParameters(
+	'(address token, bytes32 senderTag, address to, uint128 amount, bytes32 memo, uint64 gasLimit, uint64 fallbackNonce, bytes callbackData, bytes encryptedSender) withdrawal, bytes32 remainingQueue',
+)
+
+export type ZonePortalActivityKind = 'deposits' | 'withdrawals' | 'batches'
+
+export type ZonePortalAsset = {
+	address: Address.Address
+	balance: string
+	decimals: number
+	symbol: string
+}
+
+export type ZonePortalOverview = {
+	isZonePortal: true
+	assets: ZonePortalAsset[]
+	counts: {
+		deposits: number
+		withdrawals: number
+		batches: number
+	}
+}
+
+export type ZonePortalBatchReference = {
+	index: string
+	transactionHash: Hex.Hex
+}
+
+export type ZonePortalDeposit = {
+	kind: 'deposit'
+	timestamp: number
+	transactionHash: Hex.Hex
+	sender: Address.Address
+	token: Address.Address
+	amount: string
+	processedInBatch: ZonePortalBatchReference | null
+}
+
+export type ZonePortalWithdrawal = {
+	kind: 'withdrawal'
+	timestamp: number
+	transactionHash: Hex.Hex
+	recipient: Address.Address
+	token: Address.Address
+	amount: string
+	processedInBatch: ZonePortalBatchReference | null
+}
+
+export type ZonePortalBatch = {
+	kind: 'batch'
+	timestamp: number
+	transactionHash: Hex.Hex
+	batchIndex: string
+	withdrawalQueueIndex: string | null
+	lastProcessedDepositNumber: string
+}
+
+export type ZonePortalActivity =
+	| ZonePortalDeposit
+	| ZonePortalWithdrawal
+	| ZonePortalBatch
+
+export type ZonePortalActivityResponse = {
+	items: ZonePortalActivity[]
+	total: number
+	page: number
+	limit: number
+}
 
 export function isZonePortalAddress(address: Address.Address): boolean {
-	return address.toLowerCase().startsWith(zonePortalPrefix)
+	return getZonePortalId(address) !== undefined
 }
 
 export function getZonePortalId(address: Address.Address): bigint | undefined {
-	if (!isZonePortalAddress(address)) return
-	return BigInt(`0x${address.slice(zonePortalPrefix.length)}`)
+	const normalized = address.toLowerCase()
+	if (!normalized.startsWith(zonePortalPrefix)) return
+
+	const zoneId = BigInt(`0x${normalized.slice(zonePortalPrefix.length)}`)
+	if (zoneId === 0n || zoneId > maxZoneId) return
+	return zoneId
+}
+
+export function withdrawalQueueHashFromInput(input: Hex.Hex): Hex.Hex | null {
+	try {
+		const decoded = decodeFunctionData({
+			abi: processWithdrawalsAbi,
+			data: input,
+		})
+		if (decoded.functionName !== 'processWithdrawals') return null
+
+		const [withdrawals, remainingQueue] = decoded.args
+		return withdrawals
+			.toReversed()
+			.reduce(
+				(queueHash, withdrawal) =>
+					keccak256(
+						encodeAbiParameters(withdrawalQueueHashParameters, [
+							withdrawal,
+							queueHash,
+						]),
+					),
+				remainingQueue,
+			)
+	} catch {
+		return null
+	}
 }

--- a/apps/explorer/src/lib/server/address-history.ts
+++ b/apps/explorer/src/lib/server/address-history.ts
@@ -250,7 +250,7 @@ export function toEnrichedTransaction(
 				`[history] failed to parse known events for ${row.hash}:`,
 				error,
 			)
-			return []
+			return activityEvents
 		}
 	})()
 

--- a/apps/explorer/src/lib/server/zone-portal.ts
+++ b/apps/explorer/src/lib/server/zone-portal.ts
@@ -1,0 +1,325 @@
+import * as Address from 'ox/Address'
+import type { Config } from 'wagmi'
+import { Actions } from 'wagmi/tempo'
+import { zeroHash } from 'viem'
+import { Addresses as ZoneAddresses } from 'viem-zones/tempo'
+import {
+	Abis,
+	zoneFactoryRegistryAbi,
+	zonePortalActivityAbi,
+	zonePortalReadAbi,
+} from '#lib/abis'
+import {
+	isZonePortalAddress,
+	type ZonePortalActivityKind,
+	type ZonePortalActivityResponse,
+	type ZonePortalAsset,
+	type ZonePortalBatch,
+	type ZonePortalDeposit,
+	type ZonePortalOverview,
+	type ZonePortalWithdrawal,
+	withdrawalQueueHashFromInput,
+} from '#lib/domain/zones'
+import { tempoQueryBuilder } from '#lib/server/tempo-queries-provider'
+import { getBatchedClient, getWagmiConfig } from '#wagmi.config'
+
+function portalQueryBuilder(chainId: number) {
+	return tempoQueryBuilder(chainId).withAbi(zonePortalActivityAbi)
+}
+
+async function countDeposits(address: Address.Address, chainId: number) {
+	const result = await portalQueryBuilder(chainId)
+		.selectFrom('depositmade')
+		.select((eb) => eb.fn.count('tx_hash').as('count'))
+		.where('address', '=', address.toLowerCase() as Address.Address)
+		.executeTakeFirst()
+	return Number(result?.count ?? 0)
+}
+
+async function countWithdrawals(address: Address.Address, chainId: number) {
+	const result = await portalQueryBuilder(chainId)
+		.selectFrom('withdrawalprocessed')
+		.select((eb) => eb.fn.count('tx_hash').as('count'))
+		.where('address', '=', address.toLowerCase() as Address.Address)
+		.executeTakeFirst()
+	return Number(result?.count ?? 0)
+}
+
+async function countBatches(address: Address.Address, chainId: number) {
+	const result = await portalQueryBuilder(chainId)
+		.selectFrom('batchsubmitted')
+		.select((eb) => eb.fn.count('tx_hash').as('count'))
+		.where('address', '=', address.toLowerCase() as Address.Address)
+		.executeTakeFirst()
+	return Number(result?.count ?? 0)
+}
+
+async function getEnabledAssets(
+	address: Address.Address,
+	tokenCount: bigint,
+): Promise<ZonePortalAsset[]> {
+	const client = getBatchedClient()
+	const config = getWagmiConfig()
+	const tokens = await Promise.all(
+		Array.from({ length: Number(tokenCount) }, (_, index) =>
+			client.readContract({
+				address,
+				abi: zonePortalReadAbi,
+				functionName: 'enabledTokenAt',
+				args: [BigInt(index)],
+			}),
+		),
+	)
+
+	return Promise.all(
+		tokens.map(async (token) => {
+			const [metadata, balance] = await Promise.all([
+				Actions.token.getMetadata(config as Config, { token }),
+				client.readContract({
+					address: token,
+					abi: Abis.tip20,
+					functionName: 'balanceOf',
+					args: [address],
+				}),
+			])
+
+			return {
+				address: Address.checksum(token),
+				balance: balance.toString(),
+				decimals: metadata.decimals,
+				symbol: metadata.symbol,
+			}
+		}),
+	)
+}
+
+export async function fetchZonePortalOverview(params: {
+	address: Address.Address
+	chainId: number
+}): Promise<ZonePortalOverview> {
+	const { address, chainId } = params
+	if (!isZonePortalAddress(address))
+		throw new Error('Address is not a Zone Portal')
+
+	const client = getBatchedClient()
+	const registered = await client.readContract({
+		address: ZoneAddresses.zoneFactory,
+		abi: zoneFactoryRegistryAbi,
+		functionName: 'isZonePortal',
+		args: [address],
+	})
+	if (!registered) throw new Error('Address is not a registered Zone Portal')
+
+	const [tokenCount, deposits, withdrawals, batches] = await Promise.all([
+		client.readContract({
+			address,
+			abi: zonePortalReadAbi,
+			functionName: 'enabledTokenCount',
+		}),
+		countDeposits(address, chainId),
+		countWithdrawals(address, chainId),
+		countBatches(address, chainId),
+	])
+
+	return {
+		isZonePortal: true,
+		assets: await getEnabledAssets(address, tokenCount),
+		counts: { deposits, withdrawals, batches },
+	}
+}
+
+async function fetchDeposits(params: {
+	address: Address.Address
+	chainId: number
+	page: number
+	limit: number
+}): Promise<ZonePortalActivityResponse> {
+	const { address, chainId, page, limit } = params
+	const portal = address.toLowerCase() as Address.Address
+	const qb = portalQueryBuilder(chainId)
+	const [rows, total] = await Promise.all([
+		qb
+			.selectFrom('depositmade')
+			.select([
+				'block_timestamp',
+				'tx_hash',
+				'sender',
+				'token',
+				'netAmount',
+				'depositNumber',
+			])
+			.where('address', '=', portal)
+			.orderBy('block_num', 'desc')
+			.orderBy('log_idx', 'desc')
+			.limit(limit)
+			.offset((page - 1) * limit)
+			.execute(),
+		countDeposits(address, chainId),
+	])
+
+	const items: ZonePortalDeposit[] = await Promise.all(
+		rows.map(async (row) => {
+			const batch = await portalQueryBuilder(chainId)
+				.selectFrom('batchsubmitted')
+				.select(['tx_hash', 'withdrawalBatchIndex'])
+				.where('address', '=', portal)
+				.where('lastProcessedDepositNumber', '>=', row.depositNumber)
+				.orderBy('lastProcessedDepositNumber', 'asc')
+				.orderBy('withdrawalBatchIndex', 'asc')
+				.limit(1)
+				.executeTakeFirst()
+
+			return {
+				kind: 'deposit',
+				timestamp: row.block_timestamp,
+				transactionHash: row.tx_hash,
+				sender: Address.checksum(row.sender),
+				token: Address.checksum(row.token),
+				amount: row.netAmount.toString(),
+				processedInBatch: batch
+					? {
+							index: batch.withdrawalBatchIndex.toString(),
+							transactionHash: batch.tx_hash,
+						}
+					: null,
+			}
+		}),
+	)
+
+	return { items, total, page, limit }
+}
+
+async function fetchWithdrawals(params: {
+	address: Address.Address
+	chainId: number
+	page: number
+	limit: number
+}): Promise<ZonePortalActivityResponse> {
+	const { address, chainId, page, limit } = params
+	const portal = address.toLowerCase() as Address.Address
+	const [rows, total] = await Promise.all([
+		portalQueryBuilder(chainId)
+			.selectFrom('withdrawalprocessed')
+			.select(['block_timestamp', 'tx_hash', 'to', 'token', 'amount'])
+			.where('address', '=', portal)
+			.orderBy('block_num', 'desc')
+			.orderBy('log_idx', 'desc')
+			.limit(limit)
+			.offset((page - 1) * limit)
+			.execute(),
+		countWithdrawals(address, chainId),
+	])
+
+	const client = getBatchedClient()
+	const batchesByTransaction = new Map(
+		await Promise.all(
+			[...new Set(rows.map((row) => row.tx_hash))].map(
+				async (transactionHash) => {
+					const transaction = await client.getTransaction({
+						hash: transactionHash,
+					})
+					const callData =
+						'calls' in transaction && transaction.calls
+							? transaction.calls.find(
+									(call) => call.to && Address.isEqual(call.to, address),
+								)?.data
+							: transaction.input
+					const queueHash = callData
+						? withdrawalQueueHashFromInput(callData)
+						: null
+					const batch = queueHash
+						? await portalQueryBuilder(chainId)
+								.selectFrom('batchsubmitted')
+								.select(['tx_hash', 'withdrawalBatchIndex'])
+								.where('address', '=', portal)
+								.where('withdrawalQueueHash', '=', queueHash)
+								.limit(1)
+								.executeTakeFirst()
+						: undefined
+					return [transactionHash, batch] as const
+				},
+			),
+		),
+	)
+
+	const items: ZonePortalWithdrawal[] = rows.map((row) => {
+		const batch = batchesByTransaction.get(row.tx_hash)
+		return {
+			kind: 'withdrawal',
+			timestamp: row.block_timestamp,
+			transactionHash: row.tx_hash,
+			recipient: Address.checksum(row.to),
+			token: Address.checksum(row.token),
+			amount: row.amount.toString(),
+			processedInBatch: batch
+				? {
+						index: batch.withdrawalBatchIndex.toString(),
+						transactionHash: batch.tx_hash,
+					}
+				: null,
+		}
+	})
+
+	return { items, total, page, limit }
+}
+
+async function fetchBatches(params: {
+	address: Address.Address
+	chainId: number
+	page: number
+	limit: number
+}): Promise<ZonePortalActivityResponse> {
+	const { address, chainId, page, limit } = params
+	const portal = address.toLowerCase() as Address.Address
+	const [rows, total] = await Promise.all([
+		portalQueryBuilder(chainId)
+			.selectFrom('batchsubmitted')
+			.select([
+				'block_timestamp',
+				'tx_hash',
+				'withdrawalBatchIndex',
+				'withdrawalQueueIndex',
+				'withdrawalQueueHash',
+				'lastProcessedDepositNumber',
+			])
+			.where('address', '=', portal)
+			.orderBy('block_num', 'desc')
+			.orderBy('log_idx', 'desc')
+			.limit(limit)
+			.offset((page - 1) * limit)
+			.execute(),
+		countBatches(address, chainId),
+	])
+
+	const items: ZonePortalBatch[] = rows.map((row) => {
+		return {
+			kind: 'batch',
+			timestamp: row.block_timestamp,
+			transactionHash: row.tx_hash,
+			batchIndex: row.withdrawalBatchIndex.toString(),
+			withdrawalQueueIndex:
+				row.withdrawalQueueHash === zeroHash
+					? null
+					: row.withdrawalQueueIndex.toString(),
+			lastProcessedDepositNumber: row.lastProcessedDepositNumber.toString(),
+		}
+	})
+
+	return { items, total, page, limit }
+}
+
+export async function fetchZonePortalActivity(params: {
+	address: Address.Address
+	chainId: number
+	kind: ZonePortalActivityKind
+	page: number
+	limit: number
+}): Promise<ZonePortalActivityResponse> {
+	if (!isZonePortalAddress(params.address)) {
+		throw new Error('Address is not a Zone Portal')
+	}
+
+	if (params.kind === 'deposits') return fetchDeposits(params)
+	if (params.kind === 'withdrawals') return fetchWithdrawals(params)
+	return fetchBatches(params)
+}

--- a/apps/explorer/src/lib/zone-portal.ts
+++ b/apps/explorer/src/lib/zone-portal.ts
@@ -1,0 +1,137 @@
+import { queryOptions } from '@tanstack/react-query'
+import type { Address } from 'ox'
+import * as z from 'zod/mini'
+import type {
+	ZonePortalActivityKind,
+	ZonePortalActivityResponse,
+	ZonePortalOverview,
+} from '#lib/domain/zones'
+import { getApiUrl } from '#lib/env'
+import { zAddress, zHash } from '#lib/zod'
+
+const AssetSchema = z.object({
+	address: zAddress(),
+	balance: z.string(),
+	decimals: z.number(),
+	symbol: z.string(),
+})
+
+const OverviewSchema = z.object({
+	isZonePortal: z.literal(true),
+	assets: z.array(AssetSchema),
+	counts: z.object({
+		deposits: z.number(),
+		withdrawals: z.number(),
+		batches: z.number(),
+	}),
+})
+
+const BatchReferenceSchema = z.object({
+	index: z.string(),
+	transactionHash: zHash(),
+})
+
+const DepositSchema = z.object({
+	kind: z.literal('deposit'),
+	timestamp: z.number(),
+	transactionHash: zHash(),
+	sender: zAddress(),
+	token: zAddress(),
+	amount: z.string(),
+	processedInBatch: z.nullable(BatchReferenceSchema),
+})
+
+const WithdrawalSchema = z.object({
+	kind: z.literal('withdrawal'),
+	timestamp: z.number(),
+	transactionHash: zHash(),
+	recipient: zAddress(),
+	token: zAddress(),
+	amount: z.string(),
+	processedInBatch: z.nullable(BatchReferenceSchema),
+})
+
+const BatchSchema = z.object({
+	kind: z.literal('batch'),
+	timestamp: z.number(),
+	transactionHash: zHash(),
+	batchIndex: z.string(),
+	withdrawalQueueIndex: z.nullable(z.string()),
+	lastProcessedDepositNumber: z.string(),
+})
+
+const ActivityResponseSchema = z.object({
+	items: z.array(z.union([DepositSchema, WithdrawalSchema, BatchSchema])),
+	total: z.number(),
+	page: z.number(),
+	limit: z.number(),
+})
+
+function errorMessage(value: unknown, fallback: string): string {
+	if (
+		value &&
+		typeof value === 'object' &&
+		'error' in value &&
+		typeof value.error === 'string'
+	)
+		return value.error
+	return fallback
+}
+
+export function zonePortalOverviewQueryOptions(address: Address.Address) {
+	return queryOptions({
+		queryKey: ['zone-portal-overview', address],
+		queryFn: async ({ signal }): Promise<ZonePortalOverview> => {
+			const response = await fetch(
+				getApiUrl(`/api/address/zone-portal/${address}`),
+				{ signal },
+			)
+			const json: unknown = await response.json()
+			if (!response.ok) {
+				throw new Error(errorMessage(json, 'Failed to load Zone Portal'))
+			}
+			return z.parse(OverviewSchema, json)
+		},
+		staleTime: 4_000,
+		refetchOnWindowFocus: true,
+	})
+}
+
+export function zonePortalActivityQueryOptions(params: {
+	address: Address.Address
+	kind: ZonePortalActivityKind
+	page: number
+	limit: number
+}) {
+	const search = new URLSearchParams({
+		page: String(params.page),
+		limit: String(params.limit),
+	})
+	return queryOptions({
+		queryKey: [
+			'zone-portal-activity',
+			params.address,
+			params.kind,
+			params.page,
+			params.limit,
+		],
+		queryFn: async ({ signal }): Promise<ZonePortalActivityResponse> => {
+			const response = await fetch(
+				getApiUrl(
+					`/api/address/zone-portal/${params.address}/${params.kind}`,
+					search,
+				),
+				{ signal },
+			)
+			const json: unknown = await response.json()
+			if (!response.ok) {
+				throw new Error(
+					errorMessage(json, 'Failed to load Zone Portal activity'),
+				)
+			}
+			return z.parse(ActivityResponseSchema, json)
+		},
+		staleTime: 4_000,
+		refetchOnWindowFocus: true,
+	})
+}

--- a/apps/explorer/src/routeTree.gen.ts
+++ b/apps/explorer/src/routeTree.gen.ts
@@ -38,10 +38,12 @@ import { Route as ApiTxTraceHashRouteImport } from './routes/api/tx/trace/$hash'
 import { Route as ApiTxBalanceChangesHashRouteImport } from './routes/api/tx/balance-changes/$hash'
 import { Route as ApiTokenLogoAddressRouteImport } from './routes/api/token/logo/$address'
 import { Route as ApiContractCreationAddressRouteImport } from './routes/api/contract/creation/$address'
+import { Route as ApiAddressZonePortalAddressRouteImport } from './routes/api/address/zone-portal/$address'
 import { Route as ApiAddressMetadataAddressRouteImport } from './routes/api/address/metadata/$address'
 import { Route as ApiAddressHistoryAddressRouteImport } from './routes/api/address/history/$address'
 import { Route as ApiAddressBalancesAddressRouteImport } from './routes/api/address/balances/$address'
 import { Route as LayoutBlockCountdownTargetBlockRouteImport } from './routes/_layout/block/countdown.$targetBlock'
+import { Route as ApiAddressZonePortalAddressKindRouteImport } from './routes/api/address/zone-portal/$address/$kind'
 
 const SearchRoute = SearchRouteImport.update({
   id: '/search',
@@ -188,6 +190,12 @@ const ApiContractCreationAddressRoute =
     path: '/api/contract/creation/$address',
     getParentRoute: () => rootRouteImport,
   } as any)
+const ApiAddressZonePortalAddressRoute =
+  ApiAddressZonePortalAddressRouteImport.update({
+    id: '/api/address/zone-portal/$address',
+    path: '/api/address/zone-portal/$address',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const ApiAddressMetadataAddressRoute =
   ApiAddressMetadataAddressRouteImport.update({
     id: '/api/address/metadata/$address',
@@ -211,6 +219,12 @@ const LayoutBlockCountdownTargetBlockRoute =
     id: '/block/countdown/$targetBlock',
     path: '/block/countdown/$targetBlock',
     getParentRoute: () => LayoutRoute,
+  } as any)
+const ApiAddressZonePortalAddressKindRoute =
+  ApiAddressZonePortalAddressKindRouteImport.update({
+    id: '/$kind',
+    path: '/$kind',
+    getParentRoute: () => ApiAddressZonePortalAddressRoute,
   } as any)
 
 export interface FileRoutesByFullPath {
@@ -242,10 +256,12 @@ export interface FileRoutesByFullPath {
   '/api/address/balances/$address': typeof ApiAddressBalancesAddressRoute
   '/api/address/history/$address': typeof ApiAddressHistoryAddressRoute
   '/api/address/metadata/$address': typeof ApiAddressMetadataAddressRoute
+  '/api/address/zone-portal/$address': typeof ApiAddressZonePortalAddressRouteWithChildren
   '/api/contract/creation/$address': typeof ApiContractCreationAddressRoute
   '/api/token/logo/$address': typeof ApiTokenLogoAddressRoute
   '/api/tx/balance-changes/$hash': typeof ApiTxBalanceChangesHashRoute
   '/api/tx/trace/$hash': typeof ApiTxTraceHashRoute
+  '/api/address/zone-portal/$address/$kind': typeof ApiAddressZonePortalAddressKindRoute
 }
 export interface FileRoutesByTo {
   '/search': typeof SearchRoute
@@ -276,10 +292,12 @@ export interface FileRoutesByTo {
   '/api/address/balances/$address': typeof ApiAddressBalancesAddressRoute
   '/api/address/history/$address': typeof ApiAddressHistoryAddressRoute
   '/api/address/metadata/$address': typeof ApiAddressMetadataAddressRoute
+  '/api/address/zone-portal/$address': typeof ApiAddressZonePortalAddressRouteWithChildren
   '/api/contract/creation/$address': typeof ApiContractCreationAddressRoute
   '/api/token/logo/$address': typeof ApiTokenLogoAddressRoute
   '/api/tx/balance-changes/$hash': typeof ApiTxBalanceChangesHashRoute
   '/api/tx/trace/$hash': typeof ApiTxTraceHashRoute
+  '/api/address/zone-portal/$address/$kind': typeof ApiAddressZonePortalAddressKindRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -312,10 +330,12 @@ export interface FileRoutesById {
   '/api/address/balances/$address': typeof ApiAddressBalancesAddressRoute
   '/api/address/history/$address': typeof ApiAddressHistoryAddressRoute
   '/api/address/metadata/$address': typeof ApiAddressMetadataAddressRoute
+  '/api/address/zone-portal/$address': typeof ApiAddressZonePortalAddressRouteWithChildren
   '/api/contract/creation/$address': typeof ApiContractCreationAddressRoute
   '/api/token/logo/$address': typeof ApiTokenLogoAddressRoute
   '/api/tx/balance-changes/$hash': typeof ApiTxBalanceChangesHashRoute
   '/api/tx/trace/$hash': typeof ApiTxTraceHashRoute
+  '/api/address/zone-portal/$address/$kind': typeof ApiAddressZonePortalAddressKindRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -348,10 +368,12 @@ export interface FileRouteTypes {
     | '/api/address/balances/$address'
     | '/api/address/history/$address'
     | '/api/address/metadata/$address'
+    | '/api/address/zone-portal/$address'
     | '/api/contract/creation/$address'
     | '/api/token/logo/$address'
     | '/api/tx/balance-changes/$hash'
     | '/api/tx/trace/$hash'
+    | '/api/address/zone-portal/$address/$kind'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/search'
@@ -382,10 +404,12 @@ export interface FileRouteTypes {
     | '/api/address/balances/$address'
     | '/api/address/history/$address'
     | '/api/address/metadata/$address'
+    | '/api/address/zone-portal/$address'
     | '/api/contract/creation/$address'
     | '/api/token/logo/$address'
     | '/api/tx/balance-changes/$hash'
     | '/api/tx/trace/$hash'
+    | '/api/address/zone-portal/$address/$kind'
   id:
     | '__root__'
     | '/_layout'
@@ -417,10 +441,12 @@ export interface FileRouteTypes {
     | '/api/address/balances/$address'
     | '/api/address/history/$address'
     | '/api/address/metadata/$address'
+    | '/api/address/zone-portal/$address'
     | '/api/contract/creation/$address'
     | '/api/token/logo/$address'
     | '/api/tx/balance-changes/$hash'
     | '/api/tx/trace/$hash'
+    | '/api/address/zone-portal/$address/$kind'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -436,6 +462,7 @@ export interface RootRouteChildren {
   ApiAddressBalancesAddressRoute: typeof ApiAddressBalancesAddressRoute
   ApiAddressHistoryAddressRoute: typeof ApiAddressHistoryAddressRoute
   ApiAddressMetadataAddressRoute: typeof ApiAddressMetadataAddressRoute
+  ApiAddressZonePortalAddressRoute: typeof ApiAddressZonePortalAddressRouteWithChildren
   ApiContractCreationAddressRoute: typeof ApiContractCreationAddressRoute
   ApiTokenLogoAddressRoute: typeof ApiTokenLogoAddressRoute
   ApiTxBalanceChangesHashRoute: typeof ApiTxBalanceChangesHashRoute
@@ -647,6 +674,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiContractCreationAddressRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/address/zone-portal/$address': {
+      id: '/api/address/zone-portal/$address'
+      path: '/api/address/zone-portal/$address'
+      fullPath: '/api/address/zone-portal/$address'
+      preLoaderRoute: typeof ApiAddressZonePortalAddressRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/address/metadata/$address': {
       id: '/api/address/metadata/$address'
       path: '/api/address/metadata/$address'
@@ -674,6 +708,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/block/countdown/$targetBlock'
       preLoaderRoute: typeof LayoutBlockCountdownTargetBlockRouteImport
       parentRoute: typeof LayoutRoute
+    }
+    '/api/address/zone-portal/$address/$kind': {
+      id: '/api/address/zone-portal/$address/$kind'
+      path: '/$kind'
+      fullPath: '/api/address/zone-portal/$address/$kind'
+      preLoaderRoute: typeof ApiAddressZonePortalAddressKindRouteImport
+      parentRoute: typeof ApiAddressZonePortalAddressRoute
     }
   }
 }
@@ -721,6 +762,20 @@ const LayoutRouteChildren: LayoutRouteChildren = {
 const LayoutRouteWithChildren =
   LayoutRoute._addFileChildren(LayoutRouteChildren)
 
+interface ApiAddressZonePortalAddressRouteChildren {
+  ApiAddressZonePortalAddressKindRoute: typeof ApiAddressZonePortalAddressKindRoute
+}
+
+const ApiAddressZonePortalAddressRouteChildren: ApiAddressZonePortalAddressRouteChildren =
+  {
+    ApiAddressZonePortalAddressKindRoute: ApiAddressZonePortalAddressKindRoute,
+  }
+
+const ApiAddressZonePortalAddressRouteWithChildren =
+  ApiAddressZonePortalAddressRoute._addFileChildren(
+    ApiAddressZonePortalAddressRouteChildren,
+  )
+
 const rootRouteChildren: RootRouteChildren = {
   LayoutRoute: LayoutRouteWithChildren,
   SearchRoute: SearchRoute,
@@ -734,6 +789,8 @@ const rootRouteChildren: RootRouteChildren = {
   ApiAddressBalancesAddressRoute: ApiAddressBalancesAddressRoute,
   ApiAddressHistoryAddressRoute: ApiAddressHistoryAddressRoute,
   ApiAddressMetadataAddressRoute: ApiAddressMetadataAddressRoute,
+  ApiAddressZonePortalAddressRoute:
+    ApiAddressZonePortalAddressRouteWithChildren,
   ApiContractCreationAddressRoute: ApiContractCreationAddressRoute,
   ApiTokenLogoAddressRoute: ApiTokenLogoAddressRoute,
   ApiTxBalanceChangesHashRoute: ApiTxBalanceChangesHashRoute,

--- a/apps/explorer/src/routes/_layout/address/$address.tsx
+++ b/apps/explorer/src/routes/_layout/address/$address.tsx
@@ -26,9 +26,11 @@ import { BreadcrumbsSlot } from '#comps/Breadcrumbs'
 import { ContractTabContent, InteractTabContent } from '#comps/Contract'
 import { Tip20TokenTabContent } from '#comps/Tip20ContractInfo'
 import { DataGrid } from '#comps/DataGrid'
+import { InfoCard } from '#comps/InfoCard'
 import { Pagination } from '#comps/Pagination'
 import { Midcut } from '#comps/Midcut'
 import { NotFound } from '#comps/NotFound'
+import { RelativeTime } from '#comps/RelativeTime'
 import { Sections } from '#comps/Sections'
 import {
 	TimeColumnHeader,
@@ -75,7 +77,7 @@ import {
 } from '#lib/domain/contracts'
 import * as Tip20 from '#lib/domain/tip20'
 import { HexFormatter, PriceFormatter } from '#lib/formatting'
-import { useIsMounted, useMediaQuery } from '#lib/hooks'
+import { useCopy, useIsMounted, useMediaQuery } from '#lib/hooks'
 import {
 	buildAddressDescription,
 	buildAddressOgImageUrl,
@@ -92,6 +94,16 @@ import {
 import { areUsdPricedTokens } from '#lib/pricing'
 import { fetchAddressMetadata } from '#lib/server/address-metadata'
 import { getFeeTokenForChain } from '#lib/fee-token'
+import {
+	type ZonePortalActivityKind,
+	type ZonePortalBatchReference,
+	type ZonePortalOverview,
+	isZonePortalAddress,
+} from '#lib/domain/zones'
+import {
+	zonePortalActivityQueryOptions,
+	zonePortalOverviewQueryOptions,
+} from '#lib/zone-portal'
 import { getTempoChain, getWagmiConfig } from '#wagmi.config.ts'
 import type { EnrichedTransaction } from '#routes/api/address/history/$address.ts'
 import ChevronFirst from '~icons/lucide/chevron-first'
@@ -100,6 +112,8 @@ import ChevronLeft from '~icons/lucide/chevron-left'
 import ChevronRight from '~icons/lucide/chevron-right'
 import EyeIcon from '~icons/lucide/eye'
 import EyeOffIcon from '~icons/lucide/eye-off'
+import CopyIcon from '~icons/lucide/copy'
+import PlayIcon from '~icons/lucide/play'
 import XIcon from '~icons/lucide/x'
 
 type TokenMetadata = Actions.token.getMetadata.ReturnValue
@@ -118,6 +132,9 @@ const ASSETS_PER_PAGE = 10
 const HISTORY_PAGE_SIZE = 10
 
 const allTabs = [
+	'deposits',
+	'withdrawals',
+	'batches',
 	'transactions',
 	'holdings',
 	'transfers',
@@ -451,6 +468,13 @@ function RouteComponent() {
 
 	Address.assert(address)
 	const isMounted = useIsMounted()
+	const isZonePortal = isZonePortalAddress(address)
+	const [portalLive, setPortalLive] = React.useState(true)
+	const { data: zonePortalOverview } = useQuery({
+		...zonePortalOverviewQueryOptions(address),
+		enabled: isMounted && isZonePortal,
+		refetchInterval: portalLive ? 4_000 : false,
+	})
 
 	const { data: addressMetadata } = useQuery({
 		...addressMetadataQueryOptions(address),
@@ -491,7 +515,9 @@ function RouteComponent() {
 	// Build visible tabs based on address type
 	const isTip20 = Tip20.isTip20Address(address)
 	const visibleTabs: TabValue[] = React.useMemo(() => {
-		const tabs: TabValue[] = ['transactions']
+		const tabs: TabValue[] = isZonePortal
+			? ['deposits', 'withdrawals', 'batches', 'transactions']
+			: ['transactions']
 		if (!isTip20) {
 			tabs.push('transfers', 'holdings')
 		}
@@ -506,7 +532,7 @@ function RouteComponent() {
 			tabs.push('contract', 'interact')
 		}
 		return tabs
-	}, [isToken, isTip20, isContract])
+	}, [isToken, isTip20, isContract, isZonePortal])
 
 	const setActiveSection = React.useCallback(
 		(newIndex: number) => {
@@ -657,6 +683,8 @@ function RouteComponent() {
 				isToken={isToken}
 				tokenMetadata={tokenMetadata}
 				tokenLogoURI={tokenLogoURI}
+				isZonePortal={isZonePortal}
+				zonePortalOverview={zonePortalOverview}
 			/>
 			<SectionsWrapper
 				address={address}
@@ -682,6 +710,9 @@ function RouteComponent() {
 				dir={dir}
 				period={period}
 				onPeriodChange={setPeriod}
+				zonePortalOverview={zonePortalOverview}
+				portalLive={portalLive}
+				onPortalLiveChange={setPortalLive}
 			/>
 		</div>
 	)
@@ -705,18 +736,22 @@ function AccountCardWithTimestamps(props: {
 	assetsData: AssetData[]
 	accountType?: AccountType
 	addressMetadata?: Awaited<ReturnType<typeof fetchAddressMetadata>>
+	isZonePortal: boolean
 	isToken?: boolean
 	tokenLogoURI?: string | undefined
 	tokenMetadata?: TokenMetadata | null
+	zonePortalOverview?: ZonePortalOverview | undefined
 }) {
 	const {
 		address,
 		assetsData,
 		accountType: initialAccountType,
 		addressMetadata,
+		isZonePortal,
 		isToken,
 		tokenLogoURI,
 		tokenMetadata,
+		zonePortalOverview,
 	} = props
 
 	const resolvedAccountType = addressMetadata?.accountType ?? initialAccountType
@@ -736,6 +771,20 @@ function AccountCardWithTimestamps(props: {
 			}),
 		[assetsData, isTokenListed],
 	)
+
+	if (isZonePortal)
+		return (
+			<ZonePortalCard
+				address={address}
+				createdTimestamp={createdTimestamp}
+				lastActivityTimestamp={
+					addressMetadata?.lastActivityTimestamp
+						? BigInt(addressMetadata.lastActivityTimestamp)
+						: undefined
+				}
+				overview={zonePortalOverview}
+			/>
+		)
 
 	return (
 		<div className="min-[800px]:self-start flex flex-col gap-2">
@@ -769,6 +818,122 @@ function AccountCardWithTimestamps(props: {
 	)
 }
 
+type ZonePortalCardProps = {
+	address: Address.Address
+	createdTimestamp?: bigint | undefined
+	lastActivityTimestamp?: bigint | undefined
+	overview?: ZonePortalOverview | undefined
+}
+
+function ZonePortalCard(props: ZonePortalCardProps): React.JSX.Element {
+	const { address, createdTimestamp, lastActivityTimestamp, overview } = props
+	const { copy, notifying } = useCopy()
+	const numberFormat = React.useMemo(() => new Intl.NumberFormat('en-US'), [])
+
+	return (
+		<InfoCard
+			title={<InfoCard.Title>Zone Portal</InfoCard.Title>}
+			className="min-[800px]:self-start min-[1240px]:w-[258px]"
+			sections={[
+				<button
+					key="address"
+					type="button"
+					onClick={() => copy(address)}
+					className="w-full text-left cursor-pointer press-down text-tertiary"
+					title={address}
+				>
+					<div className="flex items-center gap-[8px] mb-[8px]">
+						<span className="text-[13px] font-normal">Address</span>
+						<div className="relative flex items-center">
+							<CopyIcon className="size-3" />
+							{notifying && (
+								<span className="absolute left-[calc(100%+8px)] text-[13px] leading-[16px]">
+									copied
+								</span>
+							)}
+						</div>
+					</div>
+					<p className="max-w-[21ch] break-all font-mono text-[14px] leading-[17px] text-primary">
+						{address}
+					</p>
+				</button>,
+				<div key="balances" className="w-full min-w-0">
+					<p className="mb-2 text-[13px] text-tertiary">Balances</p>
+					<div className="flex flex-col gap-2">
+						{overview ? (
+							overview.assets.map((asset) => (
+								<div
+									key={asset.address}
+									className="flex min-w-0 items-center justify-between gap-2 text-[13px]"
+								>
+									<Link
+										to="/token/$address"
+										params={{ address: asset.address }}
+										className="flex min-w-0 items-center gap-1.5 text-base-content-positive press-down"
+									>
+										<TokenIcon address={asset.address} name={asset.symbol} />
+										<span className="truncate">{asset.symbol}</span>
+									</Link>
+									<Amount.Base
+										value={BigInt(asset.balance)}
+										decimals={asset.decimals}
+										short
+										shortMaximumFractionDigits={6}
+									/>
+								</div>
+							))
+						) : (
+							<span className="text-[13px] text-tertiary">…</span>
+						)}
+					</div>
+				</div>,
+				{
+					label: 'Deposits',
+					value: overview ? (
+						<span className="text-[13px] text-primary">
+							{numberFormat.format(overview.counts.deposits)}
+						</span>
+					) : (
+						<span className="text-[13px] text-tertiary">…</span>
+					),
+				},
+				{
+					label: 'Withdrawals',
+					value: overview ? (
+						<span className="text-[13px] text-primary">
+							{numberFormat.format(overview.counts.withdrawals)}
+						</span>
+					) : (
+						<span className="text-[13px] text-tertiary">…</span>
+					),
+				},
+				{
+					label: 'Active',
+					value: lastActivityTimestamp ? (
+						<RelativeTime
+							timestamp={lastActivityTimestamp}
+							className="text-[13px] text-primary"
+						/>
+					) : (
+						<span className="text-[13px] text-tertiary">…</span>
+					),
+				},
+				{
+					label: 'Created',
+					value: createdTimestamp ? (
+						<RelativeTime
+							timestamp={createdTimestamp}
+							className="text-[13px] text-primary"
+						/>
+					) : (
+						<span className="text-[13px] text-tertiary">…</span>
+					),
+				},
+			]}
+		/>
+	)
+}
+
 function SectionsWrapper(props: {
 	address: Address.Address
 	page: number
@@ -793,6 +958,9 @@ function SectionsWrapper(props: {
 	dir?: 'sent' | 'received' | undefined
 	period?: '24h' | '7d' | undefined
 	onPeriodChange: (period: '24h' | '7d' | undefined) => void
+	zonePortalOverview?: ZonePortalOverview | undefined
+	portalLive: boolean
+	onPortalLiveChange: (live: boolean) => void
 }) {
 	const {
 		address,
@@ -818,6 +986,9 @@ function SectionsWrapper(props: {
 		dir,
 		period,
 		onPeriodChange,
+		zonePortalOverview,
+		portalLive,
+		onPortalLiveChange,
 	} = props
 	const { timeFormat, cycleTimeFormat, formatLabel } = useTimeFormat()
 	const { voucher } = Route.useSearch()
@@ -838,7 +1009,25 @@ function SectionsWrapper(props: {
 	const isTransfersTabActive = visibleTabs[activeSection] === 'transfers'
 	const isHoldersTabActive = visibleTabs[activeSection] === 'holders'
 	const isContractTabActive = visibleTabs[activeSection] === 'contract'
+	const activeTab = visibleTabs[activeSection]
+	const isZonePortalTab =
+		activeTab === 'deposits' ||
+		activeTab === 'withdrawals' ||
+		activeTab === 'batches'
+	const zonePortalKind: ZonePortalActivityKind = isZonePortalTab
+		? activeTab
+		: 'deposits'
 	const queryClient = useQueryClient()
+	const zonePortalActivityQuery = useQuery({
+		...zonePortalActivityQueryOptions({
+			address,
+			kind: zonePortalKind,
+			page,
+			limit,
+		}),
+		enabled: isMounted && isZonePortalTab,
+		refetchInterval: portalLive && page === 1 ? 4_000 : false,
+	})
 
 	// Fetch readable source first so highlighting never delays contract data.
 	const contractSourceQuery = useQuery({
@@ -1217,6 +1406,126 @@ function SectionsWrapper(props: {
 		{ label: 'Percentage', align: 'end', minWidth: 100 },
 	]
 
+	const zoneTimeColumn: DataGrid.Column = {
+		label: (
+			<TimeColumnHeader
+				label="Time"
+				formatLabel={formatLabel}
+				onCycle={cycleTimeFormat}
+				className="cursor-pointer text-secondary transition-colors hover:text-accent"
+			/>
+		),
+		align: 'start',
+		minWidth: 86,
+		width: '0.6fr',
+	}
+
+	const zoneDepositColumns: DataGrid.Column[] = [
+		zoneTimeColumn,
+		{ label: 'Asset / amount', align: 'start', minWidth: 160, width: '1.2fr' },
+		{ label: 'From', align: 'start', minWidth: 135, width: '1fr' },
+		{
+			label: (
+				<InfoColumnLabel
+					label="Processed in"
+					info="A deposit becomes usable in the private zone after an accepted batch processes it. Pending means no accepted batch has processed it yet."
+				/>
+			),
+			align: 'start',
+			minWidth: 115,
+			width: '0.8fr',
+		},
+		{ label: 'Hash', align: 'end', minWidth: 120, width: '1fr' },
+	]
+
+	const zoneWithdrawalColumns: DataGrid.Column[] = [
+		zoneTimeColumn,
+		{ label: 'Asset / amount', align: 'start', minWidth: 160, width: '1.2fr' },
+		{ label: 'Recipient', align: 'start', minWidth: 135, width: '1fr' },
+		{
+			label: (
+				<InfoColumnLabel
+					label="Processed in"
+					info="A withdrawal is delivered on Tempo by the batch that proves it."
+				/>
+			),
+			align: 'start',
+			minWidth: 115,
+			width: '0.8fr',
+		},
+		{ label: 'Hash', align: 'end', minWidth: 120, width: '1fr' },
+	]
+
+	const zoneBatchColumns: DataGrid.Column[] = [
+		zoneTimeColumn,
+		{ label: 'Batch', align: 'start', minWidth: 90, width: '0.7fr' },
+		{
+			label: (
+				<InfoColumnLabel
+					label="Last deposit"
+					info="The highest public deposit number accepted by this batch. A dash means no deposit has been accepted yet."
+				/>
+			),
+			align: 'start',
+			minWidth: 125,
+			width: '0.9fr',
+		},
+		{
+			label: (
+				<InfoColumnLabel
+					label="Withdrawal queue"
+					info="The queue index assigned when this batch adds encrypted withdrawals. A dash means the batch added none."
+				/>
+			),
+			align: 'start',
+			minWidth: 145,
+			width: '1.1fr',
+		},
+		{ label: 'Hash', align: 'end', minWidth: 120, width: '1fr' },
+	]
+
+	const zonePortalContextual = (
+		<button
+			type="button"
+			onClick={() => onPortalLiveChange(!portalLive)}
+			className={cx(
+				'flex items-center gap-1 rounded-[4px] px-1.5 py-0.5 text-[11px] font-medium press-down',
+				portalLive
+					? 'bg-positive/10 text-positive hover:bg-positive/20'
+					: 'bg-base-alt text-tertiary hover:bg-base-alt/80',
+			)}
+			title={portalLive ? 'Pause live updates' : 'Resume live updates'}
+		>
+			{portalLive ? (
+				<>
+					<span className="relative flex size-2">
+						<span className="absolute inline-flex size-full animate-ping rounded-full bg-positive opacity-75" />
+						<span className="relative inline-flex size-2 rounded-full bg-positive" />
+					</span>
+					<span>Live</span>
+				</>
+			) : (
+				<>
+					<PlayIcon className="size-3" />
+					<span>Paused</span>
+				</>
+			)}
+		</button>
+	)
+
+	const zonePortalError = zonePortalActivityQuery.error ? (
+		<div className="rounded-[10px] bg-card-header p-4.5">
+			<p className="text-sm font-medium text-red-400">
+				Zone activity is temporarily unavailable
+			</p>
+			<p className="mt-1 text-xs text-tertiary">
+				{zonePortalActivityQuery.error instanceof Error
+					? zonePortalActivityQuery.error.message
+					: 'Unknown error'}
+			</p>
+		</div>
+	) : null
+
 	// Holdings uses local pagination state (decoupled from URL `page` param)
 	const [holdingsPage, setHoldingsPage] = React.useState(1)
 	const [showAllHoldings, setShowAllHoldings] = React.useState(false)
@@ -1260,6 +1569,202 @@ function SectionsWrapper(props: {
 	// Build sections based on visible tabs
 	const sections = visibleTabs.map((tabName) => {
 		switch (tabName) {
+			case 'deposits': {
+				const deposits =
+					zonePortalActivityQuery.data?.items.filter(
+						(item) => item.kind === 'deposit',
+					) ?? []
+				const total = zonePortalActivityQuery.data?.total ?? 0
+				return {
+					title: 'Deposits',
+					totalItems: zonePortalOverview?.counts.deposits,
+					itemsLabel: 'deposits',
+					contextual: zonePortalContextual,
+					content: zonePortalError ?? (
+						<DataGrid
+							columns={{
+								stacked: zoneDepositColumns,
+								tabs: zoneDepositColumns,
+							}}
+							items={() =>
+								deposits.map((deposit) => ({
+									key: `${deposit.transactionHash}-${deposit.timestamp}`,
+									cells: [
+										<TimestampCell
+											key="time"
+											timestamp={BigInt(deposit.timestamp)}
+											link={`/receipt/${deposit.transactionHash}`}
+											format={timeFormat}
+										/>,
+										<Amount
+											key="amount"
+											value={deposit.amount}
+											token={deposit.token}
+										/>,
+										<AddressCell
+											key="from"
+											address={deposit.sender}
+											label="From"
+										/>,
+										<ProcessedInBatchCell
+											key="batch"
+											batch={deposit.processedInBatch}
+											fallback="Pending"
+										/>,
+										<LinkedTransactionHash
+											key="hash"
+											hash={deposit.transactionHash}
+										/>,
+									],
+									link: {
+										href: `/receipt/${deposit.transactionHash}`,
+										title: `View receipt ${deposit.transactionHash}`,
+									},
+								}))
+							}
+							totalItems={total}
+							displayCount={total}
+							page={page}
+							fetching={zonePortalActivityQuery.isFetching}
+							loading={zonePortalActivityQuery.isPending}
+							itemsLabel="deposits"
+							itemsPerPage={limit}
+							pagination="simple"
+							emptyState="No deposits found."
+						/>
+					),
+				}
+			}
+			case 'withdrawals': {
+				const withdrawals =
+					zonePortalActivityQuery.data?.items.filter(
+						(item) => item.kind === 'withdrawal',
+					) ?? []
+				const total = zonePortalActivityQuery.data?.total ?? 0
+				return {
+					title: 'Withdrawals',
+					totalItems: zonePortalOverview?.counts.withdrawals,
+					itemsLabel: 'withdrawals',
+					contextual: zonePortalContextual,
+					content: zonePortalError ?? (
+						<DataGrid
+							columns={{
+								stacked: zoneWithdrawalColumns,
+								tabs: zoneWithdrawalColumns,
+							}}
+							items={() =>
+								withdrawals.map((withdrawal) => ({
+									key: `${withdrawal.transactionHash}-${withdrawal.timestamp}`,
+									cells: [
+										<TimestampCell
+											key="time"
+											timestamp={BigInt(withdrawal.timestamp)}
+											link={`/receipt/${withdrawal.transactionHash}`}
+											format={timeFormat}
+										/>,
+										<Amount
+											key="amount"
+											value={withdrawal.amount}
+											token={withdrawal.token}
+										/>,
+										<AddressCell
+											key="to"
+											address={withdrawal.recipient}
+											label="To"
+										/>,
+										<ProcessedInBatchCell
+											key="batch"
+											batch={withdrawal.processedInBatch}
+											fallback="—"
+										/>,
+										<LinkedTransactionHash
+											key="hash"
+											hash={withdrawal.transactionHash}
+										/>,
+									],
+									link: {
+										href: `/receipt/${withdrawal.transactionHash}`,
+										title: `View receipt ${withdrawal.transactionHash}`,
+									},
+								}))
+							}
+							totalItems={total}
+							displayCount={total}
+							page={page}
+							fetching={zonePortalActivityQuery.isFetching}
+							loading={zonePortalActivityQuery.isPending}
+							itemsLabel="withdrawals"
+							itemsPerPage={limit}
+							pagination="simple"
+							emptyState="No withdrawals found."
+						/>
+					),
+				}
+			}
+			case 'batches': {
+				const batches =
+					zonePortalActivityQuery.data?.items.filter(
+						(item) => item.kind === 'batch',
+					) ?? []
+				const total = zonePortalActivityQuery.data?.total ?? 0
+				return {
+					title: 'Batches',
+					totalItems: zonePortalOverview?.counts.batches,
+					itemsLabel: 'batches',
+					contextual: zonePortalContextual,
+					content: zonePortalError ?? (
+						<DataGrid
+							columns={{
+								stacked: zoneBatchColumns,
+								tabs: zoneBatchColumns,
+							}}
+							items={() =>
+								batches.map((batch) => ({
+									key: batch.transactionHash,
+									cells: [
+										<TimestampCell
+											key="time"
+											timestamp={BigInt(batch.timestamp)}
+											link={`/receipt/${batch.transactionHash}`}
+											format={timeFormat}
+										/>,
+										<span key="batch" className="whitespace-nowrap font-mono">
+											#{batch.batchIndex}
+										</span>,
+										<span key="deposit" className="text-[13px] text-primary">
+											{batch.lastProcessedDepositNumber === '0'
+												? '—'
+												: `#${batch.lastProcessedDepositNumber}`}
+										</span>,
+										<span key="queue" className="text-[13px] text-primary">
+											{batch.withdrawalQueueIndex
+												? `#${batch.withdrawalQueueIndex}`
+												: '—'}
+										</span>,
+										<LinkedTransactionHash
+											key="hash"
+											hash={batch.transactionHash}
+										/>,
+									],
+									link: {
+										href: `/receipt/${batch.transactionHash}`,
+										title: `View receipt ${batch.transactionHash}`,
+									},
+								}))
+							}
+							totalItems={total}
+							displayCount={total}
+							page={page}
+							fetching={zonePortalActivityQuery.isFetching}
+							loading={zonePortalActivityQuery.isPending}
+							itemsLabel="batches"
+							itemsPerPage={limit}
+							pagination="simple"
+							emptyState="No batches found."
+						/>
+					),
+				}
+			}
 			case 'transactions':
 				return {
 					title: 'Transactions',
@@ -1777,6 +2282,74 @@ function SectionsWrapper(props: {
 			activeSection={activeSection}
 			onSectionChange={onSectionChange}
 		/>
+	)
+}
+
+type InfoColumnLabelProps = { label: string; info: string }
+
+function InfoColumnLabel(props: InfoColumnLabelProps): React.JSX.Element {
+	return (
+		<span className="inline-flex items-center gap-1">
+			<span>{props.label}</span>
+			<span
+				className="cursor-help text-[11px] text-tertiary"
+				title={props.info}
+				role="img"
+				aria-label={props.info}
+			>
+				ⓘ
+			</span>
+		</span>
+	)
+}
+
+type ProcessedInBatchCellProps = {
+	batch: ZonePortalBatchReference | null
+	fallback: string
+}
+
+function ProcessedInBatchCell(
+	props: ProcessedInBatchCellProps,
+): React.JSX.Element {
+	if (!props.batch) {
+		return (
+			<span className="whitespace-nowrap text-[13px] text-tertiary">
+				{props.fallback}
+			</span>
+		)
+	}
+
+	return (
+		<span className="whitespace-nowrap text-[13px]">
+			Batch{' '}
+			<Link
+				to="/receipt/$hash"
+				params={{ hash: props.batch.transactionHash }}
+				preload="intent"
+				className="text-accent transition-colors hover:text-accent/80 press-down"
+				title={`View batch #${props.batch.index}`}
+			>
+				#{props.batch.index}
+			</Link>
+		</span>
+	)
+}
+
+type LinkedTransactionHashProps = { hash: Hex.Hex }
+
+function LinkedTransactionHash(
+	props: LinkedTransactionHashProps,
+): React.JSX.Element {
+	return (
+		<Link
+			to="/receipt/$hash"
+			params={{ hash: props.hash }}
+			preload="intent"
+			className="w-full text-[13px] text-tertiary press-down"
+			title={props.hash}
+		>
+			<Midcut value={props.hash} prefix="0x" align="end" />
+		</Link>
 	)
 }
 

--- a/apps/explorer/src/routes/api/address/zone-portal/$address.ts
+++ b/apps/explorer/src/routes/api/address/zone-portal/$address.ts
@@ -1,0 +1,34 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { getChainId } from 'wagmi/actions'
+import type { ZonePortalOverview } from '#lib/domain/zones'
+import { fetchZonePortalOverview } from '#lib/server/zone-portal'
+import { zAddress } from '#lib/zod'
+import { getWagmiConfig } from '#wagmi.config'
+
+export const Route = createFileRoute('/api/address/zone-portal/$address')({
+	server: {
+		handlers: {
+			GET: async ({ params }) => {
+				try {
+					const address = zAddress().parse(params.address)
+					const response = await fetchZonePortalOverview({
+						address,
+						chainId: getChainId(getWagmiConfig()),
+					})
+					return Response.json(response satisfies ZonePortalOverview)
+				} catch (error) {
+					console.error(error)
+					return Response.json(
+						{
+							error:
+								error instanceof Error
+									? error.message
+									: 'Failed to load Zone Portal',
+						},
+						{ status: 500 },
+					)
+				}
+			},
+		},
+	},
+})

--- a/apps/explorer/src/routes/api/address/zone-portal/$address/$kind.ts
+++ b/apps/explorer/src/routes/api/address/zone-portal/$address/$kind.ts
@@ -1,0 +1,54 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { getChainId } from 'wagmi/actions'
+import * as z from 'zod/mini'
+import type { ZonePortalActivityResponse } from '#lib/domain/zones'
+import { getRequestURL } from '#lib/env'
+import { fetchZonePortalActivity } from '#lib/server/zone-portal'
+import { zAddress } from '#lib/zod'
+import { getWagmiConfig } from '#wagmi.config'
+
+const SearchSchema = z.object({
+	page: z.prefault(z.coerce.number(), 1),
+	limit: z.prefault(z.coerce.number(), 10),
+})
+
+const KindSchema = z.enum(['deposits', 'withdrawals', 'batches'])
+
+export const Route = createFileRoute('/api/address/zone-portal/$address/$kind')(
+	{
+		server: {
+			handlers: {
+				GET: async ({ params }) => {
+					try {
+						const address = zAddress().parse(params.address)
+						const kind = KindSchema.parse(params.kind)
+						const search = SearchSchema.parse(
+							Object.fromEntries(getRequestURL().searchParams),
+						)
+						const page = Math.max(1, Math.floor(search.page))
+						const limit = Math.min(10, Math.max(1, Math.floor(search.limit)))
+						const response = await fetchZonePortalActivity({
+							address,
+							chainId: getChainId(getWagmiConfig()),
+							kind,
+							page,
+							limit,
+						})
+						return Response.json(response satisfies ZonePortalActivityResponse)
+					} catch (error) {
+						console.error(error)
+						return Response.json(
+							{
+								error:
+									error instanceof Error
+										? error.message
+										: 'Failed to load Zone Portal activity',
+							},
+							{ status: 500 },
+						)
+					}
+				},
+			},
+		},
+	},
+)

--- a/apps/explorer/test/known-events.test.ts
+++ b/apps/explorer/test/known-events.test.ts
@@ -115,6 +115,33 @@ function mockZoneEventLog(event: AbiEvent, address: Address.Address) {
 	)
 }
 
+const encryptedDepositMadeAbi = [
+	{
+		type: 'event',
+		name: 'DepositMade',
+		inputs: [
+			{
+				indexed: true,
+				name: 'newCurrentDepositQueueHash',
+				type: 'bytes32',
+			},
+			{ indexed: true, name: 'sender', type: 'address' },
+			{ indexed: false, name: 'token', type: 'address' },
+			{ indexed: false, name: 'netAmount', type: 'uint128' },
+			{ indexed: false, name: 'fee', type: 'uint128' },
+			{ indexed: false, name: 'keyIndex', type: 'uint256' },
+			{ indexed: false, name: 'ephemeralPubkeyX', type: 'bytes32' },
+			{ indexed: false, name: 'ephemeralPubkeyYParity', type: 'uint8' },
+			{ indexed: false, name: 'ciphertext', type: 'bytes' },
+			{ indexed: false, name: 'nonce', type: 'bytes12' },
+			{ indexed: false, name: 'tag', type: 'bytes16' },
+			{ indexed: false, name: 'tempoRefundRecipient', type: 'address' },
+			{ indexed: false, name: 'depositNumber', type: 'uint64' },
+		],
+		anonymous: false,
+	},
+] as const
+
 describe('parseKnownEvents', () => {
 	it('describes every Zone write call', () => {
 		const portal = '0x5ad0000000000000000000000000000000000003' as const
@@ -670,5 +697,48 @@ describe('parseKnownEvents', () => {
 
 		expect(knownEvents).toHaveLength(1)
 		expect(knownEvents[0]?.type).toBe('zone deposit')
+	})
+
+	it('does not expose the encrypted recipient of current Zone deposits', () => {
+		const hash = `0x${'4'.repeat(64)}` as const
+		const netAmount = 1_000_000n
+		const topics = encodeEventTopics({
+			abi: encryptedDepositMadeAbi,
+			eventName: 'DepositMade',
+			args: {
+				newCurrentDepositQueueHash: zeroHash,
+				sender: accountAddress,
+			},
+		}) as [Hex.Hex, ...Hex.Hex[]]
+		const data = encodeAbiParameters(
+			encryptedDepositMadeAbi[0].inputs.filter((input) => !input.indexed),
+			[
+				userTokenAddress,
+				netAmount,
+				0n,
+				3n,
+				zeroHash,
+				3,
+				`0x${'11'.repeat(64)}`,
+				`0x${'22'.repeat(12)}`,
+				`0x${'33'.repeat(16)}`,
+				recipientAddress,
+				70n,
+			],
+		)
+		const receipt = mockReceipt(
+			[mockLog({ address: UNKNOWN_ZONE_PORTAL, topics, data }, hash)],
+			accountAddress,
+			hash,
+		)
+
+		const [event] = parseKnownEvents(receipt, { getTokenMetadata })
+		expect(event?.type).toBe('zone deposit')
+		expect(event?.parts[0]).toEqual({
+			type: 'action',
+			value: 'Private Zone Deposit',
+		})
+		expect(event?.parts).toHaveLength(2)
+		expect(event?.parts.some((part) => part.type === 'account')).toBe(false)
 	})
 })

--- a/apps/explorer/test/transaction-activities.test.ts
+++ b/apps/explorer/test/transaction-activities.test.ts
@@ -188,7 +188,7 @@ describe('activitiesToKnownEvents', () => {
 		],
 		[
 			'private-shares-redeemed',
-			'Private Zone Deposit',
+			'Private Zone Withdrawal',
 			'outputAmount',
 			'outputToken',
 		],
@@ -263,10 +263,85 @@ describe('activitiesToKnownEvents', () => {
 									: token,
 						},
 					},
-					{ type: 'text', value: 'to' },
-					{ type: 'account', value: portal },
+					...(type === 'private-assets-deposited'
+						? [
+								{ type: 'text' as const, value: 'to' },
+								{ type: 'account' as const, value: portal },
+							]
+						: []),
 				],
 			},
 		])
+	})
+})
+
+describe('selectTransactionDescriptionEvents for Zones', () => {
+	const zoneDeposit = {
+		type: 'zone deposit',
+		parts: [{ type: 'action' as const, value: 'Deposit to Zone' }],
+	}
+
+	test('prefers a decoded Zone event over generic API activities', () => {
+		expect(
+			selectTransactionDescriptionEvents({
+				activityEvents: [
+					{ type: 'approval', parts: [] },
+					{ type: 'transfer', parts: [] },
+				],
+				fallbackEvents: [{ type: 'approval', parts: [] }, zoneDeposit],
+				knownCall: null,
+			}),
+		).toEqual([zoneDeposit])
+	})
+
+	test('prefers a decoded Zone event over generic token and nonce activities', () => {
+		expect(
+			selectTransactionDescriptionEvents({
+				activityEvents: [
+					{ type: 'mint', parts: [] },
+					{ type: 'burn', parts: [] },
+					{
+						type: 'nonce incremented',
+						parts: [{ type: 'action' as const, value: 'Nonce Incremented' }],
+					},
+				],
+				fallbackEvents: [zoneDeposit],
+				knownCall: null,
+			}),
+		).toEqual([zoneDeposit])
+	})
+
+	test('preserves semantic API activities for Earn transactions', () => {
+		const vaultDeposit = {
+			type: 'private-assets-deposited',
+			parts: [{ type: 'action' as const, value: 'Vault Deposit' }],
+		}
+		expect(
+			selectTransactionDescriptionEvents({
+				activityEvents: [vaultDeposit],
+				fallbackEvents: [zoneDeposit],
+				knownCall: null,
+			}),
+		).toEqual([vaultDeposit])
+	})
+
+	test('does not duplicate private Zone activity with a low-level decoded call', () => {
+		const decodedCall = {
+			type: 'zone encrypted deposit',
+			parts: [
+				{ type: 'action' as const, value: 'Encrypted Deposit to Zone 1' },
+			],
+		}
+		const privateDeposit = {
+			type: 'private-assets-deposited',
+			parts: [{ type: 'action' as const, value: 'Private Zone Deposit' }],
+		}
+		expect(
+			selectTransactionDescriptionEvents({
+				activityEvents: [privateDeposit],
+				fallbackEvents: [decodedCall],
+				knownCall: decodedCall,
+			}),
+		).toEqual([privateDeposit])
 	})
 })

--- a/apps/explorer/test/zone-portal.test.ts
+++ b/apps/explorer/test/zone-portal.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+import { encodeFunctionData, parseAbi, zeroHash } from 'viem'
+import {
+	isZonePortalAddress,
+	withdrawalQueueHashFromInput,
+} from '../src/lib/domain/zones'
+
+describe('Zone Portal presentation', () => {
+	it('recognizes reserved Zone Portal addresses only', () => {
+		expect(
+			isZonePortalAddress('0x5ad0000000000000000000000000000000000001'),
+		).toBe(true)
+		expect(
+			isZonePortalAddress('0x5ad00000000000000000000000000000ffffffff'),
+		).toBe(true)
+		expect(
+			isZonePortalAddress('0x5ad0000000000000000000000000000000000000'),
+		).toBe(false)
+		expect(
+			isZonePortalAddress('0x5ad1000000000000000000000000000000000000'),
+		).toBe(false)
+	})
+
+	it('reconstructs the committed withdrawal queue hash from processing calldata', () => {
+		const input = encodeFunctionData({
+			abi: parseAbi([
+				'function processWithdrawals((address token, bytes32 senderTag, address to, uint128 amount, bytes32 memo, uint64 gasLimit, uint64 fallbackNonce, bytes callbackData, bytes encryptedSender)[] withdrawals, bytes32 remainingQueue)',
+			]),
+			functionName: 'processWithdrawals',
+			args: [
+				[
+					{
+						token: '0x20c0000000000000000000000000000000000000',
+						senderTag: `0x${'11'.repeat(32)}`,
+						to: '0x8117E0ba6239B9695f780DEb010F72a2Fa4bdfb6',
+						amount: 100n,
+						memo: zeroHash,
+						gasLimit: 0n,
+						fallbackNonce: 1n,
+						callbackData: '0x',
+						encryptedSender: '0x',
+					},
+				],
+				zeroHash,
+			],
+		})
+
+		expect(withdrawalQueueHashFromInput(input)).toBe(
+			'0x50c3f41591c910c4a8e89df89eafa1e212ac3241300afa1671fca791afdf9972',
+		)
+	})
+
+	it('ignores calldata for other portal functions', () => {
+		expect(withdrawalQueueHashFromInput('0x12345678')).toBeNull()
+	})
+})


### PR DESCRIPTION
## Summary
- add live Zone Portal deposits, withdrawals, and batches with receipt and processing-batch links
- show per-asset balances plus deposit and withdrawal counts in the portal sidebar
- render private Zone and vault activity with current mainnet and legacy event support

## Validation
- `pnpm --filter explorer check`
- `pnpm --filter explorer test`
- `VITE_TEMPO_ENV=mainnet pnpm --filter explorer build`
- `pnpm precommit`

Prompted by: @snario