### PR TITLE
revert(snapshots): roll back Worker snapshot routes

### DIFF
--- a/apps/tempo-snapshots-viewer/src/index.ts
+++ b/apps/tempo-snapshots-viewer/src/index.ts
@@ -316,20 +316,9 @@ app.get('/latest.txt', (context) => serveLatest({}, context.env))
 app.get('/:chainId/latest.txt', (context) =>
 	serveLatest({ chainId: context.req.param('chainId') }, context.env),
 )
-app.get('/:chainId/manifest.json', (context) => {
-	const chainId = context.req.param('chainId')
-	if (/^\d+$/.test(chainId)) {
-		return serveManifest({ chainId }, context.env)
-	}
-
-	return serveSnapshot(
-		{
-			headers: context.req.raw.headers,
-			snapshotName: `${chainId}/manifest.json`,
-		},
-		context.env,
-	)
-})
+app.get('/:chainId/manifest.json', (context) =>
+	serveManifest({ chainId: context.req.param('chainId') }, context.env),
+)
 app.get('/:chainId/:snapshotName', (context) =>
 	serveSnapshot(
 		{

--- a/apps/tempo-snapshots-viewer/src/index.ts
+++ b/apps/tempo-snapshots-viewer/src/index.ts
@@ -323,17 +323,7 @@ app.get('/:chainId/:snapshotName', (context) =>
 	serveSnapshot(
 		{
 			headers: context.req.raw.headers,
-			snapshotName: `${context.req.param('chainId')}/${context.req.param('snapshotName')}`,
-			fallbackSnapshotName: context.req.param('snapshotName'),
-		},
-		context.env,
-	),
-)
-app.get('/*', (context) =>
-	serveSnapshot(
-		{
-			headers: context.req.raw.headers,
-			snapshotName: decodeURIComponent(context.req.path.slice(1)),
+			snapshotName: context.req.param('snapshotName'),
 		},
 		context.env,
 	),
@@ -399,28 +389,15 @@ async function serveManifest(
 }
 
 async function serveSnapshot(
-	{
-		headers,
-		snapshotName,
-		fallbackSnapshotName,
-	}: {
-		headers: Headers
-		snapshotName: string
-		fallbackSnapshotName?: string
-	},
+	{ headers, snapshotName }: { snapshotName: string; headers: Headers },
 	env: Env,
 ): Promise<Response> {
 	const rangeHeader = headers.get('Range')
 
-	const getOptions: R2GetOptions = {
+	const object = await env.SNAPSHOTS.get(snapshotName, {
 		onlyIf: headers,
 		range: headers,
-	}
-	const object =
-		(await env.SNAPSHOTS.get(snapshotName, getOptions)) ||
-		(fallbackSnapshotName
-			? await env.SNAPSHOTS.get(fallbackSnapshotName, getOptions)
-			: null)
+	})
 
 	if (object === null) {
 		return error(404, 'Object Not Found')

--- a/apps/tempo-snapshots-viewer/wrangler.json
+++ b/apps/tempo-snapshots-viewer/wrangler.json
@@ -24,7 +24,7 @@
 		}
 	],
 	"vars": {
-		"R2_PUBLIC_URL": "https://snapshots.tempo.xyz"
+		"R2_PUBLIC_URL": "https://tempo-node-snapshots.tempoxyz.dev"
 	},
 	"routes": [
 		{


### PR DESCRIPTION
Reverts #1217 and #1216 at the requester’s direction.

This restores the previous snapshot Worker URL and manifest routing behavior; no other apps are changed.

Validation:
- `pnpm --filter tempo-snapshots-viewer check:types`
- `pnpm --filter tempo-snapshots-viewer check:biome`