### PR TITLE
fix(explorer): hide private zone receipt side amounts

### DIFF
--- a/apps/explorer/src/lib/domain/receipt-presentation.ts
+++ b/apps/explorer/src/lib/domain/receipt-presentation.ts
@@ -19,6 +19,11 @@ const RECEIVE_POLICY_GUARD = Address.from(
 	'0xB10C000000000000000000000000000000000000',
 )
 
+const PRIVATE_ZONE_ACTIONS = new Set([
+	'Private Zone Deposit',
+	'Private Zone Withdrawal',
+])
+
 export type ReceiptVoucher = {
 	packetSize: number
 	packetCount: number
@@ -201,6 +206,12 @@ function enrichAmount(
 export function getReceiptEventSideAmount(
 	event: KnownEvent,
 ): NonNullable<KnownEvent['totalAmount']> | undefined {
+	if (
+		event.parts.some(
+			(part) => part.type === 'action' && PRIVATE_ZONE_ACTIONS.has(part.value),
+		)
+	)
+		return undefined
 	if (event.totalAmount) return event.totalAmount
 	const amounts = event.parts.flatMap((part) =>
 		part.type === 'amount' ? [part.value] : [],

--- a/apps/explorer/test/receipt-presentation.test.ts
+++ b/apps/explorer/test/receipt-presentation.test.ts
@@ -147,6 +147,39 @@ describe('receipt presentation', () => {
 		).toBe('$6')
 	})
 
+	test('hides side amounts for private Zone activity', () => {
+		const amount = { token, value: 5_000n, decimals: 6 }
+		const privateDeposit: KnownEvent = {
+			type: 'private-assets-deposited',
+			parts: [
+				{ type: 'action', value: 'Private Zone Deposit' },
+				{ type: 'amount', value: amount },
+			],
+		}
+		const privateWithdrawal: KnownEvent = {
+			type: 'private-shares-redeemed',
+			parts: [
+				{ type: 'action', value: 'Private Zone Withdrawal' },
+				{ type: 'amount', value: amount },
+			],
+			totalAmount: { ...amount, value: 10_000n },
+		}
+		const publicWithdrawal: KnownEvent = {
+			...privateWithdrawal,
+			parts: [
+				{ type: 'action', value: 'Withdraw from Zone 1' },
+				{ type: 'amount', value: amount },
+			],
+		}
+
+		expect(getReceiptEventSideAmount(privateDeposit)).toBeUndefined()
+		expect(getReceiptEventSideAmount(privateWithdrawal)).toBeUndefined()
+		expect(getReceiptEventSideAmount(publicWithdrawal)).toEqual({
+			...amount,
+			value: 10_000n,
+		})
+	})
+
 	test('derives regular totals from the same visible token flows', () => {
 		const presentation = build([
 			{

--- a/apps/explorer/test/receipt-text.test.ts
+++ b/apps/explorer/test/receipt-text.test.ts
@@ -117,7 +117,7 @@ describe('renderReceiptText', () => {
 
 		expect(text).toContain('SUMMARY: PRIVATE ZONE WITHDRAWAL')
 		expect(lines.find((line) => line.startsWith('1. '))).toMatch(
-			/^1\. PRIVATE ZONE WITHDRAWAL\s+0\.25 SENPATHUSDE$/,
+			/^1\. PRIVATE ZONE WITHDRAWAL\s+–$/,
 		)
 		expect(text).toContain('  0.25012 SENPATHUSDE TO 0X8117…DFB6')
 		expect(lines.find((line) => line.startsWith('2. '))).toMatch(
@@ -125,7 +125,7 @@ describe('renderReceiptText', () => {
 		)
 		expect(text).toContain('  0.25012 SENPATHUSDE FOR 0.5 DLUSD')
 		expect(lines.find((line) => line.startsWith('3. '))).toMatch(
-			/^3\. PRIVATE ZONE DEPOSIT\s+0\.5 DLUSD$/,
+			/^3\. PRIVATE ZONE DEPOSIT\s+–$/,
 		)
 		expect(lines.find((line) => line.startsWith('FEE '))).toMatch(
 			/^FEE \(PATHUSD\)\s+<\$0\.01$/,


### PR DESCRIPTION
## Summary\n\n- Hide receipt-side summary amounts for **Private Zone Withdrawal** and **Private Zone Deposit**\n- Preserve the precise token amounts in each event detail line\n- Keep side amounts unchanged for public Zone and other receipt events\n- Apply the same presentation rule to the receipt card and TXT export\n\n## Screenshots\n\n| Before | After |\n|--------|-------|\n| ![Before: rounded private Zone amounts appear on the right](https://files.catbox.moe/8s3g04.png) | ![After: private Zone right-side amounts are removed](https://files.catbox.moe/lj0khv.png) |\n\n## Test plan\n\n- **pnpm check**\n- **pnpm check:types**\n- **pnpm test** in **apps/explorer** — 125 tests passed\n- **pnpm precommit**\n- Browser verification against the affected receipt