### PR TITLE
fix(explorer): align receipt exports with receipt UI

### DIFF
--- a/apps/explorer/src/comps/Receipt.tsx
+++ b/apps/explorer/src/comps/Receipt.tsx
@@ -8,6 +8,10 @@ import { ReceiptMark } from '#comps/ReceiptMark'
 import { useTokenListMembership } from '#comps/TokenListMembership'
 import { TxEventDescription, TxEventMemoLine } from '#comps/TxEventDescription'
 import type { KnownEvent } from '#lib/domain/known-events'
+import {
+	getReceiptEventSideAmount,
+	isReceiptEventVisible,
+} from '#lib/domain/receipt-presentation'
 import { DateFormatter, PriceFormatter } from '#lib/formatting'
 import { useCopy } from '#lib/hooks'
 import {
@@ -57,11 +61,7 @@ export function Receipt(props: Receipt.Props) {
 	const showUsdFeePrefix = TEMPO_FEE_TOKEN
 		? isTokenListed(TEMPO_CHAIN_ID, TEMPO_FEE_TOKEN)
 		: true
-	const filteredEvents = events.filter(
-		(event) =>
-			event.type !== 'active key count changed' &&
-			event.type !== 'nonce incremented',
-	)
+	const filteredEvents = events.filter(isReceiptEventVisible)
 	const handleShare = async () => {
 		const url = new URL(
 			`/receipt/${hash}${exportSearch}`,
@@ -169,7 +169,6 @@ export function Receipt(props: Receipt.Props) {
 								const amountParts = event.parts.filter(
 									(part) => part.type === 'amount',
 								)
-								const firstAmountPart = amountParts[0]
 								const displayTotalAmount = event.totalAmount
 								const amountTokens = displayTotalAmount
 									? [displayTotalAmount]
@@ -186,14 +185,7 @@ export function Receipt(props: Receipt.Props) {
 										: TEMPO_FEE_TOKEN
 											? isTokenListed(TEMPO_CHAIN_ID, TEMPO_FEE_TOKEN)
 											: true
-								const sideAmount =
-									displayTotalAmount ??
-									(event.type === 'swap' && firstAmountPart?.type === 'amount'
-										? firstAmountPart.value
-										: amountParts.length === 1 &&
-												firstAmountPart?.type === 'amount'
-											? firstAmountPart.value
-											: undefined)
+								const sideAmount = getReceiptEventSideAmount(event)
 								return (
 									<div
 										key={`${event.type}-${index}`}
@@ -292,14 +284,16 @@ export function Receipt(props: Receipt.Props) {
 										const showUsdPrefix = hasTokenAmount(item)
 											? isUsdPricedToken(TEMPO_CHAIN_ID, item, isTokenListed)
 											: showUsdFeePrefix
-										const formattedAmount = showUsdPrefix
-											? PriceFormatter.format(item.amount, {
-													decimals: item.decimals,
-													format: 'short',
-												})
-											: PriceFormatter.formatAmountShort(
-													Value.format(item.amount, item.decimals),
-												)
+										const formattedAmount =
+											item.display ??
+											(showUsdPrefix
+												? PriceFormatter.format(item.amount, {
+														decimals: item.decimals,
+														format: 'short',
+													})
+												: PriceFormatter.formatAmountShort(
+														Value.format(item.amount, item.decimals),
+													))
 										return (
 											<div
 												key={`${item.token ?? item.symbol ?? 'fee'}-${index}`}
@@ -428,6 +422,7 @@ export namespace Receipt {
 		symbol?: string
 		token?: Address.Address
 		payer?: Address.Address
+		display?: string
 	}
 
 	export function ExportLink(props: ExportLink.Props): React.JSX.Element {

--- a/apps/explorer/src/lib/domain/receipt-export.ts
+++ b/apps/explorer/src/lib/domain/receipt-export.ts
@@ -1,0 +1,19 @@
+export type ReceiptResponseType =
+	| 'application/json'
+	| 'application/pdf'
+	| 'text/plain'
+	| undefined
+
+export function getReceiptResponseType(
+	pathname: string,
+	accept: string,
+	isTerminal: boolean,
+): ReceiptResponseType {
+	if (pathname.endsWith('.pdf')) return 'application/pdf'
+	if (pathname.endsWith('.json')) return 'application/json'
+	if (pathname.endsWith('.txt')) return 'text/plain'
+	if (accept.includes('application/pdf')) return 'application/pdf'
+	if (accept.includes('application/json')) return 'application/json'
+	if (isTerminal || accept.includes('text/plain')) return 'text/plain'
+	return undefined
+}

--- a/apps/explorer/src/lib/domain/receipt-presentation.ts
+++ b/apps/explorer/src/lib/domain/receipt-presentation.ts
@@ -1,0 +1,290 @@
+import * as Address from 'ox/Address'
+import * as Value from 'ox/Value'
+import type { TransactionReceipt } from 'viem'
+import type { FeeBreakdownItem, LineItems } from '#lib/domain/receipt'
+import type { KnownEvent } from '#lib/domain/known-events'
+import {
+	calculateKnownEventsTotal,
+	hasNonAdditiveVaultActivity,
+} from '#lib/domain/known-event-totals'
+import { isNonceIncrementedEvent } from '#lib/domain/transaction-activities'
+import { PriceFormatter } from '#lib/formatting'
+import {
+	areUsdPricedTokens,
+	hasTokenAmount,
+	isUsdPricedToken,
+} from '#lib/pricing'
+
+const RECEIVE_POLICY_GUARD = Address.from(
+	'0xB10C000000000000000000000000000000000000',
+)
+
+export type ReceiptVoucher = {
+	packetSize: number
+	packetCount: number
+}
+
+type IsTokenListed = (
+	chainId: number,
+	address: Address.Address | undefined,
+) => boolean
+
+type ReceiptPresentationParams = {
+	chainId: number
+	feeBreakdown: FeeBreakdownItem[]
+	feeToken: Address.Address | undefined
+	isTokenListed: IsTokenListed
+	knownEvents: KnownEvent[]
+	lineItems: Pick<LineItems.Result, 'feeTotals' | 'totals'>
+	receipt: Pick<TransactionReceipt, 'effectiveGasPrice' | 'from' | 'gasUsed'>
+	voucher: ReceiptVoucher | null
+}
+
+export type ReceiptPresentation = {
+	events: KnownEvent[]
+	fee: number
+	feeBreakdown: Array<FeeBreakdownItem & { display: string }>
+	feeDisplay: string
+	total?: number
+	totalDisplay?: string
+}
+
+export function buildReceiptPresentation(
+	params: ReceiptPresentationParams,
+): ReceiptPresentation {
+	const events = getReceiptDisplayEvents(
+		params.knownEvents,
+		params.voucher,
+		params.feeToken,
+	)
+	const feeBreakdown = params.feeBreakdown
+		.filter(
+			(item) =>
+				!item.payer ||
+				item.payer.toLowerCase() === params.receipt.from.toLowerCase(),
+		)
+		.map((item) => ({
+			...item,
+			display:
+				hasTokenAmount(item) &&
+				isUsdPricedToken(params.chainId, item, params.isTokenListed)
+					? PriceFormatter.format(item.amount, {
+							decimals: item.decimals,
+							format: 'short',
+						})
+					: PriceFormatter.formatAmountShort(
+							Value.format(item.amount, item.decimals),
+						),
+		}))
+	const feePrice = params.lineItems.feeTotals[0]?.price
+	const previousFee = feePrice
+		? Number(Value.format(feePrice.amount, feePrice.decimals))
+		: 0
+	const totalPrice = params.lineItems.totals[0]?.price
+	const previousTotal = totalPrice
+		? Number(Value.format(totalPrice.amount, totalPrice.decimals))
+		: undefined
+	const fallbackFeeAmount =
+		params.receipt.effectiveGasPrice * params.receipt.gasUsed
+	const feeRaw = feePrice
+		? Value.format(feePrice.amount, feePrice.decimals)
+		: Value.format(fallbackFeeAmount, 18)
+	const fee = Number(feeRaw)
+	const feeTokens = feeBreakdown.filter(hasTokenAmount)
+	const showUsdFeePrefix =
+		feeTokens.length > 0
+			? areUsdPricedTokens(params.chainId, feeTokens, params.isTokenListed)
+			: params.feeToken
+				? params.isTokenListed(params.chainId, params.feeToken)
+				: true
+	const feeDisplay = showUsdFeePrefix
+		? PriceFormatter.format(fee)
+		: PriceFormatter.formatAmountShort(feeRaw)
+
+	const streamingTotal = params.voucher
+		? params.voucher.packetSize * params.voucher.packetCount
+		: undefined
+	const eventsTotal = calculateKnownEventsTotal(events)
+	const eventsTotalDisplayValue =
+		eventsTotal > 0n ? Number(Value.format(eventsTotal, 18)) : undefined
+	const eventTotalTokens = getKnownEventAmounts(events)
+	const total =
+		streamingTotal !== undefined
+			? streamingTotal
+			: eventsTotalDisplayValue !== undefined
+				? eventsTotalDisplayValue + fee
+				: previousTotal !== undefined
+					? previousTotal - previousFee + fee
+					: fee
+	const totalTokens = params.lineItems.totals
+		.map((item) => item.price)
+		.filter(hasTokenAmount)
+	const showUsdTotalPrefix = (() => {
+		if (streamingTotal !== undefined) return true
+		if (eventsTotalDisplayValue !== undefined) {
+			return areUsdPricedTokens(
+				params.chainId,
+				eventTotalTokens,
+				params.isTokenListed,
+			)
+		}
+		if (totalTokens.length > 0) {
+			return areUsdPricedTokens(
+				params.chainId,
+				totalTokens,
+				params.isTokenListed,
+			)
+		}
+		return showUsdFeePrefix
+	})()
+	const totalDisplayValue =
+		streamingTotal !== undefined
+			? streamingTotal
+			: eventsTotalDisplayValue !== undefined
+				? eventsTotalDisplayValue + fee
+				: previousTotal !== undefined
+					? previousTotal
+					: total
+	const totalDisplay = showUsdTotalPrefix
+		? PriceFormatter.format(totalDisplayValue)
+		: PriceFormatter.formatAmountShort(String(totalDisplayValue))
+
+	return {
+		events,
+		fee,
+		feeBreakdown,
+		feeDisplay,
+		...(!hasNonAdditiveVaultActivity(events) || params.voucher
+			? { total, totalDisplay }
+			: {}),
+	}
+}
+
+export function enrichReceiptEventAmounts(
+	events: KnownEvent[],
+	getTokenMetadata: (token: Address.Address) =>
+		| {
+				currency: string
+				decimals: number
+				symbol: string
+		  }
+		| undefined,
+): KnownEvent[] {
+	return events.map((event) => ({
+		...event,
+		parts: event.parts.map((part) => {
+			if (part.type !== 'amount') return part
+			return { ...part, value: enrichAmount(part.value, getTokenMetadata) }
+		}),
+		...(event.totalAmount
+			? {
+					totalAmount: enrichAmount(event.totalAmount, getTokenMetadata),
+				}
+			: {}),
+	}))
+}
+
+function enrichAmount(
+	amount: NonNullable<KnownEvent['totalAmount']>,
+	getTokenMetadata: Parameters<typeof enrichReceiptEventAmounts>[1],
+): NonNullable<KnownEvent['totalAmount']> {
+	const metadata = getTokenMetadata(amount.token)
+	if (!metadata) return amount
+	return {
+		...amount,
+		currency: amount.currency ?? metadata.currency,
+		decimals: amount.decimals ?? metadata.decimals,
+		symbol: amount.symbol ?? metadata.symbol,
+	}
+}
+
+export function getReceiptEventSideAmount(
+	event: KnownEvent,
+): NonNullable<KnownEvent['totalAmount']> | undefined {
+	if (event.totalAmount) return event.totalAmount
+	const amounts = event.parts.flatMap((part) =>
+		part.type === 'amount' ? [part.value] : [],
+	)
+	if (event.type === 'swap') return amounts[0]
+	return amounts.length === 1 ? amounts[0] : undefined
+}
+
+export function isReceiptEventVisible(event: KnownEvent): boolean {
+	return (
+		event.type !== 'active key count changed' && !isNonceIncrementedEvent(event)
+	)
+}
+
+function getReceiptDisplayEvents(
+	knownEvents: KnownEvent[],
+	voucher: ReceiptVoucher | null,
+	feeToken: Address.Address | undefined,
+): KnownEvent[] {
+	const hasBlockedTransfer = knownEvents.some(
+		(event) => event.type === 'transfer blocked',
+	)
+	return (
+		voucher
+			? [buildStreamedPaymentEvent(voucher, feeToken), ...knownEvents]
+			: knownEvents
+	).filter(
+		(event) =>
+			isReceiptEventVisible(event) &&
+			(!hasBlockedTransfer ||
+				event.type !== 'send' ||
+				!event.meta?.to ||
+				!Address.isEqual(event.meta.to, RECEIVE_POLICY_GUARD)),
+	)
+}
+
+function buildStreamedPaymentEvent(
+	voucher: ReceiptVoucher,
+	feeToken: Address.Address | undefined,
+): KnownEvent {
+	const totalMicros = BigInt(
+		Math.round(voucher.packetSize * voucher.packetCount * 1_000_000),
+	)
+	return {
+		type: 'streamed payment',
+		parts: [
+			{ type: 'action', value: 'Streamed Payment' },
+			...(feeToken
+				? [
+						{
+							type: 'amount' as const,
+							value: {
+								value: totalMicros,
+								decimals: 6,
+								currency: 'USD',
+								token: feeToken,
+								symbol: 'pathUSD',
+							},
+						},
+					]
+				: []),
+		],
+		note: [
+			[
+				'Packets',
+				{
+					type: 'number',
+					value: [BigInt(voucher.packetCount), 0] as [bigint, number],
+				},
+			],
+			['Per packet', { type: 'text', value: `$${voucher.packetSize}` }],
+			['Settlement', { type: 'text', value: 'final voucher proven on-chain' }],
+		],
+	}
+}
+
+function getKnownEventAmounts(
+	events: readonly KnownEvent[],
+): NonNullable<KnownEvent['totalAmount']>[] {
+	return events.flatMap((event) => {
+		if (event.type === 'approval') return []
+		if (event.totalAmount) return [event.totalAmount]
+		return event.parts.flatMap((part) =>
+			part.type === 'amount' ? [part.value] : [],
+		)
+	})
+}

--- a/apps/explorer/src/lib/domain/receipt-text.ts
+++ b/apps/explorer/src/lib/domain/receipt-text.ts
@@ -1,0 +1,129 @@
+import * as Value from 'ox/Value'
+import { maxUint256, type TransactionReceipt } from 'viem'
+import type { KnownEvent, KnownEventPart } from '#lib/domain/known-events'
+import type { ReceiptPresentation } from '#lib/domain/receipt-presentation'
+import {
+	DateFormatter,
+	HexFormatter,
+	PriceFormatter,
+	RoleFormatter,
+} from '#lib/formatting'
+
+const width = 76
+const indent = '  '
+
+type ReceiptTextData = {
+	block: { timestamp: bigint }
+	receipt: Pick<
+		TransactionReceipt,
+		'blockNumber' | 'from' | 'status' | 'transactionHash'
+	>
+}
+
+export function renderReceiptText(
+	data: ReceiptTextData,
+	presentation: ReceiptPresentation,
+): string {
+	const { block, receipt } = data
+	const { events, feeBreakdown, feeDisplay, totalDisplay } = presentation
+	const formattedTime = DateFormatter.formatTimestampTime(block.timestamp)
+	const lines: string[] = [center('TEMPO RECEIPT'), '']
+
+	lines.push(`Block: ${receipt.blockNumber.toString()}`)
+	lines.push(`Sender: ${receipt.from}`)
+	lines.push(`Hash: ${receipt.transactionHash}`)
+	lines.push(`Date: ${DateFormatter.formatTimestampDate(block.timestamp)}`)
+	lines.push(
+		`Time: ${formattedTime.time} ${formattedTime.timezone}${formattedTime.offset}`,
+	)
+	if (receipt.status === 'reverted') lines.push('Status: Failed')
+
+	if (events.length > 0) {
+		lines.push('', '-'.repeat(width), '')
+		for (const [index, event] of events.entries()) {
+			lines.push(`${index + 1}. ${formatEvent(event)}`)
+			if (typeof event.note === 'string') {
+				lines.push(`${indent}Memo: ${event.note}`)
+			} else if (event.note) {
+				for (const [label, part] of event.note) {
+					const value = formatPart(part)
+					lines.push(
+						`${indent}${label}${part.type === 'text' && part.value === '' ? '' : ':'}${value ? ` ${value}` : ''}`,
+					)
+				}
+			}
+		}
+	}
+
+	if (feeBreakdown.length > 0) {
+		lines.push('')
+		for (const item of feeBreakdown) {
+			const label = item.symbol ? `Fee (${item.symbol})` : 'Fee'
+			lines.push(leftRight(label, item.display))
+		}
+	} else {
+		lines.push('', leftRight('Fee', feeDisplay))
+	}
+
+	if (totalDisplay !== undefined) lines.push(leftRight('Total', totalDisplay))
+
+	return lines.join('\n')
+}
+
+function formatEvent(event: KnownEvent): string {
+	return event.parts.map(formatPart).filter(Boolean).join(' ')
+}
+
+function formatPart(part: KnownEventPart): string {
+	switch (part.type) {
+		case 'account':
+			return HexFormatter.truncate(part.value)
+		case 'action':
+		case 'text':
+			return part.value
+		case 'amount': {
+			const precisionLossTolerance = 10n ** 64n
+			if (
+				part.value.value >
+				(maxUint256 / precisionLossTolerance) * precisionLossTolerance
+			)
+				return 'infinite'
+			const value = PriceFormatter.formatAmount(
+				Value.format(part.value.value, part.value.decimals ?? 18),
+			)
+			const suffix = part.value.symbol ?? part.value.currency
+			return suffix ? `${value} ${suffix}` : value
+		}
+		case 'contractCall':
+			return `call ${HexFormatter.truncate(part.value.address)}`
+		case 'duration':
+			return DateFormatter.formatDuration(part.value)
+		case 'hex':
+			return HexFormatter.truncate(part.value)
+		case 'number':
+			return PriceFormatter.formatAmount(
+				Array.isArray(part.value)
+					? Value.format(part.value[0], part.value[1])
+					: Value.format(BigInt(part.value)),
+			)
+		case 'role':
+			return (
+				RoleFormatter.getRoleName(part.value) ??
+				HexFormatter.shortenHex(part.value)
+			)
+		case 'tick':
+			return part.value.toLocaleString()
+		case 'token':
+			return part.value.symbol ?? HexFormatter.truncate(part.value.address)
+	}
+}
+
+function center(text: string): string {
+	const padding = Math.max(0, Math.floor((width - text.length) / 2))
+	return ' '.repeat(padding) + text
+}
+
+function leftRight(left: string, right: string): string {
+	const spacing = Math.max(1, width - left.length - right.length)
+	return left + ' '.repeat(spacing) + right
+}

--- a/apps/explorer/src/lib/domain/receipt-text.ts
+++ b/apps/explorer/src/lib/domain/receipt-text.ts
@@ -1,7 +1,10 @@
 import * as Value from 'ox/Value'
 import { maxUint256, type TransactionReceipt } from 'viem'
 import type { KnownEvent, KnownEventPart } from '#lib/domain/known-events'
-import type { ReceiptPresentation } from '#lib/domain/receipt-presentation'
+import {
+	getReceiptEventSideAmount,
+	type ReceiptPresentation,
+} from '#lib/domain/receipt-presentation'
 import {
 	DateFormatter,
 	HexFormatter,
@@ -20,35 +23,54 @@ type ReceiptTextData = {
 	>
 }
 
+type ReceiptTextOptions = {
+	summary?: string
+}
+
 export function renderReceiptText(
 	data: ReceiptTextData,
 	presentation: ReceiptPresentation,
+	options: ReceiptTextOptions = {},
 ): string {
 	const { block, receipt } = data
 	const { events, feeBreakdown, feeDisplay, totalDisplay } = presentation
 	const formattedTime = DateFormatter.formatTimestampTime(block.timestamp)
 	const lines: string[] = [center('TEMPO RECEIPT'), '']
 
-	lines.push(`Block: ${receipt.blockNumber.toString()}`)
-	lines.push(`Sender: ${receipt.from}`)
-	lines.push(`Hash: ${receipt.transactionHash}`)
-	lines.push(`Date: ${DateFormatter.formatTimestampDate(block.timestamp)}`)
+	lines.push(`TX HASH: ${receipt.transactionHash}`)
+	lines.push(`DATE: ${DateFormatter.formatTimestampDate(block.timestamp)}`)
 	lines.push(
-		`Time: ${formattedTime.time} ${formattedTime.timezone}${formattedTime.offset}`,
+		`TIME: ${formattedTime.time} ${formattedTime.timezone}${formattedTime.offset}`,
 	)
-	if (receipt.status === 'reverted') lines.push('Status: Failed')
+	lines.push(`BLOCK: ${receipt.blockNumber.toString()}`)
+	lines.push(`SENDER: ${receipt.from}`)
+	if (options.summary) lines.push(`SUMMARY: ${options.summary.toUpperCase()}`)
+	if (receipt.status === 'reverted') lines.push('STATUS: FAILED')
 
 	if (events.length > 0) {
 		lines.push('', '-'.repeat(width), '')
 		for (const [index, event] of events.entries()) {
-			lines.push(`${index + 1}. ${formatEvent(event)}`)
+			const action = getEventAction(event)
+			const sideAmount = getReceiptEventSideAmount(event)
+			lines.push(
+				leftRight(
+					`${index + 1}. ${action.toUpperCase()}`,
+					sideAmount ? formatAmount(sideAmount, true).toUpperCase() : '–',
+				),
+			)
+			const details = event.parts
+				.filter((part) => part.type !== 'action')
+				.map(formatPart)
+				.filter(Boolean)
+				.join(' ')
+			if (details) lines.push(`${indent}${details.toUpperCase()}`)
 			if (typeof event.note === 'string') {
-				lines.push(`${indent}Memo: ${event.note}`)
+				lines.push(`${indent}MEMO: ${event.note.toUpperCase()}`)
 			} else if (event.note) {
 				for (const [label, part] of event.note) {
 					const value = formatPart(part)
 					lines.push(
-						`${indent}${label}${part.type === 'text' && part.value === '' ? '' : ':'}${value ? ` ${value}` : ''}`,
+						`${indent}${label.toUpperCase()}${part.type === 'text' && part.value === '' ? '' : ':'}${value ? ` ${value.toUpperCase()}` : ''}`,
 					)
 				}
 			}
@@ -58,20 +80,21 @@ export function renderReceiptText(
 	if (feeBreakdown.length > 0) {
 		lines.push('')
 		for (const item of feeBreakdown) {
-			const label = item.symbol ? `Fee (${item.symbol})` : 'Fee'
+			const label = item.symbol ? `FEE (${item.symbol.toUpperCase()})` : 'FEE'
 			lines.push(leftRight(label, item.display))
 		}
 	} else {
-		lines.push('', leftRight('Fee', feeDisplay))
+		lines.push('', leftRight('FEE', feeDisplay))
 	}
 
-	if (totalDisplay !== undefined) lines.push(leftRight('Total', totalDisplay))
+	if (totalDisplay !== undefined) lines.push(leftRight('TOTAL', totalDisplay))
 
 	return lines.join('\n')
 }
 
-function formatEvent(event: KnownEvent): string {
-	return event.parts.map(formatPart).filter(Boolean).join(' ')
+function getEventAction(event: KnownEvent): string {
+	const action = event.parts.find((part) => part.type === 'action')
+	return action?.type === 'action' ? action.value : event.type
 }
 
 function formatPart(part: KnownEventPart): string {
@@ -81,19 +104,8 @@ function formatPart(part: KnownEventPart): string {
 		case 'action':
 		case 'text':
 			return part.value
-		case 'amount': {
-			const precisionLossTolerance = 10n ** 64n
-			if (
-				part.value.value >
-				(maxUint256 / precisionLossTolerance) * precisionLossTolerance
-			)
-				return 'infinite'
-			const value = PriceFormatter.formatAmount(
-				Value.format(part.value.value, part.value.decimals ?? 18),
-			)
-			const suffix = part.value.symbol ?? part.value.currency
-			return suffix ? `${value} ${suffix}` : value
-		}
+		case 'amount':
+			return formatAmount(part.value, false)
 		case 'contractCall':
 			return `call ${HexFormatter.truncate(part.value.address)}`
 		case 'duration':
@@ -116,6 +128,24 @@ function formatPart(part: KnownEventPart): string {
 		case 'token':
 			return part.value.symbol ?? HexFormatter.truncate(part.value.address)
 	}
+}
+
+function formatAmount(
+	amount: NonNullable<KnownEvent['totalAmount']>,
+	short: boolean,
+): string {
+	const precisionLossTolerance = 10n ** 64n
+	if (
+		amount.value >
+		(maxUint256 / precisionLossTolerance) * precisionLossTolerance
+	)
+		return 'infinite'
+	const raw = Value.format(amount.value, amount.decimals ?? 18)
+	const value = short
+		? PriceFormatter.formatAmountShort(raw)
+		: PriceFormatter.formatAmount(raw)
+	const suffix = amount.symbol ?? amount.currency
+	return suffix ? `${value} ${suffix}` : value
 }
 
 function center(text: string): string {

--- a/apps/explorer/src/lib/og.ts
+++ b/apps/explorer/src/lib/og.ts
@@ -3,6 +3,7 @@ import * as Value from 'ox/Value'
 import type { AccountType } from '#lib/account'
 import type { KnownEvent, KnownEventPart } from '#lib/domain/known-events'
 import { DEFAULT_KNOWN_EVENT_AMOUNT_DECIMALS } from '#lib/domain/known-event-totals'
+import { getReceiptEventSideAmount } from '#lib/domain/receipt-presentation'
 import { DateFormatter, HexFormatter } from '#lib/formatting'
 import {
 	type AddressOgParams,
@@ -173,18 +174,15 @@ export function formatEventForOgServer(event: KnownEvent): string {
 	const detailParts = event.parts.filter((p) => p.type !== 'action')
 	const details = detailParts.map(formatEventPart).filter(Boolean).join(' ')
 
-	let usdAmount = ''
-	for (const part of event.parts) {
-		if (part.type === 'amount') {
-			const formatted = formatAmount(part.value, false)
-			usdAmount = formatted.startsWith('<')
-				? `<$${formatted.slice(1)}`
-				: `$${formatted}`
-			break
-		}
-	}
+	const sideAmount = getReceiptEventSideAmount(event)
+	const formattedSideAmount = sideAmount ? formatAmount(sideAmount, false) : ''
+	const usdAmount = formattedSideAmount.startsWith('<')
+		? `<$${formattedSideAmount.slice(1)}`
+		: formattedSideAmount
+			? `$${formattedSideAmount}`
+			: ''
 
-	return `${truncateOgText(action, 20)}|${truncateOgText(details, 60)}|${truncateOgText(usdAmount, 15)}`
+	return `${truncateOgText(action, 40)}|${truncateOgText(details, 180)}|${truncateOgText(usdAmount, 30)}`
 }
 
 export function formatDate(timestamp: number): string {

--- a/apps/explorer/src/routes/_layout/receipt/$hash.tsx
+++ b/apps/explorer/src/routes/_layout/receipt/$hash.tsx
@@ -273,7 +273,15 @@ export const Route = createFileRoute('/_layout/receipt/$hash')({
 						data,
 						voucherData,
 					)
-					const text = renderReceiptText(data, presentation)
+					const summary = buildTxSummary({
+						receipt: data.receipt,
+						transaction: data.transaction,
+						knownEvents: presentation.events,
+						trace: null,
+					})
+					const text = renderReceiptText(data, presentation, {
+						summary: summary.headline,
+					})
 					return new Response(text, {
 						headers: {
 							'Content-Type': 'text/plain; charset=utf-8',

--- a/apps/explorer/src/routes/_layout/receipt/$hash.tsx
+++ b/apps/explorer/src/routes/_layout/receipt/$hash.tsx
@@ -8,40 +8,40 @@ import {
 	useLocation,
 	useNavigate,
 } from '@tanstack/react-router'
-import * as Address from 'ox/Address'
 import * as Hex from 'ox/Hex'
 import * as Json from 'ox/Json'
-import * as Value from 'ox/Value'
 import { getPublicClient } from 'wagmi/actions'
 import * as z from 'zod/mini'
 import { NotFound } from '#comps/NotFound'
 import { Receipt } from '#comps/Receipt'
 import { useTokenListMembership } from '#comps/TokenListMembership'
 import { apostrophe } from '#lib/chars'
+import { getReceiptResponseType } from '#lib/domain/receipt-export'
 import {
 	decodeKnownTransactionCall,
 	parseKnownEvents,
-	type KnownEvent,
 } from '#lib/domain/known-events'
-import {
-	calculateKnownEventsTotal,
-	hasNonAdditiveVaultActivity,
-} from '#lib/domain/known-event-totals'
 import { getFeeBreakdown, LineItems } from '#lib/domain/receipt'
+import {
+	buildReceiptPresentation,
+	enrichReceiptEventAmounts,
+	type ReceiptPresentation,
+	type ReceiptVoucher,
+} from '#lib/domain/receipt-presentation'
+import { renderReceiptText } from '#lib/domain/receipt-text'
 import { buildTxSummary } from '#lib/domain/tx-summary'
 import * as Tip20 from '#lib/domain/tip20'
 import {
 	activitiesToKnownEvents,
 	selectTransactionDescriptionEvents,
 } from '#lib/domain/transaction-activities'
-import { DateFormatter, PriceFormatter } from '#lib/formatting'
+import { DateFormatter } from '#lib/formatting'
 import { useKeyboardShortcut } from '#lib/hooks'
 import {
 	buildTxDescription,
 	formatEventForOgServer,
 	OG_BASE_URL,
 } from '#lib/og'
-import { areUsdPricedTokens, hasTokenAmount } from '#lib/pricing'
 import { withLoaderTiming } from '#lib/profiling'
 import { getFeeTokenForChain } from '#lib/fee-token'
 import { fetchTransactionActivities } from '#lib/server/transaction-activities'
@@ -49,23 +49,6 @@ import { getTempoChain, getWagmiConfig } from '#wagmi.config.ts'
 
 const TEMPO_CHAIN_ID = getTempoChain().id
 const TEMPO_FEE_TOKEN = getFeeTokenForChain(TEMPO_CHAIN_ID)
-const RECEIVE_POLICY_GUARD = Address.from(
-	'0xB10C000000000000000000000000000000000000',
-)
-
-function getKnownEventAmounts(
-	events: readonly KnownEvent[],
-): NonNullable<KnownEvent['totalAmount']>[] {
-	return events.flatMap((event) => {
-		if (event.type === 'approval') return []
-		if (event.totalAmount) return [event.totalAmount]
-
-		return event.parts
-			.filter((part) => part.type === 'amount')
-			.map((part) => part.value)
-	})
-}
-
 function receiptDetailQueryOptions(params: { hash: Hex.Hex; rpcUrl?: string }) {
 	return queryOptions({
 		queryKey: ['receipt-detail', params.hash, params.rpcUrl],
@@ -104,8 +87,6 @@ async function fetchReceiptData(params: { hash: Hex.Hex; rpcUrl?: string }) {
 		Tip20.metadataFromLogs(receipt.logs),
 		fetchTransactionActivities({ data: { hash: receipt.transactionHash } }),
 	])
-	const timestampFormatted = DateFormatter.format(block.timestamp)
-
 	const lineItems = stripLineItemEvents(
 		LineItems.fromReceipt(receipt, { getTokenMetadata }),
 	)
@@ -125,11 +106,14 @@ async function fetchReceiptData(params: { hash: Hex.Hex; rpcUrl?: string }) {
 	const activityEvents = activitiesToKnownEvents(activities, {
 		portal: receipt.to,
 	})
-	const knownEvents = selectTransactionDescriptionEvents({
-		activityEvents,
-		fallbackEvents,
-		knownCall,
-	})
+	const knownEvents = enrichReceiptEventAmounts(
+		selectTransactionDescriptionEvents({
+			activityEvents,
+			fallbackEvents,
+			knownCall,
+		}),
+		getTokenMetadata,
+	)
 
 	return {
 		block,
@@ -137,9 +121,41 @@ async function fetchReceiptData(params: { hash: Hex.Hex; rpcUrl?: string }) {
 		knownEvents,
 		lineItems,
 		receipt,
-		timestampFormatted,
 		transaction,
 	}
+}
+
+function getReceiptPresentation(
+	data: Awaited<ReturnType<typeof fetchReceiptData>>,
+	voucher: ReceiptVoucher | null,
+	isTokenListed: (
+		chainId: number,
+		address: `0x${string}` | undefined,
+	) => boolean,
+): ReceiptPresentation {
+	return buildReceiptPresentation({
+		chainId: TEMPO_CHAIN_ID,
+		feeBreakdown: data.feeBreakdown,
+		feeToken: TEMPO_FEE_TOKEN,
+		isTokenListed,
+		knownEvents: data.knownEvents,
+		lineItems: data.lineItems,
+		receipt: data.receipt,
+		voucher,
+	})
+}
+
+async function getServerReceiptPresentation(
+	data: Awaited<ReturnType<typeof fetchReceiptData>>,
+	voucher: ReceiptVoucher | null,
+): Promise<ReceiptPresentation> {
+	const { getVerifiedTokenAddresses } = await import(
+		'#lib/server/verified-tokens'
+	)
+	const verifiedTokens = await getVerifiedTokenAddresses(TEMPO_CHAIN_ID)
+	return getReceiptPresentation(data, voucher, (_chainId, address) =>
+		address ? verifiedTokens.has(address.toLowerCase()) : true,
+	)
 }
 
 function parseHashFromParams(params: unknown): Hex.Hex | null {
@@ -160,6 +176,28 @@ function parseHashFromParams(params: unknown): Hex.Hex | null {
 	if (!Hex.validate(hash) || Hex.size(hash) !== 32) return null
 
 	return hash
+}
+
+function receiptExportNotFound(
+	type: ReturnType<typeof getReceiptResponseType>,
+) {
+	return type === 'application/json'
+		? Response.json({ error: 'Not found' }, { status: 404 })
+		: new Response('Not found', {
+				status: 404,
+				headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+			})
+}
+
+async function fetchReceiptDataForExport(params: {
+	hash: Hex.Hex
+	rpcUrl?: string
+}): Promise<Awaited<ReturnType<typeof fetchReceiptData>> | null> {
+	try {
+		return await fetchReceiptData(params)
+	} catch {
+		return null
+	}
 }
 
 export const Route = createFileRoute('/_layout/receipt/$hash')({
@@ -221,32 +259,21 @@ export const Route = createFileRoute('/_layout/receipt/$hash')({
 					userAgent.includes('wget') ||
 					userAgent.includes('httpie')
 
-				const type = (() => {
-					if (
-						url.pathname.endsWith('.pdf') ||
-						accept.includes('application/pdf')
-					)
-						return 'application/pdf'
-					if (
-						url.pathname.endsWith('.json') ||
-						accept.includes('application/json')
-					)
-						return 'application/json'
-					if (
-						url.pathname.endsWith('.txt') ||
-						isTerminal ||
-						accept.includes('text/plain')
-					)
-						return 'text/plain'
-				})()
+				const type = getReceiptResponseType(url.pathname, accept, isTerminal)
 
 				const rpcUrl = url.searchParams.get('r') ?? undefined
 				const hash = parseHashFromParams(params)
+				if (!hash) return type ? receiptExportNotFound(type) : next()
 
 				if (type === 'text/plain') {
-					if (!hash) return new Response('Not found', { status: 404 })
-					const data = await fetchReceiptData({ hash, rpcUrl })
-					const text = TextRenderer.render(data)
+					const data = await fetchReceiptDataForExport({ hash, rpcUrl })
+					if (!data) return receiptExportNotFound(type)
+					const voucherData = parseVoucherSearchParams(url.searchParams)
+					const presentation = await getServerReceiptPresentation(
+						data,
+						voucherData,
+					)
+					const text = renderReceiptText(data, presentation)
 					return new Response(text, {
 						headers: {
 							'Content-Type': 'text/plain; charset=utf-8',
@@ -262,28 +289,38 @@ export const Route = createFileRoute('/_layout/receipt/$hash')({
 				}
 
 				if (type === 'application/json') {
-					if (!hash)
-						return Response.json({ error: 'Not found' }, { status: 404 })
-					const data = await fetchReceiptData({
+					const data = await fetchReceiptDataForExport({
 						hash,
 						rpcUrl,
 					})
+					if (!data) return receiptExportNotFound(type)
+					const voucherData = parseVoucherSearchParams(url.searchParams)
+					const presentation = await getServerReceiptPresentation(
+						data,
+						voucherData,
+					)
 					const summary = buildTxSummary({
 						receipt: data.receipt,
 						transaction: data.transaction,
-						knownEvents: data.knownEvents,
+						knownEvents: presentation.events,
 						trace: null,
 					})
 					return Response.json(
 						JSON.parse(
 							Json.stringify({
-								version: 1,
+								version: 2,
 								summary,
 								block: data.block,
 								transaction: data.transaction,
 								receipt: data.receipt,
-								knownEvents: data.knownEvents,
-								feeBreakdown: data.feeBreakdown,
+								knownEvents: presentation.events,
+								feeBreakdown: presentation.feeBreakdown,
+								display: {
+									fee: presentation.fee,
+									feeDisplay: presentation.feeDisplay,
+									total: presentation.total,
+									totalDisplay: presentation.totalDisplay,
+								},
 								lineItems: data.lineItems,
 							}),
 						),
@@ -291,15 +328,19 @@ export const Route = createFileRoute('/_layout/receipt/$hash')({
 				}
 
 				if (type === 'application/pdf') {
+					const data = await fetchReceiptDataForExport({ hash, rpcUrl })
+					if (!data) return receiptExportNotFound(type)
 					const browser = await puppeteer.launch(env.BROWSER)
 					const page = await browser.newPage()
 
-					// Pass through authentication if present
-					const authHeader = request.headers.get('Authorization')
-					if (authHeader)
-						await page.setExtraHTTPHeaders({
-							Authorization: authHeader,
-						})
+					const forwardedHeaders = Object.fromEntries(
+						['authorization', 'cookie', 'accept-language'].flatMap((name) => {
+							const value = request.headers.get(name)
+							return value ? [[name, value]] : []
+						}),
+					)
+					if (Object.keys(forwardedHeaders).length > 0)
+						await page.setExtraHTTPHeaders(forwardedHeaders)
 
 					// Build the equivalent HTML URL, preserving existing query params
 					const htmlUrl = new URL(url.href)
@@ -307,7 +348,7 @@ export const Route = createFileRoute('/_layout/receipt/$hash')({
 					htmlUrl.searchParams.set('plain', '')
 
 					// Navigate to the HTML version of the receipt
-					await page.goto(htmlUrl.toString(), { waitUntil: 'domcontentloaded' })
+					await page.goto(htmlUrl.toString(), { waitUntil: 'networkidle0' })
 
 					// Generate PDF
 					const pdf = await page.pdf({
@@ -341,15 +382,19 @@ export const Route = createFileRoute('/_layout/receipt/$hash')({
 			z.transform((val) => val.replace(/(\.json|\.txt|\.pdf)$/, '') as Hex.Hex),
 		),
 	}),
-	head: ({ params, loaderData }) => {
+	head: ({ params, loaderData, match }) => {
 		const title = `Receipt ${params.hash.slice(0, 10)}…${params.hash.slice(-6)} ⋅ Tempo Explorer`
+		const voucherData = parseVoucherParam(match.search.voucher)
+		const presentation = loaderData
+			? getReceiptPresentation(loaderData, voucherData, () => true)
+			: null
 
 		const description = buildTxDescription(
 			loaderData
 				? {
 						timestamp: Number(loaderData.block.timestamp) * 1000,
 						from: loaderData.receipt.from,
-						events: loaderData.knownEvents ?? [],
+						events: presentation?.events ?? [],
 					}
 				: null,
 		)
@@ -364,24 +409,13 @@ export const Route = createFileRoute('/_layout/receipt/$hash')({
 			search.set('date', ogTimestamp.date)
 			search.set('time', ogTimestamp.time)
 
-			const feePrice = loaderData.lineItems.feeTotals?.[0]?.price
-			const fee = feePrice
-				? Number(Value.format(feePrice.amount, feePrice.decimals))
-				: Number(
-						Value.format(
-							BigInt(loaderData.receipt.gasUsed ?? 0) *
-								BigInt(
-									loaderData.receipt.effectiveGasPrice ??
-										loaderData.transaction.gasPrice ??
-										0,
-								),
-							18,
-						),
-					)
-			const feeDisplay = PriceFormatter.format(fee)
-			search.set('fee', feeDisplay)
+			if (presentation) {
+				search.set('fee', presentation.feeDisplay)
+				if (presentation.totalDisplay)
+					search.set('total', presentation.totalDisplay)
+			}
 
-			loaderData.knownEvents
+			presentation?.events
 				?.slice(0, 6)
 				.forEach(
 					(
@@ -415,7 +449,11 @@ export const Route = createFileRoute('/_layout/receipt/$hash')({
 
 function parseVoucherParam(
 	raw:
-		| { final_voucher?: string; packet_size?: number; number?: number }
+		| {
+				final_voucher?: string
+				packet_size?: number | string
+				number?: number | string
+		  }
 		| undefined,
 ): { packetSize: number; packetCount: number } | null {
 	if (!raw) return null
@@ -423,6 +461,32 @@ function parseVoucherParam(
 	const packetCount = Number(raw.number)
 	if (!Number.isFinite(packetSize) || !Number.isFinite(packetCount)) return null
 	return { packetSize, packetCount }
+}
+
+function parseVoucherSearchParams(
+	searchParams: URLSearchParams,
+): { packetSize: number; packetCount: number } | null {
+	const serializedVoucher = searchParams.get('voucher')
+	if (serializedVoucher) {
+		try {
+			const voucher = JSON.parse(serializedVoucher)
+			if (voucher && typeof voucher === 'object')
+				return parseVoucherParam(
+					voucher as {
+						final_voucher?: string
+						packet_size?: number | string
+						number?: number | string
+					},
+				)
+		} catch {
+			// Fall through to bracket-style query parameters.
+		}
+	}
+
+	return parseVoucherParam({
+		packet_size: searchParams.get('voucher[packet_size]') ?? undefined,
+		number: searchParams.get('voucher[number]') ?? undefined,
+	})
 }
 
 function Component() {
@@ -447,255 +511,25 @@ function Component() {
 
 	const { isTokenListed } = useTokenListMembership()
 
-	const { block, feeBreakdown, knownEvents, lineItems, receipt } = data
-	const hasBlockedTransfer = knownEvents.some(
-		(event) => event.type === 'transfer blocked',
-	)
-
-	const feePrice = lineItems.feeTotals?.[0]?.price
-	const previousFee = feePrice
-		? Number(Value.format(feePrice.amount, feePrice.decimals))
-		: 0
-
-	const totalPrice = lineItems.totals?.[0]?.price
-	const previousTotal = totalPrice
-		? Number(Value.format(totalPrice.amount, totalPrice.decimals))
-		: undefined
-
-	const fallbackFeeAmount = receipt.effectiveGasPrice * receipt.gasUsed
-	const feeRaw = feePrice
-		? Value.format(feePrice.amount, feePrice.decimals)
-		: Value.format(fallbackFeeAmount, 18)
-	const fee = Number(feeRaw)
-	const feeTokens = feeBreakdown.filter(hasTokenAmount)
-	const showUsdFeePrefix =
-		feeTokens.length > 0
-			? areUsdPricedTokens(TEMPO_CHAIN_ID, feeTokens, isTokenListed)
-			: TEMPO_FEE_TOKEN
-				? isTokenListed(TEMPO_CHAIN_ID, TEMPO_FEE_TOKEN)
-				: true
-	const feeDisplay = showUsdFeePrefix
-		? PriceFormatter.format(fee)
-		: PriceFormatter.formatAmountShort(feeRaw)
-
-	// Inject a streaming payment event when voucher params are present.
-	// For TIP-1028 blocked transfers, the TIP-20 receipt also contains the
-	// mechanical Transfer to ReceivePolicyGuard. Hide that implementation detail
-	// from the human receipt so the blocked transfer is not shown or totaled twice.
-	const displayEvents: KnownEvent[] = (
-		voucherData
-			? [
-					buildStreamedPaymentEvent(
-						voucherData.packetSize,
-						voucherData.packetCount,
-					),
-					...knownEvents,
-				]
-			: knownEvents
-	).filter(
-		(event) =>
-			!hasBlockedTransfer ||
-			event.type !== 'send' ||
-			!event.meta?.to ||
-			!Address.isEqual(event.meta.to, RECEIVE_POLICY_GUARD),
-	)
-
-	// When a voucher is present, show the streaming total as the receipt total
-	const streamingTotal = voucherData
-		? voucherData.packetSize * voucherData.packetCount
-		: undefined
-
-	const eventsTotal = calculateKnownEventsTotal(displayEvents)
-	const eventsTotalDisplayValue =
-		eventsTotal > 0n ? Number(Value.format(eventsTotal, 18)) : undefined
-	const eventTotalTokens = getKnownEventAmounts(displayEvents)
-	const hasVaultActivity = hasNonAdditiveVaultActivity(displayEvents)
-
-	const total =
-		streamingTotal !== undefined
-			? streamingTotal
-			: eventsTotalDisplayValue !== undefined
-				? eventsTotalDisplayValue + fee
-				: previousTotal !== undefined
-					? previousTotal - previousFee + fee
-					: fee
-	const totalTokens = lineItems.totals
-		.map((item) => item.price)
-		.filter(hasTokenAmount)
-	const showUsdTotalPrefix = (() => {
-		if (streamingTotal !== undefined) return true
-		if (eventsTotalDisplayValue !== undefined) {
-			return areUsdPricedTokens(TEMPO_CHAIN_ID, eventTotalTokens, isTokenListed)
-		}
-		if (totalTokens.length > 0) {
-			return areUsdPricedTokens(TEMPO_CHAIN_ID, totalTokens, isTokenListed)
-		}
-		return showUsdFeePrefix
-	})()
-	const totalDisplayValue =
-		streamingTotal !== undefined
-			? streamingTotal
-			: eventsTotalDisplayValue !== undefined
-				? eventsTotalDisplayValue + fee
-				: previousTotal !== undefined
-					? previousTotal
-					: total
-	const totalDisplay = showUsdTotalPrefix
-		? PriceFormatter.format(totalDisplayValue)
-		: PriceFormatter.formatAmountShort(String(totalDisplayValue))
+	const { block, receipt } = data
+	const presentation = getReceiptPresentation(data, voucherData, isTokenListed)
 
 	return (
 		<div className="font-mono text-[13px] flex flex-col items-center justify-center gap-8 pt-16 pb-8 grow print:pt-8 print:pb-0 print:grow-0">
 			<Receipt
 				blockNumber={receipt.blockNumber}
-				events={displayEvents}
-				fee={fee}
-				feeBreakdown={feeBreakdown}
-				feeDisplay={feeDisplay}
+				events={presentation.events}
+				fee={presentation.fee}
+				feeBreakdown={presentation.feeBreakdown}
+				feeDisplay={presentation.feeDisplay}
 				hash={receipt.transactionHash}
 				sender={receipt.from}
 				status={receipt.status}
 				timestamp={block.timestamp}
-				total={hasVaultActivity ? undefined : total}
-				totalDisplay={hasVaultActivity ? undefined : totalDisplay}
+				total={presentation.total}
+				totalDisplay={presentation.totalDisplay}
 				exportSearch={location.searchStr}
 			/>
 		</div>
 	)
-}
-
-/**
- * Builds a synthetic KnownEvent representing a streamed (off-chain) payment session.
- * The final voucher proves all prior off-chain packets were authorized.
- */
-function buildStreamedPaymentEvent(
-	packetSize: number,
-	packetCount: number,
-): KnownEvent {
-	const totalMicros = BigInt(Math.round(packetSize * packetCount * 1_000_000))
-
-	const parts: KnownEvent['parts'] = [
-		{ type: 'action', value: 'Streamed Payment' },
-	]
-
-	// Include total amount using pathUSD (6 decimals) if the fee token is available
-	if (TEMPO_FEE_TOKEN) {
-		parts.push({
-			type: 'amount',
-			value: {
-				value: totalMicros,
-				decimals: 6,
-				currency: 'USD',
-				token: TEMPO_FEE_TOKEN,
-				symbol: 'pathUSD',
-			},
-		})
-	}
-
-	return {
-		type: 'streamed payment',
-		parts,
-		note: [
-			[
-				'Packets',
-				{ type: 'number', value: [BigInt(packetCount), 0] as [bigint, number] },
-			],
-			['Per packet', { type: 'text', value: `$${packetSize}` }],
-			['Settlement', { type: 'text', value: 'final voucher proven on-chain' }],
-		],
-	}
-}
-
-namespace TextRenderer {
-	const width = 76
-	const indent = '  '
-
-	export function render(data: Awaited<ReturnType<typeof fetchReceiptData>>) {
-		const { knownEvents, lineItems, receipt, timestampFormatted, transaction } =
-			data
-		const summary = buildTxSummary({
-			receipt,
-			transaction,
-			knownEvents,
-			trace: null,
-		})
-
-		const lines: string[] = []
-
-		// Header
-		lines.push(center('TEMPO RECEIPT'))
-		lines.push('')
-
-		// Transaction details
-		lines.push(`Tx Hash: ${receipt.transactionHash}`)
-		lines.push(`Date: ${timestampFormatted}`)
-		lines.push(`Block: ${receipt.blockNumber.toString()}`)
-		lines.push(`Sender: ${receipt.from}`)
-		lines.push(`Summary: ${summary.headline}`)
-		lines.push('')
-		lines.push('-'.repeat(width))
-		lines.push('')
-
-		// Main line items
-		if (lineItems.main) {
-			for (const item of lineItems.main) {
-				// Render `left` and `right`
-				lines.push(leftRight(item.ui.left.toUpperCase(), item.ui.right))
-
-				// Render `bottom`
-				if ('bottom' in item.ui && item.ui.bottom) {
-					for (const bottom of item.ui.bottom) {
-						if (bottom.right)
-							lines.push(`${indent}${leftRight(bottom.left, bottom.right)}`)
-						else lines.push(`${indent}${bottom.left}`)
-					}
-				}
-			}
-
-			lines.push('')
-		}
-
-		// Fee breakdown
-		if (lineItems.feeBreakdown?.length) {
-			let hasVisibleFee = false
-			for (const item of lineItems.feeBreakdown) {
-				if (
-					item.payer &&
-					item.payer.toLowerCase() !== receipt.from.toLowerCase()
-				)
-					continue
-				hasVisibleFee = true
-				const label = item.symbol ? `Fee (${item.symbol})` : 'Fee'
-				const amount = PriceFormatter.format(item.amount, {
-					decimals: item.decimals,
-					format: 'short',
-				})
-				lines.push(leftRight(label.toUpperCase(), amount))
-			}
-
-			if (hasVisibleFee) lines.push('')
-		}
-
-		// Fee totals
-		if (lineItems.feeTotals)
-			for (const item of lineItems.feeTotals)
-				lines.push(leftRight(item.ui.left.toUpperCase(), item.ui.right))
-
-		// Totals
-		if (lineItems.totals)
-			for (const item of lineItems.totals)
-				lines.push(leftRight(item.ui.left.toUpperCase(), item.ui.right))
-
-		return lines.join('\n')
-	}
-
-	function center(text: string): string {
-		const padding = Math.max(0, Math.floor((width - text.length) / 2))
-		return ' '.repeat(padding) + text
-	}
-
-	function leftRight(left: string, right: string): string {
-		const spacing = Math.max(1, width - left.length - right.length)
-		return left + ' '.repeat(spacing) + right
-	}
 }

--- a/apps/explorer/test/receipt-export.test.ts
+++ b/apps/explorer/test/receipt-export.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from 'vitest'
+import { getReceiptResponseType } from '#lib/domain/receipt-export'
+
+describe('getReceiptResponseType', () => {
+	test.each([
+		['/receipt/hash.txt', 'application/json', false, 'text/plain'],
+		['/receipt/hash.json', 'text/plain', false, 'application/json'],
+		['/receipt/hash.pdf', 'application/json', false, 'application/pdf'],
+		['/receipt/hash', 'application/json', false, 'application/json'],
+		['/receipt/hash', 'text/plain', false, 'text/plain'],
+		['/receipt/hash', '*/*', true, 'text/plain'],
+		['/receipt/hash', 'text/html', false, undefined],
+	] as const)('negotiates %s independently of conflicting headers', (pathname, accept, isTerminal, expected) => {
+		expect(getReceiptResponseType(pathname, accept, isTerminal)).toBe(expected)
+	})
+})

--- a/apps/explorer/test/receipt-presentation.test.ts
+++ b/apps/explorer/test/receipt-presentation.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, test } from 'vitest'
+import type { KnownEvent } from '#lib/domain/known-events'
+import {
+	buildReceiptPresentation,
+	enrichReceiptEventAmounts,
+	getReceiptEventSideAmount,
+} from '#lib/domain/receipt-presentation'
+
+const sender = '0x0000000000000000000000000000000000000001'
+const other = '0x0000000000000000000000000000000000000002'
+const token = '0x20c0000000000000000000000000000000000000'
+const guard = '0xB10C000000000000000000000000000000000000'
+
+const receipt = {
+	effectiveGasPrice: 1n,
+	from: sender,
+	gasUsed: 1n,
+} as const
+
+const lineItems = {
+	feeTotals: [
+		{
+			price: { amount: 1n, currency: 'USD', decimals: 6, token },
+			ui: { left: 'Fee', right: '<$0.01' },
+		},
+	],
+	totals: [
+		{
+			price: { amount: 1_000_001n, currency: 'USD', decimals: 6, token },
+			ui: { left: 'Total', right: '$1' },
+		},
+	],
+}
+
+function build(events: KnownEvent[], voucher = null) {
+	return buildReceiptPresentation({
+		chainId: 4217,
+		feeBreakdown: [
+			{
+				amount: 1n,
+				currency: 'USD',
+				decimals: 6,
+				payer: sender,
+				symbol: 'pathUSD',
+				token,
+			},
+			{
+				amount: 2n,
+				currency: 'USD',
+				decimals: 6,
+				payer: other,
+				symbol: 'pathUSD',
+				token,
+			},
+		],
+		feeToken: token,
+		isTokenListed: () => true,
+		knownEvents: events,
+		lineItems,
+		receipt,
+		voucher,
+	})
+}
+
+describe('receipt presentation', () => {
+	test('hydrates missing amount metadata for every output format', () => {
+		const [event] = enrichReceiptEventAmounts(
+			[
+				{
+					type: 'send',
+					parts: [
+						{
+							type: 'amount',
+							value: { token, value: 250_120n },
+						},
+					],
+					totalAmount: { token, value: 250_120n },
+				},
+			],
+			() => ({ currency: 'USD', decimals: 6, symbol: 'pathUSD' }),
+		)
+
+		expect(event?.parts[0]).toMatchObject({
+			type: 'amount',
+			value: { currency: 'USD', decimals: 6, symbol: 'pathUSD' },
+		})
+		expect(event?.totalAmount).toMatchObject({
+			currency: 'USD',
+			decimals: 6,
+			symbol: 'pathUSD',
+		})
+	})
+
+	test('shares hidden-event, blocked-transfer, fee-payer, and voucher rules', () => {
+		const presentation = build(
+			[
+				{
+					type: 'nonce incremented',
+					parts: [{ type: 'action', value: 'Nonce Incremented' }],
+				},
+				{
+					type: 'active key count changed',
+					parts: [{ type: 'action', value: 'Active Key Count Changed' }],
+				},
+				{
+					type: 'send',
+					parts: [{ type: 'action', value: 'Send' }],
+					meta: { to: guard },
+				},
+				{
+					type: 'transfer blocked',
+					parts: [{ type: 'action', value: 'Transfer Blocked' }],
+				},
+			],
+			{ packetCount: 3, packetSize: 2 },
+		)
+
+		expect(presentation.events.map((event) => event.type)).toEqual([
+			'streamed payment',
+			'transfer blocked',
+		])
+		expect(presentation.feeBreakdown).toHaveLength(1)
+		expect(presentation.feeBreakdown[0]?.payer).toBe(sender)
+		expect(presentation.totalDisplay).toBe('$6')
+	})
+
+	test('uses the same side-amount and vault-total rules as the card', () => {
+		const first = { token, value: 1_000_000n, decimals: 6 }
+		const second = { token, value: 2_000_000n, decimals: 6 }
+		const redemption: KnownEvent = {
+			type: 'earn private redemption',
+			parts: [
+				{ type: 'action', value: 'Earn Redemption' },
+				{ type: 'amount', value: first },
+				{ type: 'text', value: 'for' },
+				{ type: 'amount', value: second },
+			],
+		}
+
+		expect(getReceiptEventSideAmount(redemption)).toBeUndefined()
+		expect(getReceiptEventSideAmount({ ...redemption, type: 'swap' })).toEqual(
+			first,
+		)
+		expect(build([redemption]).totalDisplay).toBeUndefined()
+		expect(
+			build([redemption], { packetCount: 3, packetSize: 2 }).totalDisplay,
+		).toBe('$6')
+	})
+
+	test('derives regular totals from the same visible token flows', () => {
+		const presentation = build([
+			{
+				type: 'send',
+				parts: [
+					{ type: 'action', value: 'Send' },
+					{
+						type: 'amount',
+						value: {
+							currency: 'USD',
+							decimals: 6,
+							token,
+							value: 1_000_000n,
+						},
+					},
+				],
+				meta: { from: sender, to: other },
+			},
+		])
+
+		expect(presentation.total).toBe(1.000001)
+		expect(presentation.totalDisplay).toBe('$1')
+	})
+})

--- a/apps/explorer/test/receipt-text.test.ts
+++ b/apps/explorer/test/receipt-text.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, test } from 'vitest'
+import { buildReceiptPresentation } from '#lib/domain/receipt-presentation'
+import { renderReceiptText } from '#lib/domain/receipt-text'
+
+const sender = '0xea45a23d303f43491f5db087dca0bef2832d3f2a'
+const hash =
+	'0xce5226b560dd03cf4bd17dbe3f98bbcb1a38f0c118186544d02171161b1b4dfb'
+const senpathUsde = '0x20c000000000000000000000C3268D803b51d448'
+const dlusd = '0x20c0000000000000000000006fD9A167923ba194'
+const feeToken = '0x20c0000000000000000000000000000000000000'
+
+describe('renderReceiptText', () => {
+	test('renders the same high-level events as the receipt card', () => {
+		const block = { timestamp: 1_788_390_666n }
+		const feeBreakdown = [
+			{
+				amount: 361n,
+				currency: 'USD',
+				decimals: 6,
+				symbol: 'pathUSD',
+				token: feeToken,
+				payer: sender,
+			},
+		]
+		const knownEvents = [
+			{
+				type: 'nonce incremented',
+				parts: [{ type: 'action', value: 'Nonce Incremented' }],
+			},
+			{
+				type: 'zone withdrawal',
+				parts: [
+					{ type: 'action', value: 'Private Zone Withdrawal' },
+					{
+						type: 'amount',
+						value: {
+							value: 250_120n,
+							decimals: 6,
+							symbol: 'senpathUSDE',
+							token: senpathUsde,
+						},
+					},
+					{ type: 'text', value: 'to' },
+					{
+						type: 'account',
+						value: '0x8117E0ba6239B9695f780DEb010F72a2Fa4bdfb6',
+					},
+				],
+			},
+			{
+				type: 'earn private redemption',
+				parts: [
+					{ type: 'action', value: 'Earn Redemption' },
+					{
+						type: 'amount',
+						value: {
+							value: 250_120n,
+							decimals: 6,
+							symbol: 'senpathUSDE',
+							token: senpathUsde,
+						},
+					},
+					{ type: 'text', value: 'for' },
+					{
+						type: 'amount',
+						value: {
+							value: 500_000n,
+							decimals: 6,
+							symbol: 'DLUSD',
+							token: dlusd,
+						},
+					},
+				],
+			},
+			{
+				type: 'zone deposit',
+				parts: [
+					{ type: 'action', value: 'Private Zone Deposit' },
+					{
+						type: 'amount',
+						value: {
+							value: 500_000n,
+							decimals: 6,
+							symbol: 'DLUSD',
+							token: dlusd,
+						},
+					},
+				],
+			},
+		]
+		const lineItems = {
+			feeTotals: [{ ui: { left: 'Fee', right: '<$0.01' } }],
+			totals: [{ ui: { left: 'Total', right: '$0.5' } }],
+		}
+		const receipt = {
+			blockNumber: 37_714_808n,
+			effectiveGasPrice: 1n,
+			from: sender,
+			gasUsed: 361n,
+			status: 'success',
+			transactionHash: hash,
+		} as const
+		const presentation = buildReceiptPresentation({
+			chainId: 4217,
+			feeBreakdown,
+			feeToken,
+			isTokenListed: (_chainId, token) => token !== senpathUsde,
+			knownEvents,
+			lineItems,
+			receipt,
+			voucher: null,
+		})
+		const text = renderReceiptText({ block, receipt }, presentation)
+
+		expect(text).toContain(
+			'1. Private Zone Withdrawal 0.25012 senpathUSDE to 0x8117…dfb6',
+		)
+		expect(text).toContain(
+			'2. Earn Redemption 0.25012 senpathUSDE for 0.5 DLUSD',
+		)
+		expect(text).toContain('3. Private Zone Deposit 0.5 DLUSD')
+		expect(text).toContain('Fee (pathUSD)')
+		expect(text).not.toContain('Nonce Incremented')
+		expect(text).not.toContain('Total')
+	})
+})

--- a/apps/explorer/test/receipt-text.test.ts
+++ b/apps/explorer/test/receipt-text.test.ts
@@ -110,17 +110,27 @@ describe('renderReceiptText', () => {
 			receipt,
 			voucher: null,
 		})
-		const text = renderReceiptText({ block, receipt }, presentation)
+		const text = renderReceiptText({ block, receipt }, presentation, {
+			summary: 'Private Zone Withdrawal',
+		})
+		const lines = text.split('\n')
 
-		expect(text).toContain(
-			'1. Private Zone Withdrawal 0.25012 senpathUSDE to 0x8117…dfb6',
+		expect(text).toContain('SUMMARY: PRIVATE ZONE WITHDRAWAL')
+		expect(lines.find((line) => line.startsWith('1. '))).toMatch(
+			/^1\. PRIVATE ZONE WITHDRAWAL\s+0\.25 SENPATHUSDE$/,
 		)
-		expect(text).toContain(
-			'2. Earn Redemption 0.25012 senpathUSDE for 0.5 DLUSD',
+		expect(text).toContain('  0.25012 SENPATHUSDE TO 0X8117…DFB6')
+		expect(lines.find((line) => line.startsWith('2. '))).toMatch(
+			/^2\. EARN REDEMPTION\s+–$/,
 		)
-		expect(text).toContain('3. Private Zone Deposit 0.5 DLUSD')
-		expect(text).toContain('Fee (pathUSD)')
-		expect(text).not.toContain('Nonce Incremented')
-		expect(text).not.toContain('Total')
+		expect(text).toContain('  0.25012 SENPATHUSDE FOR 0.5 DLUSD')
+		expect(lines.find((line) => line.startsWith('3. '))).toMatch(
+			/^3\. PRIVATE ZONE DEPOSIT\s+0\.5 DLUSD$/,
+		)
+		expect(lines.find((line) => line.startsWith('FEE '))).toMatch(
+			/^FEE \(PATHUSD\)\s+<\$0\.01$/,
+		)
+		expect(text).not.toContain('NONCE INCREMENTED')
+		expect(text).not.toContain('TOTAL')
 	})
 })


### PR DESCRIPTION
## Summary

- centralize receipt event filtering, token metadata, fee, and total presentation
- make TXT, JSON, PDF, and OG metadata use the same receipt presentation as HTML
- preserve streaming voucher context and normalize content negotiation and missing-receipt responses

## Screenshots

| Before | After |
| --- | --- |
| ![Production receipt OG](https://og.tempo.xyz/receipt/0xce5226b560dd03cf4bd17dbe3f98bbcb1a38f0c118186544d02171161b1b4dfb?block=37714808&sender=0xea45a23d303f43491f5db087dca0bef2832d3f2a&date=Sep+2%2C+2026&time=22%3A51&fee=%3C%240.01&ev1=Private+Zone+Withdr%E2%80%A6%7C0.25+senpathUSDE+to+0x8117%E2%80%A6dfb6%7C%240.25&ev2=Earn+Redemption%7C0.25+senpathUSDE+for+0.50+DLUSD%7C%240.25&ev3=Private+Zone+Deposit%7C0.50+DLUSD%7C%240.50) | ![Preview receipt OG](https://og.tempo.xyz/receipt/0xce5226b560dd03cf4bd17dbe3f98bbcb1a38f0c118186544d02171161b1b4dfb?block=37714808&sender=0xea45a23d303f43491f5db087dca0bef2832d3f2a&date=Sep+2%2C+2026&time=22%3A51&fee=%3C%240.01&ev1=Private+Zone+Withdrawal%7C0.25+senpathUSDE+to+0x8117%E2%80%A6dfb6%7C%240.25&ev2=Earn+Redemption%7C0.25+senpathUSDE+for+0.50+DLUSD%7C&ev3=Private+Zone+Deposit%7C0.50+DLUSD%7C%240.50) |

The preview removes the misleading standalone $0.25 side total from the two-amount Earn Redemption and preserves the full action label.

## Deploy preview

- [Receipt HTML](https://4e22098a-explorer-mainnet.porto.workers.dev/receipt/0xce5226b560dd03cf4bd17dbe3f98bbcb1a38f0c118186544d02171161b1b4dfb)
- [Receipt TXT](https://4e22098a-explorer-mainnet.porto.workers.dev/receipt/0xce5226b560dd03cf4bd17dbe3f98bbcb1a38f0c118186544d02171161b1b4dfb.txt)
- [Receipt JSON](https://4e22098a-explorer-mainnet.porto.workers.dev/receipt/0xce5226b560dd03cf4bd17dbe3f98bbcb1a38f0c118186544d02171161b1b4dfb.json)
- [Receipt PDF](https://4e22098a-explorer-mainnet.porto.workers.dev/receipt/0xce5226b560dd03cf4bd17dbe3f98bbcb1a38f0c118186544d02171161b1b4dfb.pdf)
- [Preview deployment run](https://github.com/tempoxyz/tempo-apps/actions/runs/33695348684)

Deployed verification: all four endpoints return 200; HTML, TXT, and JSON contain the same three receipt events; explicit extensions override conflicting Accept headers; missing TXT, JSON, and PDF receipts all return 404; voucher events and totals propagate to TXT and OG metadata.

## Validation

- pnpm check
- pnpm --filter explorer test (124 tests after rebasing onto current main)
- pnpm --filter explorer build
- pnpm precommit
- deployed HTML, TXT, JSON, PDF, OG, voucher, negotiation, and 404 verification