### PR TITLE
fix(explorer): clarify Earn receipt labels

### DIFF
--- a/apps/explorer/src/lib/domain/known-event-totals.ts
+++ b/apps/explorer/src/lib/domain/known-event-totals.ts
@@ -96,7 +96,8 @@ export function hasNonAdditiveVaultActivity(
 			event.parts.some(
 				(part) =>
 					part.type === 'action' &&
-					(part.value === 'Vault Deposit' || part.value === 'Vault Withdrawal'),
+					(part.value === 'Deposit to Earn' ||
+						part.value === 'Withdraw from Earn'),
 			),
 	)
 }

--- a/apps/explorer/src/lib/domain/known-events.ts
+++ b/apps/explorer/src/lib/domain/known-events.ts
@@ -28,22 +28,20 @@ import type * as Tip20 from './tip20'
 
 const abi = allAbis
 const earnEventActionOverrides: Record<string, string> = {
-	'Deposited(address,address,uint256,uint256)': 'Earn Vault Deposit',
-	'Deposited(address,uint256,uint256)': 'Earn Engine Deposit',
+	'Deposited(address,address,uint256,uint256)': 'Deposit to Earn',
+	'Deposited(address,uint256,uint256)': 'Deposit to Earn',
 	'EarnDeposit(bytes32,address,address,uint256,uint256,uint256,bytes32)':
-		'Earn Deposit',
+		'Deposit to Earn',
 	'EarnRedeem(bytes32,address,address,uint256,uint256,uint256,bytes32)':
-		'Earn Redemption',
-	'EarnVaultInitialized(address)': 'Earn Engine Bound',
-	'Redeemed(address,address,uint256,uint256)': 'Earn Vault Redemption',
-	'Redeemed(address,uint256,uint256)': 'Earn Engine Redemption',
+		'Withdraw from Earn',
+	'EarnVaultInitialized(address)': 'Earn Strategy Connected',
+	'Redeemed(address,address,uint256,uint256)': 'Withdraw from Earn',
+	'Redeemed(address,uint256,uint256)': 'Withdraw from Earn',
 	'VenueSharesDeposited(address,address,uint256,uint256,uint256)':
-		'Earn Vault In-Kind Deposit',
-	'VenueSharesDeposited(address,uint256,uint256)':
-		'Earn Engine In-Kind Deposit',
-	'WithdrewExact(address,address,uint256,uint256)':
-		'Earn Vault Exact Withdrawal',
-	'WithdrewExact(address,uint256,uint256)': 'Earn Engine Exact Withdrawal',
+		'Move Position to Earn',
+	'VenueSharesDeposited(address,uint256,uint256)': 'Move Position to Earn',
+	'WithdrewExact(address,address,uint256,uint256)': 'Withdraw from Earn',
+	'WithdrewExact(address,uint256,uint256)': 'Withdraw from Earn',
 }
 
 function formatEarnEventAction(event: AbiEvent): string {
@@ -131,6 +129,33 @@ function findEarnToken(
 	return undefined
 }
 
+function findEarnSendRecipient(
+	events: ParsedEvent[],
+	params: {
+		amount: bigint
+		from: Address.Address
+		token: Address.Address
+	},
+): Address.Address | undefined {
+	for (const candidate of events) {
+		if (
+			candidate.eventName !== 'Transfer' &&
+			candidate.eventName !== 'TransferWithMemo'
+		)
+			continue
+		if (!Address.isEqual(candidate.address, params.token)) continue
+		if (eventBigInt(candidate, 'amount') !== params.amount) continue
+
+		const from = eventAddress(candidate, 'from')
+		const to = eventAddress(candidate, 'to')
+		if (!from || !to || !Address.isEqual(from, params.from)) continue
+		if (Address.isEqual(to, params.from) || Address.isEqual(to, zeroAddress))
+			continue
+		return to
+	}
+	return undefined
+}
+
 function earnValuePart(
 	value: bigint,
 	token: Address.Address | undefined,
@@ -165,7 +190,7 @@ function createEarnReceiptSummary(
 		return {
 			type: 'earn private deposit',
 			parts: [
-				{ type: 'action', value: 'Earn Deposit' },
+				{ type: 'action', value: 'Deposit to Earn' },
 				{ type: 'amount', value: createAmount(inputAmount, inputToken) },
 				{ type: 'text', value: 'for' },
 				earnValuePart(earnShares, earnShare, createAmount),
@@ -187,7 +212,7 @@ function createEarnReceiptSummary(
 		return {
 			type: 'earn private redemption',
 			parts: [
-				{ type: 'action', value: 'Earn Redemption' },
+				{ type: 'action', value: 'Withdraw from Earn' },
 				earnValuePart(earnShares, earnShare, createAmount),
 				{ type: 'text', value: 'for' },
 				{ type: 'amount', value: createAmount(outputAmount, outputToken) },
@@ -219,7 +244,7 @@ function createEarnReceiptSummary(
 		return {
 			type: 'earn deposit',
 			parts: [
-				{ type: 'action', value: 'Earn Deposit' },
+				{ type: 'action', value: 'Deposit to Earn' },
 				earnValuePart(assets, asset, createAmount),
 				{ type: 'text', value: 'for' },
 				earnValuePart(earnShares, earnShare, createAmount),
@@ -254,7 +279,7 @@ function createEarnReceiptSummary(
 		return {
 			type: 'earn redemption',
 			parts: [
-				{ type: 'action', value: 'Earn Redemption' },
+				{ type: 'action', value: 'Withdraw from Earn' },
 				earnValuePart(earnShares, earnShare, createAmount),
 				{ type: 'text', value: 'for' },
 				earnValuePart(assets, asset, createAmount),
@@ -283,12 +308,32 @@ function createEarnReceiptSummary(
 			amount: earnShares,
 			kind: 'burn',
 		})
+		if (asset) {
+			const sendRecipient = findEarnSendRecipient(events, {
+				amount: assets,
+				from: receiver,
+				token: asset,
+			})
+			if (sendRecipient) {
+				return {
+					type: 'earn send',
+					parts: [
+						{ type: 'action', value: 'Send' },
+						{ type: 'amount', value: createAmount(assets, asset) },
+						{ type: 'text', value: 'to' },
+						{ type: 'account', value: sendRecipient },
+					],
+					note: [['Source', { type: 'text', value: 'Earn balance' }]],
+					meta: { from: receiver, to: sendRecipient },
+				}
+			}
+		}
 		return {
 			type: 'earn exact withdrawal',
 			parts: [
-				{ type: 'action', value: 'Earn Exact Withdrawal' },
+				{ type: 'action', value: 'Withdraw from Earn' },
 				earnValuePart(assets, asset, createAmount),
-				{ type: 'text', value: 'burning' },
+				{ type: 'text', value: 'using' },
 				earnValuePart(earnShares, earnShare, createAmount),
 			],
 		}
@@ -322,7 +367,7 @@ function createEarnReceiptSummary(
 		return {
 			type: 'earn in-kind deposit',
 			parts: [
-				{ type: 'action', value: 'Earn In-Kind Deposit' },
+				{ type: 'action', value: 'Move Position to Earn' },
 				earnValuePart(venueShares, venue, createAmount),
 				{ type: 'text', value: 'for' },
 				earnValuePart(earnShares, earnShare, createAmount),
@@ -341,7 +386,7 @@ function createEarnReceiptSummary(
 		return {
 			type: 'earn contribution',
 			parts: [
-				{ type: 'action', value: 'Fund Earn Contribution' },
+				{ type: 'action', value: 'Add Funds to Earn' },
 				earnValuePart(fundedAssets, asset, createAmount),
 			],
 		}
@@ -354,7 +399,7 @@ function createEarnReceiptSummary(
 		return {
 			type: 'earn contribution',
 			parts: [
-				{ type: 'action', value: 'Fund Earn Contribution' },
+				{ type: 'action', value: 'Add Funds to Earn' },
 				earnValuePart(assets, asset, createAmount),
 			],
 		}
@@ -371,7 +416,7 @@ function createEarnReceiptSummary(
 		return {
 			type: 'earn reward funding',
 			parts: [
-				{ type: 'action', value: 'Fund Earn Rewards' },
+				{ type: 'action', value: 'Add Earn Rewards' },
 				earnValuePart(earnShares, earnShare, createAmount),
 			],
 		}
@@ -396,7 +441,7 @@ function createEarnReceiptSummary(
 		return {
 			type: 'earn reward root',
 			parts: [
-				{ type: 'action', value: 'Publish Earn Reward Root' },
+				{ type: 'action', value: 'Publish Reward Allocation' },
 				{ type: 'text', value: `v${version.toString()} for` },
 				earnValuePart(entitlement, earnShare, createAmount),
 			],
@@ -466,7 +511,7 @@ function createEarnReceiptSummary(
 		return {
 			type: 'earn async redemption request',
 			parts: [
-				{ type: 'action', value: 'Request Earn Redemption' },
+				{ type: 'action', value: 'Request Earn Withdrawal' },
 				earnValuePart(earnShares, earnShare, createAmount),
 				{ type: 'text', value: 'for' },
 				{ type: 'account', value: receiver },
@@ -482,7 +527,7 @@ function createEarnReceiptSummary(
 		return {
 			type: 'earn async redemption finalized',
 			parts: [
-				{ type: 'action', value: 'Finalize Earn Redemption' },
+				{ type: 'action', value: 'Complete Earn Withdrawal' },
 				{ type: 'amount', value: createAmount(assets, asset) },
 				{ type: 'text', value: 'to' },
 				{ type: 'account', value: receiver },
@@ -497,7 +542,7 @@ function createEarnReceiptSummary(
 		return {
 			type: 'earn async redemption cancelled',
 			parts: [
-				{ type: 'action', value: 'Cancel Earn Redemption' },
+				{ type: 'action', value: 'Cancel Earn Withdrawal' },
 				{ type: 'number', value: earnShares },
 				{ type: 'text', value: 'for' },
 				{ type: 'account', value: receiver },
@@ -513,7 +558,7 @@ function createEarnReceiptSummary(
 		return {
 			type: 'earn engine migration',
 			parts: [
-				{ type: 'action', value: 'Migrate Earn Engine' },
+				{ type: 'action', value: 'Migrate Earn Strategy' },
 				{ type: 'number', value: assetsMoved },
 			],
 			note: [

--- a/apps/explorer/src/lib/domain/transaction-activities.ts
+++ b/apps/explorer/src/lib/domain/transaction-activities.ts
@@ -139,7 +139,7 @@ function vaultActivityEvent(activity: TransactionActivity): KnownEvent | null {
 		parts: [
 			{
 				type: 'action',
-				value: isDeposit ? 'Vault Deposit' : 'Vault Withdrawal',
+				value: isDeposit ? 'Deposit to Earn' : 'Withdraw from Earn',
 			},
 			source,
 			{ type: 'text', value: 'for' },

--- a/apps/explorer/test/known-event-totals.node.test.ts
+++ b/apps/explorer/test/known-event-totals.node.test.ts
@@ -124,7 +124,7 @@ describe('hasNonAdditiveVaultActivity', () => {
 		const earnDeposit: KnownEvent = {
 			type: 'earn private deposit',
 			parts: [
-				{ type: 'action', value: 'Earn Deposit' },
+				{ type: 'action', value: 'Deposit to Earn' },
 				{
 					type: 'amount',
 					value: { token: tokenAddress, value: 1_000_000n, decimals: 6 },
@@ -137,7 +137,7 @@ describe('hasNonAdditiveVaultActivity', () => {
 			hasNonAdditiveVaultActivity([
 				{
 					type: 'earn reward root',
-					parts: [{ type: 'action', value: 'Publish Earn Reward Root' }],
+					parts: [{ type: 'action', value: 'Publish Reward Allocation' }],
 				},
 			]),
 		).toBe(true)

--- a/apps/explorer/test/known-events.test.ts
+++ b/apps/explorer/test/known-events.test.ts
@@ -850,12 +850,16 @@ describe('parseKnownEvents', () => {
 	})
 
 	it.each([
-		['EarnDeposit', 7, 'Earn Deposit'],
-		['EarnRedeem', 7, 'Earn Redemption'],
-		['Deposited', 4, 'Earn Vault Deposit'],
-		['Deposited', 3, 'Earn Engine Deposit'],
-		['Redeemed', 4, 'Earn Vault Redemption'],
-		['Redeemed', 3, 'Earn Engine Redemption'],
+		['EarnDeposit', 7, 'Deposit to Earn'],
+		['EarnRedeem', 7, 'Withdraw from Earn'],
+		['Deposited', 4, 'Deposit to Earn'],
+		['Deposited', 3, 'Deposit to Earn'],
+		['Redeemed', 4, 'Withdraw from Earn'],
+		['Redeemed', 3, 'Withdraw from Earn'],
+		['VenueSharesDeposited', 5, 'Move Position to Earn'],
+		['VenueSharesDeposited', 3, 'Move Position to Earn'],
+		['WithdrewExact', 4, 'Withdraw from Earn'],
+		['WithdrewExact', 3, 'Withdraw from Earn'],
 	] as const)('labels %s/%i without relying on contract verification', (name, arity, label) => {
 		const abiEvent = earnEventsAbi.find(
 			(event) => event.name === name && event.inputs.length === arity,
@@ -919,7 +923,7 @@ describe('parseKnownEvents', () => {
 		).find((event) => event.type === 'earn deposit')
 
 		expect(summary?.parts).toEqual([
-			{ type: 'action', value: 'Earn Deposit' },
+			{ type: 'action', value: 'Deposit to Earn' },
 			{
 				type: 'amount',
 				value: { token: Address.checksum(userTokenAddress), value: assets },
@@ -930,6 +934,88 @@ describe('parseKnownEvents', () => {
 				value: { token: Address.checksum(shareToken), value: earnShares },
 			},
 		])
+	})
+
+	it('describes an Earn-funded transfer as a Send', () => {
+		const hash = `0x${'8'.repeat(64)}` as const
+		const vault = recipientAddress
+		const shareToken = Address.from(
+			'0x20c0000000000000000000000000000000000012',
+		)
+		const assets = 1_110_000n
+		const earnShares = 555_000n
+		const withdrewExact = earnEventsAbi.find(
+			(event) => event.name === 'WithdrewExact' && event.inputs.length === 4,
+		)
+		expect(withdrewExact).toBeDefined()
+		if (!withdrewExact) return
+
+		const logs = [
+			mockLog(
+				{
+					address: userTokenAddress,
+					topics: encodeEventTopics({
+						abi: Abis.tip20,
+						eventName: 'Transfer',
+						args: { from: vault, to: accountAddress },
+					}) as [Hex.Hex, ...Hex.Hex[]],
+					data: encodeAbiParameters([{ type: 'uint256' }], [assets]),
+				},
+				hash,
+			),
+			mockLog(
+				{
+					address: shareToken,
+					topics: encodeEventTopics({
+						abi: Abis.tip20,
+						eventName: 'Burn',
+						args: { from: accountAddress },
+					}) as [Hex.Hex, ...Hex.Hex[]],
+					data: encodeAbiParameters([{ type: 'uint256' }], [earnShares]),
+				},
+				hash,
+			),
+			mockZoneEventLog(withdrewExact, vault, {
+				caller: accountAddress,
+				receiver: accountAddress,
+				assets,
+				earnSharesBurned: earnShares,
+			}),
+			mockLog(
+				{
+					address: userTokenAddress,
+					topics: encodeEventTopics({
+						abi: Abis.tip20,
+						eventName: 'Transfer',
+						args: { from: accountAddress, to: recipientAddress },
+					}) as [Hex.Hex, ...Hex.Hex[]],
+					data: encodeAbiParameters([{ type: 'uint256' }], [assets]),
+				},
+				hash,
+			),
+		]
+
+		const summary = parseKnownEvents(
+			mockReceipt(logs, accountAddress, hash),
+		).find((event) => event.type === 'earn send')
+
+		expect(summary).toEqual({
+			type: 'earn send',
+			parts: [
+				{ type: 'action', value: 'Send' },
+				{
+					type: 'amount',
+					value: { token: Address.checksum(userTokenAddress), value: assets },
+				},
+				{ type: 'text', value: 'to' },
+				{ type: 'account', value: Address.checksum(recipientAddress) },
+			],
+			note: [['Source', { type: 'text', value: 'Earn balance' }]],
+			meta: {
+				from: Address.checksum(accountAddress),
+				to: Address.checksum(recipientAddress),
+			},
+		})
 	})
 
 	it('composes Earn reward funding and root publication receipt rows', () => {
@@ -982,7 +1068,7 @@ describe('parseKnownEvents', () => {
 			{
 				type: 'earn reward funding',
 				parts: [
-					{ type: 'action', value: 'Fund Earn Rewards' },
+					{ type: 'action', value: 'Add Earn Rewards' },
 					{
 						type: 'amount',
 						value: { token: Address.checksum(shareToken), value: earnShares },
@@ -992,7 +1078,7 @@ describe('parseKnownEvents', () => {
 			{
 				type: 'earn reward root',
 				parts: [
-					{ type: 'action', value: 'Publish Earn Reward Root' },
+					{ type: 'action', value: 'Publish Reward Allocation' },
 					{ type: 'text', value: 'v12 for' },
 					{
 						type: 'amount',

--- a/apps/explorer/test/receipt-presentation.test.ts
+++ b/apps/explorer/test/receipt-presentation.test.ts
@@ -130,7 +130,7 @@ describe('receipt presentation', () => {
 		const redemption: KnownEvent = {
 			type: 'earn private redemption',
 			parts: [
-				{ type: 'action', value: 'Earn Redemption' },
+				{ type: 'action', value: 'Withdraw from Earn' },
 				{ type: 'amount', value: first },
 				{ type: 'text', value: 'for' },
 				{ type: 'amount', value: second },

--- a/apps/explorer/test/receipt-text.test.ts
+++ b/apps/explorer/test/receipt-text.test.ts
@@ -50,7 +50,7 @@ describe('renderReceiptText', () => {
 			{
 				type: 'earn private redemption',
 				parts: [
-					{ type: 'action', value: 'Earn Redemption' },
+					{ type: 'action', value: 'Withdraw from Earn' },
 					{
 						type: 'amount',
 						value: {
@@ -121,7 +121,7 @@ describe('renderReceiptText', () => {
 		)
 		expect(text).toContain('  0.25012 SENPATHUSDE TO 0X8117…DFB6')
 		expect(lines.find((line) => line.startsWith('2. '))).toMatch(
-			/^2\. EARN REDEMPTION\s+–$/,
+			/^2\. WITHDRAW FROM EARN\s+–$/,
 		)
 		expect(text).toContain('  0.25012 SENPATHUSDE FOR 0.5 DLUSD')
 		expect(lines.find((line) => line.startsWith('3. '))).toMatch(

--- a/apps/explorer/test/transaction-activities.test.ts
+++ b/apps/explorer/test/transaction-activities.test.ts
@@ -136,7 +136,7 @@ describe('activitiesToKnownEvents', () => {
 		])
 	})
 
-	test('maps an Earn redemption into a Vault Withdrawal', () => {
+	test('maps an Earn redemption into a withdrawal from Earn', () => {
 		expect(
 			activitiesToKnownEvents([
 				{
@@ -158,7 +158,7 @@ describe('activitiesToKnownEvents', () => {
 			{
 				type: 'shares-redeemed',
 				parts: [
-					{ type: 'action', value: 'Vault Withdrawal' },
+					{ type: 'action', value: 'Withdraw from Earn' },
 					{
 						type: 'amount',
 						value: {
@@ -179,7 +179,7 @@ describe('activitiesToKnownEvents', () => {
 		])
 	})
 
-	test('maps a finalized Earn redemption into a Vault Withdrawal', () => {
+	test('maps a finalized Earn redemption into a withdrawal from Earn', () => {
 		expect(
 			activitiesToKnownEvents([
 				{
@@ -198,7 +198,7 @@ describe('activitiesToKnownEvents', () => {
 			{
 				type: 'shares-redemption-finalized',
 				parts: [
-					{ type: 'action', value: 'Vault Withdrawal' },
+					{ type: 'action', value: 'Withdraw from Earn' },
 					{
 						type: 'amount',
 						value: {
@@ -263,8 +263,8 @@ describe('activitiesToKnownEvents', () => {
 						type: 'action',
 						value:
 							type === 'private-assets-deposited'
-								? 'Vault Deposit'
-								: 'Vault Withdrawal',
+								? 'Deposit to Earn'
+								: 'Withdraw from Earn',
 					},
 					{
 						type: 'amount',
@@ -354,7 +354,7 @@ describe('selectTransactionDescriptionEvents for Zones', () => {
 	test('preserves semantic API activities for Earn transactions', () => {
 		const vaultDeposit = {
 			type: 'private-assets-deposited',
-			parts: [{ type: 'action' as const, value: 'Vault Deposit' }],
+			parts: [{ type: 'action' as const, value: 'Deposit to Earn' }],
 		}
 		expect(
 			selectTransactionDescriptionEvents({
@@ -376,7 +376,7 @@ describe('selectTransactionDescriptionEvents for Zones', () => {
 		}
 		const vaultDeposit = {
 			type: 'private-assets-deposited',
-			parts: [{ type: 'action' as const, value: 'Vault Deposit' }],
+			parts: [{ type: 'action' as const, value: 'Deposit to Earn' }],
 		}
 		const zoneDepositActivity = {
 			type: 'private-assets-deposited',
@@ -437,7 +437,7 @@ describe('selectTransactionDescriptionEvents for Earn receipts', () => {
 	test('prefers one composed Earn flow over generic indexed token activity', () => {
 		const earnDeposit = {
 			type: 'earn deposit',
-			parts: [{ type: 'action' as const, value: 'Earn Deposit' }],
+			parts: [{ type: 'action' as const, value: 'Deposit to Earn' }],
 		}
 
 		expect(
@@ -459,7 +459,7 @@ describe('selectTransactionDescriptionEvents for Earn receipts', () => {
 		}
 		const earnDeposit = {
 			type: 'earn private deposit',
-			parts: [{ type: 'action' as const, value: 'Earn Deposit' }],
+			parts: [{ type: 'action' as const, value: 'Deposit to Earn' }],
 		}
 		const zoneWithdrawal = {
 			type: 'zone withdrawal',


### PR DESCRIPTION
## Summary

- replace protocol terms such as “redemption,” “exact withdrawal,” “vault,” and “engine” with intent-led Earn labels
- recognize an Earn withdrawal followed by an equal-value transfer as `Send`, with `Source: Earn balance` as secondary context
- keep regular exits labeled `Withdraw from Earn` and update deposit, reward, async-withdrawal, and migration copy consistently

## Validation

- `pnpm check`
- `pnpm --filter explorer test --run` (129 tests)
- `pnpm --filter explorer build`
- `pnpm precommit`
- browser-verified the reported receipt shape; the repository-wide test command reached an unrelated fee-payer E2E that requires unavailable Docker, while all Explorer tests passed

## Screenshots

| Before | After |
| --- | --- |
| [“Earn Exact Withdrawal” receipt](https://tempoxyz.enterprise.slack.com/files/U0ANX3AM5RR/F0BUSGX0BDF/earn-labels-before.png) | [`Send` with `Source: Earn balance`](https://tempoxyz.enterprise.slack.com/files/U0ANX3AM5RR/F0BUJC5MR2P/earn-labels-after.png) |

Prompted by: @emmajam
