### PR TITLE
feat(mcp-docs-indexer): add product feedback tool

### DIFF
--- a/apps/mcp-docs-indexer/README.md
+++ b/apps/mcp-docs-indexer/README.md
@@ -8,9 +8,10 @@ canonical Markdown pages for configured sources into the instance's
 query time.
 
 The Worker exposes an optimized MCP endpoint on `mcp.tempo.xyz`. It handles
-`tools/list`, `tools/call` for `search`, and docs source `resources/*` locally
-so it can provide a compact tool schema, source-aware filters, and lower-token
-search responses. Unsupported MCP methods fall through to the AI Search MCP
+`tools/list`, local documentation tools, `send_product_feedback`, and docs
+source `resources/*` locally so it can provide compact schemas, source-aware
+filters, lower-token search responses, and a confirmed feedback delivery path.
+Unsupported MCP methods fall through to the AI Search MCP
 upstream, so clients still connect to a stable branded URL instead of the
 opaque `<instance-id>.search.ai.cloudflare.com` hostname.
 
@@ -117,6 +118,15 @@ If an AI Search metadata filter returns no chunks for a known source, the
 server retries with a wider unfiltered search, filters chunks by source
 metadata/key prefix, and remembers that source briefly so repeated filtered
 queries skip the stale metadata-filter attempt.
+
+## MCP product feedback
+
+`send_product_feedback` is a free, side-effecting tool for feedback or bug
+reports the user explicitly asks to submit. It validates the bounded report,
+rejects likely sensitive or identifying data, and sends the sanitized fields to
+the Tempo docs feedback ingress. A successful call returns `accepted: true` and
+the stable `report_id` assigned by the receiving service. Delivery failures are
+returned as tool errors and never as accepted reports.
 
 The server also exposes MCP resources:
 

