### PR TITLE
fix(snapshots): serve modular manifest paths

### DIFF
--- a/apps/tempo-snapshots-viewer/src/index.ts
+++ b/apps/tempo-snapshots-viewer/src/index.ts
@@ -316,9 +316,20 @@ app.get('/latest.txt', (context) => serveLatest({}, context.env))
 app.get('/:chainId/latest.txt', (context) =>
 	serveLatest({ chainId: context.req.param('chainId') }, context.env),
 )
-app.get('/:chainId/manifest.json', (context) =>
-	serveManifest({ chainId: context.req.param('chainId') }, context.env),
-)
+app.get('/:chainId/manifest.json', (context) => {
+	const chainId = context.req.param('chainId')
+	if (/^\d+$/.test(chainId)) {
+		return serveManifest({ chainId }, context.env)
+	}
+
+	return serveSnapshot(
+		{
+			headers: context.req.raw.headers,
+			snapshotName: `${chainId}/manifest.json`,
+		},
+		context.env,
+	)
+})
 app.get('/:chainId/:snapshotName', (context) =>
 	serveSnapshot(
 		{


### PR DESCRIPTION
## Summary
- reserve the generated latest-manifest route for numeric chain IDs
- serve modular snapshot directory manifests from R2 through the range-capable Worker

## Verification
- `pnpm --filter tempo-snapshots-viewer check:types`
- `pnpm --filter tempo-snapshots-viewer check:biome`

This corrects a route-order edge case identified before the preceding range-proxy deployment began.