### PR TITLE
fix(explorer): restore landing footer inset

### DIFF
--- a/apps/explorer/src/comps/Footer.tsx
+++ b/apps/explorer/src/comps/Footer.tsx
@@ -1,6 +1,5 @@
 import { Link as RouterLink } from '@tanstack/react-router'
 import * as React from 'react'
-import { cx } from '#lib/css'
 import {
 	applyThemeMode,
 	defaultThemeMode,
@@ -16,14 +15,9 @@ import {
 import MoonIcon from '~icons/lucide/moon'
 import SunIcon from '~icons/lucide/sun'
 
-export function Footer(props: Footer.Props): React.JSX.Element {
+export function Footer(): React.JSX.Element {
 	return (
-		<footer
-			className={cx(
-				'@container px-[24px] @min-[1240px]:px-[84px] pt-[24px] relative print:hidden',
-				props.flush ? 'pb-0' : 'pb-[48px]',
-			)}
-		>
+		<footer className="@container px-[24px] @min-[1240px]:px-[84px] pt-[24px] pb-[48px] relative print:hidden">
 			<div className="relative flex min-h-[34px] items-center justify-center">
 				<Footer.ThemeToggle />
 				<ul className="text-ui-meta flex items-center justify-center gap-[24px] select-none">
@@ -49,10 +43,6 @@ export function Footer(props: Footer.Props): React.JSX.Element {
 }
 
 export namespace Footer {
-	export interface Props {
-		flush?: boolean
-	}
-
 	export function ThemeToggle(): React.JSX.Element {
 		const [theme, setTheme] = React.useState<ThemeMode>(defaultThemeMode)
 		const nextTheme = theme === 'dark' ? 'light' : 'dark'

--- a/apps/explorer/src/comps/Layout.tsx
+++ b/apps/explorer/src/comps/Layout.tsx
@@ -26,7 +26,7 @@ export function Layout(props: Layout.Props) {
 						{children}
 					</main>
 					<div className="w-full mt-6 relative z-1 print:hidden">
-						<Footer flush={isLanding} />
+						<Footer />
 					</div>
 					{isLanding && <Sphere />}
 				</div>


### PR DESCRIPTION
## Summary

- restore the footer text and theme toggle to their original 48px bottom inset
- retain the bottom-pinned landing artwork from #1205

## Screenshots

| Before | After |
| --- | --- |
| Artwork and footer controls both flush with the viewport | Artwork flush with the viewport; footer controls restored to their original inset |

## Validation

- `pnpm --filter explorer test` (81 tests)
- `pnpm --filter explorer check` (103 environment tests, formatting, and types)
- `pnpm precommit`
- Rendered locally at 2000×1241 and visually verified

Prompted by: @snario
