### PR TITLE
fix(explorer): align landing footer with viewport

### DIFF
--- a/apps/explorer/src/comps/Footer.tsx
+++ b/apps/explorer/src/comps/Footer.tsx
@@ -1,5 +1,6 @@
 import { Link as RouterLink } from '@tanstack/react-router'
 import * as React from 'react'
+import { cx } from '#lib/css'
 import {
 	applyThemeMode,
 	defaultThemeMode,
@@ -15,9 +16,14 @@ import {
 import MoonIcon from '~icons/lucide/moon'
 import SunIcon from '~icons/lucide/sun'
 
-export function Footer(): React.JSX.Element {
+export function Footer(props: Footer.Props): React.JSX.Element {
 	return (
-		<footer className="@container px-[24px] @min-[1240px]:px-[84px] pt-[24px] pb-[48px] relative print:hidden">
+		<footer
+			className={cx(
+				'@container px-[24px] @min-[1240px]:px-[84px] pt-[24px] relative print:hidden',
+				props.flush ? 'pb-0' : 'pb-[48px]',
+			)}
+		>
 			<div className="relative flex min-h-[34px] items-center justify-center">
 				<Footer.ThemeToggle />
 				<ul className="text-ui-meta flex items-center justify-center gap-[24px] select-none">
@@ -43,6 +49,10 @@ export function Footer(): React.JSX.Element {
 }
 
 export namespace Footer {
+	export interface Props {
+		flush?: boolean
+	}
+
 	export function ThemeToggle(): React.JSX.Element {
 		const [theme, setTheme] = React.useState<ThemeMode>(defaultThemeMode)
 		const nextTheme = theme === 'dark' ? 'light' : 'dark'

--- a/apps/explorer/src/comps/Layout.tsx
+++ b/apps/explorer/src/comps/Layout.tsx
@@ -26,7 +26,7 @@ export function Layout(props: Layout.Props) {
 						{children}
 					</main>
 					<div className="w-full mt-6 relative z-1 print:hidden">
-						<Footer />
+						<Footer flush={isLanding} />
 					</div>
 					{isLanding && <Sphere />}
 				</div>

--- a/apps/explorer/src/comps/Sphere.tsx
+++ b/apps/explorer/src/comps/Sphere.tsx
@@ -23,7 +23,7 @@ export function Sphere(props: Sphere.Props) {
 	}, [])
 
 	return (
-		<div className="fixed bottom-0 w-full pointer-events-none overflow-hidden h-[300px] z-0 print:hidden hidden sm:block">
+		<div className="fixed bottom-0 w-full pointer-events-none overflow-hidden h-[242px] z-0 print:hidden hidden sm:block">
 			<div
 				ref={containerRef}
 				className="absolute top-0 z-0 w-full flex justify-center pointer-events-none"


### PR DESCRIPTION
## Summary

- align the landing artwork’s visible edge with the viewport bottom
- remove bottom padding from the footer on the landing page only
- preserve existing footer spacing on explorer detail pages

## Screenshots

| Before | After |
| --- | --- |
| Artwork and footer content stop roughly 48–59px above the viewport edge | Artwork meets the viewport edge and the landing footer sits flush with it |

## Validation

- `pnpm --filter explorer test` (80 tests)
- `pnpm --filter explorer check` (103 environment tests, formatting, and types)
- `pnpm --filter explorer check:types`
- `pnpm precommit`
- Rendered locally at 2000×1241 and visually verified against the reported viewport

> Note: the monorepo-wide `pnpm check` reaches unrelated pre-existing generated-type errors in `apps/contract-verification`; explorer-scoped checks pass.

Prompted by: @snario
