### PR TITLE
fix(explorer): restore full Zone protocol ABI

### DIFF
--- a/apps/explorer/package.json
+++ b/apps/explorer/package.json
@@ -60,6 +60,7 @@
 		"tailwindcss": "catalog:",
 		"tidx.ts": "catalog:",
 		"viem": "catalog:",
+		"viem-zones": "https://pkg.pr.new/viem@5030",
 		"wagmi": "catalog:",
 		"zod": "catalog:"
 	},

--- a/apps/explorer/src/comps/TxDecodedCalldata.tsx
+++ b/apps/explorer/src/comps/TxDecodedCalldata.tsx
@@ -2,7 +2,11 @@ import type { AbiFunction } from 'abitype'
 import { useMemo, useState } from 'react'
 import { decodeAbiParameters, parseAbiItem, slice } from 'viem'
 import type { Abi, Address, Hex } from 'viem'
-import { formatAbiValue, getAbiItem } from '#lib/domain/contracts'
+import {
+	formatAbiValue,
+	getAbiItem,
+	getContractInfo,
+} from '#lib/domain/contracts'
 import { useCopy } from '#lib/hooks'
 import { useAutoloadAbi, useLookupSignature } from '#lib/queries'
 import CopyIcon from '~icons/lucide/copy'
@@ -42,18 +46,18 @@ export function TxDecodedCalldata(props: TxDecodedCalldata.Props) {
 				abi: signatureAbi,
 				selector,
 			}) as AbiFunction)
+		const contractAbi = address ? getContractInfo(address)?.abi : undefined
+		const contractAbiItem =
+			contractAbi &&
+			(getAbiItem({
+				abi: contractAbi,
+				selector,
+			}) as AbiFunction)
 