--- a/apps/mcp-docs-indexer/src/lib/mcp.test.ts
+++ b/apps/mcp-docs-indexer/src/lib/mcp.test.ts
@@ -53,8 +53,10 @@ describe('handleMcp', () => {
 
 		expect(res).toBeDefined()
 		const body = await res?.json()
-		expect(body.result.tools).toHaveLength(3)
-		expect(body.result.tools.map((tool: Tool) => tool.annotations)).toEqual(
+		expect(body.result.tools).toHaveLength(4)
+		expect(
+			body.result.tools.slice(0, 3).map((tool: Tool) => tool.annotations),
+		).toEqual(
 			Array.from({ length: 3 }, () => ({
 				destructiveHint: false,
 				idempotentHint: true,
@@ -83,6 +85,29 @@ describe('handleMcp', () => {
 			'viem',
 			'wagmi',
 		])
+		expect(body.result.tools[3]).toMatchObject({
+			name: 'send_product_feedback',
+			annotations: {
+				destructiveHint: false,
+				idempotentHint: false,
+				openWorldHint: true,
+				readOnlyHint: false,
+			},
+			inputSchema: {
+				additionalProperties: false,
+				required: ['kind', 'summary', 'details'],
+				properties: {
+					kind: { enum: ['bug_report', 'feedback'] },
+				},
+			},
+			outputSchema: {
+				required: ['accepted', 'report_id'],
+			},
+		})
+		expect(body.result.tools[3].description).toContain(
+			'Free and side-effecting',
+		)
+		expect(body.result.tools[3].description).toContain('explicitly asks')
 	})
 
 	it('adds the codemode code tool when an executor is configured', async () => {
@@ -105,8 +130,191 @@ describe('handleMcp', () => {
 		const body = await res?.json()
 		expect(
 			body.result.tools.map((tool: { name: string }) => tool.name),
-		).toEqual(['search', 'find_pages', 'read_page', 'code'])
-		expect(body.result.tools[3].description).toContain('codemode.search')
+		).toEqual([
+			'search',
+			'find_pages',
+			'read_page',
+			'send_product_feedback',
+			'code',
+		])
+		expect(body.result.tools[4].description).toContain('codemode.search')
+	})
+
+	it('validates product feedback before submission', async () => {
+		const fetch = vi.fn()
+		vi.stubGlobal('fetch', fetch)
+		const res = await handleMcp(
+			new Request('https://mcp.tempo.xyz/', {
+				method: 'POST',
+				body: JSON.stringify({
+					jsonrpc: '2.0',
+					id: 41,
+					method: 'tools/call',
+					params: {
+						name: 'send_product_feedback',
+						arguments: {
+							kind: 'problem',
+							summary: 'Search issue',
+							details: 'Search returned no results.',
+						},
+					},
+				}),
+			}),
+			{ instance: instance(async () => ({ search_query: '', chunks: [] })) },
+		)
+
+		const body = await res?.json()
+		expect(body.error).toMatchObject({
+			code: -32602,
+			message: 'Invalid product feedback payload',
+		})
+		expect(fetch).not.toHaveBeenCalled()
+	})
+
+	it('rejects identifying data in product feedback', async () => {
+		const fetch = vi.fn()
+		vi.stubGlobal('fetch', fetch)
+		const res = await handleMcp(
+			new Request('https://mcp.tempo.xyz/', {
+				method: 'POST',
+				body: JSON.stringify({
+					jsonrpc: '2.0',
+					id: 45,
+					method: 'tools/call',
+					params: {
+						name: 'send_product_feedback',
+						arguments: {
+							kind: 'bug_report',
+							summary: 'Wallet issue',
+							details:
+								'Observed with 0x1111111111111111111111111111111111111111.',
+						},
+					},
+				}),
+			}),
+			{ instance: instance(async () => ({ search_query: '', chunks: [] })) },
+		)
+
+		const body = await res?.json()
+		expect(body.error).toMatchObject({
+			code: -32602,
+			message: 'Product feedback must exclude sensitive or identifying data',
+		})
+		expect(fetch).not.toHaveBeenCalled()
+	})
+
+	it('maps complete product feedback and returns its acknowledgement', async () => {
+		const fetch = vi.fn(async () =>
+			Response.json(
+				{ accepted: true, report_id: 'fb_report_123' },
+				{ status: 201 },
+			),
+		)
+		vi.stubGlobal('fetch', fetch)
+		const report = {
+			kind: 'bug_report',
+			summary: 'Search misses a page',
+			details: 'The page is indexed but does not appear.',
+			steps_to_reproduce: 'Search for its exact title.',
+			expected_behavior: 'The page appears.',
+			actual_behavior: 'No result appears.',
+		}
+		const res = await handleMcp(
+			new Request('https://mcp.tempo.xyz/', {
+				method: 'POST',
+				body: JSON.stringify({
+					jsonrpc: '2.0',
+					id: 42,
+					method: 'tools/call',
+					params: { name: 'send_product_feedback', arguments: report },
+				}),
+			}),
+			{ instance: instance(async () => ({ search_query: '', chunks: [] })) },
+		)
+
+		expect(fetch).toHaveBeenCalledWith(
+			'https://tempo.xyz/developers/api/feedback',
+			expect.objectContaining({
+				method: 'POST',
+				body: JSON.stringify({ source: 'mcp', ...report }),
+			}),
+		)
+		const body = await res?.json()
+		expect(body.result.structuredContent).toEqual({
+			accepted: true,
+			report_id: 'fb_report_123',
+		})
+		expect(JSON.parse(body.result.content[0].text)).toEqual(
+			body.result.structuredContent,
+		)
+	})
+
+	it('omits absent optional product feedback fields', async () => {
+		const fetch = vi.fn(async () =>
+			Response.json({ accepted: true, report_id: 'fb_report_456' }),
+		)
+		vi.stubGlobal('fetch', fetch)
+		await handleMcp(
+			new Request('https://mcp.tempo.xyz/', {
+				method: 'POST',
+				body: JSON.stringify({
+					jsonrpc: '2.0',
+					id: 43,
+					method: 'tools/call',
+					params: {
+						name: 'send_product_feedback',
+						arguments: {
+							kind: 'feedback',
+							summary: 'Result ordering',
+							details: 'Prefer exact title matches first.',
+						},
+					},
+				}),
+			}),
+			{ instance: instance(async () => ({ search_query: '', chunks: [] })) },
+		)
+
+		const payload = JSON.parse(fetch.mock.calls[0][1]?.body as string)
+		expect(payload).toEqual({
+			source: 'mcp',
+			kind: 'feedback',
+			summary: 'Result ordering',
+			details: 'Prefer exact title matches first.',
+		})
+	})
+
+	it('reports product feedback transport failures without acceptance', async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi.fn(async () => new Response('unavailable', { status: 503 })),
+		)
+		const res = await handleMcp(
+			new Request('https://mcp.tempo.xyz/', {
+				method: 'POST',
+				body: JSON.stringify({
+					jsonrpc: '2.0',
+					id: 44,
+					method: 'tools/call',
+					params: {
+						name: 'send_product_feedback',
+						arguments: {
+							kind: 'feedback',
+							summary: 'Result ordering',
+							details: 'Prefer exact title matches first.',
+						},
+					},
+				}),
+			}),
+			{ instance: instance(async () => ({ search_query: '', chunks: [] })) },
+		)
+
+		const body = await res?.json()
+		expect(body.result.isError).toBe(true)
+		expect(JSON.parse(body.result.content[0].text)).toEqual({
+			success: false,
+			error: 'Product feedback delivery failed with status 503',
+		})
+		expect(body.result.structuredContent).toBeUndefined()
 	})
 
 	it('normalizes simple source and result controls into retrieval options', async () => {

--- a/apps/mcp-docs-indexer/src/lib/mcp.ts
+++ b/apps/mcp-docs-indexer/src/lib/mcp.ts
@@ -15,6 +15,12 @@ import {
 	recordJsonRpcError,
 	recordToolCall,
 } from './metrics.js'
+import {
+	parseProductFeedback,
+	sendProductFeedback,
+	type ProductFeedback,
+	type ProductFeedbackReceipt,
+} from './product-feedback.js'
 import type { Source } from './sources.js'
 
 type JsonRpcRequest = {
@@ -27,7 +33,10 @@ type JsonRpcRequest = {
 	}
 }
 
-type ToolArguments = SearchArguments & ReadPageArguments & FindPagesArguments
+type ToolArguments = SearchArguments &
+	ReadPageArguments &
+	FindPagesArguments &
+	Record<string, unknown>
 
 type SearchArguments = {
 	query?: unknown
@@ -102,6 +111,12 @@ const READ_ONLY_TOOL_ANNOTATIONS = {
 	idempotentHint: true,
 	openWorldHint: true,
 	readOnlyHint: true,
+} as const
+const SIDE_EFFECTING_TOOL_ANNOTATIONS = {
+	destructiveHint: false,
+	idempotentHint: false,
+	openWorldHint: true,
+	readOnlyHint: false,
 } as const
 
 type SearchResultChunk = AiSearchSearchResponse['chunks'][number]
@@ -253,6 +268,11 @@ export async function handleMcp(
 			handleFindPages(req, body, context.sources ?? []),
 		)
 	}
+	if (body.params?.name === 'send_product_feedback') {
+		return trackToolCall('send_product_feedback', () =>
+			handleProductFeedback(req, body),
+		)
+	}
 	if (body.params?.name !== 'search') return undefined
 	const args = body.params.arguments
 
@@ -299,6 +319,35 @@ export async function handleMcp(
 			return toolErrorResponse(req, body.id, err)
 		}
 	})
+}
+
+async function handleProductFeedback(
+	req: Request,
+	body: JsonRpcRequest,
+): Promise<Response> {
+	let report: ProductFeedback
+	try {
+		report = parseProductFeedback(body.params?.arguments)
+	} catch (error) {
+		return jsonRpcErrorFor(
+			req,
+			body,
+			-32602,
+			error instanceof Error
+				? error.message
+				: 'Invalid product feedback payload',
+		)
+	}
+
+	try {
+		return productFeedbackToolResult(
+			req,
+			body.id,
+			await sendProductFeedback(report),
+		)
+	} catch (error) {
+		return toolErrorResponse(req, body.id, error)
+	}
 }
 
 async function createCodeServer(
@@ -1345,6 +1394,17 @@ function toolResult(
 	})
 }
 
+function productFeedbackToolResult(
+	req: Request,
+	id: JsonRpcRequest['id'],
+	receipt: ProductFeedbackReceipt,
+): Response {
+	return jsonRpc(req, id, {
+		content: [{ type: 'text', text: JSON.stringify(receipt) }],
+		structuredContent: receipt,
+	})
+}
+
 function toolErrorResponse(
 	req: Request,
 	id: JsonRpcRequest['id'],
@@ -1572,6 +1632,49 @@ function toolSchemas(sources: Source[]): Tool[] {
 					},
 				},
 				required: ['source'],
+			},
+			execution: { taskSupport: 'forbidden' },
+		},
+		{
+			name: 'send_product_feedback',
+			description:
+				'Use only when the user explicitly asks to send Tempo feedback or report a bug. Free and side-effecting: sends the approved report to Tempo maintainers. Troubleshooting or mentioning an error is not authorization. Include only the minimum sanitized reproduction details. Never include secrets, credentials, private keys, payment material, personal data, wallet or session identifiers, transaction hashes, or raw tool inputs or outputs. Do not automatically attach tempo wallet debug output.',
+			annotations: SIDE_EFFECTING_TOOL_ANNOTATIONS,
+			inputSchema: {
+				type: 'object',
+				additionalProperties: false,
+				properties: {
+					kind: {
+						type: 'string',
+						enum: ['bug_report', 'feedback'],
+					},
+					summary: { type: 'string', minLength: 1, maxLength: 200 },
+					details: { type: 'string', minLength: 1, maxLength: 3000 },
+					steps_to_reproduce: {
+						type: 'string',
+						minLength: 1,
+						maxLength: 2000,
+					},
+					expected_behavior: {
+						type: 'string',
+						minLength: 1,
+						maxLength: 2000,
+					},
+					actual_behavior: {
+						type: 'string',
+						minLength: 1,
+						maxLength: 2000,
+					},
+				},
+				required: ['kind', 'summary', 'details'],
+			},
+			outputSchema: {
+				type: 'object',
+				properties: {
+					accepted: { type: 'boolean', const: true },
+					report_id: { type: 'string', minLength: 1 },
+				},
+				required: ['accepted', 'report_id'],
 			},
 			execution: { taskSupport: 'forbidden' },
 		},

