### PR TITLE
feat(explorer): label propAMM swaps

### DIFF
--- a/apps/explorer/src/lib/abis.ts
+++ b/apps/explorer/src/lib/abis.ts
@@ -279,6 +279,12 @@ export const receivePolicyGuardAbi = parseAbi([
 	'event ReceiptBurned(address indexed token, address indexed receiver, uint8 receiptVersion, uint64 indexed blockedNonce, uint64 blockedAt, address originator, address recipient, address recoveryAuthority, address caller, uint256 amount)',
 ])
 
+// Customer-agnostic propAMM trade event. Bundling this event lets the explorer
+// identify swaps without relying on a deployment allowlist or verified ABI.
+export const propAmmEventsAbi = parseAbi([
+	'event TradeExecuted(address indexed taker, address indexed recipient, bytes32 indexed customerId, bytes32 tradeId, address tokenIn, address tokenOut, uint256 amountIn, uint256 amountOut, uint256 oraclePrice, uint256 oracleUpdatedAt)',
+])
+
 // Customer-agnostic Tempo Earn events. These are bundled separately from viem's
 // protocol ABIs so transaction logs remain readable before or without contract
 // verification. Standard Ownable events are intentionally omitted because their
@@ -360,6 +366,7 @@ export const earnEventsAbi = parseAbi([
 export const Abis = {
 	...ViemTempoAbis,
 	earn: earnEventsAbi,
+	propAmm: propAmmEventsAbi,
 	receivePolicyGuard: receivePolicyGuardAbi,
 	stablecoinDex: stablecoinDexAbi,
 	streamChannel: streamChannelAbi,

--- a/apps/explorer/src/lib/domain/known-events.ts
+++ b/apps/explorer/src/lib/domain/known-events.ts
@@ -15,6 +15,7 @@ import {
 	Abis,
 	allAbis,
 	earnEventsAbi,
+	propAmmEventsAbi,
 	zoneFactoryAbi,
 	zoneOutboxAbi,
 	zonePortalAbi,
@@ -69,6 +70,7 @@ const earnEventSignatures = new Map(
 		getEventSignature(event),
 	]),
 )
+const propAmmTradeSelector = toEventSelector(propAmmEventsAbi[0]).toLowerCase()
 
 type CreateAmount = (value: bigint, token: Address.Address) => Amount
 
@@ -766,6 +768,25 @@ function createDetectors(
 	}
 
 	return {
+		propAmm(event: ParsedEvent) {
+			if (event.topics[0]?.toLowerCase() !== propAmmTradeSelector) return null
+			const { tokenIn, tokenOut, amountIn, amountOut } = event.args as {
+				tokenIn: Address.Address
+				tokenOut: Address.Address
+				amountIn: bigint
+				amountOut: bigint
+			}
+
+			return {
+				type: 'propamm swap',
+				parts: [
+					{ type: 'action', value: 'propAMM Swap' },
+					{ type: 'amount', value: createAmount(amountIn, tokenIn) },
+					{ type: 'text', value: 'for' },
+					{ type: 'amount', value: createAmount(amountOut, tokenOut) },
+				],
+			}
+		},
 		earn(event: ParsedEvent) {
 			const selector = event.topics[0]?.toLowerCase()
 			if (!selector) return null
@@ -2018,6 +2039,7 @@ export function parseKnownEvent(
 	)
 
 	const detected =
+		detectors.propAmm(event) ||
 		detectors.zone(event) ||
 		detectors.tip20(event) ||
 		detectors.tip20Factory(event) ||
@@ -2507,6 +2529,32 @@ export function parseKnownEvents(
 			index,
 		}))
 
+	// A propAMM trade is self-identifying through TradeExecuted. Hide the two
+	// settlement transfers so the receipt shows one swap summary instead.
+	for (const trade of dedupedEvents) {
+		if (trade.topics[0]?.toLowerCase() !== propAmmTradeSelector) continue
+		const { taker, tokenIn, tokenOut, amountIn, amountOut } = trade.args as {
+			taker: Address.Address
+			tokenIn: Address.Address
+			tokenOut: Address.Address
+			amountIn: bigint
+			amountOut: bigint
+		}
+		for (const { event, index } of transferEvents) {
+			const { from, to, amount } = event.args
+			const isInput =
+				Address.isEqual(event.address, tokenIn) &&
+				Address.isEqual(from, taker) &&
+				Address.isEqual(to, trade.address) &&
+				amount === amountIn
+			const isOutput =
+				Address.isEqual(event.address, tokenOut) &&
+				Address.isEqual(from, trade.address) &&
+				amount === amountOut
+			if (isInput || isOutput) swapIndices.add(index)
+		}
+	}
+
 	// Look for swap pairs (transfer TO exchange + transfer FROM exchange)
 	for (let index = 0; index < transferEvents.length - 1; index++) {
 		const { event: event1, index: idx1 } = transferEvents[index]
@@ -2614,6 +2662,7 @@ export function parseKnownEvents(
 		const event = dedupedEvents[index]
 
 		const detected =
+			detectors.propAmm(event) ||
 			detectors.feePayer(event) ||
 			detectors.zone(event) ||
 			detectors.tip20(event) ||

--- a/apps/explorer/src/lib/domain/receipt-presentation.ts
+++ b/apps/explorer/src/lib/domain/receipt-presentation.ts
@@ -216,7 +216,7 @@ export function getReceiptEventSideAmount(
 	const amounts = event.parts.flatMap((part) =>
 		part.type === 'amount' ? [part.value] : [],
 	)
-	if (event.type === 'swap') return amounts[0]
+	if (event.type === 'swap' || event.type === 'propamm swap') return amounts[0]
 	return amounts.length === 1 ? amounts[0] : undefined
 }
 

--- a/apps/explorer/src/lib/domain/transaction-activities.ts
+++ b/apps/explorer/src/lib/domain/transaction-activities.ts
@@ -165,11 +165,14 @@ export function selectTransactionDescriptionEvents(params: {
 			(event) => zoneEventDirection(event) === 'withdrawal',
 		)
 		const earnEvents = fallbackEvents.filter(isEarnReceiptSummary)
+		const propAmmSwaps = fallbackEvents.filter(isPropAmmSwap)
 		const zoneDeposits = fallbackEvents.filter(
 			(event) => zoneEventDirection(event) === 'deposit',
 		)
-		return [...zoneWithdrawals, ...earnEvents, ...zoneDeposits]
+		return [...zoneWithdrawals, ...earnEvents, ...propAmmSwaps, ...zoneDeposits]
 	}
+	const propAmmSwaps = fallbackEvents.filter(isPropAmmSwap)
+	if (propAmmSwaps.length > 0) return propAmmSwaps
 	if (params.activityEvents.length === 0) return [...fallbackEvents]
 
 	const hasDecodedZoneEvent = fallbackEvents.some((event) =>
@@ -215,6 +218,10 @@ export function selectTransactionDescriptionEvents(params: {
 
 function isEarnReceiptSummary(event: KnownEvent): boolean {
 	return event.type.startsWith('earn ')
+}
+
+function isPropAmmSwap(event: KnownEvent): boolean {
+	return event.type === 'propamm swap'
 }
 
 function isPrivateZoneEvent(event: KnownEvent): boolean {

--- a/apps/explorer/test/known-events.test.ts
+++ b/apps/explorer/test/known-events.test.ts
@@ -14,6 +14,7 @@ import { Addresses as ZoneAddresses } from 'viem-zones/tempo'
 import {
 	Abis,
 	earnEventsAbi,
+	propAmmEventsAbi,
 	stablecoinDexAbi,
 	zoneFactoryAbi,
 	zoneOutboxAbi,
@@ -37,6 +38,8 @@ import {
 const ZONE_5_PORTAL = '0x7069DeC4E64Fd07334A0933eDe836C17259c9B23' as const
 const ZONE_E_PORTAL = '0x59831A17340EE14FE136d751EfbeA8b630470fD2' as const
 const UNKNOWN_ZONE_PORTAL = `0x${'8'.repeat(40)}` as const
+const PROP_AMM_POOL = `0x${'7'.repeat(40)}` as const
+const PROP_AMM_OUTPUT_TOKEN = `0x${'6'.repeat(40)}` as const
 
 const bounceBackAbi = [
 	{
@@ -847,6 +850,86 @@ describe('parseKnownEvents', () => {
 			expect.soft(event?.type, abiEvent.name).toBe('earn event')
 			expect.soft(event?.parts[0]?.type, abiEvent.name).toBe('action')
 		}
+	})
+
+	it('composes a propAMM swap and hides its settlement transfers', () => {
+		const hash = `0x${'5'.repeat(64)}` as const
+		const amountIn = 10_000n
+		const amountOut = 11_449n
+
+		const transferLog = (
+			token: Address.Address,
+			from: Address.Address,
+			to: Address.Address,
+			amount: bigint,
+		) =>
+			mockLog(
+				{
+					address: token,
+					topics: encodeEventTopics({
+						abi: Abis.tip20,
+						eventName: 'Transfer',
+						args: { from, to },
+					}) as [Hex.Hex, ...Hex.Hex[]],
+					data: encodeAbiParameters([{ type: 'uint256' }], [amount]),
+				},
+				hash,
+			)
+
+		const tradeLog = mockZoneEventLog(propAmmEventsAbi[0], PROP_AMM_POOL, {
+			taker: accountAddress,
+			recipient: recipientAddress,
+			tokenIn: userTokenAddress,
+			tokenOut: PROP_AMM_OUTPUT_TOKEN,
+			amountIn,
+			amountOut,
+		})
+		const events = parseKnownEvents(
+			mockReceipt(
+				[
+					transferLog(
+						userTokenAddress,
+						accountAddress,
+						PROP_AMM_POOL,
+						amountIn,
+					),
+					transferLog(
+						PROP_AMM_OUTPUT_TOKEN,
+						PROP_AMM_POOL,
+						recipientAddress,
+						amountOut,
+					),
+					tradeLog,
+				],
+				accountAddress,
+				hash,
+			),
+		)
+
+		expect(events).toEqual([
+			{
+				type: 'propamm swap',
+				parts: [
+					{ type: 'action', value: 'propAMM Swap' },
+					{
+						type: 'amount',
+						value: {
+							token: Address.checksum(userTokenAddress),
+							value: amountIn,
+						},
+					},
+					{ type: 'text', value: 'for' },
+					{
+						type: 'amount',
+						value: {
+							token: Address.checksum(PROP_AMM_OUTPUT_TOKEN),
+							value: amountOut,
+						},
+					},
+				],
+			},
+		])
+		expect(parseKnownEvent(tradeLog)?.type).toBe('propamm swap')
 	})
 
 	it.each([

--- a/apps/explorer/test/transaction-activities.test.ts
+++ b/apps/explorer/test/transaction-activities.test.ts
@@ -474,4 +474,38 @@ describe('selectTransactionDescriptionEvents for Earn receipts', () => {
 			}),
 		).toEqual([zoneWithdrawal, earnDeposit, zoneDeposit])
 	})
+
+	test('keeps Earn primary and nests a propAMM swap after it', () => {
+		const earnWithdrawal = {
+			type: 'earn exact withdrawal',
+			parts: [{ type: 'action' as const, value: 'Earn Exact Withdrawal' }],
+		}
+		const propAmmSwap = {
+			type: 'propamm swap',
+			parts: [{ type: 'action' as const, value: 'propAMM Swap' }],
+		}
+
+		expect(
+			selectTransactionDescriptionEvents({
+				activityEvents: [{ type: 'transfer', parts: [] }],
+				fallbackEvents: [propAmmSwap, earnWithdrawal],
+				knownCall: null,
+			}),
+		).toEqual([earnWithdrawal, propAmmSwap])
+	})
+})
+
+test('prefers a standalone propAMM swap over generic indexed activity', () => {
+	const propAmmSwap = {
+		type: 'propamm swap',
+		parts: [{ type: 'action' as const, value: 'propAMM Swap' }],
+	}
+
+	expect(
+		selectTransactionDescriptionEvents({
+			activityEvents: [{ type: 'transfer', parts: [] }],
+			fallbackEvents: [{ type: 'send', parts: [] }, propAmmSwap],
+			knownCall: null,
+		}),
+	).toEqual([propAmmSwap])
 })


### PR DESCRIPTION
## Summary

- decode propAMM `TradeExecuted` logs into token-aware swap summaries
- hide the matching settlement transfers from transaction descriptions
- keep Earn summaries primary while showing an embedded propAMM swap immediately after them

## Before / after

| Transaction | Before | After |
| --- | --- | --- |
| [Standalone propAMM swap](https://explore.tempo.xyz/tx/0x700b60183e13510e2829186676b8e6102b3e3b74f39b49217de9398db7daf7db) | `Token Transferred 0.01 USDY` | `propAMM Swap 0.01 USDY for 0.011449 USDC.e` |
| [Earn redemption with embedded propAMM swap](https://explore.tempo.xyz/tx/0xa556243f36bef5bc1b6a63182f87afb5791786b1401b3c409af203ac9e191202) | Earn exact withdrawal only | Earn exact withdrawal, followed by the nested propAMM swap |

## Testing

- `pnpm --filter explorer check`
- `pnpm test` in `apps/explorer` (17 files, 128 tests)
- `pnpm precommit`

The monorepo-wide `pnpm check` reaches unrelated generated Cloudflare binding errors in `apps/contract-verification`; the affected Explorer checks pass.

Prompted by: @JasonwLi
