### PR TITLE
fix(explorer): recognize Zone deposit entrypoints

### DIFF
--- a/apps/explorer/src/comps/TxTraceTree.tsx
+++ b/apps/explorer/src/comps/TxTraceTree.tsx
@@ -1,7 +1,7 @@
 import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { Link } from '@tanstack/react-router'
 import { useEffect, useMemo, useState } from 'react'
-import { decodeAbiParameters, erc20Abi, slice } from 'viem'
+import { decodeAbiParameters, slice } from 'viem'
 import type { Abi, Hex } from 'viem'
 import { blockHashHistoryAbi } from '#lib/abis'
 import { cx } from '#lib/css'
@@ -22,6 +22,7 @@ import {
 	getRevertData,
 	type DecodedTraceError,
 } from '#lib/domain/trace-errors'
+import { getKnownTraceAbiItem } from '#lib/domain/trace-abi'
 import { HexFormatter } from '#lib/formatting'
 import { useCopy, usePermalinkHighlight } from '#lib/hooks'
 import type { CallTrace } from '#lib/queries'
@@ -439,9 +440,9 @@ export function useTraceTrees(
 					const contractAbiItem =
 						contractInfo?.abi && getAbiItem({ abi: contractInfo.abi, selector })
 
-					const erc20AbiItem = getAbiItem({ abi: erc20Abi, selector })
+					const knownAbiItem = getKnownTraceAbiItem(selector)
 
-					const item = autoloadAbiItem || contractAbiItem || erc20AbiItem
+					const item = autoloadAbiItem || contractAbiItem || knownAbiItem
 					if (item?.name && item.inputs) {
 						functionName = item.name
 						const rawArgs =

--- a/apps/explorer/src/lib/abis.ts
+++ b/apps/explorer/src/lib/abis.ts
@@ -235,6 +235,7 @@ const zonePortalCurrentAbi = parseAbi([
 	'event LeaderUpdated(address indexed previousLeader, address indexed newLeader, uint64 indexed epoch, uint64 activationTempoBlock)',
 	'event EnforcementModesUpdated(bool accessMode, bool gatewayMode)',
 	'event RoleUpdated(address indexed account, uint8 prev, uint8 next)',
+	'function deposit(address token, uint128 amount, uint256 keyIndex, (bytes32 ephemeralPubkeyX, uint8 ephemeralPubkeyYParity, bytes ciphertext, bytes12 nonce, bytes16 tag) encrypted, address tempoRefundRecipient) returns (bytes32 newCurrentDepositQueueHash)',
 	'function processWithdrawals((address token, bytes32 senderTag, address to, uint128 amount, bytes32 memo, uint64 gasLimit, uint64 fallbackNonce, bytes callbackData, bytes encryptedSender)[] withdrawals, bytes32 remainingQueue)',
 	'function deliverWithdrawal(address token, address target, uint128 amount, bytes32 senderTag, uint64 gasLimit, bytes data)',
 	'function submitBatch(uint64 tempoBlockNumber, uint64 recentTempoBlockNumber, (bytes32 prevBlockHash, bytes32 nextBlockHash) blockTransition, (bytes32 prevProcessedHash, bytes32 nextProcessedHash, uint64 prevDepositNumber, uint64 nextDepositNumber) depositQueueTransition, bytes32 withdrawalQueueHash, bytes verifierConfig, bytes proof, uint256 zoneHeight, bytes[] signatures)',

--- a/apps/explorer/src/lib/domain/known-events.ts
+++ b/apps/explorer/src/lib/domain/known-events.ts
@@ -2350,6 +2350,9 @@ function decodeZonePortalCall(
 
 	switch (functionName) {
 		case 'deposit': {
+			if (typeof args[1] === 'bigint')
+				return decodeEncryptedZoneDeposit(args, zoneName)
+
 			const [token, recipient, amount, memo, refundRecipient] = args as [
 				Address.Address,
 				Address.Address,
@@ -2374,26 +2377,8 @@ function decodeZonePortalCall(
 				note,
 			}
 		}
-		case 'depositEncrypted': {
-			const [token, amount, keyIndex, _encrypted, refundRecipient] = args as [
-				Address.Address,
-				bigint,
-				bigint,
-				unknown,
-				Address.Address,
-			]
-			return {
-				type: 'zone encrypted deposit',
-				parts: [
-					{ type: 'action', value: `Encrypted Deposit to ${zoneName}` },
-					{ type: 'amount', value: { token, value: amount } },
-				],
-				note: [
-					['Key Index', { type: 'number', value: keyIndex }],
-					['Refund Recipient', { type: 'account', value: refundRecipient }],
-				],
-			}
-		}
+		case 'depositEncrypted':
+			return decodeEncryptedZoneDeposit(args, zoneName)
 		case 'pause':
 			return {
 				type: 'zone portal paused',
@@ -2432,6 +2417,30 @@ function decodeZonePortalCall(
 		}
 		default:
 			return null
+	}
+}
+
+function decodeEncryptedZoneDeposit(
+	args: readonly unknown[],
+	zoneName: string,
+): KnownEvent {
+	const [token, amount, keyIndex, _encrypted, refundRecipient] = args as [
+		Address.Address,
+		bigint,
+		bigint,
+		unknown,
+		Address.Address,
+	]
+	return {
+		type: 'zone encrypted deposit',
+		parts: [
+			{ type: 'action', value: `Encrypted Deposit to ${zoneName}` },
+			{ type: 'amount', value: { token, value: amount } },
+		],
+		note: [
+			['Key Index', { type: 'number', value: keyIndex }],
+			['Refund Recipient', { type: 'account', value: refundRecipient }],
+		],
 	}
 }
 

--- a/apps/explorer/src/lib/domain/trace-abi.ts
+++ b/apps/explorer/src/lib/domain/trace-abi.ts
@@ -1,0 +1,15 @@
+import type { Hex } from 'viem'
+import { erc20Abi } from 'viem'
+import { zonePortalAbi } from '#lib/abis'
+import { getAbiItem } from '#lib/domain/contracts'
+
+/**
+ * Protocol ABIs that can identify calls even when a deployed contract has not
+ * published an ABI and its selector is absent from the signature registry.
+ */
+export function getKnownTraceAbiItem(selector: Hex) {
+	return (
+		getAbiItem({ abi: zonePortalAbi, selector }) ??
+		getAbiItem({ abi: erc20Abi, selector })
+	)
+}

--- a/apps/explorer/test/known-events.test.ts
+++ b/apps/explorer/test/known-events.test.ts
@@ -207,6 +207,27 @@ describe('parseKnownEvents', () => {
 				to: portal,
 				input: encodeFunctionData({
 					abi: zonePortalAbi,
+					functionName: 'deposit',
+					args: [
+						userTokenAddress,
+						1_000_000n,
+						1n,
+						{
+							ephemeralPubkeyX: zeroHash,
+							ephemeralPubkeyYParity: 2,
+							ciphertext: '0x1234',
+							nonce: `0x${'00'.repeat(12)}`,
+							tag: `0x${'00'.repeat(16)}`,
+						},
+						accountAddress,
+					],
+				}),
+				action: 'Encrypted Deposit to Zone 3',
+			},
+			{
+				to: portal,
+				input: encodeFunctionData({
+					abi: zonePortalAbi,
 					functionName: 'pause',
 				}),
 				action: 'Pause Zone 3 Portal',
@@ -266,7 +287,7 @@ describe('parseKnownEvents', () => {
 			decodeKnownTransactionCall({
 				to: accountAddress,
 				input: '0x',
-				calls: [{ to: calls[4].to, input: calls[4].input }],
+				calls: [{ to: calls[5].to, input: calls[5].input }],
 			})?.parts[0],
 		).toEqual({ type: 'action', value: 'Submit Zone Batch' })
 	})

--- a/apps/explorer/test/trace-abi.node.test.ts
+++ b/apps/explorer/test/trace-abi.node.test.ts
@@ -2,6 +2,12 @@ import { describe, expect, it } from 'vitest'
 import { getKnownTraceAbiItem } from '#lib/domain/trace-abi'
 
 describe('known trace ABI selectors', () => {
+	it('labels the canonical encrypted Zone deposit entrypoint', () => {
+		expect(getKnownTraceAbiItem('0x03dd6f34')).toMatchObject({
+			name: 'deposit',
+		})
+	})
+
 	it('labels encrypted deposits from legacy Zone Portal deployments', () => {
 		expect(getKnownTraceAbiItem('0xb01f22e4')).toMatchObject({
 			name: 'depositEncrypted',

--- a/apps/explorer/test/trace-abi.node.test.ts
+++ b/apps/explorer/test/trace-abi.node.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import { getKnownTraceAbiItem } from '#lib/domain/trace-abi'
+
+describe('known trace ABI selectors', () => {
+	it('labels encrypted deposits from legacy Zone Portal deployments', () => {
+		expect(getKnownTraceAbiItem('0xb01f22e4')).toMatchObject({
+			name: 'depositEncrypted',
+		})
+	})
+
+	it('keeps ERC-20 selector decoding', () => {
+		expect(getKnownTraceAbiItem('0x095ea7b3')).toMatchObject({
+			name: 'approve',
+		})
+	})
+})


### PR DESCRIPTION
## Summary

- add the current encrypted-only `deposit(...)` interface to Explorer's Zone Portal ABI
- keep historical plaintext `deposit(...)` and legacy `depositEncrypted(...)` calls decodable
- render canonical `deposit(...)` activity as an encrypted Zone deposit
- fall back to the Zone Portal ABI when deployed contracts do not publish an ABI

## Before / After

| Before | After |
|---|---|
| [Production: legacy call shown as `0xb01f22e4()`](https://explore.tempo.xyz/tx/0x3a429a4b456b44a8646d8907f2aaaf0250e2044288fbaea515107d9c18cde5eb?tab=trace) | Preview labels the actual legacy call `depositEncrypted(...)`; current `deposit(...)` calls decode under the canonical name. |

## Testing

- `pnpm --filter explorer check` (106 checks passed)
- `pnpm --filter explorer test -- --run` (84 tests passed)
- `pnpm precommit`
- Verified the reported transaction on the mainnet preview renders `depositEncrypted(...)` with decoded arguments.
- Repository-wide `pnpm check` reaches type-checking but is blocked by pre-existing generated `contract-verification` `Env` type errors; the Explorer workspace passes.

Prompted by: @snario