--- a/apps/mcp-docs-indexer/src/lib/product-feedback.ts
+++ b/apps/mcp-docs-indexer/src/lib/product-feedback.ts
@@ -1,0 +1,79 @@
+import { z } from 'zod'
+
+const FEEDBACK_ENDPOINT = 'https://tempo.xyz/developers/api/feedback'
+const FEEDBACK_TIMEOUT_MS = 5_000
+
+export const productFeedbackSchema = z
+	.object({
+		kind: z.enum(['bug_report', 'feedback']),
+		summary: z.string().trim().min(1).max(200),
+		details: z.string().trim().min(1).max(3_000),
+		steps_to_reproduce: z.string().trim().min(1).max(2_000).optional(),
+		expected_behavior: z.string().trim().min(1).max(2_000).optional(),
+		actual_behavior: z.string().trim().min(1).max(2_000).optional(),
+	})
+	.strict()
+
+const productFeedbackReceiptSchema = z.object({
+	accepted: z.literal(true),
+	report_id: z.string().min(1),
+})
+
+export type ProductFeedback = Readonly<z.infer<typeof productFeedbackSchema>>
+export type ProductFeedbackReceipt = Readonly<
+	z.infer<typeof productFeedbackReceiptSchema>
+>
+
+const SENSITIVE_CONTENT_PATTERNS = [
+	/\b0x[a-fA-F0-9]{40}\b/,
+	/\b0x[a-fA-F0-9]{64}\b/,
+	/\b(?:sk|pk|rk|ghp|gho|github_pat)_[A-Za-z0-9_=-]{16,}\b/,
+	/\b(?:Bearer|Basic)\s+[A-Za-z0-9._~+/=-]{16,}\b/i,
+	/\b(?:api[_-]?key|token|secret|password|private[_-]?key)\s*[:=]/i,
+	/\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/i,
+	/\b(?:wallet|session)[_-]?id\s*[:=]/i,
+	/\braw\s+tool\s+(?:input|output)s?\b/i,
+]
+
+export function parseProductFeedback(input: unknown): ProductFeedback {
+	const parsed = productFeedbackSchema.safeParse(input)
+	if (!parsed.success) throw new Error('Invalid product feedback payload')
+	for (const value of Object.values(parsed.data)) {
+		if (
+			typeof value === 'string' &&
+			SENSITIVE_CONTENT_PATTERNS.some((pattern) => pattern.test(value))
+		) {
+			throw new Error(
+				'Product feedback must exclude sensitive or identifying data',
+			)
+		}
+	}
+	return parsed.data
+}
+
+export async function sendProductFeedback(
+	report: ProductFeedback,
+): Promise<ProductFeedbackReceipt> {
+	let response: Response
+	try {
+		response = await fetch(FEEDBACK_ENDPOINT, {
+			body: JSON.stringify({ source: 'mcp', ...report }),
+			headers: { 'content-type': 'application/json; charset=utf-8' },
+			method: 'POST',
+			signal: AbortSignal.timeout(FEEDBACK_TIMEOUT_MS),
+		})
+	} catch {
+		throw new Error('Product feedback delivery failed')
+	}
+	if (!response.ok) {
+		throw new Error(
+			`Product feedback delivery failed with status ${response.status}`,
+		)
+	}
+
+	const receipt = productFeedbackReceiptSchema.safeParse(
+		await response.json().catch(() => undefined),
+	)
+	if (!receipt.success) throw new Error('Product feedback was not acknowledged')
+	return receipt.data
+}


### PR DESCRIPTION
## Summary

- register `send_product_feedback` as a free, side-effecting Tempo MCP tool with the requested strict schema and explicit-authorization guidance
- validate and reject likely sensitive or identifying content before transport
- send structured reports to the existing Tempo feedback ingress and return its confirmed `accepted` acknowledgement and stable `report_id`
- surface validation, transport, and malformed-acknowledgement failures without implying acceptance

## Dependency

- requires https://github.com/tempoxyz/docs/pull/863 to deploy the structured receiving contract before this Worker

## Validation

- `pnpm --filter mcp-docs-indexer check:biome`
- `pnpm --filter mcp-docs-indexer check:types`
- `pnpm --filter mcp-docs-indexer test` (79 tests)
- `pnpm check:types`
- `pnpm precommit`
- `pnpm --filter mcp-docs-indexer build`

Prompted by: @mattsse