### PR TITLE
chore(fee-payer): remove Privy deployment

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,7 @@ jobs:
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
     with:
       app: fee-payer
-      environments: '["privy","devnet","moderato","mainnet"]'
+      environments: '["devnet","moderato","mainnet"]'
 
   deploy-contract-verification:
     name: Deploy Contract Verification

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -65,8 +65,6 @@ jobs:
             env: mainnet
           #### fee-payer
           - app: fee-payer
-            env: privy
-          - app: fee-payer
             env: devnet
           - app: fee-payer
             env: moderato

--- a/apps/fee-payer/package.json
+++ b/apps/fee-payer/package.json
@@ -16,7 +16,6 @@
 		"dev:playground": "pnpm --filter fee-payer-playground dev",
 		"deploy": "wrangler deploy",
 		"deploy:mainnet": "wrangler deploy --env mainnet",
-		"deploy:privy": "wrangler deploy --env privy",
 		"format": "biome format --write .",
 		"gen:types": "CLOUDFLARE_ENV= wrangler types --env-interface='CloudflareBindings' --env-file='.env.example'",
 		"tail": "wrangler tail",

--- a/apps/fee-payer/test/billing.test.ts
+++ b/apps/fee-payer/test/billing.test.ts
@@ -12,7 +12,7 @@ const sender = '0x0000000000000000000000000000000000000003'
 const sponsorAddress = '0x0000000000000000000000000000000000000004'
 const target = '0x0000000000000000000000000000000000000005'
 const signedAt = '2026-06-20T12:00:00.000Z'
-const attributionKey = 'privy-app-123'
+const attributionKey = 'example-client-123'
 const feePayerSignature = {
 	r: `0x${'11'.repeat(32)}`,
 	s: `0x${'22'.repeat(32)}`,

--- a/apps/fee-payer/wrangler.json
+++ b/apps/fee-payer/wrangler.json
@@ -36,32 +36,6 @@
 		}
 	},
 	"env": {
-		"privy": {
-			"name": "fee-payer-privy",
-			"routes": [
-				{
-					"pattern": "privy-sponsor.testnet.tempo.xyz",
-					"zone_name": "tempo.xyz",
-					"custom_domain": true
-				}
-			],
-			"workers_dev": false,
-			"vars": {
-				"TEMPO_RPC_URL": "https://rpc.moderato.tempo.xyz",
-				"ALLOWED_ORIGINS": "*",
-				"TEMPO_ENV": "moderato"
-			},
-			"ratelimits": [
-				{
-					"name": "AddressRateLimiter",
-					"namespace_id": "888",
-					"simple": {
-						"limit": 1000,
-						"period": 60
-					}
-				}
-			]
-		},
 		"devnet": {
 			"name": "fee-payer-devnet",
 			"routes": [


### PR DESCRIPTION
## Summary

Removed the retired Privy-specific fee-payer deployment configuration.

## Motivation

The dedicated Privy fee-payer deployment is no longer needed.

## Changes

- Removed the `privy` Wrangler environment and route.
- Removed the `deploy:privy` package script.
- Replaced the Privy-specific billing attribution fixture with neutral test data.

## Testing

- Pre-commit hooks passed.
- Full fee-payer tests were not completed because the local Tempo test node stalled during startup.