### PR TITLE
fix(snapshots): proxy modular archives with ranges

### DIFF
--- a/apps/tempo-snapshots-viewer/src/index.ts
+++ b/apps/tempo-snapshots-viewer/src/index.ts
@@ -323,7 +323,17 @@ app.get('/:chainId/:snapshotName', (context) =>
 	serveSnapshot(
 		{
 			headers: context.req.raw.headers,
-			snapshotName: context.req.param('snapshotName'),
+			snapshotName: `${context.req.param('chainId')}/${context.req.param('snapshotName')}`,
+			fallbackSnapshotName: context.req.param('snapshotName'),
+		},
+		context.env,
+	),
+)
+app.get('/*', (context) =>
+	serveSnapshot(
+		{
+			headers: context.req.raw.headers,
+			snapshotName: decodeURIComponent(context.req.path.slice(1)),
 		},
 		context.env,
 	),
@@ -389,15 +399,28 @@ async function serveManifest(
 }
 
 async function serveSnapshot(
-	{ headers, snapshotName }: { snapshotName: string; headers: Headers },
+	{
+		headers,
+		snapshotName,
+		fallbackSnapshotName,
+	}: {
+		headers: Headers
+		snapshotName: string
+		fallbackSnapshotName?: string
+	},
 	env: Env,
 ): Promise<Response> {
 	const rangeHeader = headers.get('Range')
 
-	const object = await env.SNAPSHOTS.get(snapshotName, {
+	const getOptions: R2GetOptions = {
 		onlyIf: headers,
 		range: headers,
-	})
+	}
+	const object =
+		(await env.SNAPSHOTS.get(snapshotName, getOptions)) ||
+		(fallbackSnapshotName
+			? await env.SNAPSHOTS.get(fallbackSnapshotName, getOptions)
+			: null)
 
 	if (object === null) {
 		return error(404, 'Object Not Found')

--- a/apps/tempo-snapshots-viewer/wrangler.json
+++ b/apps/tempo-snapshots-viewer/wrangler.json
@@ -24,7 +24,7 @@
 		}
 	],
 	"vars": {
-		"R2_PUBLIC_URL": "https://tempo-node-snapshots.tempoxyz.dev"
+		"R2_PUBLIC_URL": "https://snapshots.tempo.xyz"
 	},
 	"routes": [
 		{


### PR DESCRIPTION
## Summary
- publish modular snapshot manifests through the Worker origin
- serve nested R2 archive paths, preserving GET Range responses for resumable restores
- retain legacy two-segment snapshot URLs as a fallback

## Verification
- `pnpm --filter tempo-snapshots-viewer check:types`
- `pnpm --filter tempo-snapshots-viewer check:biome`
- root `pnpm check` / `pnpm check:types` remain blocked by pre-existing contract-verification generated-binding errors and fee-payer lint warnings; the affected snapshot worker checks pass

## Incident context
The public R2 custom domain advertises ranges on HEAD but ignores Range on GET for the large RocksDB archive, so interrupted downloads restart from zero. The Worker already implements R2 range responses; this routes generated modular URLs through that behavior.