-		if (autoloadAbiItem) {
-			if (
-				(signatureAbiItem?.inputs?.length || 0) >
-				(autoloadAbiItem?.inputs?.length || 0)
-			)
-				return signatureAbiItem
-			return autoloadAbiItem
-		}
-
-		return signatureAbiItem
-	}, [autoloadAbi, signatureAbi, selector])
+		return [autoloadAbiItem, contractAbiItem, signatureAbiItem]
+			.filter((item): item is AbiFunction => Boolean(item))
+			.sort((a, b) => (b.inputs?.length ?? 0) - (a.inputs?.length ?? 0))[0]
+	}, [address, autoloadAbi, signatureAbi, selector])
 
 	const rawArgs = abiItem && data.length > 10 ? slice(data, 4) : undefined
 	const { args } = useMemo(() => {

--- a/apps/explorer/src/comps/TxTraceTree.tsx
+++ b/apps/explorer/src/comps/TxTraceTree.tsx
@@ -6,6 +6,7 @@ import type { Abi, Hex } from 'viem'
 import { cx } from '#lib/css'
 import { PanelToolbar, SegmentedControl } from './PanelToolbar'
 import {
+	blockHashHistoryAddress,
 	formatAbiValue,
 	getAbiItem,
 	getContractInfo,
@@ -235,11 +236,7 @@ function RawToggle(props: {
 	)
 }
 
-/**
- * Decoded view is for reading, not for exactness — a 78-digit uint256 or a
- * 200-character bytes blob wraps the whole tree and hides the arguments beside
- * it. The raw toggle still shows every byte.
- */
+/** Keep return values compact in the trace tree; the raw view preserves them. */
 function abbreviateTraceValue(value: string, max = 24): string {
 	if (value.length <= max) return value
 	return `${value.slice(0, max - 8)}…${value.slice(-6)}`
@@ -382,6 +379,8 @@ export function useTraceTrees(
 				const precompileInfo = trace.to
 					? precompileRegistry.get(trace.to.toLowerCase() as `0x${string}`)
 					: undefined
+				const isBlockHashHistory =
+					trace.to?.toLowerCase() === blockHashHistoryAddress
 
 				let functionName: string | undefined
 				let params: string | undefined
@@ -411,6 +410,10 @@ export function useTraceTrees(
 						params = decoded.params
 						decodedOutput = decoded.decodedOutput
 					}
+				} else if (isBlockHashHistory && trace.input.length === 66) {
+					functionName = 'getBlockHash'
+					params = `blockNumber: ${BigInt(trace.input)}`
+					decodedOutput = trace.output
 				} else if (selector) {
 					const autoloadAbi = abiMap.get(trace.to?.toLowerCase() ?? '')
 					const autoloadAbiItem =
@@ -432,7 +435,7 @@ export function useTraceTrees(
 								params = decoded
 									.map((v, i) => {
 										const name = item.inputs[i]?.name
-										const value = abbreviateTraceValue(formatAbiValue(v))
+										const value = formatAbiValue(v)
 										return name ? `${name}: ${value}` : value
 									})
 									.join(', ')

--- a/apps/explorer/src/lib/abis.ts
+++ b/apps/explorer/src/lib/abis.ts
@@ -1,6 +1,6 @@
 import { parseAbi } from 'viem'
 import { Abis as ViemTempoAbis, Channel as ViemTempoChannel } from 'viem/tempo'
-import { Abis as ViemZoneAbis } from 'viem/tempo/zones'
+import { Abis as ViemZoneAbis } from 'viem-zones/tempo/zones'
 
 export const tip20ChannelReserveAbi = ViemTempoAbis.tip20ChannelReserve
 export const tip20ChannelReserveAddress = ViemTempoChannel.address
@@ -103,7 +103,7 @@ export const streamChannelAbi = [
 	},
 ] as const
 
-const zonePortalAbi = [
+const zonePortalEventsAbi = [
 	{
 		type: 'event',
 		name: 'DepositMade',
@@ -207,26 +207,50 @@ const zonePortalAbi = [
 	},
 ] as const
 
-const zoneFactoryAbi = [
-	{
-		type: 'event',
-		name: 'ZoneCreated',
-		inputs: [
-			{ indexed: true, name: 'zoneId', type: 'uint32' },
-			{ indexed: true, name: 'portal', type: 'address' },
-			{ indexed: true, name: 'messenger', type: 'address' },
-			{ indexed: false, name: 'initialToken', type: 'address' },
-			{ indexed: false, name: 'sequencer', type: 'address' },
-			{ indexed: false, name: 'verifier', type: 'address' },
-			{ indexed: false, name: 'genesisBlockHash', type: 'bytes32' },
-			{ indexed: false, name: 'genesisTempoBlockHash', type: 'bytes32' },
-			{ indexed: false, name: 'genesisTempoBlockNumber', type: 'uint64' },
-		],
-		anonymous: false,
-	},
-] as const
+const zonePortalCurrentAbi = parseAbi([
+	'event BatchSubmitted(uint64 indexed withdrawalBatchIndex, uint256 indexed withdrawalQueueIndex, bytes32 nextProcessedDepositQueueHash, bytes32 nextBlockHash, bytes32 withdrawalQueueHash, uint64 lastProcessedDepositNumber)',
+	'event WithdrawalBounceBack(bytes32 indexed newCurrentDepositQueueHash, uint64 indexed fallbackNonce, address token, uint128 amount, uint64 depositNumber)',
+	'event AdminTransferStarted(address indexed currentAdmin, address indexed pendingAdmin)',
+	'event AdminTransferred(address indexed previousAdmin, address indexed newAdmin)',
+	'event DepositMade(bytes32 indexed newCurrentDepositQueueHash, address indexed sender, address token, uint128 netAmount, uint128 fee, uint256 keyIndex, bytes32 ephemeralPubkeyX, uint8 ephemeralPubkeyYParity, bytes ciphertext, bytes12 nonce, bytes16 tag, address tempoRefundRecipient, uint64 depositNumber)',
+	'event DepositBounceBack(address indexed tempoRefundRecipient, address token, uint128 amount, uint128 bouncebackFee)',
+	'event DepositBounceBackPending(address indexed tempoRefundRecipient, address token, uint128 amount, uint128 bouncebackFee)',
+	'event RefundClaimed(address indexed recipient, address indexed token, uint128 amount)',
+	'event SequencerEncryptionKeyUpdated(bytes32 x, uint8 yParity, address pubkey, uint256 keyIndex, uint64 activationBlock)',
+	'event ZoneGasRateUpdated(uint128 zoneGasRate)',
+	'event MaxTempoGasRateUpdated(uint128 maxTempoGasRate)',
+	'event BouncebackGasUpdated(uint64 bouncebackGas)',
+	'event DepositsPaused(address indexed token)',
+	'event DepositsResumed(address indexed token)',
+	'event PortalPaused(address indexed account)',
+	'event PortalResumed(address indexed account)',
+	'event AbdicationScheduled(uint8 indexed capability, uint64 effectiveAt)',
+	'event RpcUrlUpdated(string rpcUrl)',
+	'event SequencerSetUpdated(uint64 indexed nonce, uint8 threshold, address[] sequencers)',
+	'event LeaderUpdated(address indexed previousLeader, address indexed newLeader, uint64 indexed epoch, uint64 activationTempoBlock)',
+	'event EnforcementModesUpdated(bool accessMode, bool gatewayMode)',
+	'event RoleUpdated(address indexed account, uint8 prev, uint8 next)',
+	'function processWithdrawals((address token, bytes32 senderTag, address to, uint128 amount, bytes32 memo, uint64 gasLimit, uint64 fallbackNonce, bytes callbackData, bytes encryptedSender)[] withdrawals, bytes32 remainingQueue)',
+	'function deliverWithdrawal(address token, address target, uint128 amount, bytes32 senderTag, uint64 gasLimit, bytes data)',
+	'function submitBatch(uint64 tempoBlockNumber, uint64 recentTempoBlockNumber, (bytes32 prevBlockHash, bytes32 nextBlockHash) blockTransition, (bytes32 prevProcessedHash, bytes32 nextProcessedHash, uint64 prevDepositNumber, uint64 nextDepositNumber) depositQueueTransition, bytes32 withdrawalQueueHash, bytes verifierConfig, bytes proof, uint256 zoneHeight, bytes[] signatures)',
+])
+
+export const zoneMessengerAbi = parseAbi([
+	'function relayMessage(uint32 zoneId, address token, bytes32 senderTag, address target, uint128 amount, uint64 gasLimit, bytes data)',
+])
+
+export const zoneVerifierAbi = parseAbi([
+	'function verify(uint32 zoneId, uint64 tempoBlockNumber, uint64 anchorBlockNumber, bytes32 anchorBlockHash, uint64 expectedWithdrawalBatchIndex, (bytes32 prevBlockHash, bytes32 nextBlockHash) blockTransition, (bytes32 prevProcessedHash, bytes32 nextProcessedHash, uint64 prevDepositNumber, uint64 nextDepositNumber) depositQueueTransition, bytes32 withdrawalQueueHash, bytes verifierConfig, bytes proof) view returns (bool)',
+])
 
 export const stablecoinDexAbi = ViemTempoAbis.stablecoinDex
+export const zoneFactoryAbi = ViemZoneAbis.zoneFactory
+export const zoneOutboxAbi = ViemZoneAbis.zoneOutbox
+export const zonePortalAbi = [
+	...zonePortalEventsAbi,
+	...ViemZoneAbis.zonePortal,
+	...zonePortalCurrentAbi,
+] as const
 
 export const receivePolicyGuardAbi = parseAbi([
 	'event TransferBlocked(address indexed token, address indexed receiver, uint64 indexed blockedNonce, uint256 amount, uint8 receiptVersion, bytes receipt)',
@@ -239,8 +263,9 @@ export const Abis = {
 	receivePolicyGuard: receivePolicyGuardAbi,
 	stablecoinDex: stablecoinDexAbi,
 	streamChannel: streamChannelAbi,
-	zonePortal: [...ViemZoneAbis.zonePortal, ...zonePortalAbi],
-	zoneFactory: zoneFactoryAbi,
+	zoneFactory: zoneFactoryAbi.filter((item) => item.type === 'event'),
+	zoneOutbox: zoneOutboxAbi.filter((item) => item.type === 'event'),
+	zonePortal: zonePortalAbi.filter((item) => item.type === 'event'),
 } as const
 
 export const allAbis = Object.values(Abis).flat()

--- a/apps/explorer/src/lib/domain/contracts.ts
+++ b/apps/explorer/src/lib/domain/contracts.ts
@@ -8,12 +8,17 @@ import {
 	toFunctionSelector,
 } from 'viem'
 import { Addresses } from 'viem/tempo'
+import { Addresses as ZoneAddresses } from 'viem-zones/tempo'
 import {
 	Abis,
 	stablecoinDexAbi,
 	streamChannelAbi,
 	tip20ChannelReserveAbi,
 	tip20ChannelReserveAddress,
+	zoneFactoryAbi,
+	zoneMessengerAbi,
+	zonePortalAbi,
+	zoneVerifierAbi,
 } from '#lib/abis'
 import { getChainId, getPublicClient } from 'wagmi/actions'
 import { isTip20Address } from '#lib/domain/tip20.ts'
@@ -21,7 +26,9 @@ import { getWagmiConfig } from '#wagmi.config.ts'
 
 const validatorConfigV2Address =
 	'0xcccccccc00000000000000000000000000000001' as const
-const zonePortalAddressPrefix = '0x5ad000000000000000000000'
+export const blockHashHistoryAddress =
+	'0x0000f90827f1c53a10cb7a02335b175320002935' as const
+const zonePortalPrefix = '0x5ad000000000000000000000' as const
 
 /**
  * Registry of known contract addresses to their ABIs and metadata.
@@ -355,6 +362,66 @@ export const systemContractRegistry = new Map<Address.Address, ContractInfo>(<
 		},
 	],
 	[
+		ZoneAddresses.zoneFactory,
+		{
+			name: 'Zone Factory',
+			code: '0xef',
+			description: 'Create and discover Tempo Zones',
+			abi: zoneFactoryAbi,
+			category: 'system',
+			docsUrl: 'https://docs.tempo.xyz/protocol/zones',
+			address: ZoneAddresses.zoneFactory,
+		},
+	],
+	[
+		ZoneAddresses.zonePortalImplementation,
+		{
+			name: 'Zone Portal Implementation',
+			code: '0xef',
+			description: 'Bridge assets between Tempo and Tempo Zones',
+			abi: zonePortalAbi,
+			category: 'system',
+			docsUrl: 'https://docs.tempo.xyz/protocol/zones',
+			address: ZoneAddresses.zonePortalImplementation,
+		},
+	],
+	[
+		ZoneAddresses.zoneMessenger,
+		{
+			name: 'Zone Messenger',
+			code: '0xef',
+			description: 'Relay messages between Tempo and Tempo Zones',
+			abi: zoneMessengerAbi,
+			category: 'system',
+			docsUrl: 'https://docs.tempo.xyz/protocol/zones',
+			address: ZoneAddresses.zoneMessenger,
+		},
+	],
+	[
+		ZoneAddresses.zoneVerifier,
+		{
+			name: 'Zone Verifier',
+			code: '0xef',
+			description: 'Verify Tempo Zone state transitions',
+			abi: zoneVerifierAbi,
+			category: 'system',
+			docsUrl: 'https://docs.tempo.xyz/protocol/zones',
+			address: ZoneAddresses.zoneVerifier,
+		},
+	],
+	[
+		blockHashHistoryAddress,
+		{
+			name: 'Block Hash History',
+			code: '0xef',
+			description: 'EIP-2935 historical block hash storage',
+			abi: [],
+			category: 'system',
+			docsUrl: 'https://eips.ethereum.org/EIPS/eip-2935',
+			address: blockHashHistoryAddress,
+		},
+	],
+	[
 		'0x9d136eea063ede5418a6bc7beaff009bbb6cfa70',
 		{
 			name: 'Tempo Stream Channel',
@@ -384,7 +451,14 @@ export const contractRegistry = new Map<Address.Address, ContractInfo>(
  * detect if an address is a system address (i.e., not a token)
  */
 export function systemAddress(address: Address.Address): boolean {
-	return systemContractRegistry.has(address.toLowerCase() as Address.Address)
+	return (
+		systemContractRegistry.has(address.toLowerCase() as Address.Address) ||
+		isZonePortalAddress(address)
+	)
+}
+
+export function isZonePortalAddress(address: Address.Address): boolean {
+	return address.toLowerCase().startsWith(zonePortalPrefix)
 }
 
 /**
@@ -394,23 +468,23 @@ export function systemAddress(address: Address.Address): boolean {
 export function getContractInfo(
 	address: Address.Address,
 ): ContractInfo | undefined {
-	const lowerAddress = address.toLowerCase() as Address.Address
-	const registered = contractRegistry.get(lowerAddress)
+	const registered = contractRegistry.get(
+		address.toLowerCase() as Address.Address,
+	)
 	if (registered) return registered
 
-	// TIP-1091 assigns each Zone Portal a deterministic address whose low eight
-	// bytes contain the zone ID. Use the canonical ABI instead of attempting to
-	// recover an incomplete interface from the portal's minimal-proxy bytecode.
-	if (lowerAddress.startsWith(zonePortalAddressPrefix))
+	if (isZonePortalAddress(address)) {
+		const zoneId = BigInt(`0x${address.slice(zonePortalPrefix.length)}`)
 		return {
 			address,
-			name: 'Zone Portal',
+			name: `Zone Portal #${zoneId}`,
 			code: '0xef',
 			description: 'Bridge assets between Tempo and a Tempo Zone',
-			abi: Abis.zonePortal,
+			abi: zonePortalAbi,
 			category: 'system',
-			docsUrl: 'https://tips.sh/1091',
+			docsUrl: 'https://docs.tempo.xyz/protocol/zones',
 		}
+	}
 
 	// Dynamic TIP-20 token detection
 	if (isTip20Address(address))

--- a/apps/explorer/src/lib/domain/known-events.ts
+++ b/apps/explorer/src/lib/domain/known-events.ts
@@ -247,7 +247,6 @@ function createDetectors(
 
 			if (eventName === 'DepositMade') {
 				const zoneName = getZoneName(address)
-				const memo = decodeMemoForDisplay(args.memo)
 				const note: NonNullable<KnownEvent['note']> = []
 
 				if (args.fee > 0n) {
@@ -256,6 +255,23 @@ function createDetectors(
 						{ type: 'amount', value: createAmount(args.fee, args.token) },
 					])
 				}
+				if (!('to' in args)) {
+					note.push(['Key Index', { type: 'number', value: args.keyIndex }])
+					return {
+						type: 'zone encrypted deposit',
+						parts: [
+							{ type: 'action', value: `Encrypted Deposit to ${zoneName}` },
+							{
+								type: 'amount',
+								value: createAmount(args.netAmount, args.token),
+							},
+						],
+						note,
+						meta: { from: args.sender, to: address },
+					}
+				}
+
+				const memo = decodeMemoForDisplay(args.memo)
 				if (memo) note.push(['Memo', { type: 'text', value: memo }])
 
 				return {
@@ -296,14 +312,33 @@ function createDetectors(
 
 			if (eventName === 'BatchSubmitted') {
 				const zoneName = getZoneName(address)
+				const note: NonNullable<KnownEvent['note']> = [
+					['Batch Index', { type: 'number', value: args.withdrawalBatchIndex }],
+					[
+						'Processed Deposits',
+						{ type: 'hex', value: args.nextProcessedDepositQueueHash },
+					],
+					['Next Block', { type: 'hex', value: args.nextBlockHash }],
+					[
+						'Withdrawal Queue',
+						{ type: 'hex', value: args.withdrawalQueueHash },
+					],
+				]
+				if ('withdrawalQueueIndex' in args) {
+					note.splice(1, 0, [
+						'Withdrawal Queue Index',
+						{ type: 'number', value: args.withdrawalQueueIndex },
+					])
+					note.push([
+						'Last Processed Deposit',
+						{ type: 'number', value: args.lastProcessedDepositNumber },
+					])
+				}
+
 				return {
 					type: 'zone batch submitted',
 					parts: [{ type: 'action', value: `Submit ${zoneName} Batch` }],
-					note: [
-						['Processed Deposits', { type: 'text', value: '' }],
-						['Next Block', { type: 'text', value: '' }],
-						['Withdrawal Queue', { type: 'text', value: '' }],
-					],
+					note,
 				}
 			}
 
@@ -341,7 +376,30 @@ function createDetectors(
 				}
 			}
 
-			if (eventName === 'ZoneCreated')
+			if (eventName === 'ZoneCreated') {
+				const note: NonNullable<KnownEvent['note']> = [
+					[
+						'Initial Token',
+						{ type: 'token', value: { address: args.initialToken } },
+					],
+					['Verifier', { type: 'account', value: args.verifier }],
+				]
+				if ('messenger' in args) {
+					note.unshift(
+						['Messenger', { type: 'account', value: args.messenger }],
+						['Sequencer', { type: 'account', value: args.sequencer }],
+					)
+				} else {
+					note.unshift(
+						...args.sequencers.map(
+							(sequencer, index): [string, KnownEventPart] => [
+								`Sequencer ${index + 1}`,
+								{ type: 'account', value: sequencer },
+							],
+						),
+					)
+				}
+
 				return {
 					type: 'zone created',
 					parts: [
@@ -350,17 +408,10 @@ function createDetectors(
 						{ type: 'text', value: 'at' },
 						{ type: 'account', value: args.portal },
 					],
-					note: [
-						['Messenger', { type: 'account', value: args.messenger }],
-						[
-							'Initial Token',
-							{ type: 'token', value: { address: args.initialToken } },
-						],
-						['Sequencer', { type: 'account', value: args.sequencer }],
-						['Verifier', { type: 'account', value: args.verifier }],
-					],
+					note,
 					meta: { from: address, to: args.portal },
 				}
+			}
 
 			if (eventName === 'TokenEnabled') {
 				const zoneName = getZoneName(address)

--- a/apps/explorer/test/contracts.node.test.ts
+++ b/apps/explorer/test/contracts.node.test.ts
@@ -1,9 +1,19 @@
 import { describe, expect, it } from 'vitest'
-import type { Abi } from 'viem'
+import { toEventSelector, type Abi } from 'viem'
+import { Addresses as ZoneAddresses } from 'viem-zones/tempo'
 import {
+	zoneFactoryAbi,
+	zoneMessengerAbi,
+	zonePortalAbi,
+	zoneVerifierAbi,
+} from '#lib/abis'
+import {
+	getAbiItem,
 	getContractInfo,
 	getReadFunctions,
 	getWriteFunctions,
+	isZonePortalAddress,
+	systemAddress,
 } from '#lib/domain/contracts'
 
 const proxyImplementationAbi = [
@@ -93,18 +103,81 @@ describe('contract function classification', () => {
 			])
 		}
 	})
+})
 
-	it('uses the canonical ABI for deterministic Zone Portal addresses', () => {
-		const info = getContractInfo('0x5Ad0000000000000000000000000000000000002')
+describe('Zone protocol contracts', () => {
+	it('registers the Zone protocol addresses exported by viem', () => {
+		expect(getContractInfo(ZoneAddresses.zoneFactory)).toMatchObject({
+			name: 'Zone Factory',
+			abi: zoneFactoryAbi,
+		})
+		expect(
+			getContractInfo(ZoneAddresses.zonePortalImplementation),
+		).toMatchObject({
+			name: 'Zone Portal Implementation',
+			abi: zonePortalAbi,
+		})
+		expect(getContractInfo(ZoneAddresses.zoneMessenger)).toMatchObject({
+			name: 'Zone Messenger',
+			abi: zoneMessengerAbi,
+		})
+		expect(getContractInfo(ZoneAddresses.zoneVerifier)?.name).toBe(
+			'Zone Verifier',
+		)
+		expect(getContractInfo(ZoneAddresses.zoneVerifier)?.abi).toBe(
+			zoneVerifierAbi,
+		)
+	})
 
-		expect(info?.name).toBe('Zone Portal')
-		expect(getWriteFunctions(info?.abi ?? []).map((fn) => fn.name)).toEqual([
-			'deposit',
-			'depositEncrypted',
-		])
-		expect(getReadFunctions(info?.abi ?? []).map((fn) => fn.name)).toEqual([
-			'sequencerEncryptionKey',
-			'encryptionKeyCount',
-		])
+	it('exposes Zone registry and portal administration functions', () => {
+		expect(getReadFunctions(zoneFactoryAbi).map((fn) => fn.name)).toContain(
+			'zones',
+		)
+		expect(getReadFunctions(zonePortalAbi).map((fn) => fn.name)).toContain(
+			'tokenConfig',
+		)
+		expect(getWriteFunctions(zonePortalAbi).map((fn) => fn.name)).toContain(
+			'pause',
+		)
+		expect(
+			getAbiItem({ abi: zonePortalAbi, selector: '0x78fb159b' })?.name,
+		).toBe('submitBatch')
+		expect(
+			getAbiItem({ abi: zonePortalAbi, selector: '0x91aa3f04' })?.name,
+		).toBe('processWithdrawals')
+		expect(
+			getAbiItem({ abi: zonePortalAbi, selector: '0x005d97ef' })?.name,
+		).toBe('deliverWithdrawal')
+		expect(
+			getAbiItem({ abi: zoneMessengerAbi, selector: '0x11da5261' })?.name,
+		).toBe('relayMessage')
+		expect(
+			getAbiItem({ abi: zoneVerifierAbi, selector: '0x7106a43e' })?.name,
+		).toBe('verify')
+		expect(
+			zonePortalAbi.some(
+				(item) =>
+					item.type === 'event' &&
+					toEventSelector(item) ===
+						'0x5a66941dc92cb865480c966eff640c02b1d00d544b74332fd67c6f1cbfccdf39',
+			),
+		).toBe(true)
+	})
+
+	it('recognizes deterministic Zone Portal proxy addresses', () => {
+		const portal = '0x5ad0000000000000000000000000000000000003'
+
+		expect(isZonePortalAddress(portal)).toBe(true)
+		expect(systemAddress(portal)).toBe(true)
+		expect(getContractInfo(portal)).toMatchObject({
+			name: 'Zone Portal #3',
+			abi: zonePortalAbi,
+		})
+	})
+
+	it('recognizes the EIP-2935 history contract', () => {
+		expect(
+			getContractInfo('0x0000f90827f1c53a10cb7a02335b175320002935'),
+		).toMatchObject({ name: 'Block Hash History' })
 	})
 })

--- a/apps/explorer/test/known-events.test.ts
+++ b/apps/explorer/test/known-events.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from 'vitest'
 import * as Address from 'ox/Address'
 import type * as Hex from 'ox/Hex'
-import { encodeAbiParameters, encodeEventTopics, zeroHash } from 'viem'
+import { encodeAbiParameters, encodeEventTopics, toHex, zeroHash } from 'viem'
 import { Addresses } from 'viem/tempo'
-import { Abis, stablecoinDexAbi } from '#lib/abis'
+import { Abis, stablecoinDexAbi, zoneFactoryAbi } from '#lib/abis'
 import {
 	accountAddress,
 	getTokenMetadata,
@@ -202,6 +202,114 @@ describe('parseKnownEvents', () => {
 		expect(knownEvents[0]?.parts[0]).toEqual({
 			type: 'action',
 			value: 'Deposit to Zone E',
+		})
+	})
+
+	it('decodes current ZoneCreated events', () => {
+		const hash = `0x${'4'.repeat(64)}` as const
+		const portal = `0x${'7'.repeat(40)}` as const
+		const verifier = `0x${'6'.repeat(40)}` as const
+		const sequencers = [accountAddress, recipientAddress] as const
+		const logs = [
+			mockLog(
+				{
+					address: Addresses.tip20Factory,
+					topics: encodeEventTopics({
+						abi: zoneFactoryAbi,
+						eventName: 'ZoneCreated',
+						args: { zoneId: 8, portal },
+					}) as [Hex.Hex, ...Hex.Hex[]],
+					data: encodeAbiParameters(
+						[
+							{ type: 'address' },
+							{ type: 'bool' },
+							{ type: 'bool' },
+							{ type: 'address' },
+							{ type: 'address[]' },
+							{ type: 'uint8' },
+							{ type: 'address' },
+						],
+						[
+							userTokenAddress,
+							true,
+							false,
+							accountAddress,
+							sequencers,
+							2,
+							verifier,
+						],
+					),
+				},
+				hash,
+			),
+		]
+
+		const [event] = parseKnownEvents(mockReceipt(logs, accountAddress, hash), {
+			getTokenMetadata,
+		})
+
+		expect(event).toMatchObject({
+			type: 'zone created',
+			note: [
+				[
+					'Sequencer 1',
+					{ type: 'account', value: Address.checksum(accountAddress) },
+				],
+				[
+					'Sequencer 2',
+					{ type: 'account', value: Address.checksum(recipientAddress) },
+				],
+				['Initial Token', { type: 'token' }],
+				['Verifier', { type: 'account', value: Address.checksum(verifier) }],
+			],
+			meta: { to: Address.checksum(portal) },
+		})
+	})
+
+	it('decodes current BatchSubmitted events', () => {
+		const hash = `0x${'5'.repeat(64)}` as const
+		const portal = '0x5ad0000000000000000000000000000000000003' as const
+		const nextProcessedHash = `0x${'1'.repeat(64)}` as const
+		const nextBlockHash = `0x${'2'.repeat(64)}` as const
+		const withdrawalQueueHash = `0x${'3'.repeat(64)}` as const
+		const logs = [
+			mockLog(
+				{
+					address: portal,
+					topics: [
+						'0x5a66941dc92cb865480c966eff640c02b1d00d544b74332fd67c6f1cbfccdf39',
+						toHex(337n, { size: 32 }),
+						toHex(4n, { size: 32 }),
+					],
+					data: encodeAbiParameters(
+						[
+							{ type: 'bytes32' },
+							{ type: 'bytes32' },
+							{ type: 'bytes32' },
+							{ type: 'uint64' },
+						],
+						[nextProcessedHash, nextBlockHash, withdrawalQueueHash, 35n],
+					),
+				},
+				hash,
+			),
+		]
+
+		const [event] = parseKnownEvents(mockReceipt(logs, accountAddress, hash), {
+			getTokenMetadata,
+		})
+
+		expect(event).toMatchObject({
+			type: 'zone batch submitted',
+			parts: [{ type: 'action', value: 'Submit Zone Batch' }],
+			note: [
+				['Batch Index', { type: 'number', value: 337n }],
+				['Withdrawal Queue Index', { type: 'number', value: 4n }],
+				['Processed Deposits', { type: 'hex', value: nextProcessedHash }],
+				['Next Block', { type: 'hex', value: nextBlockHash }],
+				['Withdrawal Queue', { type: 'hex', value: withdrawalQueueHash }],
+				['Last Processed Deposit', { type: 'number', value: 35n }],
+			],
 		})
 	})
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -467,6 +467,9 @@ importers:
       viem:
         specifier: 'catalog:'
         version: 2.55.0(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6)
+      viem-zones:
+        specifier: https://pkg.pr.new/viem@5030
+        version: viem@https://pkg.pr.new/viem@5030(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6)
       wagmi:
         specifier: 'catalog:'
         version: 3.6.9(@tanstack/query-core@5.96.2)(@tanstack/react-query@5.96.2(react@19.2.5))(@types/react@19.2.14)(accounts@0.14.9)(react@19.2.5)(typescript@6.0.2)(viem@2.55.0(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6))
@@ -676,7 +679,7 @@ importers:
     dependencies:
       accounts:
         specifier: 'catalog:'
-        version: 0.14.9(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@types/react@19.2.14)(@wagmi/core@3.4.8)(express@5.2.1)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.55.0(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3))(wagmi@3.6.9)
+        version: 0.14.9(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@types/react@19.2.14)(@wagmi/core@3.4.8)(express@5.2.1)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.55.19(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3))(wagmi@3.6.9)
     devDependencies:
       '@cloudflare/workers-types':
         specifier: 'catalog:'
@@ -6855,6 +6858,14 @@ packages:
       typescript:
         optional: true
 
+  ox@0.14.34:
+    resolution: {integrity: sha512-12seOIk7dv8eAoGQhcWaeKZxNz304IVcDvb9U5Y7JZAEVe21Nm1YMxLjhWah+su5BD4Omx4Zz0z5x3ij9M4GYQ==}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   ox@0.9.17:
     resolution: {integrity: sha512-rKAnhzhRU3Xh3hiko+i1ZxywZ55eWQzeS/Q4HRKLx2PqfHOolisZHErSsJVipGlmQKHW5qwOED/GighEw9dbLg==}
     peerDependencies:
@@ -7503,11 +7514,6 @@ packages:
     engines: {node: '>=20.16.0'}
     hasBin: true
 
-  srvx@0.11.15:
-    resolution: {integrity: sha512-iXsux0UcOjdvs0LCMa2Ws3WwcDUozA3JN3BquNXkaFPP7TpRqgunKdEgoZ/uwb1J6xaYHfxtz9Twlh6yzwM6Tg==}
-    engines: {node: '>=20.16.0'}
-    hasBin: true
-
   srvx@0.11.22:
     resolution: {integrity: sha512-LqZxxBDMKuMAZzFzJnDCkFOrs9MZQZr0LvHiO/SuSZVdQaXD7xQ5UWTUxheJrQPve1qk9MG2B/yttUvJxw8egQ==}
     engines: {node: '>=20.16.0'}
@@ -7652,7 +7658,7 @@ packages:
     engines: {node: '>=6'}
 
   tapimo@https://pkg.pr.new/tempoxyz/api/tapimo@500:
-    resolution: {tarball: https://pkg.pr.new/tempoxyz/api/tapimo@500}
+    resolution: {integrity: sha512-IdWa52xxYx2vAZL7GXB0iYWqFriD7XQlBj+Z1MhP5VjWBrGJ1G4dY5HBvirDNoX4zBIWWiuRl8hNjwqsLxr1RA==, tarball: https://pkg.pr.new/tempoxyz/api/tapimo@500}
     version: 0.6.0
     hasBin: true
 
@@ -8018,6 +8024,23 @@ packages:
 
   viem@2.55.0:
     resolution: {integrity: sha512-5XWSTCTmNvHCeT38Fsp31uofmOZFJdj4nOUH+H2Vh/hzsx9M7r+KgL3fSYUZeVn4H0UyQxjwPFqEaV4M0CI1tA==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  viem@2.55.19:
+    resolution: {integrity: sha512-4QPIX0eYPLsOBk53NKswVMkQoxuP7GlOBnB4wM6dkDokREO4QENNc3bmyPKK1PBTViXh0TPJCHLjIuU20Qi3fg==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  viem@https://pkg.pr.new/viem@5030:
+    resolution: {integrity: sha512-7UF5oCap4591vU9Oy9JhvvcdMgtxAwnrCrvrrg+Qb4FZUlAEPpMcazzUp6IuV/EdIozk+L9RCNsVBP9aO5wCRQ==, tarball: https://pkg.pr.new/viem@5030}
+    version: 2.55.19
     peerDependencies:
       typescript: '>=5.0.4'
     peerDependenciesMeta:
@@ -11113,7 +11136,7 @@ snapshots:
 
   '@tanstack/devtools-event-bus@0.4.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)':
     dependencies:
-      ws: 8.20.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -11769,12 +11792,12 @@ snapshots:
       accounts: 0.14.9(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(@types/react@19.2.14)(@wagmi/core@3.4.8)(express@5.2.1)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.55.0(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6))(wagmi@3.6.9)
       typescript: 6.0.2
 
-  '@wagmi/connectors@8.0.9(@wagmi/core@3.4.8)(accounts@0.14.9)(typescript@6.0.2)(viem@2.55.0(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3))':
+  '@wagmi/connectors@8.0.9(@wagmi/core@3.4.8)(accounts@0.14.9)(typescript@6.0.2)(viem@2.55.19(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3))':
     dependencies:
-      '@wagmi/core': 3.4.8(@tanstack/query-core@5.96.2)(@types/react@19.2.14)(accounts@0.14.9)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.55.0(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3))
-      viem: 2.55.0(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3)
+      '@wagmi/core': 3.4.8(@tanstack/query-core@5.96.2)(@types/react@19.2.14)(accounts@0.14.9)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.55.19(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3))
+      viem: 2.55.19(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3)
     optionalDependencies:
-      accounts: 0.14.9(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@types/react@19.2.14)(@wagmi/core@3.4.8)(express@5.2.1)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.55.0(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3))(wagmi@3.6.9)
+      accounts: 0.14.9(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@types/react@19.2.14)(@wagmi/core@3.4.8)(express@5.2.1)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.55.19(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3))(wagmi@3.6.9)
       typescript: 6.0.2
     optional: true
 
@@ -11794,15 +11817,31 @@ snapshots:
       accounts: 0.8.5(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@types/react@19.2.14)(@wagmi/core@3.4.8)(express@5.2.1)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.55.0(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3))(wagmi@3.6.9)
       typescript: 6.0.2
 
-  '@wagmi/core@3.4.8(@tanstack/query-core@5.96.2)(@types/react@19.2.14)(accounts@0.14.9)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.55.0(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3))':
+  '@wagmi/core@3.4.8(@tanstack/query-core@5.96.2)(@types/react@19.2.14)(accounts@0.14.9)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.55.0(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6))':
     dependencies:
       eventemitter3: 5.0.1
       mipd: 0.0.7(typescript@6.0.2)
-      viem: 2.55.0(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3)
+      viem: 2.55.0(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6)
       zustand: 5.0.0(@types/react@19.2.14)(react@19.2.5)(use-sync-external-store@1.4.0(react@19.2.5))
     optionalDependencies:
       '@tanstack/query-core': 5.96.2
-      accounts: 0.14.9(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@types/react@19.2.14)(@wagmi/core@3.4.8)(express@5.2.1)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.55.0(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3))(wagmi@3.6.9)
+      accounts: 0.14.9(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(@types/react@19.2.14)(@wagmi/core@3.4.8)(express@5.2.1)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.55.0(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6))(wagmi@3.6.9)
+      typescript: 6.0.2
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+      - react
+      - use-sync-external-store
+
+  '@wagmi/core@3.4.8(@tanstack/query-core@5.96.2)(@types/react@19.2.14)(accounts@0.14.9)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.55.19(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3))':
+    dependencies:
+      eventemitter3: 5.0.1
+      mipd: 0.0.7(typescript@6.0.2)
+      viem: 2.55.19(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3)
+      zustand: 5.0.0(@types/react@19.2.14)(react@19.2.5)(use-sync-external-store@1.4.0(react@19.2.5))
+    optionalDependencies:
+      '@tanstack/query-core': 5.96.2
+      accounts: 0.14.9(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@types/react@19.2.14)(@wagmi/core@3.4.8)(express@5.2.1)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.55.19(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3))(wagmi@3.6.9)
       typescript: 6.0.2
     transitivePeerDependencies:
       - '@types/react'
@@ -11827,15 +11866,15 @@ snapshots:
       - react
       - use-sync-external-store
 
-  '@wagmi/core@3.4.8(@tanstack/query-core@5.96.2)(@types/react@19.2.14)(accounts@0.14.9)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.55.0(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3))':
+  '@wagmi/core@3.4.8(@tanstack/query-core@5.96.2)(@types/react@19.2.14)(accounts@0.14.9)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.55.19(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3))':
     dependencies:
       eventemitter3: 5.0.1
       mipd: 0.0.7(typescript@6.0.2)
-      viem: 2.55.0(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3)
+      viem: 2.55.19(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3)
       zustand: 5.0.0(@types/react@19.2.14)(react@19.2.5)(use-sync-external-store@1.6.0(react@19.2.5))
     optionalDependencies:
       '@tanstack/query-core': 5.96.2
-      accounts: 0.14.9(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@types/react@19.2.14)(@wagmi/core@3.4.8)(express@5.2.1)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.55.0(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3))(wagmi@3.6.9)
+      accounts: 0.14.9(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@types/react@19.2.14)(@wagmi/core@3.4.8)(express@5.2.1)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.55.19(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3))(wagmi@3.6.9)
       typescript: 6.0.2
     transitivePeerDependencies:
       - '@types/react'
@@ -11963,23 +12002,23 @@ snapshots:
       - typescript
       - use-sync-external-store
 
-  accounts@0.14.9(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@types/react@19.2.14)(@wagmi/core@3.4.8)(express@5.2.1)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.55.0(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3))(wagmi@3.6.9):
+  accounts@0.14.9(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(@types/react@19.2.14)(@wagmi/core@3.4.8)(express@5.2.1)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.55.19(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3))(wagmi@3.6.9):
     dependencies:
       hono: 4.12.31
       idb-keyval: 6.2.2
       jose: 6.2.3
       mipd: 0.0.7(typescript@6.0.2)
-      mppx: 0.6.28(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(hono@4.12.31)(typescript@6.0.2)(viem@2.55.0(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3))
+      mppx: 0.6.28(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(hono@4.12.31)(typescript@6.0.2)(viem@2.55.19(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3))
       ox: 0.14.27(typescript@6.0.2)(zod@4.4.3)
       wata: 0.0.1(typescript@6.0.2)
       webauthx: 0.1.2(typescript@6.0.2)(zod@4.4.3)
       zod: 4.4.3
       zustand: 5.0.13(@types/react@19.2.14)(react@19.2.5)(use-sync-external-store@1.6.0(react@19.2.5))
     optionalDependencies:
-      '@wagmi/core': 3.4.8(@tanstack/query-core@5.96.2)(@types/react@19.2.14)(accounts@0.14.9)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.55.0(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3))
+      '@wagmi/core': 3.4.8(@tanstack/query-core@5.96.2)(@types/react@19.2.14)(accounts@0.14.9)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.55.19(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3))
       react: 19.2.5
-      viem: 2.55.0(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3)
-      wagmi: 3.6.9(@tanstack/query-core@5.96.2)(@tanstack/react-query@5.96.2(react@19.2.5))(@types/react@19.2.14)(accounts@0.14.9)(react@19.2.5)(typescript@6.0.2)(viem@2.55.0(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3))
+      viem: 2.55.19(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3)
+      wagmi: 3.6.9(@tanstack/query-core@5.96.2)(@tanstack/react-query@5.96.2(react@19.2.5))(@types/react@19.2.14)(accounts@0.14.9)(react@19.2.5)(typescript@6.0.2)(viem@2.55.19(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3))
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
       - '@types/react'
@@ -11996,7 +12035,7 @@ snapshots:
       jose: 6.2.3
       mipd: 0.0.7(typescript@6.0.2)
       mppx: 0.8.9(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(express@5.2.1)(hono@4.12.31)(typescript@6.0.2)(viem@2.54.6(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3))
-      ox: 0.14.30(typescript@6.0.2)(zod@4.4.3)
+      ox: 0.14.34(typescript@6.0.2)(zod@4.4.3)
       wata: 0.4.0(react@19.2.5)(typescript@6.0.2)
       webauthx: 0.1.2(typescript@6.0.2)(zod@4.4.3)
       zod: 4.4.3
@@ -12022,7 +12061,7 @@ snapshots:
       idb-keyval: 6.2.2
       mipd: 0.0.7(typescript@6.0.2)
       mppx: 0.6.5(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(express@5.2.1)(hono@4.12.31)(typescript@6.0.2)(viem@2.55.0(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6))
-      ox: 0.14.30(typescript@6.0.2)(zod@4.4.3)
+      ox: 0.14.34(typescript@6.0.2)(zod@4.4.3)
       webauthx: 0.1.2(typescript@6.0.2)(zod@4.4.3)
       zod: 4.4.3
       zustand: 5.0.13(@types/react@19.2.14)(react@19.2.5)(use-sync-external-store@1.6.0(react@19.2.5))
@@ -12047,7 +12086,7 @@ snapshots:
       idb-keyval: 6.2.2
       mipd: 0.0.7(typescript@6.0.2)
       mppx: 0.6.5(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(hono@4.12.31)(typescript@6.0.2)(viem@2.55.0(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3))
-      ox: 0.14.30(typescript@6.0.2)(zod@4.4.3)
+      ox: 0.14.34(typescript@6.0.2)(zod@4.4.3)
       webauthx: 0.1.2(typescript@6.0.2)(zod@4.4.3)
       zod: 4.4.3
       zustand: 5.0.13(@types/react@19.2.14)(react@19.2.5)(use-sync-external-store@1.6.0(react@19.2.5))
@@ -13304,7 +13343,7 @@ snapshots:
   h3@2.0.1-rc.16:
     dependencies:
       rou3: 0.8.1
-      srvx: 0.11.15
+      srvx: 0.11.22
 
   has-flag@4.0.0: {}
 
@@ -13609,7 +13648,7 @@ snapshots:
   incur@0.3.25:
     dependencies:
       '@cfworker/json-schema': 4.1.1
-      '@modelcontextprotocol/server': 2.0.0-alpha.2(@cfworker/json-schema@4.1.1)
+      '@modelcontextprotocol/server': 2.0.0-alpha.4
       '@toon-format/toon': 2.2.0
       tokenx: 1.3.0
       yaml: 2.8.3
@@ -14498,11 +14537,11 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  mppx@0.6.28(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(hono@4.12.31)(typescript@6.0.2)(viem@2.55.0(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3)):
+  mppx@0.6.28(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(express@5.2.1)(hono@4.12.31)(typescript@6.0.2)(viem@2.55.19(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3)):
     dependencies:
       incur: 0.4.9
       ox: 0.14.22(typescript@6.0.2)(zod@4.4.3)
-      viem: 2.55.0(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3)
+      viem: 2.55.19(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3)
       zod: 4.4.3
     optionalDependencies:
       '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3)
@@ -14755,6 +14794,36 @@ snapshots:
       - zod
 
   ox@0.14.30(typescript@6.0.2)(zod@4.4.3):
+    dependencies:
+      '@adraffy/ens-normalize': 1.11.1
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.4(typescript@6.0.2)(zod@4.4.3)
+      eventemitter3: 5.0.1
+    optionalDependencies:
+      typescript: 6.0.2
+    transitivePeerDependencies:
+      - zod
+
+  ox@0.14.34(typescript@6.0.2)(zod@4.3.6):
+    dependencies:
+      '@adraffy/ens-normalize': 1.11.1
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.4(typescript@6.0.2)(zod@4.3.6)
+      eventemitter3: 5.0.1
+    optionalDependencies:
+      typescript: 6.0.2
+    transitivePeerDependencies:
+      - zod
+
+  ox@0.14.34(typescript@6.0.2)(zod@4.4.3):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
       '@noble/ciphers': 1.3.0
@@ -15642,8 +15711,6 @@ snapshots:
 
   srvx@0.11.12: {}
 
-  srvx@0.11.15: {}
-
   srvx@0.11.22: {}
 
   ssh-remote-port-forward@1.0.4:
@@ -16318,6 +16385,40 @@ snapshots:
       - utf-8-validate
       - zod
 
+  viem@2.55.19(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3):
+    dependencies:
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@6.0.2)(zod@4.4.3)
+      isows: 1.0.7(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
+      ox: 0.14.34(typescript@6.0.2)(zod@4.4.3)
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+    optionalDependencies:
+      typescript: 6.0.2
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - zod
+
+  viem@https://pkg.pr.new/viem@5030(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6):
+    dependencies:
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@6.0.2)(zod@4.3.6)
+      isows: 1.0.7(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
+      ox: 0.14.34(typescript@6.0.2)(zod@4.3.6)
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+    optionalDependencies:
+      typescript: 6.0.2
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - zod
+
   vite-plugin-arraybuffer@0.1.4: {}
 
   vite-plugin-devtools-json@1.0.0(vite@8.0.7(@types/node@25.5.2)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.8.3)):
@@ -16530,7 +16631,7 @@ snapshots:
     dependencies:
       '@tanstack/react-query': 5.96.2(react@19.2.5)
       '@wagmi/connectors': 8.0.9(@wagmi/core@3.4.8)(accounts@0.14.9)(typescript@6.0.2)(viem@2.55.0(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6))
-      '@wagmi/core': 3.4.8(@tanstack/query-core@5.96.2)(@types/react@19.2.14)(accounts@0.14.9)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.6.0(react@19.2.5))(viem@2.55.0(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6))
+      '@wagmi/core': 3.4.8(@tanstack/query-core@5.96.2)(@types/react@19.2.14)(accounts@0.14.9)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.55.0(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6))
       react: 19.2.5
       use-sync-external-store: 1.4.0(react@19.2.5)
       viem: 2.55.0(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.3.6)
@@ -16549,14 +16650,14 @@ snapshots:
       - immer
       - porto
 
-  wagmi@3.6.9(@tanstack/query-core@5.96.2)(@tanstack/react-query@5.96.2(react@19.2.5))(@types/react@19.2.14)(accounts@0.14.9)(react@19.2.5)(typescript@6.0.2)(viem@2.55.0(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3)):
+  wagmi@3.6.9(@tanstack/query-core@5.96.2)(@tanstack/react-query@5.96.2(react@19.2.5))(@types/react@19.2.14)(accounts@0.14.9)(react@19.2.5)(typescript@6.0.2)(viem@2.55.19(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3)):
     dependencies:
       '@tanstack/react-query': 5.96.2(react@19.2.5)
-      '@wagmi/connectors': 8.0.9(@wagmi/core@3.4.8)(accounts@0.14.9)(typescript@6.0.2)(viem@2.55.0(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3))
-      '@wagmi/core': 3.4.8(@tanstack/query-core@5.96.2)(@types/react@19.2.14)(accounts@0.14.9)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.55.0(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3))
+      '@wagmi/connectors': 8.0.9(@wagmi/core@3.4.8)(accounts@0.14.9)(typescript@6.0.2)(viem@2.55.19(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3))
+      '@wagmi/core': 3.4.8(@tanstack/query-core@5.96.2)(@types/react@19.2.14)(accounts@0.14.9)(react@19.2.5)(typescript@6.0.2)(use-sync-external-store@1.4.0(react@19.2.5))(viem@2.55.19(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3))
       react: 19.2.5
       use-sync-external-store: 1.4.0(react@19.2.5)
-      viem: 2.55.0(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3)
+      viem: 2.55.19(bufferutil@4.1.0)(typescript@6.0.2)(utf-8-validate@5.0.10)(zod@4.4.3)
     optionalDependencies:
       typescript: 6.0.2
     transitivePeerDependencies:
@@ -16625,7 +16726,7 @@ snapshots:
       '@noble/ciphers': 2.2.0
       '@noble/hashes': 2.2.0
       hono: 4.12.31
-      ox: 0.14.30(typescript@6.0.2)(zod@4.4.3)
+      ox: 0.14.34(typescript@6.0.2)(zod@4.4.3)
       rettime: 0.11.11
       zod: 4.4.3
     transitivePeerDependencies:
@@ -16637,7 +16738,7 @@ snapshots:
       '@noble/ciphers': 2.2.0
       '@noble/hashes': 2.2.0
       hono: 4.12.31
-      ox: 0.14.30(typescript@6.0.2)(zod@4.4.3)
+      ox: 0.14.34(typescript@6.0.2)(zod@4.4.3)
       zod: 4.4.3
     optionalDependencies:
       react: 19.2.5
@@ -16658,7 +16759,7 @@ snapshots:
 
   webauthx@0.1.2(typescript@6.0.2)(zod@4.4.3):
     dependencies:
-      ox: 0.14.30(typescript@6.0.2)(zod@4.4.3)
+      ox: 0.14.34(typescript@6.0.2)(zod@4.4.3)
     transitivePeerDependencies:
       - typescript
       - zod


### PR DESCRIPTION
## Summary

- restore the full Zone Factory, Portal, Messenger, Verifier, and Outbox metadata from the original #1188 stack
- identify deterministic Zone Portal addresses and render their canonical full ABI
- decode portal proxy calldata and withdrawal-related trace calls
- replace the four-function ABI introduced in #1198

The `viem-zones` alias uses the artifact from merged [wevm/viem#5030](https://github.com/wevm/viem/pull/5030), which has not reached the stable viem package yet.

## Screenshots

| Before | After |
|---|---|
| 2 writes and 2 reads | 6 writes and 11 reads, including `submitBatch`, `tokenConfig`, and portal administration |

## Validation

- `pnpm --filter explorer check` (20 files, 101 tests)
- `pnpm --filter explorer test` (13 files, 65 tests)
- `pnpm precommit`
- browser verification on the mainnet Zone E portal: full ABI rendered with zero RPC errors

Prompted by: @snario
