### PR TITLE
fix(explorer): show private zone withdrawal activity

### DIFF
--- a/apps/explorer/src/lib/domain/known-events.ts
+++ b/apps/explorer/src/lib/domain/known-events.ts
@@ -294,7 +294,8 @@ function createDetectors(
 
 				if (
 					isZonePortalAddress(args.from) &&
-					!Address.isEqual(args.to, zeroAddress)
+					!Address.isEqual(args.to, zeroAddress) &&
+					!Address.isEqual(args.to, ZoneAddresses.zoneMessenger)
 				) {
 					const zoneName = getZoneName(args.from)
 					return {
@@ -405,6 +406,10 @@ function createDetectors(
 
 			if (eventName === 'WithdrawalProcessed') {
 				const zoneName = getZoneName(address)
+				const action =
+					'senderTag' in args
+						? 'Private Zone Withdrawal'
+						: `Withdraw from ${zoneName}`
 				const note: NonNullable<KnownEvent['note']> = []
 				if (!args.callbackSuccess) {
 					note.push(['Callback', { type: 'text', value: 'Failed' }])
@@ -413,7 +418,7 @@ function createDetectors(
 				return {
 					type: 'zone withdrawal',
 					parts: [
-						{ type: 'action', value: `Withdraw from ${zoneName}` },
+						{ type: 'action', value: action },
 						{ type: 'amount', value: createAmount(args.amount, args.token) },
 						{ type: 'text', value: 'to' },
 						{ type: 'account', value: args.to },

--- a/apps/explorer/src/lib/domain/transaction-activities.ts
+++ b/apps/explorer/src/lib/domain/transaction-activities.ts
@@ -34,6 +34,8 @@ const PRIVATE_ZONE_ACTIONS: Record<string, [string, string, string]> = {
 	],
 }
 
+type ZoneDirection = 'deposit' | 'withdrawal'
+
 export function activitiesToKnownEvents(
 	activities: readonly TransactionActivity[],
 	options: { portal?: Address.Address | null } = {},
@@ -178,23 +180,46 @@ export function selectTransactionDescriptionEvents(params: {
 		params.knownCall || hasMeaningfulActivity
 			? params.activityEvents.filter((event) => !isNonceIncrementedEvent(event))
 			: params.activityEvents
-	const hasPrivateZoneActivity = activityEvents.some(isPrivateZoneEvent)
+	const representedPrivateZoneDirections = new Set(
+		activityEvents.flatMap((event) => {
+			const direction = privateZoneEventDirection(event)
+			return direction ? [direction] : []
+		}),
+	)
+	const hasPrivateZoneActivity = representedPrivateZoneDirections.size > 0
+	const supplementalZoneEvents = fallbackEvents.filter((event) => {
+		const direction = zoneEventDirection(event)
+		return (
+			event !== params.knownCall &&
+			direction !== null &&
+			!representedPrivateZoneDirections.has(direction)
+		)
+	})
+	const events = [...supplementalZoneEvents, ...activityEvents]
 	return params.knownCall && !hasPrivateZoneActivity
-		? [params.knownCall, ...activityEvents]
-		: [...activityEvents]
+		? [params.knownCall, ...events]
+		: events
 }
 
 function isPrivateZoneEvent(event: KnownEvent): boolean {
-	return (
-		PRIVATE_ZONE_ACTIONS[event.type] !== undefined ||
-		event.parts.some(
-			(part) =>
-				part.type === 'action' &&
-				['Private Zone Deposit', 'Private Zone Withdrawal'].includes(
-					part.value,
-				),
-		)
-	)
+	return privateZoneEventDirection(event) !== null
+}
+
+function privateZoneEventDirection(event: KnownEvent): ZoneDirection | null {
+	if (event.type === 'private-assets-deposited') return 'deposit'
+	if (event.type === 'private-shares-redeemed') return 'withdrawal'
+	const action = event.parts.find((part) => part.type === 'action')?.value
+	if (action === 'Private Zone Deposit') return 'deposit'
+	if (action === 'Private Zone Withdrawal') return 'withdrawal'
+	return null
+}
+
+function zoneEventDirection(event: KnownEvent): ZoneDirection | null {
+	if (event.type === 'zone deposit' || event.type === 'zone encrypted deposit')
+		return 'deposit'
+	if (event.type === 'zone withdrawal' || event.type === 'zone bounce back')
+		return 'withdrawal'
+	return null
 }
 
 export function isNonceIncrementedEvent(event: KnownEvent): boolean {

--- a/apps/explorer/test/known-events.test.ts
+++ b/apps/explorer/test/known-events.test.ts
@@ -295,6 +295,32 @@ describe('parseKnownEvents', () => {
 		}
 	})
 
+	it('labels sender-tagged Zone withdrawals as private', () => {
+		const portal = '0x5ad0000000000000000000000000000000000003' as const
+		const withdrawalProcessed = zonePortalAbi.find(
+			(item): item is AbiEvent =>
+				item.type === 'event' &&
+				item.name === 'WithdrawalProcessed' &&
+				item.inputs.some((input) => input.name === 'senderTag'),
+		)
+		expect(withdrawalProcessed).toBeDefined()
+		if (!withdrawalProcessed) return
+
+		const [event] = parseKnownEvents(
+			mockReceipt(
+				[mockZoneEventLog(withdrawalProcessed, portal)],
+				accountAddress,
+				`0x${'9'.repeat(64)}`,
+			),
+			{ getTokenMetadata },
+		)
+
+		expect(event?.parts[0]).toEqual({
+			type: 'action',
+			value: 'Private Zone Withdrawal',
+		})
+	})
+
 	it('decodes stablecoin DEX OrderFlipped buy and sell events', () => {
 		const hash = `0x${'6'.repeat(64)}` as const
 		const amount = 1_000_000n
@@ -439,6 +465,45 @@ describe('parseKnownEvents', () => {
 		expect(knownEvents[0]?.parts[0]).toEqual({
 			type: 'action',
 			value: 'Deposit to Zone E',
+		})
+	})
+
+	it('does not label a Zone Messenger transfer as a completed withdrawal', () => {
+		const hash = `0x${'4'.repeat(64)}` as const
+		const amount = 500_000n
+		const logs = [
+			mockLog(
+				{
+					address: userTokenAddress,
+					topics: encodeEventTopics({
+						abi: Abis.tip20,
+						eventName: 'Transfer',
+						args: {
+							from: ZONE_5_PORTAL,
+							to: ZoneAddresses.zoneMessenger,
+						},
+					}) as [Hex.Hex, ...Hex.Hex[]],
+					data: encodeAbiParameters([{ type: 'uint256' }], [amount]),
+				},
+				hash,
+			),
+		]
+
+		const [event] = parseKnownEvents(mockReceipt(logs, accountAddress, hash), {
+			getTokenMetadata,
+		})
+
+		expect(event).toMatchObject({
+			type: 'send',
+			parts: [
+				{ type: 'action', value: 'Send' },
+				{ type: 'amount' },
+				{ type: 'text', value: 'to' },
+				{
+					type: 'account',
+					value: Address.checksum(ZoneAddresses.zoneMessenger),
+				},
+			],
 		})
 	})
 

--- a/apps/explorer/test/transaction-activities.test.ts
+++ b/apps/explorer/test/transaction-activities.test.ts
@@ -325,6 +325,33 @@ describe('selectTransactionDescriptionEvents for Zones', () => {
 		).toEqual([vaultDeposit])
 	})
 
+	test('preserves a Zone withdrawal alongside private Earn activity', () => {
+		const zoneWithdrawal = {
+			type: 'zone withdrawal',
+			parts: [{ type: 'action' as const, value: 'Private Zone Withdrawal' }],
+		}
+		const privateZoneDeposit = {
+			type: 'zone deposit',
+			parts: [{ type: 'action' as const, value: 'Private Zone Deposit' }],
+		}
+		const vaultDeposit = {
+			type: 'private-assets-deposited',
+			parts: [{ type: 'action' as const, value: 'Vault Deposit' }],
+		}
+		const zoneDepositActivity = {
+			type: 'private-assets-deposited',
+			parts: [{ type: 'action' as const, value: 'Private Zone Deposit' }],
+		}
+
+		expect(
+			selectTransactionDescriptionEvents({
+				activityEvents: [vaultDeposit, zoneDepositActivity],
+				fallbackEvents: [privateZoneDeposit, zoneWithdrawal],
+				knownCall: null,
+			}),
+		).toEqual([zoneWithdrawal, vaultDeposit, zoneDepositActivity])
+	})
+
 	test('does not duplicate private Zone activity with a low-level decoded call', () => {
 		const decodedCall = {
 			type: 'zone encrypted deposit',


### PR DESCRIPTION
## Summary\n\n- Show sender-tagged Zone withdrawals as **Private Zone Withdrawal**\n- Preserve the decoded withdrawal alongside the vault mint/deposit activity rows\n- Exclude the protocol-internal messenger transfer from completed-withdrawal labeling\n- Add regression coverage for the exact transaction and both withdrawal variants\n\n## Screenshots\n\n| Before | After |\n|--------|-------|\n| ![Before: withdrawal missing from transaction overview](https://files.catbox.moe/w17caf.png) | ![After: Private Zone Withdrawal shown first](https://files.catbox.moe/n0edmj.png) |\n\n## Test plan\n\n- **pnpm check**\n- **pnpm check:types**\n- **pnpm test** in **apps/explorer**\n- **pnpm precommit**\n- Browser verification against the affected transaction