### PR TITLE
fix(explorer): restore Zone event descriptions

### DIFF
--- a/apps/explorer/src/lib/domain/contracts.ts
+++ b/apps/explorer/src/lib/domain/contracts.ts
@@ -17,18 +17,21 @@ import {
 	tip20ChannelReserveAddress,
 	zoneFactoryAbi,
 	zoneMessengerAbi,
+	zoneOutboxAbi,
 	zonePortalAbi,
 	zoneVerifierAbi,
 } from '#lib/abis'
 import { getChainId, getPublicClient } from 'wagmi/actions'
 import { isTip20Address } from '#lib/domain/tip20.ts'
+import { getZonePortalId, isZonePortalAddress } from '#lib/domain/zones.ts'
 import { getWagmiConfig } from '#wagmi.config.ts'
+
+export { isZonePortalAddress } from '#lib/domain/zones.ts'
 
 const validatorConfigV2Address =
 	'0xcccccccc00000000000000000000000000000001' as const
 export const blockHashHistoryAddress =
 	'0x0000f90827f1c53a10cb7a02335b175320002935' as const
-const zonePortalPrefix = '0x5ad000000000000000000000' as const
 
 /**
  * Registry of known contract addresses to their ABIs and metadata.
@@ -386,6 +389,18 @@ export const systemContractRegistry = new Map<Address.Address, ContractInfo>(<
 		},
 	],
 	[
+		ZoneAddresses.zoneOutbox,
+		{
+			name: 'Zone Outbox',
+			code: '0xef',
+			description: 'Request withdrawals from a Tempo Zone',
+			abi: zoneOutboxAbi,
+			category: 'system',
+			docsUrl: 'https://docs.tempo.xyz/protocol/zones',
+			address: ZoneAddresses.zoneOutbox,
+		},
+	],
+	[
 		ZoneAddresses.zoneMessenger,
 		{
 			name: 'Zone Messenger',
@@ -457,10 +472,6 @@ export function systemAddress(address: Address.Address): boolean {
 	)
 }
 
-export function isZonePortalAddress(address: Address.Address): boolean {
-	return address.toLowerCase().startsWith(zonePortalPrefix)
-}
-
 /**
  * Get contract info by address (case-insensitive).
  * Also handles TIP-20 tokens that aren't explicitly registered.
@@ -474,7 +485,7 @@ export function getContractInfo(
 	if (registered) return registered
 
 	if (isZonePortalAddress(address)) {
-		const zoneId = BigInt(`0x${address.slice(zonePortalPrefix.length)}`)
+		const zoneId = getZonePortalId(address)
 		return {
 			address,
 			name: `Zone Portal #${zoneId}`,

--- a/apps/explorer/src/lib/domain/known-events.ts
+++ b/apps/explorer/src/lib/domain/known-events.ts
@@ -9,7 +9,18 @@ import {
 	zeroAddress,
 } from 'viem'
 import { Addresses } from 'viem/tempo'
-import { Abis, allAbis } from '#lib/abis'
+import { Addresses as ZoneAddresses } from 'viem-zones/tempo'
+import {
+	Abis,
+	allAbis,
+	zoneFactoryAbi,
+	zoneOutboxAbi,
+	zonePortalAbi,
+} from '#lib/abis'
+import {
+	getZonePortalId,
+	isZonePortalAddress as isDeterministicZonePortalAddress,
+} from '#lib/domain/zones'
 import { decodeMemoForDisplay, isMppAttributionMemo } from '#lib/domain/memo'
 import type * as Tip20 from './tip20'
 
@@ -45,15 +56,16 @@ const KNOWN_ZONES: ReadonlyMap<Address.Address, { name: string }> = new Map([
 	],
 ])
 
-const ZONE_PORTAL_EVENT_NAMES = new Set([
-	'DepositMade',
-	'EncryptedDepositMade',
-	'BatchSubmitted',
-	'WithdrawalProcessed',
-	'BounceBack',
-	'SequencerTransferred',
-	'TokenEnabled',
-])
+const ZONE_EVENT_NAMES = new Set(
+	[...Abis.zoneFactory, ...Abis.zonePortal, ...Abis.zoneOutbox]
+		.filter((item) => item.type === 'event')
+		.map((item) => item.name),
+)
+const ZONE_PORTAL_EVENT_NAMES = new Set(
+	Abis.zonePortal
+		.filter((item) => item.type === 'event')
+		.map((item) => item.name),
+)
 
 function createZoneDepositTransferKey(params: {
 	sender: Address.Address
@@ -112,6 +124,54 @@ function checksumAddress(address: string): Address.Address {
 	return Address.from(address, { checksum: true })
 }
 
+function humanizeIdentifier(value: string): string {
+	return value
+		.replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+		.replace(/^./, (character) => character.toUpperCase())
+}
+
+function formatZoneEventAction(eventName: string, zoneName: string): string {
+	const transformations = [
+		['Updated', 'Update'],
+		['Paused', 'Pause'],
+		['Resumed', 'Resume'],
+		['Transferred', 'Transfer'],
+		['Started', 'Start'],
+		['Scheduled', 'Schedule'],
+		['Claimed', 'Claim'],
+		['Requested', 'Request'],
+	] as const
+
+	for (const [suffix, verb] of transformations) {
+		if (!eventName.endsWith(suffix)) continue
+		const subject = humanizeIdentifier(eventName.slice(0, -suffix.length))
+		return `${verb} ${zoneName} ${subject}`
+	}
+
+	return `${zoneName} ${humanizeIdentifier(eventName)}`
+}
+
+function formatZoneEventArgument(value: unknown): KnownEventPart {
+	if (typeof value === 'bigint' || typeof value === 'number')
+		return { type: 'number', value }
+	if (typeof value === 'boolean')
+		return { type: 'text', value: value ? 'Yes' : 'No' }
+	if (typeof value === 'string') {
+		if (/^0x[\da-fA-F]{40}$/.test(value))
+			return { type: 'account', value: checksumAddress(value) }
+		if (/^0x[\da-fA-F]*$/.test(value))
+			return { type: 'hex', value: value as Hex.Hex }
+		return { type: 'text', value }
+	}
+
+	return {
+		type: 'text',
+		value: JSON.stringify(value, (_, item) =>
+			typeof item === 'bigint' ? item.toString() : item,
+		),
+	}
+}
+
 function decodeClaimReceiptV1(receipt: Hex.Hex) {
 	try {
 		const [
@@ -168,9 +228,17 @@ function createZonePortalMetadata(events: ParsedEvent[]) {
 			continue
 		}
 
-		if (ZONE_PORTAL_EVENT_NAMES.has(event.eventName)) {
+		if (
+			isDeterministicZonePortalAddress(event.address) ||
+			ZONE_PORTAL_EVENT_NAMES.has(event.eventName)
+		) {
 			const portal = checksumAddress(event.address)
-			zonePortals.set(portal, zonePortals.get(portal) ?? { name: 'Zone' })
+			const zoneId = getZonePortalId(portal)
+			zonePortals.set(portal, {
+				name:
+					zonePortals.get(portal)?.name ??
+					(zoneId === undefined ? 'Zone' : `Zone ${zoneId}`),
+			})
 		}
 	}
 
@@ -444,6 +512,31 @@ function createDetectors(
 						['Previous', { type: 'account', value: args.previousSequencer }],
 					],
 					meta: { from: address, to: args.newSequencer },
+				}
+			}
+
+			if (ZONE_EVENT_NAMES.has(eventName)) {
+				const zoneName = isZonePortalAddress(address)
+					? getZoneName(address)
+					: 'Zone'
+				const note = Object.entries(args).map(
+					([name, value]): [string, KnownEventPart] => [
+						humanizeIdentifier(name),
+						formatZoneEventArgument(value),
+					],
+				)
+
+				return {
+					type: `zone ${eventName
+						.replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+						.toLowerCase()}`,
+					parts: [
+						{
+							type: 'action',
+							value: formatZoneEventAction(eventName, zoneName),
+						},
+					],
+					note: note.length > 0 ? note : undefined,
 				}
 			}
 
@@ -2101,6 +2194,7 @@ const VALIDATOR_CONFIG = '0xcccccccc00000000000000000000000000000000'
 type CallDecoder = (
 	functionName: string,
 	args: readonly unknown[],
+	to: Address.Address,
 ) => KnownEvent | null
 
 function decodeValidatorConfigCall(
@@ -2205,6 +2299,176 @@ function decodeValidatorConfigCall(
 	}
 }
 
+function decodeZoneFactoryCall(
+	functionName: string,
+	args: readonly unknown[],
+): KnownEvent | null {
+	if (functionName !== 'createZone') return null
+
+	const [params] = args as readonly [
+		{
+			initialToken: Address.Address
+			admin: Address.Address
+			sequencer?: Address.Address
+			sequencers?: readonly Address.Address[]
+			threshold?: number
+			rpcUrl: string
+			verifier?: Address.Address
+		},
+	]
+	const sequencers =
+		params.sequencers ?? (params.sequencer ? [params.sequencer] : [])
+	const note: NonNullable<KnownEvent['note']> = [
+		['Admin', { type: 'account', value: params.admin }],
+		...sequencers.map((sequencer, index): [string, KnownEventPart] => [
+			`Sequencer ${index + 1}`,
+			{ type: 'account', value: sequencer },
+		]),
+		['RPC URL', { type: 'text', value: params.rpcUrl }],
+	]
+	if (params.threshold !== undefined)
+		note.push(['Threshold', { type: 'number', value: params.threshold }])
+	if (params.verifier)
+		note.push(['Verifier', { type: 'account', value: params.verifier }])
+
+	return {
+		type: 'zone creation',
+		parts: [
+			{ type: 'action', value: 'Create Zone' },
+			{ type: 'text', value: 'with' },
+			{ type: 'token', value: { address: params.initialToken } },
+		],
+		note,
+	}
+}
+
+function decodeZonePortalCall(
+	functionName: string,
+	args: readonly unknown[],
+	to: Address.Address,
+): KnownEvent | null {
+	const zoneId = getZonePortalId(to)
+	const zoneName = zoneId === undefined ? 'Zone' : `Zone ${zoneId}`
+
+	switch (functionName) {
+		case 'deposit': {
+			const [token, recipient, amount, memo, refundRecipient] = args as [
+				Address.Address,
+				Address.Address,
+				bigint,
+				Hex.Hex,
+				Address.Address,
+			]
+			const note: NonNullable<KnownEvent['note']> = [
+				['Refund Recipient', { type: 'account', value: refundRecipient }],
+			]
+			const decodedMemo = decodeMemoForDisplay(memo)
+			if (decodedMemo)
+				note.unshift(['Memo', { type: 'text', value: decodedMemo }])
+			return {
+				type: 'zone deposit',
+				parts: [
+					{ type: 'action', value: `Deposit to ${zoneName}` },
+					{ type: 'amount', value: { token, value: amount } },
+					{ type: 'text', value: 'for' },
+					{ type: 'account', value: recipient },
+				],
+				note,
+			}
+		}
+		case 'depositEncrypted': {
+			const [token, amount, keyIndex, _encrypted, refundRecipient] = args as [
+				Address.Address,
+				bigint,
+				bigint,
+				unknown,
+				Address.Address,
+			]
+			return {
+				type: 'zone encrypted deposit',
+				parts: [
+					{ type: 'action', value: `Encrypted Deposit to ${zoneName}` },
+					{ type: 'amount', value: { token, value: amount } },
+				],
+				note: [
+					['Key Index', { type: 'number', value: keyIndex }],
+					['Refund Recipient', { type: 'account', value: refundRecipient }],
+				],
+			}
+		}
+		case 'pause':
+			return {
+				type: 'zone portal paused',
+				parts: [{ type: 'action', value: `Pause ${zoneName} Portal` }],
+			}
+		case 'submitBatch': {
+			const [
+				tempoBlockNumber,
+				_recentTempoBlockNumber,
+				_blockTransition,
+				_depositQueueTransition,
+				withdrawalQueueHash,
+				_verifierConfig,
+				_proof,
+				zoneHeight,
+			] = args as [
+				bigint,
+				bigint,
+				unknown,
+				unknown,
+				Hex.Hex,
+				Hex.Hex,
+				Hex.Hex,
+				bigint,
+				readonly Hex.Hex[],
+			]
+			return {
+				type: 'zone batch submission',
+				parts: [{ type: 'action', value: `Submit ${zoneName} Batch` }],
+				note: [
+					['Tempo Block', { type: 'number', value: tempoBlockNumber }],
+					['Zone Height', { type: 'number', value: zoneHeight }],
+					['Withdrawal Queue', { type: 'hex', value: withdrawalQueueHash }],
+				],
+			}
+		}
+		default:
+			return null
+	}
+}
+
+function decodeZoneOutboxCall(
+	functionName: string,
+	args: readonly unknown[],
+): KnownEvent | null {
+	if (functionName !== 'requestWithdrawal') return null
+	const [token, recipient, amount, memo, gasLimit, fallbackRecipient] =
+		args as [
+			Address.Address,
+			Address.Address,
+			bigint,
+			Hex.Hex,
+			bigint,
+			Address.Address,
+		]
+	const note: NonNullable<KnownEvent['note']> = [
+		['Gas Limit', { type: 'number', value: gasLimit }],
+		['Fallback Recipient', { type: 'account', value: fallbackRecipient }],
+	]
+	const decodedMemo = decodeMemoForDisplay(memo)
+	if (decodedMemo) note.unshift(['Memo', { type: 'text', value: decodedMemo }])
+	return {
+		type: 'zone withdrawal request',
+		parts: [
+			{ type: 'action', value: 'Request Zone Withdrawal' },
+			{ type: 'amount', value: { token, value: amount } },
+			{ type: 'text', value: 'to' },
+			{ type: 'account', value: recipient },
+		],
+		note,
+	}
+}
+
 const callDecoders: Record<
 	string,
 	{ abi: readonly unknown[]; decoder: CallDecoder }
@@ -2212,6 +2476,18 @@ const callDecoders: Record<
 	[VALIDATOR_CONFIG.toLowerCase()]: {
 		abi: Abis.validatorConfig,
 		decoder: decodeValidatorConfigCall,
+	},
+	[ZoneAddresses.zoneFactory.toLowerCase()]: {
+		abi: zoneFactoryAbi,
+		decoder: decodeZoneFactoryCall,
+	},
+	[ZoneAddresses.zonePortalImplementation.toLowerCase()]: {
+		abi: zonePortalAbi,
+		decoder: decodeZonePortalCall,
+	},
+	[ZoneAddresses.zoneOutbox.toLowerCase()]: {
+		abi: zoneOutboxAbi,
+		decoder: decodeZoneOutboxCall,
 	},
 }
 
@@ -2226,7 +2502,9 @@ export function decodeKnownCall(
 ): KnownEvent | null {
 	if (!input || input === '0x') return null
 
-	const entry = callDecoders[to.toLowerCase()]
+	const entry = isDeterministicZonePortalAddress(to)
+		? { abi: zonePortalAbi, decoder: decodeZonePortalCall }
+		: callDecoders[to.toLowerCase()]
 	if (!entry) return null
 
 	try {
@@ -2234,7 +2512,7 @@ export function decodeKnownCall(
 			abi: entry.abi as readonly unknown[],
 			data: input,
 		})
-		return entry.decoder(decoded.functionName, decoded.args ?? [])
+		return entry.decoder(decoded.functionName, decoded.args ?? [], to)
 	} catch {
 		return null
 	}

--- a/apps/explorer/src/lib/domain/zones.ts
+++ b/apps/explorer/src/lib/domain/zones.ts
@@ -1,0 +1,12 @@
+import type { Address } from 'ox'
+
+const zonePortalPrefix = '0x5ad000000000000000000000' as const
+
+export function isZonePortalAddress(address: Address.Address): boolean {
+	return address.toLowerCase().startsWith(zonePortalPrefix)
+}
+
+export function getZonePortalId(address: Address.Address): bigint | undefined {
+	if (!isZonePortalAddress(address)) return
+	return BigInt(`0x${address.slice(zonePortalPrefix.length)}`)
+}

--- a/apps/explorer/test/known-events.test.ts
+++ b/apps/explorer/test/known-events.test.ts
@@ -1,9 +1,23 @@
 import { describe, expect, it } from 'vitest'
 import * as Address from 'ox/Address'
 import type * as Hex from 'ox/Hex'
-import { encodeAbiParameters, encodeEventTopics, toHex, zeroHash } from 'viem'
+import type { AbiEvent, AbiParameter } from 'viem'
+import {
+	encodeAbiParameters,
+	encodeEventTopics,
+	encodeFunctionData,
+	toHex,
+	zeroHash,
+} from 'viem'
 import { Addresses } from 'viem/tempo'
-import { Abis, stablecoinDexAbi, zoneFactoryAbi } from '#lib/abis'
+import { Addresses as ZoneAddresses } from 'viem-zones/tempo'
+import {
+	Abis,
+	stablecoinDexAbi,
+	zoneFactoryAbi,
+	zoneOutboxAbi,
+	zonePortalAbi,
+} from '#lib/abis'
 import {
 	accountAddress,
 	getTokenMetadata,
@@ -12,7 +26,7 @@ import {
 	recipientAddress,
 	userTokenAddress,
 } from '#lib/demo'
-import { parseKnownEvents } from '#lib/domain/known-events'
+import { decodeKnownCall, parseKnownEvents } from '#lib/domain/known-events'
 
 const ZONE_5_PORTAL = '0x7069DeC4E64Fd07334A0933eDe836C17259c9B23' as const
 const ZONE_E_PORTAL = '0x59831A17340EE14FE136d751EfbeA8b630470fD2' as const
@@ -57,7 +71,191 @@ const depositMadeAbi = [
 	},
 ] as const
 
+function sampleZoneEventValue(parameter: AbiParameter): unknown {
+	const array = /^(.*)\[\]$/.exec(parameter.type)
+	if (array?.[1])
+		return [
+			sampleZoneEventValue({ ...parameter, type: array[1] } as AbiParameter),
+		]
+	if (parameter.type === 'address') return accountAddress
+	if (parameter.type === 'bool') return true
+	if (parameter.type === 'string') return 'test'
+	if (parameter.type === 'bytes') return '0x1234'
+	if (parameter.type.startsWith('bytes')) {
+		const size = Number(parameter.type.slice('bytes'.length))
+		return `0x${'11'.repeat(size)}`
+	}
+	if (/^u?int\d*$/.test(parameter.type)) return 1n
+	throw new Error(`Missing sample value for ${parameter.type}`)
+}
+
+function mockZoneEventLog(event: AbiEvent, address: Address.Address) {
+	const args = Object.fromEntries(
+		event.inputs.map((input) => [input.name, sampleZoneEventValue(input)]),
+	)
+	const dataInputs = event.inputs.filter((input) => !input.indexed)
+	return mockLog(
+		{
+			address,
+			topics: encodeEventTopics({
+				abi: [event],
+				eventName: event.name,
+				args,
+			}) as [Hex.Hex, ...Hex.Hex[]],
+			data: encodeAbiParameters(
+				dataInputs,
+				dataInputs.map(sampleZoneEventValue),
+			),
+		},
+		`0x${'9'.repeat(64)}`,
+	)
+}
+
 describe('parseKnownEvents', () => {
+	it('describes every Zone write call', () => {
+		const portal = '0x5ad0000000000000000000000000000000000003' as const
+		const calls = [
+			{
+				to: ZoneAddresses.zoneFactory,
+				input: encodeFunctionData({
+					abi: zoneFactoryAbi,
+					functionName: 'createZone',
+					args: [
+						{
+							initialToken: userTokenAddress,
+							accessMode: true,
+							gatewayMode: false,
+							allowedAccounts: [accountAddress],
+							zoneGateways: [],
+							admin: accountAddress,
+							sequencers: [recipientAddress],
+							threshold: 1,
+							rpcUrl: 'https://zone.example',
+						},
+					],
+				}),
+				action: 'Create Zone',
+			},
+			{
+				to: portal,
+				input: encodeFunctionData({
+					abi: zonePortalAbi,
+					functionName: 'deposit',
+					args: [
+						userTokenAddress,
+						recipientAddress,
+						1_000_000n,
+						zeroHash,
+						accountAddress,
+					],
+				}),
+				action: 'Deposit to Zone 3',
+			},
+			{
+				to: portal,
+				input: encodeFunctionData({
+					abi: zonePortalAbi,
+					functionName: 'depositEncrypted',
+					args: [
+						userTokenAddress,
+						1_000_000n,
+						1n,
+						{
+							ephemeralPubkeyX: zeroHash,
+							ephemeralPubkeyYParity: 2,
+							ciphertext: '0x1234',
+							nonce: `0x${'00'.repeat(12)}`,
+							tag: `0x${'00'.repeat(16)}`,
+						},
+						accountAddress,
+					],
+				}),
+				action: 'Encrypted Deposit to Zone 3',
+			},
+			{
+				to: portal,
+				input: encodeFunctionData({
+					abi: zonePortalAbi,
+					functionName: 'pause',
+				}),
+				action: 'Pause Zone 3 Portal',
+			},
+			{
+				to: portal,
+				input: encodeFunctionData({
+					abi: zonePortalAbi,
+					functionName: 'submitBatch',
+					args: [
+						1n,
+						0n,
+						{ prevBlockHash: zeroHash, nextBlockHash: zeroHash },
+						{
+							prevProcessedHash: zeroHash,
+							nextProcessedHash: zeroHash,
+							prevDepositNumber: 0n,
+							nextDepositNumber: 0n,
+						},
+						zeroHash,
+						'0x',
+						'0x',
+						1n,
+						[],
+					],
+				}),
+				action: 'Submit Zone 3 Batch',
+			},
+			{
+				to: ZoneAddresses.zoneOutbox,
+				input: encodeFunctionData({
+					abi: zoneOutboxAbi,
+					functionName: 'requestWithdrawal',
+					args: [
+						userTokenAddress,
+						recipientAddress,
+						1_000_000n,
+						zeroHash,
+						100_000n,
+						accountAddress,
+						'0x',
+						'0x',
+					],
+				}),
+				action: 'Request Zone Withdrawal',
+			},
+		] as const
+
+		for (const call of calls) {
+			expect(decodeKnownCall(call.to, call.input)?.parts[0]).toEqual({
+				type: 'action',
+				value: call.action,
+			})
+		}
+	})
+
+	it('maps every Zone ABI event to a known event', () => {
+		const portal = '0x5ad0000000000000000000000000000000000003' as const
+		const eventGroups = [
+			{ abi: zoneFactoryAbi, address: Addresses.tip20Factory },
+			{ abi: zonePortalAbi, address: portal },
+			{ abi: zoneOutboxAbi, address: accountAddress },
+		] as const
+
+		for (const { abi, address } of eventGroups) {
+			for (const item of abi) {
+				if (item.type !== 'event') continue
+				const receipt = mockReceipt(
+					[mockZoneEventLog(item, address)],
+					accountAddress,
+					`0x${'9'.repeat(64)}`,
+				)
+				expect(
+					parseKnownEvents(receipt, { getTokenMetadata }),
+					`${item.name} should be a known event`,
+				).toHaveLength(1)
+			}
+		}
+	})
+
 	it('decodes stablecoin DEX OrderFlipped buy and sell events', () => {
 		const hash = `0x${'6'.repeat(64)}` as const
 		const amount = 1_000_000n
@@ -301,7 +499,7 @@ describe('parseKnownEvents', () => {
 
 		expect(event).toMatchObject({
 			type: 'zone batch submitted',
-			parts: [{ type: 'action', value: 'Submit Zone Batch' }],
+			parts: [{ type: 'action', value: 'Submit Zone 3 Batch' }],
 			note: [
 				['Batch Index', { type: 'number', value: 337n }],
 				['Withdrawal Queue Index', { type: 'number', value: 4n }],


### PR DESCRIPTION
## Summary

- restore decoding for all Zone Factory, Portal, and Outbox events from the original #1188 stack
- label batch submissions, deposits, withdrawals, token enablements, sequencer changes, and other Zone operations
- decode Zone Factory, Portal, and Outbox transaction calldata into human-readable descriptions
- keep this isolated from private Earn receipt presentation

## Stack

- Depends on #1200

## Screenshots

| Before | After |
|---|---|
| Generic nonce or selector labels | Zone-specific labels such as `Submit Zone 2 Batch` with decoded metadata |

## Validation

- `pnpm --filter explorer check` (20 files, 101 tests)
- `pnpm --filter explorer test` (13 files, 67 tests)
- `pnpm precommit`

Prompted by: @snario
