### PR TITLE
fix(explorer): reduce transaction detail latency

### DIFF
--- a/apps/explorer/src/comps/Sections.tsx
+++ b/apps/explorer/src/comps/Sections.tsx
@@ -12,24 +12,28 @@ export function Sections(props: Sections.Props) {
 
 	const sections = sections_.filter((section) => section.visible !== false)
 
-	const [collapsedSections, setCollapsedSections] = React.useState<boolean[]>(
-		new Array(sections.length).fill(true),
+	const [expandedSections, setExpandedSections] = React.useState<Set<string>>(
+		() => new Set(),
 	)
 
-	const toggleSection = (index: number) => {
-		setCollapsedSections((collapsed) =>
-			collapsed.map((v, i) => (i === index ? !v : v)),
-		)
+	const toggleSection = (title: string) => {
+		setExpandedSections((expanded) => {
+			const next = new Set(expanded)
+			if (next.has(title)) next.delete(title)
+			else next.add(title)
+			return next
+		})
 	}
 
 	if (mode === 'stacked')
 		return (
 			<Sections.Context.Provider value={{ mode }}>
 				<div className="flex flex-col gap-[14px]">
-					{sections.map((section, index) => {
+					{sections.map((section) => {
 						const itemsLabel = section.itemsLabel ?? 'items'
 						const isCollapsed =
-							section.autoCollapse !== false && collapsedSections[index]
+							section.autoCollapse !== false &&
+							!expandedSections.has(section.title)
 
 						const canCollapse = section.autoCollapse !== false
 
@@ -45,7 +49,7 @@ export function Sections(props: Sections.Props) {
 								{canCollapse ? (
 									<button
 										type="button"
-										onClick={() => toggleSection(index)}
+										onClick={() => toggleSection(section.title)}
 										className={cx(
 											'h-[52px] flex items-center justify-between px-[18px] cursor-pointer press-down -outline-offset-2!',
 											isCollapsed ? 'rounded-[10px]!' : 'rounded-t-[10px]!',

--- a/apps/explorer/src/comps/TxBalanceChanges.tsx
+++ b/apps/explorer/src/comps/TxBalanceChanges.tsx
@@ -14,14 +14,7 @@ import {
 } from '#lib/queries/balance-changes'
 
 export function TxBalanceChanges(props: TxBalanceChanges.Props) {
-	const { data, page } = props
-
-	if (data.total === 0)
-		return (
-			<div className="px-[18px] py-[24px] text-[13px] text-tertiary text-center">
-				No balance changes for this transaction.
-			</div>
-		)
+	const { data, loading = false, page } = props
 
 	const cols: DataGrid.Column[] = [
 		{ label: 'Address', align: 'start', width: '2fr', minWidth: 140 },
@@ -30,6 +23,13 @@ export function TxBalanceChanges(props: TxBalanceChanges.Props) {
 		{ label: 'After', align: 'end', width: '2fr', minWidth: 160 },
 		{ label: 'Change', align: 'end', width: '2fr', minWidth: 160 },
 	]
+
+	if (data.total === 0 && !loading)
+		return (
+			<div className="px-[18px] py-[24px] text-[13px] text-tertiary text-center">
+				No balance changes for this transaction.
+			</div>
+		)
 
 	return (
 		<DataGrid
@@ -73,6 +73,7 @@ export function TxBalanceChanges(props: TxBalanceChanges.Props) {
 			itemsLabel="changes"
 			itemsPerPage={LIMIT}
 			emptyState="No balance changes detected."
+			loading={loading}
 			pagination="simple"
 			showSimpleCount={false}
 		/>
@@ -82,6 +83,7 @@ export function TxBalanceChanges(props: TxBalanceChanges.Props) {
 export namespace TxBalanceChanges {
 	export interface Props {
 		data: BalanceChangesData
+		loading?: boolean | undefined
 		page: number
 	}
 

--- a/apps/explorer/src/lib/queries/balance-changes.ts
+++ b/apps/explorer/src/lib/queries/balance-changes.ts
@@ -1,3 +1,7 @@
+import { queryOptions } from '@tanstack/react-query'
+import type { Hex } from 'ox'
+import type { BalanceChangesData } from '#routes/api/tx/balance-changes/$hash'
+
 export type {
 	BalanceChangesData,
 	TokenBalanceChange,
@@ -5,3 +9,26 @@ export type {
 } from '#routes/api/tx/balance-changes/$hash'
 
 export const LIMIT = 20
+
+export function balanceChangesQueryOptions(params: {
+	hash: Hex.Hex
+	limit: number
+	offset: number
+}) {
+	return queryOptions({
+		queryKey: ['balance-changes', params.hash, params.limit, params.offset],
+		queryFn: async (): Promise<BalanceChangesData> => {
+			const search = new URLSearchParams({
+				limit: String(params.limit),
+				offset: String(params.offset),
+			})
+			const response = await fetch(
+				`/api/tx/balance-changes/${params.hash}?${search.toString()}`,
+			)
+			if (!response.ok)
+				throw new Error(`Failed to fetch balance changes: ${response.status}`)
+			return response.json()
+		},
+		staleTime: Infinity,
+	})
+}

--- a/apps/explorer/src/lib/queries/trace.ts
+++ b/apps/explorer/src/lib/queries/trace.ts
@@ -1,7 +1,8 @@
 import { queryOptions } from '@tanstack/react-query'
 import type { Address, Hex } from 'ox'
 import { zeroAddress } from 'viem'
-import { getWagmiConfig } from '#wagmi.config.ts'
+import { withImmutableDataCache } from '#lib/server/immutable-data-cache'
+import { getTempoChain, getWagmiConfig } from '#wagmi.config.ts'
 
 export interface CallTrace {
 	type: 'CALL' | 'DELEGATECALL' | 'STATICCALL' | 'CREATE' | 'CREATE2'
@@ -34,7 +35,7 @@ export interface TraceData {
 	prestate: PrestateDiff | null
 }
 
-export async function fetchTraceData(hash: Hex.Hex): Promise<TraceData> {
+async function fetchTraceDataUncached(hash: Hex.Hex): Promise<TraceData> {
 	const config = getWagmiConfig()
 	const client = config.getClient()
 
@@ -66,10 +67,22 @@ export async function fetchTraceData(hash: Hex.Hex): Promise<TraceData> {
 	return { trace: unwrapped ?? null, prestate }
 }
 
+export async function fetchTraceData(hash: Hex.Hex): Promise<TraceData> {
+	return withImmutableDataCache({
+		key: `trace:v1:${getTempoChain().id}:${hash.toLowerCase()}`,
+		load: () => fetchTraceDataUncached(hash),
+	})
+}
+
 export function traceQueryOptions(params: { hash: string }) {
 	return queryOptions({
 		queryKey: ['trace', params.hash],
-		queryFn: () => fetchTraceData(params.hash as Hex.Hex),
+		queryFn: async (): Promise<TraceData> => {
+			const response = await fetch(`/api/tx/trace/${params.hash}`)
+			if (!response.ok)
+				throw new Error(`Failed to fetch transaction trace: ${response.status}`)
+			return response.json()
+		},
 		staleTime: Infinity,
 	})
 }

--- a/apps/explorer/src/lib/queries/trace.ts
+++ b/apps/explorer/src/lib/queries/trace.ts
@@ -71,6 +71,9 @@ export async function fetchTraceData(hash: Hex.Hex): Promise<TraceData> {
 	return withImmutableDataCache({
 		key: `trace:v1:${getTempoChain().id}:${hash.toLowerCase()}`,
 		load: () => fetchTraceDataUncached(hash),
+		// Trace RPC errors are represented as null so the page can still render.
+		// Do not let a transient error become a cached missing trace.
+		shouldCache: (data) => data.trace !== null && data.prestate !== null,
 	})
 }
 

--- a/apps/explorer/src/lib/queries/tx.ts
+++ b/apps/explorer/src/lib/queries/tx.ts
@@ -13,7 +13,8 @@ import {
 } from '#lib/domain/known-events'
 import { getFeeBreakdown } from '#lib/domain/receipt'
 import * as Tip20 from '#lib/domain/tip20'
-import { getWagmiConfig } from '#wagmi.config.ts'
+import { withImmutableDataCache } from '#lib/server/immutable-data-cache'
+import { getTempoChain, getWagmiConfig } from '#wagmi.config.ts'
 
 const transferTopic = toEventSelector(
 	'event Transfer(address indexed, address indexed, uint256)',
@@ -29,7 +30,7 @@ export function txQueryOptions(params: { hash: Hex.Hex }) {
 	})
 }
 
-async function fetchTxData(params: { hash: Hex.Hex }) {
+async function fetchTxDataUncached(params: { hash: Hex.Hex }) {
 	const config = getWagmiConfig()
 
 	const receipt = await getTransactionReceipt(config, { hash: params.hash })
@@ -119,6 +120,13 @@ async function fetchTxData(params: { hash: Hex.Hex }) {
 		receipt,
 		transaction,
 	}
+}
+
+async function fetchTxData(params: { hash: Hex.Hex }) {
+	return withImmutableDataCache({
+		key: `tx-detail:v1:${getTempoChain().id}:${params.hash.toLowerCase()}`,
+		load: () => fetchTxDataUncached(params),
+	})
 }
 
 export type TxData = Awaited<ReturnType<typeof fetchTxData>>

--- a/apps/explorer/src/lib/server/immutable-data-cache.ts
+++ b/apps/explorer/src/lib/server/immutable-data-cache.ts
@@ -5,6 +5,7 @@ const CACHE_ORIGIN = 'https://explore.tempo.xyz'
 export async function withImmutableDataCache<T>(options: {
 	key: string
 	load: () => Promise<T>
+	shouldCache?: ((data: T) => boolean) | undefined
 	ttlSeconds?: number | undefined
 }): Promise<T> {
 	if (typeof window !== 'undefined' || typeof caches === 'undefined')
@@ -23,6 +24,8 @@ export async function withImmutableDataCache<T>(options: {
 	}
 
 	const data = await options.load()
+	if (options.shouldCache && !options.shouldCache(data)) return data
+
 	try {
 		await cache.put(
 			cacheKey,

--- a/apps/explorer/src/lib/server/immutable-data-cache.ts
+++ b/apps/explorer/src/lib/server/immutable-data-cache.ts
@@ -1,0 +1,40 @@
+import * as Json from 'ox/Json'
+
+const CACHE_ORIGIN = 'https://explore.tempo.xyz'
+
+export async function withImmutableDataCache<T>(options: {
+	key: string
+	load: () => Promise<T>
+	ttlSeconds?: number | undefined
+}): Promise<T> {
+	if (typeof window !== 'undefined' || typeof caches === 'undefined')
+		return options.load()
+
+	const cache = (caches as unknown as { default: Cache }).default
+	const cacheKey = new Request(
+		`${CACHE_ORIGIN}/__immutable-data/${encodeURIComponent(options.key)}`,
+	)
+
+	try {
+		const cached = await cache.match(cacheKey)
+		if (cached) return Json.parse(await cached.text()) as T
+	} catch {
+		await cache.delete(cacheKey).catch(() => false)
+	}
+
+	const data = await options.load()
+	try {
+		await cache.put(
+			cacheKey,
+			new Response(Json.stringify(data), {
+				headers: {
+					'Cache-Control': `public, max-age=${options.ttlSeconds ?? 3600}`,
+					'Content-Type': 'application/json',
+				},
+			}),
+		)
+	} catch {
+		// Cache availability must never make the underlying request fail.
+	}
+	return data
+}

--- a/apps/explorer/src/lib/server/transaction-activities.ts
+++ b/apps/explorer/src/lib/server/transaction-activities.ts
@@ -6,6 +6,7 @@ import type {
 	ActivityDataValue,
 	TransactionActivity,
 } from '#lib/domain/transaction-activities'
+import { withImmutableDataCache } from '#lib/server/immutable-data-cache'
 import { api } from '#lib/server/tempo-api'
 import { zHash } from '#lib/zod'
 import { getBatchedClient, getTempoChain } from '#wagmi.config.ts'
@@ -15,9 +16,13 @@ const InputSchema = z.object({ hash: zHash() })
 export const fetchTransactionActivities = createServerFn({ method: 'GET' })
 	.inputValidator((input) => InputSchema.parse(input))
 	.handler(async ({ data }): Promise<TransactionActivity[]> => {
-		return enrichVaultTokens(
-			await getTransactionActivities(data.hash, getTempoChain().id),
-		)
+		const chainId = getTempoChain().id
+		return withImmutableDataCache({
+			key: `transaction-activities:v1:${chainId}:${data.hash.toLowerCase()}`,
+			load: async () =>
+				enrichVaultTokens(await getTransactionActivities(data.hash, chainId)),
+			ttlSeconds: 300,
+		})
 	})
 
 export async function getTransactionActivities(

--- a/apps/explorer/src/routes/_layout/receipt/$hash.tsx
+++ b/apps/explorer/src/routes/_layout/receipt/$hash.tsx
@@ -44,6 +44,7 @@ import {
 } from '#lib/og'
 import { withLoaderTiming } from '#lib/profiling'
 import { getFeeTokenForChain } from '#lib/fee-token'
+import { withImmutableDataCache } from '#lib/server/immutable-data-cache'
 import { fetchTransactionActivities } from '#lib/server/transaction-activities'
 import { getTempoChain, getWagmiConfig } from '#wagmi.config.ts'
 
@@ -73,7 +74,10 @@ function stripLineItemEvents(
 	}
 }
 
-async function fetchReceiptData(params: { hash: Hex.Hex; rpcUrl?: string }) {
+async function fetchReceiptDataUncached(params: {
+	hash: Hex.Hex
+	rpcUrl?: string
+}) {
 	const config = getWagmiConfig()
 	const client = getPublicClient(config)
 	if (!client) throw new Error('RPC client unavailable')
@@ -123,6 +127,16 @@ async function fetchReceiptData(params: { hash: Hex.Hex; rpcUrl?: string }) {
 		receipt,
 		transaction,
 	}
+}
+
+async function fetchReceiptData(params: { hash: Hex.Hex; rpcUrl?: string }) {
+	if (params.rpcUrl) return fetchReceiptDataUncached(params)
+
+	return withImmutableDataCache({
+		key: `receipt-detail:v1:${TEMPO_CHAIN_ID}:${params.hash.toLowerCase()}`,
+		load: () => fetchReceiptDataUncached(params),
+		ttlSeconds: 300,
+	})
 }
 
 function getReceiptPresentation(

--- a/apps/explorer/src/routes/_layout/tx/$hash.tsx
+++ b/apps/explorer/src/routes/_layout/tx/$hash.tsx
@@ -1,4 +1,4 @@
-import { useQueryClient } from '@tanstack/react-query'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 import {
 	createFileRoute,
 	Link,
@@ -52,7 +52,6 @@ import { useKeyboardShortcut, useMediaQuery } from '#lib/hooks'
 import { buildOgImageUrl, buildTxDescription, OG_BASE_URL } from '#lib/og'
 import {
 	autoloadAbiQueryOptions,
-	LIMIT,
 	lookupSignatureQueryOptions,
 	type TxData,
 	txQueryOptions,
@@ -61,13 +60,16 @@ import {
 } from '#lib/queries'
 import type { BalanceChangesData } from '#lib/queries/balance-changes'
 import {
+	balanceChangesQueryOptions,
+	LIMIT as BALANCE_CHANGES_LIMIT,
+} from '#lib/queries/balance-changes'
+import {
 	type CallTrace,
 	type PrestateDiff,
 	traceQueryOptions,
 } from '#lib/queries/trace'
 import { withLoaderTiming } from '#lib/profiling'
 import { zHash } from '#lib/zod'
-import { fetchBalanceChanges } from '#routes/api/tx/balance-changes/$hash'
 import { fetchTransactionActivities } from '#lib/server/transaction-activities'
 import ChevronDownIcon from '~icons/lucide/chevron-down'
 
@@ -75,6 +77,14 @@ const defaultSearchValues = {
 	tab: 'overview',
 	page: 1,
 } as const
+
+const EMPTY_BALANCE_CHANGES: BalanceChangesData = {
+	changes: [],
+	tokenMetadata: {},
+	total: 0,
+}
+
+const EMPTY_TRACE_DATA = { trace: null, prestate: null } as const
 
 const RECEIVE_POLICY_GUARD = OxAddressUtil.from(
 	'0xB10C000000000000000000000000000000000000',
@@ -107,32 +117,20 @@ export const Route = createFileRoute('/_layout/tx/$hash')({
 	search: {
 		middlewares: [stripSearchParams(defaultSearchValues)],
 	},
-	loaderDeps: ({ search: { page } }) => ({ page }),
-	loader: ({ params, context, deps: { page } }) =>
+	loader: ({ params, context }) =>
 		withLoaderTiming('/_layout/tx/$hash', async () => {
 			const { hash } = params
 
 			try {
-				const offset = (page - 1) * LIMIT
-
-				const [txData, balanceChangesData, traceData, activities] =
-					await Promise.all([
-						context.queryClient.ensureQueryData(txQueryOptions({ hash })),
-						fetchBalanceChanges({ hash, limit: LIMIT, offset }).catch(() => ({
-							changes: [],
-							tokenMetadata: {},
-							total: 0,
-						})),
-						context.queryClient
-							.ensureQueryData(traceQueryOptions({ hash }))
-							.catch(() => ({ trace: null, prestate: null })),
-						fetchTransactionActivities({ data: { hash } }),
-					])
+				const [txData, activities] = await Promise.all([
+					context.queryClient.ensureQueryData(txQueryOptions({ hash })),
+					fetchTransactionActivities({ data: { hash } }),
+				])
 
 				const activityEvents = activitiesToKnownEvents(activities, {
 					portal: txData.receipt.to,
 				})
-				return { ...txData, balanceChangesData, traceData, activityEvents }
+				return { ...txData, activityEvents }
 			} catch (error) {
 				console.error(error)
 				throw notFound({
@@ -183,9 +181,7 @@ function RouteComponent() {
 	const navigate = useNavigate()
 	const { tab, page } = Route.useSearch()
 	const {
-		balanceChangesData,
 		activityEvents,
-		traceData,
 		block,
 		feeBreakdown,
 		knownCall,
@@ -194,6 +190,21 @@ function RouteComponent() {
 		receipt,
 		transaction,
 	} = Route.useLoaderData()
+	const hash = receipt.transactionHash
+	const balanceChangesQuery = useQuery({
+		...balanceChangesQueryOptions({
+			hash,
+			limit: BALANCE_CHANGES_LIMIT,
+			offset: (page - 1) * BALANCE_CHANGES_LIMIT,
+		}),
+		enabled: typeof window !== 'undefined',
+	})
+	const traceQuery = useQuery({
+		...traceQueryOptions({ hash }),
+		enabled: typeof window !== 'undefined',
+	})
+	const balanceChangesData = balanceChangesQuery.data ?? EMPTY_BALANCE_CHANGES
+	const traceData = traceQuery.data ?? EMPTY_TRACE_DATA
 
 	const isMobile = useMediaQuery('(max-width: 799px)')
 	const mode = isMobile ? 'stacked' : 'tabs'
@@ -281,7 +292,13 @@ function RouteComponent() {
 		title: 'Balances',
 		totalItems: balanceChangesData.total,
 		itemsLabel: 'balances',
-		content: <TxBalanceChanges data={balanceChangesData} page={page} />,
+		content: (
+			<TxBalanceChanges
+				data={balanceChangesData}
+				loading={balanceChangesQuery.isPending}
+				page={page}
+			/>
+		),
 	})
 
 	if (hasCalls && calls) {

--- a/apps/explorer/src/routes/api/tx/balance-changes/$hash.ts
+++ b/apps/explorer/src/routes/api/tx/balance-changes/$hash.ts
@@ -6,8 +6,13 @@ import { getTransactionReceipt, readContract } from 'viem/actions'
 import { Abis } from '#lib/abis'
 import * as z from 'zod/mini'
 import { mapWithConcurrency } from '#lib/network.ts'
+import { withImmutableDataCache } from '#lib/server/immutable-data-cache'
 import { zHash } from '#lib/zod'
-import { getWagmiConfig, type WagmiConfig } from '#wagmi.config.ts'
+import {
+	getTempoChain,
+	getWagmiConfig,
+	type WagmiConfig,
+} from '#wagmi.config.ts'
 
 const DEFAULT_LIMIT = 20
 const MAX_LIMIT = 100
@@ -122,7 +127,7 @@ async function getTokenMetadata(
 	return { decimals, symbol }
 }
 
-export async function fetchBalanceChanges(params: {
+async function fetchBalanceChangesUncached(params: {
 	hash: Address.Address
 	limit: number
 	offset: number
@@ -190,6 +195,17 @@ export async function fetchBalanceChanges(params: {
 		tokenMetadata,
 		total,
 	}
+}
+
+export async function fetchBalanceChanges(params: {
+	hash: Address.Address
+	limit: number
+	offset: number
+}): Promise<BalanceChangesData> {
+	return withImmutableDataCache({
+		key: `balance-changes:v1:${getTempoChain().id}:${params.hash.toLowerCase()}:${params.limit}:${params.offset}`,
+		load: () => fetchBalanceChangesUncached(params),
+	})
 }
 
 const querySchema = z.object({

--- a/apps/explorer/src/wagmi.config.ts
+++ b/apps/explorer/src/wagmi.config.ts
@@ -1,6 +1,6 @@
 import { createIsomorphicFn, createServerFn } from '@tanstack/react-start'
 import { getRequestHeader } from '@tanstack/react-start/server'
-import { createPublicClient } from 'viem'
+import { createPublicClient, fallback } from 'viem'
 import { tempoDevnet, tempoLocalnet } from 'viem/chains'
 import { tempoActions } from 'viem/tempo'
 import { loadBalance, rateLimit } from '@tempo/rpc-utils'
@@ -45,6 +45,19 @@ export const getTempoChain = createIsomorphicFn()
 	)
 
 const RPC_PROXY_HOSTNAME = 'proxy.tempo.xyz'
+const PRIMARY_RPC_TIMEOUT_MS = 1_500
+const FALLBACK_RPC_TIMEOUT_MS = 3_000
+
+function rpcHttp(
+	url: string | undefined,
+	options: { headers?: Record<string, string> | undefined; timeout: number },
+) {
+	return http(url, {
+		batch: true,
+		fetchOptions: options.headers ? { headers: options.headers } : undefined,
+		timeout: options.timeout,
+	})
+}
 
 function getRpcProxyUrl() {
 	const chain = getTempoChain()
@@ -72,30 +85,38 @@ const getTempoTransport = createIsomorphicFn()
 		// Browser traffic should only hit the RPC proxy. Direct chain RPC endpoints
 		// may require credentials that are only available server-side.
 		return loadBalance([
-			rateLimit(http(proxy.http), {
+			rateLimit(rpcHttp(proxy.http, { timeout: FALLBACK_RPC_TIMEOUT_MS }), {
 				requestsPerSecond: 20,
 			}),
 		])
 	})
 	.server(() => {
 		const chain = getTempoChain()
-
-		// Tempo API RPC passthrough (mainnet + testnet; requires an API key).
+		const proxy = getRpcProxyUrl()
+		const fallbackUrls = getFallbackUrls()
 		const apiKey = serverEnv.TEMPO_API_KEY
+		const transports = [
+			rpcHttp(proxy.http, { timeout: PRIMARY_RPC_TIMEOUT_MS }),
+			...fallbackUrls.http.map((url) =>
+				rpcHttp(url, { timeout: PRIMARY_RPC_TIMEOUT_MS }),
+			),
+		]
+
+		// Keep the authenticated API passthrough as the final fallback. Its latency
+		// is materially higher than the chain RPCs, so it should not sit on the
+		// successful request path.
 		if (
 			apiKey &&
 			(chain.id === tempoMainnet.id || chain.id === tempoTestnet.id)
 		)
-			return http(`${tempoApiUrl}/rpc/${chain.id}`, {
-				fetchOptions: { headers: { 'tempo-api-key': apiKey } },
-			})
+			transports.push(
+				rpcHttp(`${tempoApiUrl}/rpc/${chain.id}`, {
+					headers: { 'tempo-api-key': apiKey },
+					timeout: FALLBACK_RPC_TIMEOUT_MS,
+				}),
+			)
 
-		const proxy = getRpcProxyUrl()
-		const fallbackUrls = getFallbackUrls()
-		return loadBalance([
-			http(proxy.http),
-			...fallbackUrls.http.map((url) => http(url)),
-		])
+		return fallback(transports)
 	})
 
 export function getWagmiConfig() {

--- a/apps/explorer/test/immutable-data-cache.node.test.ts
+++ b/apps/explorer/test/immutable-data-cache.node.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { withImmutableDataCache } from '../src/lib/server/immutable-data-cache'
+
+function mockCache() {
+	const entries = new Map<string, Response>()
+	const cache = {
+		delete: vi.fn(async (request: Request) => entries.delete(request.url)),
+		match: vi.fn(async (request: Request) => entries.get(request.url)?.clone()),
+		put: vi.fn(async (request: Request, response: Response) => {
+			entries.set(request.url, response.clone())
+		}),
+	}
+
+	vi.stubGlobal('caches', { default: cache })
+	return cache
+}
+
+afterEach(() => {
+	vi.unstubAllGlobals()
+})
+
+describe('withImmutableDataCache', () => {
+	it('caches values and preserves bigint fields', async () => {
+		const cache = mockCache()
+		const load = vi.fn(async () => ({ blockNumber: 37_704_533n }))
+
+		await expect(
+			withImmutableDataCache({ key: 'receipt:1', load }),
+		).resolves.toEqual({ blockNumber: 37_704_533n })
+		await expect(
+			withImmutableDataCache({ key: 'receipt:1', load }),
+		).resolves.toEqual({ blockNumber: 37_704_533n })
+
+		expect(load).toHaveBeenCalledOnce()
+		expect(cache.put).toHaveBeenCalledOnce()
+	})
+
+	it('returns fresh data when the cache is unavailable', async () => {
+		const cache = mockCache()
+		cache.match.mockRejectedValueOnce(new Error('cache unavailable'))
+		cache.put.mockRejectedValueOnce(new Error('cache unavailable'))
+
+		await expect(
+			withImmutableDataCache({
+				key: 'receipt:3',
+				load: async () => ({ status: 'success' }),
+			}),
+		).resolves.toEqual({ status: 'success' })
+	})
+})

--- a/apps/explorer/test/immutable-data-cache.node.test.ts
+++ b/apps/explorer/test/immutable-data-cache.node.test.ts
@@ -47,4 +47,27 @@ describe('withImmutableDataCache', () => {
 			}),
 		).resolves.toEqual({ status: 'success' })
 	})
+
+	it('does not cache values rejected by shouldCache', async () => {
+		const cache = mockCache()
+		const load = vi.fn(async () => ({ trace: null }))
+
+		await expect(
+			withImmutableDataCache({
+				key: 'trace:1',
+				load,
+				shouldCache: (data) => data.trace !== null,
+			}),
+		).resolves.toEqual({ trace: null })
+		await expect(
+			withImmutableDataCache({
+				key: 'trace:1',
+				load,
+				shouldCache: (data) => data.trace !== null,
+			}),
+		).resolves.toEqual({ trace: null })
+
+		expect(load).toHaveBeenCalledTimes(2)
+		expect(cache.put).not.toHaveBeenCalled()
+	})
 })


### PR DESCRIPTION
## Summary

- route server-side RPC reads through the low-latency Tempo proxy/direct RPCs, retaining the authenticated Tempo API as a bounded fallback
- enable viem JSON-RPC batching and cache immutable receipt/transaction-derived data in Cloudflare Cache API
- remove trace and balance-change queries from blocking transaction SSR and hydrate those panels client-side via cached explorer APIs

## Root cause

Receipt and transaction detail routes synchronously fan out across several RPC calls during SSR. In production, the configured `TEMPO_API_KEY` made the higher-latency API passthrough the sole server transport, so its tail latency compounded across dependent request phases. Each SSR request also created a fresh query cache, so immutable transaction data was recomputed on every page load.

## Cloudflare preview

[Mainnet Worker preview](https://pr-1229-explorer-mainnet.porto.workers.dev)

GitHub skipped the normal preview job because the PR author association is `CONTRIBUTOR`; this was uploaded manually with `wrangler versions upload --env mainnet --preview-alias pr-1229`. It is an isolated Worker version and receives no production traffic.

## Edge benchmarks

Repeated requests include a unique query string to bypass page-level HTTP caching. TTFB includes network latency from the same client. The application cache keys intentionally ignore the query string.

### Reported hash

`0x003acd00bf113c046de81f1123e16767ee67731eb9b06a4dd154fa82f260d822`

| Route | Production median | Preview cold | Preview warm median | Warm improvement |
|---|---:|---:|---:|---:|
| Receipt | 583ms | 1.180s | 71ms | 8.2× faster |
| Transaction | 7.622s | 811ms | 134ms | 56.8× faster |

The transaction response also shrank from about 784KB to 432KB by moving trace and balance-change payloads off the blocking SSR path.

### Previously unseen hashes (cold path)

Three recent hashes per route, requested once from each deployment:

| Route | Production median | Preview median | Improvement |
|---|---:|---:|---:|
| Receipt | 916ms | 639ms | 30% faster |
| Transaction | 1.063s | 495ms | 53% faster |

The reported receipt's first preview request was approximately tied with production because both paid the upstream cold-path cost. Subsequent requests are served from Cloudflare's immutable-data cache.

## Screenshots

No intended visual change; the balance-change panel now shows its existing skeleton state while deferred data loads. The deployed preview was browser-verified to hydrate the full balance updates and trace data with no console warnings or errors.

| Before | After |
|---|---|
| [Production transaction](https://explore.tempo.xyz/tx/0x003acd00bf113c046de81f1123e16767ee67731eb9b06a4dd154fa82f260d822) | [Preview transaction](https://pr-1229-explorer-mainnet.porto.workers.dev/tx/0x003acd00bf113c046de81f1123e16767ee67731eb9b06a4dd154fa82f260d822) |

## Verification

- `pnpm check`
- `pnpm check:types`
- `pnpm --filter explorer test --run` (124 tests)
- `pnpm precommit`
- production build and Cloudflare Worker version upload
- browser verification of deployed transaction details, balances, and trace
