### PR TITLE
fix(explorer): value Earn shares by underlying assets

### DIFF
--- a/apps/explorer/src/lib/address-balances.ts
+++ b/apps/explorer/src/lib/address-balances.ts
@@ -12,6 +12,11 @@ export type TokenBalance = {
 	symbol?: string
 	decimals?: number
 	currency?: string
+	valuation?: {
+		amount: string
+		currency: string
+		decimals: number
+	}
 }
 
 export type BalancesResponse = {
@@ -25,6 +30,7 @@ export type AssetData = {
 		| { name?: string; symbol?: string; decimals?: number; currency?: string }
 		| undefined
 	balance: bigint | undefined
+	valuation: { amount: bigint; currency: string; decimals: number } | undefined
 }
 
 async function fetchAddressBalances(
@@ -69,6 +75,13 @@ export function useBalancesData(
 				currency: token.currency,
 			},
 			balance: BigInt(token.balance),
+			valuation: token.valuation
+				? {
+						amount: BigInt(token.valuation.amount),
+						currency: token.valuation.currency,
+						decimals: token.valuation.decimals,
+					}
+				: undefined,
 		}))
 	}, [data])
 
@@ -81,18 +94,32 @@ export function calculateTotalHoldings(
 		isTokenListed?: ((address: Address.Address) => boolean) | undefined
 	},
 ): number | undefined {
-	const PRICE_PER_TOKEN = 1
 	let total: number | undefined
 	for (const asset of assetsData) {
-		if (asset.metadata?.currency !== 'USD') continue
 		if (options?.isTokenListed && !options.isTokenListed(asset.address)) {
 			continue
 		}
-		const decimals = asset.metadata?.decimals
-		const balance = asset.balance
-		if (decimals === undefined || balance === undefined) continue
-		total =
-			(total ?? 0) + Number(formatUnits(balance, decimals)) * PRICE_PER_TOKEN
+		const value = getAssetValue(asset)
+		if (!value || value.currency !== 'USD') continue
+		total = (total ?? 0) + Number(formatUnits(value.amount, value.decimals))
 	}
 	return total
+}
+
+/** Returns a token's explicit valuation, falling back to its face value. */
+export function getAssetValue(
+	asset: AssetData,
+): { amount: bigint; currency: string; decimals: number } | undefined {
+	if (asset.valuation) return asset.valuation
+	if (
+		asset.balance === undefined ||
+		asset.metadata?.currency === undefined ||
+		asset.metadata.decimals === undefined
+	)
+		return undefined
+	return {
+		amount: asset.balance,
+		currency: asset.metadata.currency,
+		decimals: asset.metadata.decimals,
+	}
 }

--- a/apps/explorer/src/lib/server/address-balances.ts
+++ b/apps/explorer/src/lib/server/address-balances.ts
@@ -3,8 +3,10 @@ import { type InferResponseType, parseResponse } from 'hono/client'
 import type { Address } from 'ox'
 import { formatUnits } from 'viem'
 import { getChainId } from 'wagmi/actions'
+import * as z from 'zod/mini'
 
 import type { BalancesResponse, TokenBalance } from '#lib/address-balances'
+import { serverEnv, tempoApiUrl } from '#lib/server/env'
 import { api } from '#lib/server/tempo-api'
 import { zAddress } from '#lib/zod'
 import { getWagmiConfig } from '#wagmi.config.ts'
@@ -17,13 +19,28 @@ type BalancesApiResponse = InferResponseType<
 	200
 >
 
