### PR TITLE
fix(explorer): align simulator typography

### DIFF
--- a/apps/explorer/src/comps/SimulateCallForm.tsx
+++ b/apps/explorer/src/comps/SimulateCallForm.tsx
@@ -195,14 +195,14 @@ export function SimulateCallForm(
 				)}
 
 				{isBatch && (
-					<p className="text-[11px] text-content-dimmed">
+					<p className="type-card text-content-dimmed">
 						Calls run in order against each other{'’'}s state, the way a Tempo
 						batch transaction executes.
 					</p>
 				)}
 
 				{props.formError && (
-					<p className="text-[12px] text-negative">{props.formError}</p>
+					<p className="type-card text-negative">{props.formError}</p>
 				)}
 			</div>
 		</div>
@@ -243,7 +243,7 @@ function ContextBar(props: {
 	return (
 		<div className="flex flex-col gap-[8px] border-b border-card-border px-[16px] py-[10px]">
 			<div className="flex items-center justify-between gap-[8px]">
-				<span className="text-[11px] text-tertiary">Simulate against</span>
+				<span className="type-card text-tertiary">Simulate against</span>
 				<SegmentedControl
 					size="sm"
 					value={pinned ? 'pinned' : 'latest'}
@@ -296,7 +296,7 @@ function LoadTransaction(props: {
 	const id = React.useId()
 	return (
 		<div className="flex flex-col gap-[5px] rounded-[8px] border border-dashed border-card-border px-[10px] py-[9px]">
-			<label className="text-[11px] text-tertiary" htmlFor={id}>
+			<label className="type-card text-tertiary" htmlFor={id}>
 				Replay an existing transaction
 			</label>
 			<div className="flex gap-[6px]">
@@ -314,7 +314,7 @@ function LoadTransaction(props: {
 				</Button>
 			</div>
 			{props.error && (
-				<span className="text-[11px] text-negative">{props.error}</span>
+				<span className="type-card text-negative">{props.error}</span>
 			)}
 		</div>
 	)
@@ -334,7 +334,7 @@ function StepTabs(props: {
 }): React.JSX.Element {
 	return (
 		<div className="flex flex-col gap-[6px]">
-			<span className="text-[11px] text-tertiary">
+			<span className="type-card text-tertiary">
 				Calls
 				<span className="ml-[6px] text-content-dimmed">
 					{props.calls.length} in order
@@ -350,7 +350,7 @@ function StepTabs(props: {
 								onClick={() => props.onSelect(index)}
 								title={call.to || `Call ${index + 1}`}
 								className={cx(
-									'flex h-[26px] items-center gap-[6px] rounded-[6px] border px-[8px] text-[11px] cursor-pointer press-down transition-colors',
+									'flex h-[28px] items-center gap-[6px] rounded-[6px] border px-[8px] type-card cursor-pointer press-down transition-colors',
 									selected
 										? 'border-accent bg-accent/8 text-primary'
 										: 'border-card-border text-tertiary hover:text-secondary',
@@ -588,14 +588,14 @@ export function CalldataField(props: {
 					/>
 				) : props.hasTarget && !abi ? (
 					// No ABI is a fact, not an error — say it once and stay usable.
-					<span className="text-[11px] text-content-dimmed">
+					<span className="type-card text-content-dimmed">
 						no ABI · hex only
 					</span>
 				) : undefined
 			}
 		>
 			{mismatch && mode === 'decoded' && (
-				<div className="rounded-[6px] border border-warning/40 bg-warning-background px-[9px] py-[6px] text-[11px] text-secondary">
+				<div className="rounded-[6px] border border-warning/40 bg-warning-background px-[9px] py-[6px] type-card text-secondary">
 					This calldata doesn{'’'}t match any function in the contract{'’'}s ABI
 					— showing hex.
 				</div>
@@ -635,7 +635,7 @@ export function CalldataField(props: {
 							key={`${input.name}-${input.type}-${index}`}
 							className="flex flex-col gap-[4px]"
 						>
-							<span className="text-[11px] text-tertiary">
+							<span className="type-card text-tertiary">
 								{input.name || `arg ${index}`}
 								<span className="ml-[6px] font-mono text-content-dimmed">
 									{input.type}
@@ -685,8 +685,8 @@ export function CalldataField(props: {
 					))}
 
 					{data && data !== '0x' && (
-						<div className="flex items-center gap-[8px] border-t border-dashed border-card-border pt-[8px] text-[11px]">
-							<span className="min-w-0 flex-1 truncate font-mono text-tertiary">
+						<div className="flex items-center gap-[8px] border-t border-dashed border-card-border pt-[8px] type-card">
+							<span className="min-w-0 flex-1 truncate type-card-data text-tertiary">
 								{data}
 							</span>
 							<span className="shrink-0 text-content-dimmed">
@@ -721,7 +721,7 @@ export function CalldataField(props: {
 						)}
 					/>
 					{byteLength > 0 && (
-						<span className="text-[11px] text-content-dimmed">
+						<span className="type-card text-content-dimmed">
 							{byteLength} bytes
 							{byteLength > MAX_URL_CALLDATA_BYTES &&
 								' · too long for a shareable link'}
@@ -756,12 +756,12 @@ export function OptionalRow(props: {
 				<button
 					type="button"
 					onClick={() => setOpen(true)}
-					className="flex min-w-0 flex-1 items-center gap-[8px] text-left text-[12px] text-tertiary cursor-pointer press-down hover:text-secondary"
+					className="flex min-w-0 flex-1 items-center gap-[8px] text-left type-card text-tertiary cursor-pointer press-down hover:text-secondary"
 				>
 					<span className="shrink-0 text-content-dimmed">{props.icon}</span>
 					<span className="shrink-0">{props.label}</span>
 					{set && (
-						<span className="min-w-0 truncate font-mono text-[11px] text-primary">
+						<span className="min-w-0 truncate type-card-data text-primary">
 							{props.summary}
 						</span>
 					)}
@@ -790,7 +790,7 @@ export function OptionalRow(props: {
 		<div className="flex flex-col gap-[8px] rounded-[8px] border border-card-border bg-card-header p-[9px]">
 			<div className="flex items-center gap-[8px]">
 				<span className="shrink-0 text-content-dimmed">{props.icon}</span>
-				<span className="text-[12px] text-secondary">{props.label}</span>
+				<span className="type-card text-secondary">{props.label}</span>
 				<button
 					type="button"
 					onClick={() => setOpen(false)}

--- a/apps/explorer/src/comps/SimulateGasPanel.tsx
+++ b/apps/explorer/src/comps/SimulateGasPanel.tsx
@@ -62,7 +62,7 @@ export function SimulateGasPanel(
 					onSelect={props.onSelectFrame}
 				/>
 			) : (
-				<p className="border-b border-dashed border-card-border px-[16px] py-[10px] text-[11px] text-content-dimmed">
+				<p className="border-b border-dashed border-card-border px-[16px] py-[10px] type-card text-content-dimmed">
 					{present.length > 1
 						? `${present.length} calls — pick one call above to see its flamegraph.`
 						: frames.length === 1
@@ -113,9 +113,9 @@ function FrameTable(props: {
 	)
 
 	return (
-		<table className="w-full text-[12px]">
+		<table className="w-full type-card">
 			<thead>
-				<tr className="border-b border-card-border bg-base-alt text-[11px] text-tertiary">
+				<tr className="border-b border-card-border bg-base-alt type-card text-tertiary">
 					{props.showCall && (
 						<th className="w-[64px] px-[16px] py-[6px] text-left font-normal">
 							Call
@@ -155,7 +155,7 @@ function FrameTable(props: {
 							)}
 						>
 							{props.showCall && (
-								<td className="px-[16px] py-[6px] font-mono text-[11px] text-tertiary">
+								<td className="px-[16px] py-[6px] type-card-data text-tertiary">
 									{frame.call ?? ''}
 								</td>
 							)}

--- a/apps/explorer/src/comps/SimulateResultPane.tsx
+++ b/apps/explorer/src/comps/SimulateResultPane.tsx
@@ -119,12 +119,12 @@ export function SimulateResultHeader(
 						className="shrink-0"
 						title={`Gas used by the simulated call, out of a ${limit.toLocaleString()} limit. Estimated — no fee is charged or synthesized.`}
 					>
-						<span className="font-mono text-[12px] text-tertiary">gas </span>
+						<span className="type-card-data text-tertiary">gas </span>
 						<GasRatio used={execution.gasUsed} limit={limit} />
 					</span>
 
 					<span
-						className="shrink-0 font-mono text-[12px]"
+						className="shrink-0 type-card-data"
 						title={
 							input.block === 'latest'
 								? 'Executed at the end of the latest block.'
@@ -141,7 +141,7 @@ export function SimulateResultHeader(
 						</span>
 					</span>
 
-					<span className="shrink-0 text-[11px] text-content-dimmed">
+					<span className="shrink-0 type-card text-content-dimmed">
 						{networkName(input.chainId)}
 					</span>
 				</>
@@ -214,7 +214,7 @@ export function SimulateTabs(props: SimulateTabs.Props): React.JSX.Element {
 						{tab.count !== undefined && (
 							<span
 								className={cx(
-									'font-mono text-[11px]',
+									'type-card-data',
 									active ? 'text-tertiary' : 'text-content-dimmed',
 								)}
 							>
@@ -361,7 +361,7 @@ function FailureAnswer(props: {
 						{errorName}
 					</span>
 					{errorArgs.length > 0 && (
-						<dl className="grid gap-x-[14px] gap-y-[3px] font-mono text-[12px] min-[520px]:grid-cols-[max-content_minmax(0,1fr)]">
+						<dl className="grid gap-x-[14px] gap-y-[3px] type-card-data min-[520px]:grid-cols-[max-content_minmax(0,1fr)]">
 							{errorArgs.map((arg) => (
 								<React.Fragment key={arg.label}>
 									<dt className="text-tertiary">{arg.label}</dt>
@@ -382,7 +382,7 @@ function FailureAnswer(props: {
 					)}
 				</div>
 			) : (
-				<div className="rounded-[7px] border border-negative/25 bg-negative/6 px-[11px] py-[9px] font-mono text-[12px] break-all text-secondary">
+				<div className="rounded-[7px] border border-negative/25 bg-negative/6 px-[11px] py-[9px] type-card-data break-all text-secondary">
 					{decoded?.raw ?? props.returnData ?? 'No revert data returned.'}
 				</div>
 			)}
@@ -391,7 +391,7 @@ function FailureAnswer(props: {
 				<button
 					type="button"
 					onClick={() => props.onJump(failedNode.id)}
-					className="inline-flex w-fit items-center gap-[4px] text-[11px] text-accent cursor-pointer press-down hover:underline"
+					className="inline-flex w-fit items-center gap-[4px] type-card text-accent cursor-pointer press-down hover:underline"
 				>
 					<ArrowRightIcon className="size-[11px]" />
 					Show {call ?? 'the failing frame'} in the trace
@@ -418,14 +418,14 @@ export function SimulateDiff(props: {
 	const statusChanged = props.execution.status !== props.original.status
 	if (!statusChanged && gasDiff === 0n && eventDiff === 0 && balanceDiff === 0)
 		return (
-			<div className="flex items-center gap-[6px] border-b border-dashed border-card-border px-[16px] py-[7px] text-[11px]">
+			<div className="flex items-center gap-[6px] border-b border-dashed border-card-border px-[16px] py-[7px] type-card">
 				<span className="text-tertiary">{props.label}</span>
 				<Chip tone="neutral">no change</Chip>
 			</div>
 		)
 
 	return (
-		<div className="flex flex-wrap items-center gap-[6px] border-b border-dashed border-card-border px-[16px] py-[7px] text-[11px]">
+		<div className="flex flex-wrap items-center gap-[6px] border-b border-dashed border-card-border px-[16px] py-[7px] type-card">
 			<span className="mr-[2px] text-tertiary">{props.label}</span>
 			{statusChanged && (
 				<Chip tone="negative">
@@ -511,7 +511,7 @@ export function SimulateOverview(props: {
 				<span className="text-[13px] font-medium text-primary">
 					Balance changes
 				</span>
-				<span className="font-mono text-[12px] text-tertiary">
+				<span className="type-card-data text-tertiary">
 					{props.assetChanges.length}
 				</span>
 			</div>
@@ -542,9 +542,7 @@ export function SimulateStepBar(props: {
 	const failed = props.calls.filter((call) => call.status === 'reverted').length
 	return (
 		<div className="flex flex-wrap items-center gap-[6px] border-b border-card-border px-[16px] py-[8px]">
-			<span className="mr-[2px] shrink-0 text-[11px] text-tertiary">
-				Showing
-			</span>
+			<span className="mr-[2px] shrink-0 type-card text-tertiary">Showing</span>
 			{/* A batch is one transaction, so seeing all of it is the default; the
 			    per-call chips narrow the evidence rather than switching between
 			    unrelated views. */}
@@ -553,7 +551,7 @@ export function SimulateStepBar(props: {
 				onClick={() => props.onSelect(undefined)}
 				title="Every call of the batch, in order"
 				className={cx(
-					'flex h-[24px] shrink-0 items-center gap-[6px] rounded-[6px] border px-[8px] text-[11px] cursor-pointer press-down transition-colors',
+					'flex h-[28px] shrink-0 items-center gap-[6px] rounded-[6px] border px-[8px] type-card cursor-pointer press-down transition-colors',
 					props.step === undefined
 						? 'border-accent bg-accent/10 font-medium text-primary'
 						: 'border-card-border text-tertiary hover:border-tertiary/40 hover:text-secondary',
@@ -609,25 +607,25 @@ export function SimulateCallHeading(props: {
 			>
 				{failed ? '✗' : '✓'}
 			</span>
-			<span className="shrink-0 text-[11px] text-tertiary">
+			<span className="shrink-0 type-card text-tertiary">
 				Call {call.index + 1} of {props.total}
 			</span>
 			<span
 				className={cx(
-					'min-w-0 truncate font-mono text-[12px]',
+					'min-w-0 truncate type-card-data',
 					failed ? 'text-negative' : 'text-primary',
 				)}
 			>
 				{label}
 			</span>
-			<span className="ml-auto shrink-0 font-mono text-[11px] text-tertiary">
+			<span className="ml-auto shrink-0 type-card-data text-tertiary">
 				{call.gasUsed.toLocaleString()} gas
 			</span>
 			<button
 				type="button"
 				onClick={props.onIsolate}
 				title="Show only this call"
-				className="shrink-0 text-[11px] text-accent cursor-pointer press-down hover:underline"
+				className="shrink-0 type-card text-accent cursor-pointer press-down hover:underline"
 			>
 				Isolate
 			</button>
@@ -651,7 +649,7 @@ function StepChip(props: {
 			onClick={props.onSelect}
 			title={`Call ${call.index + 1} of ${props.total} — ${call.to}${failed ? ' · reverted' : ' · succeeded'}`}
 			className={cx(
-				'flex h-[24px] shrink-0 items-center gap-[6px] rounded-[6px] border pr-[8px] pl-[5px] text-[11px] cursor-pointer press-down transition-colors',
+				'flex h-[28px] shrink-0 items-center gap-[6px] rounded-[6px] border pr-[8px] pl-[5px] type-card cursor-pointer press-down transition-colors',
 				selected
 					? 'border-accent bg-accent/10 text-primary'
 					: 'border-card-border text-tertiary hover:border-tertiary/40 hover:text-secondary',
@@ -699,11 +697,11 @@ export function SimulateBalances(props: {
 	}
 
 	return (
-		<table className="w-full text-[12px]">
+		<table className="w-full type-card">
 			<thead>
-				{/* Tinted, 11px, its own bottom rule: a column header has to look
+				{/* Tinted card text with its own bottom rule: a column header has to look
 				    like chrome, not like the first row of data. */}
-				<tr className="border-b border-card-border bg-base-alt text-[11px] text-tertiary">
+				<tr className="border-b border-card-border bg-base-alt type-card text-tertiary">
 					<th className="px-[16px] py-[6px] text-left font-normal">Account</th>
 					<th className="px-[10px] py-[6px] text-left font-normal">Token</th>
 					<th className="px-[16px] py-[6px] text-right font-normal">Change</th>
@@ -795,7 +793,7 @@ export function SimulateEvents(props: {
 					key={`${event.type}-${index}`}
 					className="flex items-start gap-[10px] px-[16px] py-[9px] text-[13px]"
 				>
-					<span className="mt-[3px] shrink-0 font-mono text-[11px] text-content-dimmed tabular-nums">
+					<span className="mt-[3px] shrink-0 type-card-data text-content-dimmed tabular-nums">
 						{index + 1}
 					</span>
 					<TxEventDescription event={event} />

--- a/apps/explorer/src/comps/SimulateShared.tsx
+++ b/apps/explorer/src/comps/SimulateShared.tsx
@@ -1,13 +1,12 @@
 /**
  * Shared primitives for the simulator.
  *
- * The simulator is the densest screen in the explorer, so it commits to one
- * type and colour ramp and never improvises:
+ * The simulator uses the explorer's shared card typography roles:
  *
- *   11px  labels, units, meta, chips        text-tertiary / text-content-dimmed
- *   12px  mono data — trace, hex, numbers   text-primary / text-secondary
- *   13px  titles and readable prose         text-primary (medium) / text-secondary
- *   14px  exactly one headline per pane     text-primary (medium)
+ *   type-card       labels, controls, prose
+ *   type-card-data  trace, hex, numbers
+ *   14px            exactly one headline per pane
+ *   11px            compact status chips only
  *
  * Weight carries hierarchy, not size: `font-medium` marks a title or the one
  * value that is the answer, everything else is `font-normal`. There is no bold.
@@ -42,19 +41,19 @@ import RotateCcwIcon from '~icons/lucide/rotate-ccw'
 /* Controls                                                                   */
 /* -------------------------------------------------------------------------- */
 
-/** Label above a control. 11px tertiary, always. */
+/** Label above a control. */
 export function Field(props: Field.Props): React.JSX.Element {
 	return (
 		<div className="flex min-w-0 flex-col gap-[5px]">
 			<div className="flex items-center justify-between gap-[8px]">
-				<span className="text-[11px] text-tertiary">{props.label}</span>
+				<span className="type-card text-tertiary">{props.label}</span>
 				{props.action}
 			</div>
 			{props.children}
 			{props.hint && (
 				<span
 					className={cx(
-						'text-[11px]',
+						'type-card',
 						props.invalid ? 'text-negative' : 'text-content-dimmed',
 					)}
 				>
@@ -77,7 +76,7 @@ export declare namespace Field {
 }
 
 const inputClassName =
-	'w-full min-w-0 rounded-[6px] border border-card-border bg-base-plane px-[9px] py-[6px] font-mono text-[12px] text-primary outline-none transition-colors placeholder:text-field-content-secondary focus:border-accent'
+	'w-full min-w-0 rounded-[6px] border border-card-border bg-base-plane px-[9px] py-[6px] type-card-data text-primary outline-none transition-colors placeholder:text-field-content-secondary focus:border-accent'
 
 /** Invalid state is applied on blur, never on mount — see `draftFieldErrors`. */
 export function inputClass(invalid?: boolean): string {
@@ -92,7 +91,7 @@ export function Button(props: Button.Props): React.JSX.Element {
 			type="button"
 			{...rest}
 			className={cx(
-				'flex h-[28px] shrink-0 items-center gap-[6px] rounded-[7px] px-[10px] text-[12px] cursor-pointer press-down transition-colors disabled:cursor-not-allowed disabled:opacity-50',
+				'flex h-[28px] shrink-0 items-center gap-[6px] rounded-[7px] px-[10px] type-card cursor-pointer press-down transition-colors disabled:cursor-not-allowed disabled:opacity-50',
 				// `text-white-black` is white on the light-mode accent and black on the
 				// lighter dark-mode accent, which is the readable pairing in both.
 				tone === 'primary'
@@ -148,19 +147,18 @@ export declare namespace Chip {
 }
 
 /**
- * A label/value pair in the result header. The label is 11px tertiary and the
- * value is 12px mono, so a column of them aligns on both axes without a table.
+ * A label/value pair in the result header using the shared card roles.
  */
 export function Fact(props: Fact.Props): React.JSX.Element {
 	return (
 		<div className="flex min-w-0 items-baseline gap-[8px]">
 			<span
-				className="w-[72px] shrink-0 text-[11px] text-tertiary"
+				className="w-[72px] shrink-0 type-card text-tertiary"
 				title={props.hint}
 			>
 				{props.label}
 			</span>
-			<span className="min-w-0 truncate font-mono text-[12px] text-primary">
+			<span className="min-w-0 truncate type-card-data text-primary">
 				{props.children}
 			</span>
 		</div>
@@ -188,7 +186,7 @@ export function GasMeter(props: GasMeter.Props): React.JSX.Element {
 	return (
 		<div className="flex flex-col gap-[6px]">
 			<div className="flex items-baseline justify-between gap-[8px]">
-				<span className="text-[11px] text-tertiary">Gas used</span>
+				<span className="type-card text-tertiary">Gas used</span>
 				<GasRatio used={props.used} limit={props.limit} />
 			</div>
 			<div className="h-[4px] w-full overflow-hidden rounded-full bg-distinct">
@@ -237,7 +235,7 @@ export function GasRatio(props: {
 }): React.JSX.Element {
 	const pct = gasPercent(props.used, props.limit)
 	return (
-		<span className={cx('font-mono text-[12px]', props.className)}>
+		<span className={cx('type-card-data', props.className)}>
 			<span className="text-primary">{props.used.toLocaleString()}</span>
 			<span className="text-content-dimmed">
 				{' / '}
@@ -289,7 +287,7 @@ export function PanelEmpty(props: {
 	children: React.ReactNode
 }): React.JSX.Element {
 	return (
-		<div className="px-[16px] py-[18px] text-[12px] text-tertiary">
+		<div className="px-[16px] py-[18px] type-card text-tertiary">
 			{props.children}
 		</div>
 	)
@@ -302,11 +300,11 @@ export function PanelError(props: {
 	const rateLimited =
 		props.error instanceof SimulationApiError && props.error.status === 429
 	return (
-		<div className="flex flex-col gap-[4px] px-[16px] py-[14px] text-[12px]">
+		<div className="flex flex-col gap-[4px] px-[16px] py-[14px] type-card">
 			<span className="text-negative">
 				{rateLimited ? 'Rate limited' : props.title}
 			</span>
-			<span className="font-mono text-[11px] break-all text-tertiary">
+			<span className="type-card-data break-all text-tertiary">
 				{props.error.message}
 			</span>
 		</div>
@@ -334,12 +332,12 @@ export function SimulationFailure(props: {
 			<CircleAlertIcon className="mt-[2px] size-[14px] shrink-0 text-negative" />
 			<div className="flex min-w-0 flex-1 flex-col gap-[6px]">
 				<h2 className="text-[13px] font-medium text-negative">{title}</h2>
-				<p className="text-[12px] text-secondary">{hint}</p>
+				<p className="type-card text-secondary">{hint}</p>
 				<div className="flex flex-col gap-[4px]">
 					{messages.map((message) => (
 						<code
 							key={message}
-							className="block rounded-[6px] bg-distinct px-[9px] py-[6px] font-mono text-[11px] break-all text-tertiary"
+							className="block rounded-[6px] bg-distinct px-[9px] py-[6px] type-card-data break-all text-tertiary"
 						>
 							{message}
 						</code>

--- a/apps/explorer/src/routes/_layout/simulate.tsx
+++ b/apps/explorer/src/routes/_layout/simulate.tsx
@@ -543,13 +543,13 @@ function SimulatePage(): React.JSX.Element {
 	const showOutput = pane === 'output' || pane === 'split'
 
 	return (
-		<div className="flex w-full flex-col px-[24px] pt-8 pb-12 min-[800px]:pt-14 min-[1240px]:px-[84px]">
+		<div className="flex w-full flex-col px-[24px] pt-8 pb-12 type-card min-[800px]:pt-14 min-[1240px]:px-[84px]">
 			<div className="mb-[12px] flex flex-wrap items-center gap-x-[14px] gap-y-[8px]">
 				<h1 className="shrink-0 text-[18px] font-medium text-primary">
 					Simulate
 				</h1>
 				<p
-					className="min-w-0 flex-1 truncate font-mono text-[12px] text-tertiary"
+					className="min-w-0 flex-1 truncate type-card-data text-tertiary"
 					title={summary}
 				>
 					{summary}
@@ -1190,7 +1190,7 @@ function SimulationEmptyState(props: {
 				/>
 			</div>
 			<div className="flex flex-col gap-[12px] px-[16px] py-[16px]">
-				<p className="max-w-[520px] text-[12px] leading-[18px] text-tertiary">
+				<p className="max-w-[520px] type-card text-tertiary">
 					Fill in a call and run it, or replay an existing transaction by hash
 					against the state of its parent block. Nothing is signed and nothing
 					is broadcast.


### PR DESCRIPTION
## Summary
- replace the simulator's private 11/12px type ramp with the explorer's shared card typography roles
- use Satoshi card text for labels, controls, prose, and tables
- use Geist Mono card data for addresses, calldata, gas, counts, and trace values
- retain smaller text only for compact status chips and keyboard hints

## Screenshots

| Before | After |
| --- | --- |
| Simulator labels and fields used a separate 11/12px scale from the rest of Explorer. | Simulator UI and data use the shared 13px/16px/400 card roles. |

## Validation
- `pnpm --filter explorer check`
- `pnpm --filter explorer test -- --run`
- `VITE_TEMPO_ENV=mainnet pnpm --filter explorer build`
- `pnpm precommit`
- repository-wide `pnpm check` reaches an unrelated existing `contract-verification` generated-Env type failure; Explorer checks pass

Prompted by: @snario
