### PR TITLE
fix(explorer): restore Zone trace labels

### DIFF
--- a/apps/explorer/src/comps/TxTraceTree.tsx
+++ b/apps/explorer/src/comps/TxTraceTree.tsx
@@ -3,6 +3,7 @@ import { Link } from '@tanstack/react-router'
 import { useEffect, useMemo, useState } from 'react'
 import { decodeAbiParameters, erc20Abi, slice } from 'viem'
 import type { Abi, Hex } from 'viem'
+import { blockHashHistoryAbi } from '#lib/abis'
 import { cx } from '#lib/css'
 import { PanelToolbar, SegmentedControl } from './PanelToolbar'
 import {
@@ -371,6 +372,7 @@ export function useTraceTrees(
 			function buildNode(
 				trace: CallTrace,
 				path: number[] = [],
+				parentTrace?: CallTrace,
 			): TxTraceTree.Node {
 				const currentFrameIndex = frameIndex++
 				const hasSelector = trace.input && trace.input.length >= 10
@@ -399,7 +401,7 @@ export function useTraceTrees(
 						})
 					: undefined
 
-				if (precompileInfo && trace.to) {
+				if (precompileInfo && precompileInfo.abi.length === 0 && trace.to) {
 					const decoded = decodePrecompile(
 						trace.to,
 						trace.input || '0x',
@@ -410,10 +412,25 @@ export function useTraceTrees(
 						params = decoded.params
 						decodedOutput = decoded.decodedOutput
 					}
-				} else if (isBlockHashHistory && trace.input.length === 66) {
-					functionName = 'getBlockHash'
-					params = `blockNumber: ${BigInt(trace.input)}`
-					decodedOutput = trace.output
+				} else if (isBlockHashHistory) {
+					const [getBlockHash] = blockHashHistoryAbi
+					try {
+						const [blockNumber] = decodeAbiParameters(
+							getBlockHash.inputs,
+							trace.input,
+						)
+						functionName = getBlockHash.name
+						params = `blockNumber: ${blockNumber}`
+						if (trace.output && trace.output !== '0x') {
+							const [blockHash] = decodeAbiParameters(
+								getBlockHash.outputs,
+								trace.output,
+							)
+							decodedOutput = blockHash
+						}
+					} catch {
+						// EIP-2935 rejects malformed raw calldata.
+					}
 				} else if (selector) {
 					const autoloadAbi = abiMap.get(trace.to?.toLowerCase() ?? '')
 					const autoloadAbiItem =
@@ -471,10 +488,12 @@ export function useTraceTrees(
 						}
 					}
 				}
+				if (trace.type === 'DELEGATECALL' && parentTrace?.input === trace.input)
+					params = 'same args as parent'
 
 				const children =
 					trace.calls?.map((child, index) =>
-						buildNode(child, [...path, index]),
+						buildNode(child, [...path, index], trace),
 					) ?? []
 				return {
 					trace,

--- a/apps/explorer/src/comps/TxTransactionRow.tsx
+++ b/apps/explorer/src/comps/TxTransactionRow.tsx
@@ -14,6 +14,7 @@ import {
 	calculateKnownEventsTotal,
 	NORMALIZED_KNOWN_EVENT_TOTAL_DECIMALS,
 } from '#lib/domain/known-event-totals'
+import { isNonceIncrementedEvent } from '#lib/domain/transaction-activities'
 import { PriceFormatter } from '#lib/formatting'
 import { areUsdPricedTokens } from '#lib/pricing'
 import { getFeeTokenForChain } from '#lib/fee-token'
@@ -69,6 +70,11 @@ export function TransactionDescription(props: {
 	accountAddress: Address.Address
 }) {
 	const { knownEvents, accountAddress } = props
+	const meaningfulEvents = knownEvents.filter(
+		(event) => !isNonceIncrementedEvent(event),
+	)
+	const visibleEvents =
+		meaningfulEvents.length > 0 ? meaningfulEvents : knownEvents
 
 	const transformEvent = React.useCallback(
 		(event: KnownEvent) => getPerspectiveEvent(event, accountAddress),
@@ -77,7 +83,7 @@ export function TransactionDescription(props: {
 
 	return (
 		<TxEventDescription.ExpandGroup
-			events={knownEvents}
+			events={visibleEvents}
 			seenAs={accountAddress}
 			transformEvent={transformEvent}
 		/>

--- a/apps/explorer/src/lib/abis.ts
+++ b/apps/explorer/src/lib/abis.ts
@@ -5,6 +5,11 @@ import { Abis as ViemZoneAbis } from 'viem-zones/tempo/zones'
 export const tip20ChannelReserveAbi = ViemTempoAbis.tip20ChannelReserve
 export const tip20ChannelReserveAddress = ViemTempoChannel.address
 
+/** Semantic ABI for EIP-2935's selectorless raw-calldata read. */
+export const blockHashHistoryAbi = parseAbi([
+	'function getBlockHash(uint256 blockNumber) view returns (bytes32 blockHash)',
+])
+
 export const streamChannelAbi = [
 	{
 		type: 'event',

--- a/apps/explorer/src/lib/domain/contracts.ts
+++ b/apps/explorer/src/lib/domain/contracts.ts
@@ -11,6 +11,7 @@ import { Addresses } from 'viem/tempo'
 import { Addresses as ZoneAddresses } from 'viem-zones/tempo'
 import {
 	Abis,
+	blockHashHistoryAbi,
 	stablecoinDexAbi,
 	streamChannelAbi,
 	tip20ChannelReserveAbi,
@@ -51,11 +52,12 @@ export type ContractInfo = {
 }
 
 function makePrecompile(
-	data: Omit<ContractInfo, 'code' | 'abi' | 'category'>,
+	data: Omit<ContractInfo, 'code' | 'abi' | 'category'> & { abi?: Abi },
 ): [Address.Address, ContractInfo] {
+	const { abi = [], ...metadata } = data
 	return [
 		data.address,
-		{ ...data, code: '0x' as Hex.Hex, abi: [] as Abi, category: 'precompile' },
+		{ ...metadata, code: '0x' as Hex.Hex, abi, category: 'precompile' },
 	]
 }
 
@@ -173,6 +175,13 @@ export const precompileRegistry = new Map<Address.Address, ContractInfo>([
 		name: 'p256Verify',
 		description: 'ECDSA signature verification on secp256r1 (P-256)',
 		docsUrl: 'https://www.evm.codes/precompiled#0x100',
+	}),
+	makePrecompile({
+		address: Addresses.signatureVerifier,
+		name: 'Signature Verification',
+		description: 'Recover and verify Tempo signature types',
+		abi: Abis.signatureVerifier,
+		docsUrl: 'https://github.com/tempoxyz/tempo/blob/main/tips/tip-1020.md',
 	}),
 ])
 
@@ -430,7 +439,7 @@ export const systemContractRegistry = new Map<Address.Address, ContractInfo>(<
 			name: 'Block Hash History',
 			code: '0xef',
 			description: 'EIP-2935 historical block hash storage',
-			abi: [],
+			abi: blockHashHistoryAbi,
 			category: 'system',
 			docsUrl: 'https://eips.ethereum.org/EIPS/eip-2935',
 			address: blockHashHistoryAddress,
@@ -488,12 +497,12 @@ export function getContractInfo(
 		const zoneId = getZonePortalId(address)
 		return {
 			address,
-			name: `Zone Portal #${zoneId}`,
+			name: `Zone Portal Proxy #${zoneId}`,
 			code: '0xef',
-			description: 'Bridge assets between Tempo and a Tempo Zone',
+			description: `ERC-1167 minimal proxy for Tempo Zone ${zoneId}`,
 			abi: zonePortalAbi,
 			category: 'system',
-			docsUrl: 'https://docs.tempo.xyz/protocol/zones',
+			docsUrl: 'https://eips.ethereum.org/EIPS/eip-1167',
 		}
 	}
 

--- a/apps/explorer/src/lib/domain/known-events.ts
+++ b/apps/explorer/src/lib/domain/known-events.ts
@@ -2517,3 +2517,22 @@ export function decodeKnownCall(
 		return null
 	}
 }
+
+export function decodeKnownTransactionCall(
+	transaction: TransactionLike,
+): KnownEvent | null {
+	const queue: TransactionLike[] = [transaction]
+
+	while (queue.length > 0) {
+		const call = queue.shift()
+		if (!call) break
+		const input = call.input ?? call.data
+		if (call.to && input && input !== '0x') {
+			const decoded = decodeKnownCall(call.to, input)
+			if (decoded) return decoded
+		}
+		if (call.calls) queue.push(...call.calls)
+	}
+
+	return null
+}

--- a/apps/explorer/src/lib/domain/known-events.ts
+++ b/apps/explorer/src/lib/domain/known-events.ts
@@ -379,7 +379,6 @@ function createDetectors(
 			}
 
 			if (eventName === 'BatchSubmitted') {
-				const zoneName = getZoneName(address)
 				const note: NonNullable<KnownEvent['note']> = [
 					['Batch Index', { type: 'number', value: args.withdrawalBatchIndex }],
 					[
@@ -405,7 +404,7 @@ function createDetectors(
 
 				return {
 					type: 'zone batch submitted',
-					parts: [{ type: 'action', value: `Submit ${zoneName} Batch` }],
+					parts: [{ type: 'action', value: 'Submit Zone Batch' }],
 					note,
 				}
 			}
@@ -2424,7 +2423,7 @@ function decodeZonePortalCall(
 			]
 			return {
 				type: 'zone batch submission',
-				parts: [{ type: 'action', value: `Submit ${zoneName} Batch` }],
+				parts: [{ type: 'action', value: 'Submit Zone Batch' }],
 				note: [
 					['Tempo Block', { type: 'number', value: tempoBlockNumber }],
 					['Zone Height', { type: 'number', value: zoneHeight }],

--- a/apps/explorer/src/lib/domain/transaction-activities.ts
+++ b/apps/explorer/src/lib/domain/transaction-activities.ts
@@ -32,6 +32,12 @@ export function activitiesToKnownEvents(
 	options: { portal?: Address.Address | null } = {},
 ): KnownEvent[] {
 	return activities.flatMap((activity) => {
+		if (
+			activity.title.trim().toLowerCase() === 'unknown' ||
+			activity.type.trim().toLowerCase() === 'unknown'
+		)
+			return []
+
 		const privateZone = PRIVATE_ZONE_ACTIONS[activity.type]
 		if (privateZone) {
 			const [action, amountKey, tokenKey] = privateZone
@@ -130,6 +136,35 @@ function vaultActivityEvent(activity: TransactionActivity): KnownEvent | null {
 			destination,
 		],
 	}
+}
+
+export function selectTransactionDescriptionEvents(params: {
+	activityEvents: readonly KnownEvent[]
+	fallbackEvents: readonly KnownEvent[]
+	knownCall: KnownEvent | null
+}): KnownEvent[] {
+	if (params.activityEvents.length === 0) return [...params.fallbackEvents]
+	const hasMeaningfulActivity = params.activityEvents.some(
+		(event) => !isNonceIncrementedEvent(event),
+	)
+	const activityEvents =
+		params.knownCall || hasMeaningfulActivity
+			? params.activityEvents.filter((event) => !isNonceIncrementedEvent(event))
+			: params.activityEvents
+	return params.knownCall
+		? [params.knownCall, ...activityEvents]
+		: [...activityEvents]
+}
+
+export function isNonceIncrementedEvent(event: KnownEvent): boolean {
+	return (
+		event.type.trim().toLowerCase() === 'nonce incremented' ||
+		event.parts.some(
+			(part) =>
+				part.type === 'action' &&
+				part.value.trim().toLowerCase() === 'nonce incremented',
+		)
+	)
 }
 
 function activityAddress(

--- a/apps/explorer/src/lib/queries/blocks.ts
+++ b/apps/explorer/src/lib/queries/blocks.ts
@@ -4,7 +4,7 @@ import type { Block, Log, TransactionReceipt } from 'viem'
 import { getBlock } from 'wagmi/actions'
 import type { Actions } from 'wagmi/tempo'
 import {
-	decodeKnownCall,
+	decodeKnownTransactionCall,
 	type KnownEvent,
 	parseKnownEvents,
 } from '#lib/domain/known-events'
@@ -138,10 +138,7 @@ export function blockKnownEventsQueryOptions(
 
 				// Try to decode known contract calls (e.g., validator precompile)
 				// Prioritize decoded calls over fee-only events
-				const knownCall =
-					transaction.to && transaction.input && transaction.input !== '0x'
-						? decodeKnownCall(transaction.to, transaction.input)
-						: null
+				const knownCall = decodeKnownTransactionCall(transaction)
 
 				const events = knownCall
 					? [knownCall, ...parsedEvents.filter((e) => e.type !== 'fee')]

--- a/apps/explorer/src/lib/queries/tx.ts
+++ b/apps/explorer/src/lib/queries/tx.ts
@@ -4,7 +4,7 @@ import { toEventSelector } from 'viem'
 import { getBlock, getTransaction, getTransactionReceipt } from 'wagmi/actions'
 import {
 	type Authorization,
-	decodeKnownCall,
+	decodeKnownTransactionCall,
 	parseAuthorizationEvents,
 	parseKnownEvent,
 	isStreamChannelAddress,
@@ -48,10 +48,7 @@ async function fetchTxData(params: { hash: Hex.Hex }) {
 
 	// Try to decode known contract calls (e.g., validator precompile)
 	// Prioritize decoded calls over fee-only events since they're more descriptive
-	const knownCall =
-		transaction.to && transaction.input && transaction.input !== '0x'
-			? decodeKnownCall(transaction.to, transaction.input)
-			: null
+	const knownCall = decodeKnownTransactionCall(transaction)
 
 	// Parse EIP-7702 authorization list for delegate account events
 	const authorizationList =
@@ -116,6 +113,7 @@ async function fetchTxData(params: { hash: Hex.Hex }) {
 	return {
 		block,
 		feeBreakdown,
+		knownCall,
 		knownEvents,
 		knownEventsByLog,
 		receipt,

--- a/apps/explorer/src/lib/server/address-history.ts
+++ b/apps/explorer/src/lib/server/address-history.ts
@@ -6,10 +6,15 @@ import type { Config } from 'wagmi'
 import { Actions } from 'wagmi/tempo'
 import * as z from 'zod/mini'
 
-import { type KnownEvent, parseKnownEvents } from '#lib/domain/known-events'
+import {
+	decodeKnownTransactionCall,
+	type KnownEvent,
+	parseKnownEvents,
+} from '#lib/domain/known-events'
 import { isTip20Address, type Metadata } from '#lib/domain/tip20'
 import {
 	activitiesToKnownEvents,
+	selectTransactionDescriptionEvents,
 	type TransactionActivity,
 } from '#lib/domain/transaction-activities'
 import { api } from '#lib/server/tempo-api'
@@ -210,10 +215,15 @@ export function toEnrichedTransaction(
 
 	const knownEvents = (() => {
 		if (!options.includeKnownEvents || !receipt) return []
+		const transaction = {
+			to,
+			input: row.input,
+			data: row.input,
+			calls: row.meta?.rpc?.calls as never,
+		}
 		const activityEvents = activitiesToKnownEvents(options.activities ?? [])
-		if (activityEvents.length > 0) return activityEvents
 		try {
-			return parseKnownEvents(
+			const parsedEvents = parseKnownEvents(
 				{
 					from: receipt.sender,
 					to,
@@ -222,15 +232,19 @@ export function toEnrichedTransaction(
 					contractAddress: receipt.contractAddress ?? null,
 				} as unknown as TransactionReceipt,
 				{
-					transaction: {
-						to,
-						input: row.input,
-						data: row.input,
-						calls: row.meta?.rpc?.calls as never,
-					} as never,
+					transaction,
 					getTokenMetadata: options.getTokenMetadata,
 				},
 			)
+			const knownCall = decodeKnownTransactionCall(transaction)
+			const fallbackEvents = knownCall
+				? [knownCall, ...parsedEvents.filter((event) => event.type !== 'fee')]
+				: parsedEvents
+			return selectTransactionDescriptionEvents({
+				activityEvents,
+				fallbackEvents,
+				knownCall,
+			})
 		} catch (error) {
 			console.error(
 				`[history] failed to parse known events for ${row.hash}:`,

--- a/apps/explorer/src/routes/_layout/receipt/$hash.tsx
+++ b/apps/explorer/src/routes/_layout/receipt/$hash.tsx
@@ -19,7 +19,7 @@ import { Receipt } from '#comps/Receipt'
 import { useTokenListMembership } from '#comps/TokenListMembership'
 import { apostrophe } from '#lib/chars'
 import {
-	decodeKnownCall,
+	decodeKnownTransactionCall,
 	parseKnownEvents,
 	type KnownEvent,
 } from '#lib/domain/known-events'
@@ -27,7 +27,10 @@ import { calculateKnownEventsTotal } from '#lib/domain/known-event-totals'
 import { getFeeBreakdown, LineItems } from '#lib/domain/receipt'
 import { buildTxSummary } from '#lib/domain/tx-summary'
 import * as Tip20 from '#lib/domain/tip20'
-import { activitiesToKnownEvents } from '#lib/domain/transaction-activities'
+import {
+	activitiesToKnownEvents,
+	selectTransactionDescriptionEvents,
+} from '#lib/domain/transaction-activities'
 import { DateFormatter, PriceFormatter } from '#lib/formatting'
 import { useKeyboardShortcut } from '#lib/hooks'
 import {
@@ -111,10 +114,7 @@ async function fetchReceiptData(params: { hash: Hex.Hex; rpcUrl?: string }) {
 
 	// Try to decode known contract calls (e.g., validator precompile)
 	// Prioritize decoded calls over fee-only events since they're more descriptive
-	const knownCall =
-		transaction.to && transaction.input && transaction.input !== '0x'
-			? decodeKnownCall(transaction.to, transaction.input)
-			: null
+	const knownCall = decodeKnownTransactionCall(transaction)
 
 	const fallbackEvents = knownCall
 		? [knownCall, ...parsedEvents.filter((e) => e.type !== 'fee')]
@@ -122,8 +122,11 @@ async function fetchReceiptData(params: { hash: Hex.Hex; rpcUrl?: string }) {
 	const activityEvents = activitiesToKnownEvents(activities, {
 		portal: receipt.to,
 	})
-	const knownEvents =
-		activityEvents.length > 0 ? activityEvents : fallbackEvents
+	const knownEvents = selectTransactionDescriptionEvents({
+		activityEvents,
+		fallbackEvents,
+		knownCall,
+	})
 
 	return {
 		block,

--- a/apps/explorer/src/routes/_layout/tx/$hash.tsx
+++ b/apps/explorer/src/routes/_layout/tx/$hash.tsx
@@ -43,7 +43,10 @@ import {
 } from '#lib/domain/tx-event-groups'
 import type { FeeBreakdownItem } from '#lib/domain/receipt'
 import { isTip20Address } from '#lib/domain/tip20'
-import { activitiesToKnownEvents } from '#lib/domain/transaction-activities'
+import {
+	activitiesToKnownEvents,
+	selectTransactionDescriptionEvents,
+} from '#lib/domain/transaction-activities'
 import { PriceFormatter } from '#lib/formatting'
 import { useKeyboardShortcut, useMediaQuery } from '#lib/hooks'
 import { buildOgImageUrl, buildTxDescription, OG_BASE_URL } from '#lib/og'
@@ -148,10 +151,11 @@ export const Route = createFileRoute('/_layout/tx/$hash')({
 			? buildTxDescription({
 					timestamp: Number(loaderData.block.timestamp) * 1000,
 					from: loaderData.receipt.from,
-					events:
-						loaderData.activityEvents.length > 0
-							? loaderData.activityEvents
-							: (loaderData.knownEvents ?? []),
+					events: selectTransactionDescriptionEvents({
+						activityEvents: loaderData.activityEvents,
+						fallbackEvents: loaderData.knownEvents ?? [],
+						knownCall: loaderData.knownCall,
+					}),
 				})
 			: 'View transaction details on Tempo Explorer.'
 
@@ -182,6 +186,7 @@ function RouteComponent() {
 		traceData,
 		block,
 		feeBreakdown,
+		knownCall,
 		knownEvents,
 		knownEventsByLog = [],
 		receipt,
@@ -200,8 +205,11 @@ function RouteComponent() {
 			!event.meta?.to ||
 			!OxAddressUtil.isEqual(event.meta.to, RECEIVE_POLICY_GUARD),
 	)
-	const descriptionEvents =
-		activityEvents.length > 0 ? activityEvents : displayKnownEvents
+	const descriptionEvents = selectTransactionDescriptionEvents({
+		activityEvents,
+		fallbackEvents: displayKnownEvents,
+		knownCall,
+	})
 
 	useKeyboardShortcut({
 		t: () =>
@@ -225,14 +233,13 @@ function RouteComponent() {
 			buildTxSummary({
 				receipt,
 				transaction,
-				knownEvents: activityEvents.length > 0 ? activityEvents : knownEvents,
+				knownEvents: descriptionEvents,
 				trace: traceData.trace,
 				balanceChangesData,
 			}),
 		[
 			receipt,
-			knownEvents,
-			activityEvents,
+			descriptionEvents,
 			traceData.trace,
 			balanceChangesData,
 			transaction,

--- a/apps/explorer/test/address-history.node.test.ts
+++ b/apps/explorer/test/address-history.node.test.ts
@@ -112,7 +112,7 @@ describe('toEnrichedTransaction', () => {
 
 		expect(result.knownEvents[0]?.parts[0]).toEqual({
 			type: 'action',
-			value: 'Submit Zone 3 Batch',
+			value: 'Submit Zone Batch',
 		})
 		expect(result.knownEvents).not.toContainEqual(
 			expect.objectContaining({ type: 'nonce incremented' }),

--- a/apps/explorer/test/address-history.node.test.ts
+++ b/apps/explorer/test/address-history.node.test.ts
@@ -1,4 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { encodeFunctionData, zeroHash } from 'viem'
+import { zonePortalAbi } from '#lib/abis'
 import {
 	fetchAddressHistoryData,
 	toEnrichedTransaction,
@@ -64,6 +66,59 @@ function row(overrides: Record<string, unknown> = {}) {
 }
 
 describe('toEnrichedTransaction', () => {
+	it('prioritizes nested Zone calls over indexed activities', () => {
+		const portal = '0x5ad0000000000000000000000000000000000003'
+		const input = encodeFunctionData({
+			abi: zonePortalAbi,
+			functionName: 'submitBatch',
+			args: [
+				1n,
+				0n,
+				{ prevBlockHash: zeroHash, nextBlockHash: zeroHash },
+				{
+					prevProcessedHash: zeroHash,
+					nextProcessedHash: zeroHash,
+					prevDepositNumber: 0n,
+					nextDepositNumber: 0n,
+				},
+				zeroHash,
+				'0x',
+				'0x',
+				1n,
+				[],
+			],
+		})
+		const result = toEnrichedTransaction(
+			row({
+				recipient: portal,
+				meta: {
+					receipt: receipt({ recipient: portal }),
+					rpc: { calls: [{ to: portal, input }] },
+				},
+			}),
+			{
+				includeKnownEvents: true,
+				getTokenMetadata: () => undefined,
+				activities: [
+					{
+						id: 'nonce',
+						title: 'Nonce Incremented',
+						type: 'nonce',
+						data: {},
+					},
+				],
+			},
+		)
+
+		expect(result.knownEvents[0]?.parts[0]).toEqual({
+			type: 'action',
+			value: 'Submit Zone 3 Batch',
+		})
+		expect(result.knownEvents).not.toContainEqual(
+			expect.objectContaining({ type: 'nonce incremented' }),
+		)
+	})
+
 	it('maps a Cadent row + humanized receipt to the UI contract', () => {
 		const result = toEnrichedTransaction(row(), {
 			includeKnownEvents: false,

--- a/apps/explorer/test/contracts.node.test.ts
+++ b/apps/explorer/test/contracts.node.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest'
-import { toEventSelector, type Abi } from 'viem'
+import {
+	decodeAbiParameters,
+	encodeAbiParameters,
+	toEventSelector,
+	type Abi,
+} from 'viem'
 import { Addresses as ZoneAddresses } from 'viem-zones/tempo'
 import {
 	zoneFactoryAbi,
@@ -170,14 +175,37 @@ describe('Zone protocol contracts', () => {
 		expect(isZonePortalAddress(portal)).toBe(true)
 		expect(systemAddress(portal)).toBe(true)
 		expect(getContractInfo(portal)).toMatchObject({
-			name: 'Zone Portal #3',
+			name: 'Zone Portal Proxy #3',
+			description: 'ERC-1167 minimal proxy for Tempo Zone 3',
 			abi: zonePortalAbi,
 		})
 	})
 
 	it('recognizes the EIP-2935 history contract', () => {
-		expect(
-			getContractInfo('0x0000f90827f1c53a10cb7a02335b175320002935'),
-		).toMatchObject({ name: 'Block Hash History' })
+		const info = getContractInfo('0x0000f90827f1c53a10cb7a02335b175320002935')
+		expect(info).toMatchObject({ name: 'Block Hash History' })
+		const getBlockHash = info?.abi.find(
+			(item) => item.type === 'function' && item.name === 'getBlockHash',
+		)
+		expect(getBlockHash?.type).toBe('function')
+		if (!getBlockHash || getBlockHash.type !== 'function') return
+		const input = encodeAbiParameters(getBlockHash.inputs, [31_767_176n])
+		expect(decodeAbiParameters(getBlockHash.inputs, input)).toEqual([
+			31_767_176n,
+		])
+	})
+
+	it('recognizes the TIP-1020 signature verification precompile', () => {
+		const info = getContractInfo('0x5165300000000000000000000000000000000000')
+		expect(info).toMatchObject({
+			name: 'Signature Verification',
+			category: 'precompile',
+		})
+		expect(info?.abi).toContainEqual(
+			expect.objectContaining({ type: 'function', name: 'recover' }),
+		)
+		expect(info?.abi).toContainEqual(
+			expect.objectContaining({ type: 'function', name: 'verify' }),
+		)
 	})
 })

--- a/apps/explorer/test/known-events.test.ts
+++ b/apps/explorer/test/known-events.test.ts
@@ -206,7 +206,7 @@ describe('parseKnownEvents', () => {
 						[],
 					],
 				}),
-				action: 'Submit Zone 3 Batch',
+				action: 'Submit Zone Batch',
 			},
 			{
 				to: ZoneAddresses.zoneOutbox,
@@ -241,7 +241,7 @@ describe('parseKnownEvents', () => {
 				input: '0x',
 				calls: [{ to: calls[4].to, input: calls[4].input }],
 			})?.parts[0],
-		).toEqual({ type: 'action', value: 'Submit Zone 3 Batch' })
+		).toEqual({ type: 'action', value: 'Submit Zone Batch' })
 	})
 
 	it('maps every Zone ABI event to a known event', () => {
@@ -511,7 +511,7 @@ describe('parseKnownEvents', () => {
 
 		expect(event).toMatchObject({
 			type: 'zone batch submitted',
-			parts: [{ type: 'action', value: 'Submit Zone 3 Batch' }],
+			parts: [{ type: 'action', value: 'Submit Zone Batch' }],
 			note: [
 				['Batch Index', { type: 'number', value: 337n }],
 				['Withdrawal Queue Index', { type: 'number', value: 4n }],

--- a/apps/explorer/test/known-events.test.ts
+++ b/apps/explorer/test/known-events.test.ts
@@ -26,7 +26,11 @@ import {
 	recipientAddress,
 	userTokenAddress,
 } from '#lib/demo'
-import { decodeKnownCall, parseKnownEvents } from '#lib/domain/known-events'
+import {
+	decodeKnownCall,
+	decodeKnownTransactionCall,
+	parseKnownEvents,
+} from '#lib/domain/known-events'
 
 const ZONE_5_PORTAL = '0x7069DeC4E64Fd07334A0933eDe836C17259c9B23' as const
 const ZONE_E_PORTAL = '0x59831A17340EE14FE136d751EfbeA8b630470fD2' as const
@@ -230,6 +234,14 @@ describe('parseKnownEvents', () => {
 				value: call.action,
 			})
 		}
+
+		expect(
+			decodeKnownTransactionCall({
+				to: accountAddress,
+				input: '0x',
+				calls: [{ to: calls[4].to, input: calls[4].input }],
+			})?.parts[0],
+		).toEqual({ type: 'action', value: 'Submit Zone 3 Batch' })
 	})
 
 	it('maps every Zone ABI event to a known event', () => {

--- a/apps/explorer/test/transaction-activities.test.ts
+++ b/apps/explorer/test/transaction-activities.test.ts
@@ -16,7 +16,7 @@ describe('activitiesToKnownEvents', () => {
 	test('omits nonce activity when a decoded call is available', () => {
 		const knownCall = {
 			type: 'zone batch submission',
-			parts: [{ type: 'action' as const, value: 'Submit Zone 3 Batch' }],
+			parts: [{ type: 'action' as const, value: 'Submit Zone Batch' }],
 		}
 		const activity = {
 			type: 'nonce incremented',
@@ -50,7 +50,7 @@ describe('activitiesToKnownEvents', () => {
 	test('omits nonce activity when another indexed activity is available', () => {
 		const batch = {
 			type: 'zone batch submission',
-			parts: [{ type: 'action' as const, value: 'Submit Zone 3 Batch' }],
+			parts: [{ type: 'action' as const, value: 'Submit Zone Batch' }],
 		}
 		const nonce = {
 			type: 'nonce incremented',
@@ -69,7 +69,7 @@ describe('activitiesToKnownEvents', () => {
 	test('recognizes nonce activity from its rendered action', () => {
 		const batch = {
 			type: 'zone batch submission',
-			parts: [{ type: 'action' as const, value: 'Submit Zone 3 Batch' }],
+			parts: [{ type: 'action' as const, value: 'Submit Zone Batch' }],
 		}
 		const nonce = {
 			type: 'nonce',

--- a/apps/explorer/test/transaction-activities.test.ts
+++ b/apps/explorer/test/transaction-activities.test.ts
@@ -1,7 +1,90 @@
 import { describe, expect, test } from 'vitest'
-import { activitiesToKnownEvents } from '#lib/domain/transaction-activities'
+import {
+	activitiesToKnownEvents,
+	selectTransactionDescriptionEvents,
+} from '#lib/domain/transaction-activities'
 
 describe('activitiesToKnownEvents', () => {
+	test('omits unknown activities so local descriptions can be used', () => {
+		expect(
+			activitiesToKnownEvents([
+				{ id: 'unknown', title: 'Unknown', type: 'unknown', data: {} },
+			]),
+		).toEqual([])
+	})
+
+	test('omits nonce activity when a decoded call is available', () => {
+		const knownCall = {
+			type: 'zone batch submission',
+			parts: [{ type: 'action' as const, value: 'Submit Zone 3 Batch' }],
+		}
+		const activity = {
+			type: 'nonce incremented',
+			parts: [{ type: 'action' as const, value: 'Nonce Incremented' }],
+		}
+
+		expect(
+			selectTransactionDescriptionEvents({
+				activityEvents: [activity],
+				fallbackEvents: [],
+				knownCall,
+			}),
+		).toEqual([knownCall])
+	})
+
+	test('preserves nonce activity when no decoded call is available', () => {
+		const activity = {
+			type: 'nonce incremented',
+			parts: [{ type: 'action' as const, value: 'Nonce Incremented' }],
+		}
+
+		expect(
+			selectTransactionDescriptionEvents({
+				activityEvents: [activity],
+				fallbackEvents: [],
+				knownCall: null,
+			}),
+		).toEqual([activity])
+	})
+
+	test('omits nonce activity when another indexed activity is available', () => {
+		const batch = {
+			type: 'zone batch submission',
+			parts: [{ type: 'action' as const, value: 'Submit Zone 3 Batch' }],
+		}
+		const nonce = {
+			type: 'nonce incremented',
+			parts: [{ type: 'action' as const, value: 'Nonce Incremented' }],
+		}
+
+		expect(
+			selectTransactionDescriptionEvents({
+				activityEvents: [batch, nonce],
+				fallbackEvents: [],
+				knownCall: null,
+			}),
+		).toEqual([batch])
+	})
+
+	test('recognizes nonce activity from its rendered action', () => {
+		const batch = {
+			type: 'zone batch submission',
+			parts: [{ type: 'action' as const, value: 'Submit Zone 3 Batch' }],
+		}
+		const nonce = {
+			type: 'nonce',
+			parts: [{ type: 'action' as const, value: 'Nonce Incremented' }],
+		}
+
+		expect(
+			selectTransactionDescriptionEvents({
+				activityEvents: [batch, nonce],
+				fallbackEvents: [],
+				knownCall: null,
+			}),
+		).toEqual([batch])
+	})
+
 	test('preserves token amounts and perspective for transfers', () => {
 		expect(
 			activitiesToKnownEvents([


### PR DESCRIPTION
## Summary

- restore Zone call descriptions across transaction pages, receipts, block queries, and address history
- prefer decoded Zone calls such as `Submit Zone 2 Batch` over generic nonce activity
- restore proxy, nested call, batch, messenger, verifier, and withdrawal trace labels
- preserve the current private Zone and Earn activity handling while suppressing secondary nonce-only descriptions

## Stack

- Depends on #1201, which depends on #1200

## Screenshots

| Before | After |
|---|---|
| Zone Portal history shows `Nonce Incremented`; traces show selectors | History shows decoded Zone actions; traces name portal, batch, messenger, verifier, and withdrawal calls |

## Validation

- `pnpm --filter explorer check` (20 files, 103 tests)
- `pnpm --filter explorer test` (13 files, 72 tests)
- `pnpm precommit`
- confirmed the live source transaction currently appears as `Nonce Incremented`; regression tests cover its restored call-description precedence

Prompted by: @snario
