### PR TITLE
fix(explorer): preserve unrelated propAMM output transfers

### DIFF
--- a/apps/explorer/src/lib/domain/known-events.ts
+++ b/apps/explorer/src/lib/domain/known-events.ts
@@ -2533,13 +2533,15 @@ export function parseKnownEvents(
 	// settlement transfers so the receipt shows one swap summary instead.
 	for (const trade of dedupedEvents) {
 		if (trade.topics[0]?.toLowerCase() !== propAmmTradeSelector) continue
-		const { taker, tokenIn, tokenOut, amountIn, amountOut } = trade.args as {
-			taker: Address.Address
-			tokenIn: Address.Address
-			tokenOut: Address.Address
-			amountIn: bigint
-			amountOut: bigint
-		}
+		const { taker, recipient, tokenIn, tokenOut, amountIn, amountOut } =
+			trade.args as {
+				taker: Address.Address
+				recipient: Address.Address
+				tokenIn: Address.Address
+				tokenOut: Address.Address
+				amountIn: bigint
+				amountOut: bigint
+			}
 		for (const { event, index } of transferEvents) {
 			const { from, to, amount } = event.args
 			const isInput =
@@ -2550,6 +2552,7 @@ export function parseKnownEvents(
 			const isOutput =
 				Address.isEqual(event.address, tokenOut) &&
 				Address.isEqual(from, trade.address) &&
+				Address.isEqual(to, recipient) &&
 				amount === amountOut
 			if (isInput || isOutput) swapIndices.add(index)
 		}

--- a/apps/explorer/test/known-events.test.ts
+++ b/apps/explorer/test/known-events.test.ts
@@ -40,6 +40,7 @@ const ZONE_E_PORTAL = '0x59831A17340EE14FE136d751EfbeA8b630470fD2' as const
 const UNKNOWN_ZONE_PORTAL = `0x${'8'.repeat(40)}` as const
 const PROP_AMM_POOL = `0x${'7'.repeat(40)}` as const
 const PROP_AMM_OUTPUT_TOKEN = `0x${'6'.repeat(40)}` as const
+const UNRELATED_RECIPIENT = `0x${'4'.repeat(40)}` as const
 
 const bounceBackAbi = [
 	{
@@ -852,7 +853,7 @@ describe('parseKnownEvents', () => {
 		}
 	})
 
-	it('composes a propAMM swap and hides its settlement transfers', () => {
+	it('composes a propAMM swap and hides only its settlement transfers', () => {
 		const hash = `0x${'5'.repeat(64)}` as const
 		const amountIn = 10_000n
 		const amountOut = 11_449n
@@ -899,6 +900,12 @@ describe('parseKnownEvents', () => {
 						recipientAddress,
 						amountOut,
 					),
+					transferLog(
+						PROP_AMM_OUTPUT_TOKEN,
+						PROP_AMM_POOL,
+						UNRELATED_RECIPIENT,
+						amountOut,
+					),
 					tradeLog,
 				],
 				accountAddress,
@@ -906,7 +913,12 @@ describe('parseKnownEvents', () => {
 			),
 		)
 
-		expect(events).toEqual([
+		expect(events).toHaveLength(2)
+		expect(events[0]).toMatchObject({
+			type: 'send',
+			meta: { from: PROP_AMM_POOL, to: UNRELATED_RECIPIENT },
+		})
+		expect(events.slice(-1)).toEqual([
 			{
 				type: 'propamm swap',
 				parts: [


### PR DESCRIPTION
## Summary

- Match propAMM output settlement transfers against the `TradeExecuted` recipient
- Preserve unrelated pool transfers that happen to use the same token and amount
- Extend the existing propAMM receipt test with the colliding-transfer case

## Root cause

The propAMM receipt composer identified output settlement transfers by pool, token, and amount. `TradeExecuted` also identifies the recipient, but that field was not part of the match. If the same transaction contained another pool transfer with the same token and amount to a different address, both transfers were marked as settlement activity and hidden from the receipt summary.

## Before / after

| Scenario | Before | After |
| --- | --- | --- |
| Pool sends the expected output to `TradeExecuted.recipient` | Hidden as propAMM settlement | Unchanged |
| Pool sends the same token and amount to another recipient | Also hidden | Preserved as a separate transfer |

Normal propAMM receipt rendering is unchanged, so there is no separate visual screenshot.

## Testing

- `pnpm --filter explorer test --run test/known-events.test.ts` (39 tests)
- `pnpm --filter explorer test --run` (17 files, 128 tests)
- `pnpm --filter explorer check` (Biome, typecheck, and 113 node tests)
- Pre-commit hooks on the two changed files
