### PR TITLE
ci: use the vendored third-party actions from tempoxyz/gh-actions

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -5,7 +5,7 @@ runs:
   using: 'composite'
   steps:
     - name: Set up pnpm
-      uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320
+      uses: tempoxyz/gh-actions/vendor/pnpm/action-setup@6f436eb3a168279692739e8c0c9fdb52b94bfae7
 
     - name: Set up Node
       uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -133,7 +133,7 @@ jobs:
 
       - name: Deploy to GitHub Pages (main only)
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453
+        uses: tempoxyz/gh-actions/vendor/peaceiris/actions-gh-pages@6f436eb3a168279692739e8c0c9fdb52b94bfae7
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./apps/explorer/.sonda

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -86,7 +86,7 @@ jobs:
 
       - name: Deploy Workers
         if: steps.changes.outputs.relevant == 'true'
-        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0
+        uses: tempoxyz/gh-actions/vendor/cloudflare/wrangler-action@6f436eb3a168279692739e8c0c9fdb52b94bfae7
         env:
           NODE_ENV: production
           CLOUDFLARE_ENV: ${{ matrix.env || '' }}

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -38,7 +38,7 @@ jobs:
           persist-credentials: false
 
       - name: "Generate Directory Listings"
-        uses: jayanta525/github-pages-directory-listing@624ac8c4e56893256d3772f61a88e3b14d54314e
+        uses: tempoxyz/gh-actions/vendor/jayanta525/github-pages-directory-listing@6f436eb3a168279692739e8c0c9fdb52b94bfae7
         with:
           FOLDER: apps/tokenlist/data #directory to generate index
 

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -117,7 +117,7 @@ jobs:
       - name: Upload Worker Version
         if: steps.changes.outputs.relevant == 'true'
         id: deploy
-        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0
+        uses: tempoxyz/gh-actions/vendor/cloudflare/wrangler-action@6f436eb3a168279692739e8c0c9fdb52b94bfae7
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
## Summary

Points this repository's workflows at the copies of third-party actions vendored in [tempoxyz/gh-actions](https://github.com/tempoxyz/gh-actions) under `vendor/`, pinned to a full commit SHA. Each vendored copy is an exact upstream commit recorded in [`vendor-manifest.yml`](https://github.com/tempoxyz/gh-actions/blob/6f436eb3a168279692739e8c0c9fdb52b94bfae7/vendor-manifest.yml), with the same inputs and outputs as upstream. This prepares for restricting the org Actions policy to enterprise-owned, `actions/*` and `github/*` actions.

| Before | After (vendored copy) |
| --- | --- |
| `cloudflare/wrangler-action` | [`tempoxyz/gh-actions/vendor/cloudflare/wrangler-action`](https://github.com/tempoxyz/gh-actions/tree/6f436eb3a168279692739e8c0c9fdb52b94bfae7/vendor/cloudflare/wrangler-action) |
| `jayanta525/github-pages-directory-listing` | [`tempoxyz/gh-actions/vendor/jayanta525/github-pages-directory-listing`](https://github.com/tempoxyz/gh-actions/tree/6f436eb3a168279692739e8c0c9fdb52b94bfae7/vendor/jayanta525/github-pages-directory-listing) |
| `peaceiris/actions-gh-pages` | [`tempoxyz/gh-actions/vendor/peaceiris/actions-gh-pages`](https://github.com/tempoxyz/gh-actions/tree/6f436eb3a168279692739e8c0c9fdb52b94bfae7/vendor/peaceiris/actions-gh-pages) |
| `pnpm/action-setup` | [`tempoxyz/gh-actions/vendor/pnpm/action-setup`](https://github.com/tempoxyz/gh-actions/tree/6f436eb3a168279692739e8c0c9fdb52b94bfae7/vendor/pnpm/action-setup) |

## Verification

- Every target path exists in the vendored tree at the pinned commit.
- `actionlint` and `zizmor` (regular persona, offline) report no new findings (actionlint 8 -> 8, zizmor 8 -> 8).
