### PR TITLE
refactor(explorer): standardize card typography

### DIFF
--- a/apps/explorer/src/comps/AccountCard.tsx
+++ b/apps/explorer/src/comps/AccountCard.tsx
@@ -69,18 +69,16 @@ export function AccountCard(props: AccountCard.Props) {
 					title={address}
 				>
 					<div className="flex items-center gap-[8px] mb-[8px]">
-						<span className="text-[13px] font-normal capitalize">Address</span>
+						<span className="capitalize">Address</span>
 						<div className="relative flex items-center">
 							<CopyIcon className="w-[12px] h-[12px]" />
 							{notifying && (
-								<span className="absolute left-[calc(100%+8px)] text-[13px] leading-[16px]">
-									copied
-								</span>
+								<span className="absolute left-[calc(100%+8px)]">copied</span>
 							)}
 						</div>
 					</div>
 					{/* 42 chars / 2 lines = 21ch */}
-					<p className="text-[14px] font-normal leading-[17px] text-primary break-all max-w-[21ch] font-mono">
+					<p className="type-card-data text-primary break-all max-w-[21ch]">
 						{address}
 					</p>
 				</button>,
@@ -89,7 +87,7 @@ export function AccountCard(props: AccountCard.Props) {
 							{
 								label: 'Master ID',
 								value: (
-									<span className="text-[13px] text-primary">
+									<span className="text-primary">
 										{virtualAddressParts.masterId}
 									</span>
 								),
@@ -97,7 +95,7 @@ export function AccountCard(props: AccountCard.Props) {
 							{
 								label: 'User Tag',
 								value: (
-									<span className="text-[13px] text-primary">
+									<span className="text-primary">
 										{virtualAddressParts.userTag}
 									</span>
 								),
@@ -108,9 +106,7 @@ export function AccountCard(props: AccountCard.Props) {
 					? [
 							{
 								label: 'Holdings',
-								value: (
-									<span className="text-[13px] text-tertiary">Forwarded</span>
-								),
+								value: <span className="text-tertiary">Forwarded</span>,
 							},
 						]
 					: !hideHoldings
@@ -119,13 +115,11 @@ export function AccountCard(props: AccountCard.Props) {
 									label: 'Holdings',
 									value: (
 										<ClientOnly
-											fallback={
-												<span className="text-tertiary text-[13px]">…</span>
-											}
+											fallback={<span className="text-tertiary">…</span>}
 										>
 											{totalValue !== undefined ? (
 												<span
-													className="text-[13px] text-primary"
+													className="text-primary"
 													title={PriceFormatter.format(totalValue)}
 												>
 													{PriceFormatter.format(totalValue, {
@@ -133,7 +127,7 @@ export function AccountCard(props: AccountCard.Props) {
 													})}
 												</span>
 											) : (
-												<span className="text-tertiary text-[13px]">…</span>
+												<span className="text-tertiary">…</span>
 											)}
 										</ClientOnly>
 									),
@@ -143,16 +137,14 @@ export function AccountCard(props: AccountCard.Props) {
 				{
 					label: 'Active',
 					value: (
-						<ClientOnly
-							fallback={<span className="text-tertiary text-[13px]">…</span>}
-						>
+						<ClientOnly fallback={<span className="text-tertiary">…</span>}>
 							{lastActivityTimestamp ? (
 								<RelativeTime
 									timestamp={lastActivityTimestamp}
-									className="text-[13px] text-primary"
+									className="text-primary"
 								/>
 							) : (
-								<span className="text-tertiary text-[13px]">…</span>
+								<span className="text-tertiary">…</span>
 							)}
 						</ClientOnly>
 					),
@@ -160,16 +152,14 @@ export function AccountCard(props: AccountCard.Props) {
 				{
 					label: 'Created',
 					value: (
-						<ClientOnly
-							fallback={<span className="text-tertiary text-[13px]">…</span>}
-						>
+						<ClientOnly fallback={<span className="text-tertiary">…</span>}>
 							{createdTimestamp ? (
 								<RelativeTime
 									timestamp={createdTimestamp}
-									className="text-[13px] text-primary"
+									className="text-primary"
 								/>
 							) : (
-								<span className="text-tertiary text-[13px]">…</span>
+								<span className="text-tertiary">…</span>
 							)}
 						</ClientOnly>
 					),

--- a/apps/explorer/src/comps/BlockCard.tsx
+++ b/apps/explorer/src/comps/BlockCard.tsx
@@ -74,7 +74,7 @@ export function BlockCard(props: BlockCard.Props) {
 
 	return (
 		<InfoCard
-			className="text-[13px]"
+			className="type-card"
 			sections={[
 				<button
 					key="block-number"
@@ -84,13 +84,11 @@ export function BlockCard(props: BlockCard.Props) {
 					title={String(blockNumber ?? 0n)}
 				>
 					<div className="flex items-center gap-[8px] mb-[8px]">
-						<span className="text-[13px] font-normal">Block</span>
+						<span>Block</span>
 						<div className="relative flex items-center">
 							<CopyIcon className="w-[12px] h-[12px] text-content-dimmed" />
 							{copyBlock.notifying && (
-								<span className="absolute left-[calc(100%+8px)] text-[13px] leading-[16px]">
-									copied
-								</span>
+								<span className="absolute left-[calc(100%+8px)]">copied</span>
 							)}
 						</div>
 					</div>
@@ -127,9 +125,8 @@ export function BlockCard(props: BlockCard.Props) {
 									)}
 								</div>
 							</div>
-							{/* the 15px font size needs to match the block number wrapper font size to make sure they align */}
 							{/* 22 chars/line * (1ch + 1px tracking) */}
-							<div className="text-[15px] font-mono font-normal leading-[18px] tracking-[1px] text-primary break-all max-w-[calc(22ch+22px)]">
+							<div className="type-card-data tracking-[1px] text-primary break-all max-w-[calc(22ch+22px)]">
 								{hash}
 							</div>
 						</button>
@@ -179,7 +176,7 @@ export function BlockCard(props: BlockCard.Props) {
 							className="flex w-full items-center justify-between text-tertiary cursor-pointer press-down"
 							onClick={() => setShowAdvanced((prev) => !prev)}
 						>
-							<span className="text-[13px]">Advanced</span>
+							<span>Advanced</span>
 							<ChevronDown
 								className={cx(
 									'size-[14px] text-content-dimmed',
@@ -333,7 +330,7 @@ export namespace BlockCard {
 		if (!hash) {
 			return (
 				<div className="flex items-center justify-between gap-[8px] text-primary lowercase">
-					<span className="text-[12px] text-tertiary shrink-0">{label}</span>
+					<span className="text-tertiary shrink-0">{label}</span>
 					<span className="text-tertiary">—</span>
 				</div>
 			)
@@ -346,7 +343,7 @@ export namespace BlockCard {
 				className="w-full flex items-center justify-between gap-[8px] text-primary lowercase cursor-pointer press-down"
 				title={hash}
 			>
-				<span className="text-[12px] text-tertiary shrink-0 font-sans">
+				<span className="text-tertiary shrink-0 font-sans">
 					{notifying ? 'copied' : label}
 				</span>
 				<div className="flex items-center gap-[8px] min-w-0 flex-1 justify-end font-mono">

--- a/apps/explorer/src/comps/InfoCard.tsx
+++ b/apps/explorer/src/comps/InfoCard.tsx
@@ -16,16 +16,16 @@ export function InfoCard(props: InfoCard.Props) {
 			<div
 				key={key}
 				className={cx(
-					'flex items-center px-4.5 py-3',
+					'flex items-center px-4.5 py-3 type-card',
 					!isLast && 'border-b border-dashed border-card-border',
 				)}
 			>
 				{isSectionEntry ? (
 					<div className="flex items-center gap-2 justify-between w-full">
-						<span className="text-[13px] font-normal capitalize text-tertiary shrink-0 font-sans">
+						<span className="capitalize text-tertiary shrink-0">
 							{section.label}
 						</span>
-						<div className="min-w-0 flex-1 flex justify-end font-mono text-primary">
+						<div className="min-w-0 flex-1 flex justify-end type-card-data text-primary">
 							{section.value}
 						</div>
 					</div>
@@ -39,14 +39,14 @@ export function InfoCard(props: InfoCard.Props) {
 	return (
 		<section
 			className={cx(
-				'font-sans',
+				'type-card',
 				'w-full min-[1240px]:w-fit',
 				'rounded-[10px] border border-card-border bg-card-header overflow-hidden shadow-[0px_12px_40px_rgba(0,0,0,0.06)]',
 				className,
 			)}
 		>
 			{hasTitle && (
-				<div className="flex items-center h-9 px-4 text-[13px] text-tertiary font-normal bg-card-header">
+				<div className="flex items-center h-9 px-4 text-tertiary bg-card-header">
 					{title}
 				</div>
 			)}
@@ -68,7 +68,7 @@ InfoCard.Title = function InfoCardTitle(props: {
 	return (
 		<h1
 			className={cx(
-				'text-[13px] text-tertiary select-none flex items-center gap-2',
+				'text-tertiary select-none flex items-center gap-2',
 				props.className,
 			)}
 		>

--- a/apps/explorer/src/comps/TxTransactionCard.tsx
+++ b/apps/explorer/src/comps/TxTransactionCard.tsx
@@ -26,7 +26,7 @@ export function TxTransactionCard(props: TxTransactionCard.Props) {
 							{
 								label: 'Error',
 								value: (
-									<span className="text-right font-sans text-[13px] text-primary">
+									<span className="text-right type-card text-primary">
 										{error}
 									</span>
 								),
@@ -41,18 +41,16 @@ export function TxTransactionCard(props: TxTransactionCard.Props) {
 					title={hash}
 				>
 					<div className="flex items-center gap-[8px] mb-[8px] font-sans">
-						<span className="text-[13px] font-normal capitalize">Hash</span>
+						<span className="capitalize">Hash</span>
 						<div className="relative flex items-center">
 							<CopyIcon className="w-[12px] h-[12px]" />
 							{notifying && (
-								<span className="absolute left-[calc(100%+8px)] text-[13px] leading-[16px]">
-									copied
-								</span>
+								<span className="absolute left-[calc(100%+8px)]">copied</span>
 							)}
 						</div>
 					</div>
 					{/* 66 chars / 3 lines = 22ch */}
-					<p className="text-[14px] font-normal leading-[17px] text-primary break-all max-w-[22ch] font-mono">
+					<p className="type-card-data text-primary break-all max-w-[22ch]">
 						{hash}
 					</p>
 				</button>,
@@ -62,7 +60,7 @@ export function TxTransactionCard(props: TxTransactionCard.Props) {
 						<Link
 							to="/block/$id"
 							params={{ id: String(blockNumber) }}
-							className="text-[13px] text-accent hover:underline press-down font-mono tabular-nums"
+							className="text-accent hover:underline press-down font-mono tabular-nums"
 						>
 							{blockNumber}
 						</Link>
@@ -86,7 +84,7 @@ export function TxTransactionCard(props: TxTransactionCard.Props) {
 						<FormattedTimestamp
 							timestamp={timestamp}
 							format={timeFormat}
-							className="text-[13px] text-primary font-mono"
+							className="text-primary font-mono"
 						/>
 					),
 				},
@@ -96,7 +94,7 @@ export function TxTransactionCard(props: TxTransactionCard.Props) {
 						<Link
 							to="/address/$address"
 							params={{ address: from }}
-							className="text-[13px] text-accent hover:underline press-down w-full font-mono max-w-[50ch]"
+							className="text-accent hover:underline press-down w-full font-mono max-w-[50ch]"
 							title={from}
 						>
 							<Midcut value={from} prefix="0x" min={4} align="end" />
@@ -110,7 +108,7 @@ export function TxTransactionCard(props: TxTransactionCard.Props) {
 								<Link
 									to="/address/$address"
 									params={{ address: to }}
-									className="text-[13px] text-accent hover:underline press-down w-full font-mono max-w-[50ch]"
+									className="text-accent hover:underline press-down w-full font-mono max-w-[50ch]"
 									title={to}
 								>
 									<Midcut value={to} prefix="0x" min={4} align="end" />
@@ -119,11 +117,7 @@ export function TxTransactionCard(props: TxTransactionCard.Props) {
 						}
 					: {
 							label: 'To',
-							value: (
-								<span className="text-[13px] text-tertiary">
-									Contract Creation
-								</span>
-							),
+							value: <span className="text-tertiary">Contract Creation</span>,
 						},
 				<Link
 					key="receipt"
@@ -131,7 +125,7 @@ export function TxTransactionCard(props: TxTransactionCard.Props) {
 					params={{ hash }}
 					className="press-down flex items-center justify-between w-full print:hidden py-[6px]"
 				>
-					<span className="text-[13px] text-tertiary">Receipt</span>
+					<span className="text-tertiary">Receipt</span>
 					<span className="text-[12px] text-tertiary hover:text-primary px-[8px] py-[2px] border border-base-border rounded-full transition-colors">
 						View →
 					</span>
@@ -150,7 +144,7 @@ export function TxTransactionCard(props: TxTransactionCard.Props) {
 					className="press-down flex items-center justify-between w-full print:hidden py-[6px]"
 					title="Replay this transaction against the state of its parent block"
 				>
-					<span className="text-[13px] text-tertiary">Simulate</span>
+					<span className="text-tertiary">Simulate</span>
 					<span
 						className={cx(
 							'text-[12px] px-[8px] py-[2px] border rounded-full transition-colors',

--- a/apps/explorer/src/routes/styles.css
+++ b/apps/explorer/src/routes/styles.css
@@ -183,6 +183,22 @@ input[type="number"] {
 	line-height: 1.25rem;
 }
 
+@utility type-card {
+	font-family: var(--font-sans);
+	font-size: 13px;
+	font-style: normal;
+	font-weight: 400;
+	line-height: 16px;
+}
+
+@utility type-card-data {
+	font-family: var(--font-mono);
+	font-size: 13px;
+	font-style: normal;
+	font-weight: 400;
+	line-height: 16px;
+}
+
 @utility text-ui-meta {
 	color: var(--color-primary);
 	text-align: center;


### PR DESCRIPTION
## Summary
- add shared `type-card` and `type-card-data` typography roles
- standardize account, transaction, and block cards on 13px text, 16px line height, and normal weight
- reserve Satoshi for interface copy and Geist Mono for addresses, hashes, timestamps, and numeric data

## Screenshots

| Before | After |
| --- | --- |
| Card content used scattered 12px, 13px, 14px, and 15px declarations with local line heights and weights. | Core card content uses the shared 13px/16px/400 typography roles, with compact badges retained as explicit exceptions. |

## Validation
- `pnpm --filter explorer check`
- `pnpm --filter explorer test -- --run`
- `VITE_TEMPO_ENV=mainnet pnpm --filter explorer build`
- `pnpm precommit`
- rendered `/demo/address` locally with `VITE_ENABLE_DEMO=true`

Prompted by: @snario