+const EarnPositionsResponse = z.object({
+	data: z.array(
+		z.object({
+			assetAmount: z.object({
+				amount: z.string(),
+				currency: z.string(),
+				decimals: z.number(),
+			}),
+			shareToken: z.object({ address: z.string() }),
+		}),
+	),
+})
+
+type EarnPosition = z.infer<typeof EarnPositionsResponse>['data'][number]
+
 /**
  * Maps API balance rows (token metadata included) into the page's shape,
  * sorted USD-denominated tokens first by value, then others by raw balance.
  */
 export function mapBalances(data: BalancesApiResponse['data']): TokenBalance[] {
-	return data
-		.map(
+	return sortBalances(
+		data.map(
 			(item): TokenBalance => ({
 				token: item.token.address,
 				balance: item.amount,
@@ -32,26 +49,75 @@ export function mapBalances(data: BalancesApiResponse['data']): TokenBalance[] {
 				currency: item.token.currency,
 				decimals: item.token.decimals,
 			}),
+		),
+	)
+}
+
+function usdValue(balance: TokenBalance): number | undefined {
+	const value = balance.valuation ?? {
+		amount: balance.balance,
+		currency: balance.currency,
+		decimals: balance.decimals ?? TIP20_DECIMALS,
+	}
+	if (value.currency !== 'USD') return undefined
+	return Number(formatUnits(BigInt(value.amount), value.decimals))
+}
+
+function sortBalances(balances: TokenBalance[]): TokenBalance[] {
+	return balances.sort((a, b) => {
+		const aValue = usdValue(a)
+		const bValue = usdValue(b)
+		if (aValue !== undefined && bValue !== undefined) return bValue - aValue
+		if (aValue !== undefined) return -1
+		if (bValue !== undefined) return 1
+		return Number(BigInt(b.balance) - BigInt(a.balance))
+	})
+}
+
+/** Applies API-computed underlying asset values to matching Earn share tokens. */
+export function applyEarnPositionValues(
+	balances: TokenBalance[],
+	positions: EarnPosition[],
+): TokenBalance[] {
+	const values = new Map(
+		positions.map((position) => [
+			position.shareToken.address.toLowerCase(),
+			position.assetAmount,
+		]),
+	)
+	return sortBalances(
+		balances.map((balance) => ({
+			...balance,
+			valuation: values.get(balance.token.toLowerCase()),
+		})),
+	)
+}
+
+async function fetchEarnPositions(params: {
+	address: Address.Address
+	chainId: number
+	limit: number
+}): Promise<EarnPosition[]> {
+	try {
+		const url = new URL(
+			`/v1/earn/addresses/${params.address}/positions`,
+			tempoApiUrl,
 		)
-		.sort((a, b) => {
-			const aIsUsd = a.currency === 'USD'
-			const bIsUsd = b.currency === 'USD'
-
-			if (aIsUsd && bIsUsd) {
-				const aValue = Number(
-					formatUnits(BigInt(a.balance), a.decimals ?? TIP20_DECIMALS),
-				)
-				const bValue = Number(
-					formatUnits(BigInt(b.balance), b.decimals ?? TIP20_DECIMALS),
-				)
-				return bValue - aValue
-			}
-
-			if (aIsUsd) return -1
-			if (bIsUsd) return 1
-
-			return Number(BigInt(b.balance) - BigInt(a.balance))
+		url.searchParams.set('chainId', String(params.chainId))
+		url.searchParams.set('limit', String(params.limit))
+		url.searchParams.set('verified', 'true')
+		const response = await fetch(url, {
+			headers: serverEnv.TEMPO_API_KEY
+				? { 'tempo-api-key': serverEnv.TEMPO_API_KEY }
+				: undefined,
+			signal: AbortSignal.timeout(4_000),
 		})
+		if (!response.ok) throw new Error(`Tempo API returned ${response.status}`)
+		return EarnPositionsResponse.parse(await response.json()).data
+	} catch (error) {
+		console.error('Failed to fetch Earn position values:', error)
+		return []
+	}
 }
 
 export async function fetchAddressBalancesData(params: {
@@ -62,14 +128,17 @@ export async function fetchAddressBalancesData(params: {
 	const { address, chainId } = params
 	const maxTokens = params.maxTokens ?? MAX_TOKENS
 
-	const { data } = await parseResponse(
-		api.v1.addresses[':address'].balances.$get({
-			param: { address },
-			query: { chainId: String(chainId), limit: String(maxTokens) },
-		}),
-	)
+	const [{ data }, earnPositions] = await Promise.all([
+		parseResponse(
+			api.v1.addresses[':address'].balances.$get({
+				param: { address },
+				query: { chainId: String(chainId), limit: String(maxTokens) },
+			}),
+		),
+		fetchEarnPositions({ address, chainId, limit: maxTokens }),
+	])
 
-	return { balances: mapBalances(data) }
+	return { balances: applyEarnPositionValues(mapBalances(data), earnPositions) }
 }
 
 export const fetchAddressBalances = createServerFn({ method: 'GET' })

--- a/apps/explorer/src/routes/_layout/address/$address.tsx
+++ b/apps/explorer/src/routes/_layout/address/$address.tsx
@@ -58,6 +58,7 @@ import {
 	type BalancesResponse,
 	balancesQueryOptions,
 	calculateTotalHoldings,
+	getAssetValue,
 	useBalancesData,
 } from '#lib/address-balances'
 import {
@@ -2567,16 +2568,15 @@ function AssetAmount(props: { asset: AssetData }) {
 function AssetValue(props: { asset: AssetData }) {
 	const { asset } = props
 	const { isTokenListed } = useTokenListMembership()
-	if (asset.metadata?.currency !== 'USD')
-		return <span className="text-tertiary">—</span>
 	if (!isTokenListed(TEMPO_CHAIN_ID, asset.address))
 		return <span className="text-tertiary">—</span>
-	if (asset.metadata?.decimals === undefined || asset.balance === undefined)
-		return <span className="text-tertiary">…</span>
+	const value = getAssetValue(asset)
+	if (!value) return <span className="text-tertiary">…</span>
+	if (value.currency !== 'USD') return <span className="text-tertiary">—</span>
 	return (
 		<span>
-			{PriceFormatter.format(asset.balance, {
-				decimals: asset.metadata.decimals,
+			{PriceFormatter.format(value.amount, {
+				decimals: value.decimals,
 				format: 'short',
 			})}
 		</span>

--- a/apps/explorer/test/address-balances.node.test.ts
+++ b/apps/explorer/test/address-balances.node.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from 'vitest'
+import { type AssetData, calculateTotalHoldings } from '#lib/address-balances'
+import { applyEarnPositionValues } from '#lib/server/address-balances'
+
+const shareToken = '0x20c000000000000000000000baac91f6ca72f768'
+
+describe('Earn share valuations', () => {
+	test('uses the underlying asset value for holdings totals', () => {
+		const assets: AssetData[] = [
+			{
+				address: shareToken,
+				balance: 2_497_405_051n,
+				metadata: { currency: 'USD', decimals: 6 },
+				valuation: {
+					amount: 4_992_789_782n,
+					currency: 'USD',
+					decimals: 6,
+				},
+			},
+		]
+
+		expect(calculateTotalHoldings(assets)).toBe(4_992.789782)
+	})
+
+	test('attaches API-computed values to matching share-token balances', () => {
+		const [balance] = applyEarnPositionValues(
+			[
+				{
+					token: shareToken,
+					balance: '2497405051',
+					currency: 'USD',
+					decimals: 6,
+				},
+			],
+			[
+				{
+					assetAmount: {
+						amount: '4992789782',
+						currency: 'USD',
+						decimals: 6,
+					},
+					shareToken: { address: shareToken },
+				},
+			],
+		)
+
+		expect(balance?.valuation).toEqual({
+			amount: '4992789782',
+			currency: 'USD',
+			decimals: 6,
+		})
+	})
+})


### PR DESCRIPTION
## Summary

- fetch verified Earn positions alongside address balances
- value matching Earn shares in their underlying vault asset
- use converted values for the row, account total, and holdings sort order
- preserve the existing face-value fallback if the Earn valuation request is unavailable

## Screenshots

| Before | After |
|---|---|
| [Production: 2,497.41 shares displayed as **$2.5K**](https://explore.tempo.xyz/address/0x178Ec615D158ba352f9e84a6e42F3b9e8c8A8Fbd?tab=holdings) | [Preview: 2,497.41 shares displayed as **$4.99K** based on 4,992.789782 pathUSD](https://7b2fd1be-explorer-mainnet.porto.workers.dev/address/0x178Ec615D158ba352f9e84a6e42F3b9e8c8A8Fbd?tab=holdings) |

## Testing

- `pnpm --filter explorer check`
- `pnpm --filter explorer test --run`
- `pnpm check:types`
- `pnpm precommit`
- Mainnet preview verified at **$4.99K**

Prompted by: @Slokh