### PR TITLE
fix: resolve open Dependabot and code scanning alerts

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,46 @@
+name: CodeQL
+on:
+  push:
+    branches: [main]
+  pull_request:
+  schedule:
+    # Weekly, Monday 06:30 UTC
+    - cron: '30 6 * * 1'
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ${{ vars.DEPOT_ENABLED == 'true' && 'depot-ubuntu-latest' || 'ubuntu-latest' }}
+    permissions:
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [actions, javascript-typescript]
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: none
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938
+        with:
+          # Match the categories used by the previous default-setup analyses so
+          # their stale alerts are superseded and closed on the next main run.
+          category: /language:${{ matrix.language }}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5524,8 +5524,8 @@ packages:
   fast-fifo@1.3.2:
     resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
 
-  fast-uri@3.1.2:
-    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
+  fast-uri@3.1.7:
+    resolution: {integrity: sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==}
 
   fault@2.0.1:
     resolution: {integrity: sha512-WtySTkS4OKev5JtpHXnib4Gxiurzh5NCGvWrFaZ34m6JehfTUhKZvn9njTfw48t6JumVQOmrKqpmGcdwxnhqBQ==}
@@ -6604,13 +6604,8 @@ packages:
   nan@2.26.2:
     resolution: {integrity: sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw==}
 
-  nanoid@3.3.11:
-    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
-    hasBin: true
-
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -12140,7 +12135,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.2
+      fast-uri: 3.1.7
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -13171,7 +13166,7 @@ snapshots:
 
   fast-fifo@1.3.2: {}
 
-  fast-uri@3.1.2: {}
+  fast-uri@3.1.7: {}
 
   fault@2.0.1:
     dependencies:
@@ -14606,9 +14601,7 @@ snapshots:
   nan@2.26.2:
     optional: true
 
-  nanoid@3.3.11: {}
-
-  nanoid@3.3.16: {}
+  nanoid@3.3.18: {}
 
   nanoid@5.1.15: {}
 
@@ -15027,13 +15020,13 @@ snapshots:
 
   postcss@8.5.21:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
   postcss@8.5.8:
     dependencies:
-      nanoid: 3.3.11
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 


### PR DESCRIPTION
## Summary

Resolves everything currently open under **Security → Dependabot** (3 alerts) and **Security → Code scanning** (10 alerts). Upgrades only, no `overrides`.

### Dependabot

| Alert | Package | Before | After | Pulled in via |
| --- | --- | --- | --- | --- |
| #133 · GHSA-xwg4-73v4-xw9w (high) | `nanoid` | 3.3.11 / 3.3.16 | 3.3.18 | `postcss` ← `vite` |
| #131, #132 · GHSA-f65p-4m7j-42xc, GHSA-jqff-g426-hqxp (high) | `fast-uri` | 3.1.2 | 3.1.7 | `ajv` ← `@modelcontextprotocol/sdk`, `@scalar/openapi-parser` |

Both bumps are inside the dependents' declared ranges (`^3.3.11`, `^3.0.1`), so this is a plain transitive upgrade in `pnpm-lock.yaml`.

Why not `pnpm update nanoid fast-uri`: in this repo it also re-resolves unrelated subtrees (the `@tempoxyz/lints` git ref, the `accounts` → `hono`/`zod`/`ox`/`zustand` tree, `@libsql/*`, `seroval`, …), a ~280-line diff. The two entries were bumped in place with the registry integrity hashes instead. `pnpm install --lockfile-only` leaves the result byte-identical and `pnpm install --frozen-lockfile` verifies the hashes on fetch.

### Code scanning

All 10 open alerts are `js/incomplete-sanitization` findings on `apps/tokenlist/src/svg-encode.ts`, which was deleted in #1079 (June). They never auto-closed because their most recent instance is on `main@fb3407fb` (2026-05-26): no CodeQL analysis has been uploaded for `main` since then, and CodeQL default setup is now `not-configured` for the repo (only the separate Code Quality scan runs).

This adds `.github/workflows/codeql.yml` (advanced setup):

- `actions` + `javascript-typescript`, on push to `main`, pull requests, weekly, and manual dispatch
- SHA-pinned actions, `permissions: {}` at the top with `contents: read` / `security-events: write` on the job, `persist-credentials: false`, Depot runner expression, matching the existing workflows
- `category: /language:<lang>`, the same categories the old default-setup analyses used, so the first run on `main` after merge supersedes the stale analysis and closes the 10 alerts

If you would rather turn default setup back on in repo settings instead, drop the second commit: GitHub rejects advanced-setup CodeQL uploads while default setup is enabled.

## Verification

- `pnpm install --frozen-lockfile` ✅
- `pnpm gen:types && pnpm check` (Biome + `tsgo` across all workspaces) ✅
- `vitest --run`: explorer 128, contract-verification 228, mcp-docs-indexer 74, tokenlist 2 ✅
- fee-payer: not runnable here (its global setup needs the local `ghcr.io/tempoxyz/tempo` container to answer within 5 s and it never did); the Test workflow runs it on `pnpm-lock.yaml` changes
- `actionlint` and `zizmor` clean on the new workflow; `prek` hooks pass
- `pnpm audit` no longer reports `nanoid` or `fast-uri`

## Notes (out of scope, for follow-up)

- `pnpm audit --prod` still lists reviewed advisories that Dependabot shows as *fixed* but which survive as second copies in the lockfile: `postcss@8.5.8` (under `vite`, alongside 8.5.21), `seroval@1.5.1` (alongside 1.5.4), `undici@7.24.x`, plus `vite@8.0.7`, `kysely@0.28.15`, `browserslist@4.28.1`.
- Pre-existing: a local `pnpm install` finishes with `ERR_PNPM_IGNORED_BUILDS` for `es5-ext@0.10.64` (`strictDepBuilds`). Not touched here; CI installs with `--ignore-scripts`.
