### PR TITLE
fix(explorer): link TIP-403 policy IDs

### DIFF
--- a/apps/explorer/src/comps/Tip20ContractInfo.tsx
+++ b/apps/explorer/src/comps/Tip20ContractInfo.tsx
@@ -125,7 +125,17 @@ export function Tip20TokenTabContent(
 						<ConfigRow label="Currency" value={config?.currency ?? undefined} />
 						<ConfigRow
 							label="Transfer Policy ID"
-							value={config?.transferPolicyId ?? undefined}
+							value={
+								config?.transferPolicyId ? (
+									<Link
+										to="/policy/$id"
+										params={{ id: config.transferPolicyId }}
+										className="text-accent hover:underline"
+									>
+										{config.transferPolicyId}
+									</Link>
+								) : undefined
+							}
 						/>
 						<ConfigRow
 							label="Paused"
@@ -241,7 +251,7 @@ export function Tip20TokenTabContent(
 	)
 }
 
-function ConfigRow(props: { label: string; value: string | undefined }) {
+function ConfigRow(props: { label: string; value: React.ReactNode }) {
 	return (
 		<div className="flex items-center justify-between gap-[12px]">
 			<span className="text-secondary">{props.label}</span>


### PR DESCRIPTION
## Summary

- link TIP-403 transfer policy IDs from token configuration to their explorer policy pages
- preserve the existing loading placeholder when policy data is unavailable

## Screenshots

| Before | After |
| --- | --- |
| Transfer policy ID rendered as plain text | Transfer policy ID rendered as a link to `/policy/$id` |

## Testing

- `pnpm check`
- `pnpm --filter explorer test --run` (112 passed)
- `pnpm precommit`
- `pnpm test` (explorer passed; unrelated fee-payer tests require a local Tempo node at `localhost:9545`, unavailable in this sandbox)

Prompted by: @deodad
