### PR TITLE
fix(explorer): load verified proxy ABIs and preserve mutability

### DIFF
--- a/apps/explorer/src/comps/Contract.tsx
+++ b/apps/explorer/src/comps/Contract.tsx
@@ -11,7 +11,11 @@ import { ContractWriter } from '#comps/ContractWriter.tsx'
 import { cx } from '#lib/css'
 import { ellipsis } from '#lib/chars.ts'
 import type { ContractSource } from '#lib/domain/contract-source.ts'
-import { autoloadAbi, getContractAbi } from '#lib/domain/contracts.ts'
+import {
+	autoloadAbi,
+	getContractAbi,
+	isInferredAbi,
+} from '#lib/domain/contracts.ts'
 import {
 	detectProxy,
 	type ProxyInfo,
@@ -33,6 +37,17 @@ const proxyTypeUrls: Record<ProxyType, string> = {
 
 function proxyTypeUrl(type: ProxyType | undefined): string {
 	return type ? proxyTypeUrls[type] : proxyTypeUrls['EIP-1967']
+}
+
+function InferredAbiNotice({ abi }: { abi: Abi }): React.JSX.Element | null {
+	if (!isInferredAbi(abi)) return null
+	return (
+		<p className="px-[16px] py-[10px] text-[13px] text-secondary border-b border-dashed border-distinct">
+			Inferred ABI: function names, read/write classifications, and return types
+			may be incomplete or incorrect. Verify the contract source for an accurate
+			ABI.
+		</p>
+	)
 }
 
 /**
@@ -106,6 +121,7 @@ export function ContractTabContent(props: {
 			{source && <SourceSection {...source} docsUrl={docsUrl} />}
 
 			{/* ABI Section */}
+			<InferredAbiNotice abi={abi} />
 			<CollapsibleSection
 				first={!isTip20}
 				title={<span title="Contract ABI">ABI</span>}
@@ -371,6 +387,7 @@ export function InteractTabContent(props: {
 			)}
 
 			{/* Write Contract Section (Implementation functions via proxy) */}
+			<InferredAbiNotice abi={abi} />
 			<CollapsibleSection
 				first={!isProxy}
 				title={isProxy ? 'Write (via Proxy)' : 'Write'}
@@ -411,6 +428,7 @@ export function InteractTabContent(props: {
 							These are functions defined on the proxy contract itself, not the
 							implementation.
 						</div>
+						<InferredAbiNotice abi={proxyAbi} />
 						<ContractReader address={address} abi={proxyAbi} />
 						<ContractWriter address={address} abi={proxyAbi} />
 					</div>

--- a/apps/explorer/src/lib/domain/contracts.ts
+++ b/apps/explorer/src/lib/domain/contracts.ts
@@ -26,6 +26,7 @@ import { getChainId, getPublicClient } from 'wagmi/actions'
 import { isTip20Address } from '#lib/domain/tip20.ts'
 import { getZonePortalId, isZonePortalAddress } from '#lib/domain/zones.ts'
 import { getWagmiConfig } from '#wagmi.config.ts'
+import { clientEnv } from '#lib/env.ts'
 
 export { isZonePortalAddress } from '#lib/domain/zones.ts'
 
@@ -542,6 +543,15 @@ export type WriteFunction = AbiFunction & {
  */
 type WhatsabiAbiFunction = AbiFunction & { selector?: string }
 
+/** Bytecode-extracted entries carry selectors; compiler ABIs do not. */
+export function isInferredAbi(abi: Abi): boolean {
+	return abi.some(
+		(item) =>
+			item.type === 'function' &&
+			Boolean((item as WhatsabiAbiFunction).selector),
+	)
+}
+
 /**
  * Get the function selector, using whatsabi's extracted selector if available,
  * otherwise computing it from the function signature.
@@ -664,9 +674,6 @@ export function getReadFunctions(abi: Abi): ReadFunction[] {
 	const functions = abi.filter((item): item is ReadFunction => {
 		if (item.type !== 'function') return false
 		if (!Array.isArray(item.inputs)) return false
-		if (looksLikeWriteFunction(item.name) && !looksLikeReadFunction(item.name))
-			return false
-
 		const whatsabiItem = item as WhatsabiAbiFunction
 		const isWhatsabi = Boolean(whatsabiItem.selector)
 
@@ -674,12 +681,10 @@ export function getReadFunctions(abi: Abi): ReadFunction[] {
 		if (!isWhatsabi) {
 			if (!Array.isArray(item.outputs) || item.outputs.length === 0)
 				return false
-			// Some verified/proxy ABIs contain incorrect mutability metadata.
-			// Prefer a recognized getter name over that metadata so those functions
-			// remain callable from the Read section.
-			if (looksLikeReadFunction(item.name)) return true
 			return item.stateMutability === 'view' || item.stateMutability === 'pure'
 		}
+		if (looksLikeWriteFunction(item.name) && !looksLikeReadFunction(item.name))
+			return false
 
 		// For whatsabi ABIs, stateMutability is often wrong (everything is nonpayable)
 		// Use name-based heuristics instead
@@ -721,16 +726,12 @@ export function getWriteFunctions(abi: Abi): WriteFunction[] {
 			item.stateMutability === 'nonpayable' ||
 			item.stateMutability === 'payable'
 		if (!isNonpayableOrPayable) return false
-		// ABI sources used for proxy implementations can carry incorrect
-		// mutability metadata. Do not expose recognized getters as transactions,
-		// regardless of whether the entry came from whatsabi or a verified ABI.
-		if (looksLikeReadFunction(item.name)) return false
-
 		const whatsabiItem = item as WhatsabiAbiFunction
 		const isWhatsabi = Boolean(whatsabiItem.selector)
 
 		// For whatsabi ABIs, filter out functions that look like read functions
 		if (isWhatsabi) {
+			if (looksLikeReadFunction(item.name)) return false
 			// Functions with no inputs that don't look like writes are likely getters
 			if (item.inputs.length === 0 && !looksLikeWriteFunction(item.name))
 				return false
@@ -1030,7 +1031,7 @@ export async function lookupSignature(
 
 const signatureLookupCache = new Map<Hex.Hex, Promise<string | null>>()
 
-class TempoABILoader {
+export class TempoABILoader {
 	readonly name = 'TempoABILoader'
 	readonly chainId: number
 
@@ -1047,7 +1048,7 @@ class TempoABILoader {
 
 	async loadABI(address: string): Promise<unknown[]> {
 		try {
-			const url = `${import.meta.env.VITE_CONTRACT_VERIFICATION_API_BASE_URL}/v2/contract/${this.chainId}/${address.toLowerCase()}?fields=abi`
+			const url = `${clientEnv.CONTRACT_VERIFICATION_API_BASE_URL}/v2/contract/${this.chainId}/${address.toLowerCase()}?fields=abi`
 			const response = await fetch(url)
 			if (!response.ok) return []
 			const data = (await response.json()) as { abi?: unknown[] }

--- a/apps/explorer/src/lib/env.ts
+++ b/apps/explorer/src/lib/env.ts
@@ -9,7 +9,10 @@ const clientEnvSchema = z.object({
 	),
 })
 
-export const clientEnv = clientEnvSchema.parse(import.meta.env)
+export const clientEnv = clientEnvSchema.parse({
+	CONTRACT_VERIFICATION_API_BASE_URL: import.meta.env
+		.VITE_CONTRACT_VERIFICATION_API_BASE_URL,
+})
 
 export type TempoEnv = 'testnet' | 'mainnet' | 'devnet' | 'nextfork'
 

--- a/apps/explorer/test/contracts.node.test.ts
+++ b/apps/explorer/test/contracts.node.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
 	decodeAbiParameters,
 	encodeAbiParameters,
@@ -17,11 +17,13 @@ import {
 	getContractInfo,
 	getReadFunctions,
 	getWriteFunctions,
+	isInferredAbi,
 	isZonePortalAddress,
 	systemAddress,
+	TempoABILoader,
 } from '#lib/domain/contracts'
 
-const proxyImplementationAbi = [
+const inferredImplementationAbi = [
 	{
 		type: 'function',
 		name: 'supportsInterface',
@@ -83,12 +85,67 @@ const proxyImplementationAbi = [
 	},
 ] as const satisfies Abi
 
-const whatsabiImplementationAbi = proxyImplementationAbi.map((fn, index) => ({
+const proxyImplementationAbi = inferredImplementationAbi.map((fn, index) => ({
 	...fn,
-	selector: `0x${index.toString(16).padStart(8, '0')}`,
+	stateMutability: index < 6 ? 'view' : 'nonpayable',
 })) as Abi
 
+const whatsabiImplementationAbi = inferredImplementationAbi.map(
+	(fn, index) => ({
+		...fn,
+		selector: `0x${index.toString(16).padStart(8, '0')}`,
+	}),
+) as Abi
+
 describe('contract function classification', () => {
+	it('trusts compiler mutability even when names suggest the opposite', () => {
+		const abi = [
+			{
+				type: 'function',
+				name: 'paused',
+				stateMutability: 'view',
+				inputs: [],
+				outputs: [{ type: 'bool' }],
+			},
+			{
+				type: 'function',
+				name: 'calculateAndStore',
+				stateMutability: 'nonpayable',
+				inputs: [],
+				outputs: [{ type: 'uint256' }],
+			},
+			{
+				type: 'function',
+				name: 'getAndPay',
+				stateMutability: 'payable',
+				inputs: [],
+				outputs: [{ type: 'uint256' }],
+			},
+			{
+				type: 'function',
+				name: 'compute',
+				stateMutability: 'pure',
+				inputs: [],
+				outputs: [{ type: 'uint256' }],
+			},
+		] as const satisfies Abi
+		expect(getReadFunctions(abi).map((fn) => fn.name)).toEqual([
+			'paused',
+			'compute',
+		])
+		expect(getWriteFunctions(abi).map((fn) => fn.name)).toEqual([
+			'calculateAndStore',
+			'getAndPay',
+		])
+		expect(getReadFunctions(abi)[0]).toBe(abi[0])
+	})
+
+	it('identifies inferred entries without relabeling compiler ABIs', () => {
+		expect(isInferredAbi(whatsabiImplementationAbi)).toBe(true)
+		expect(isInferredAbi(proxyImplementationAbi)).toBe(false)
+		expect(isInferredAbi([])).toBe(false)
+	})
+
 	it('keeps getter-style implementation functions out of Write', () => {
 		for (const abi of [proxyImplementationAbi, whatsabiImplementationAbi]) {
 			const reads = getReadFunctions(abi)
@@ -107,6 +164,72 @@ describe('contract function classification', () => {
 				'setMinterAllowance',
 			])
 		}
+	})
+})
+
+describe('Tempo ABI lookup', () => {
+	afterEach(() => {
+		vi.unstubAllGlobals()
+		vi.unstubAllEnvs()
+		vi.resetModules()
+	})
+
+	it('loads the verified implementation ABI from the default host without losing metadata', async () => {
+		const abi = [
+			{
+				type: 'function',
+				name: 'paused',
+				stateMutability: 'view',
+				inputs: [],
+				outputs: [{ type: 'bool' }],
+			},
+		]
+		const fetch = vi
+			.fn()
+			.mockResolvedValue(Response.json({ match: 'exact_match', abi }))
+		vi.stubGlobal('fetch', fetch)
+		const loader = new TempoABILoader({ chainId: 4217 })
+		const result = await loader.loadABI(
+			'0x3B3F2e2aa07460a9ba95ffd06ad9597398Bbbab7',
+		)
+		expect(fetch).toHaveBeenCalledWith(
+			'https://contracts.tempo.xyz/v2/contract/4217/0x3b3f2e2aa07460a9ba95ffd06ad9597398bbbab7?fields=abi',
+		)
+		expect(result).toEqual(abi)
+		expect(isInferredAbi(result as Abi)).toBe(false)
+	})
+
+	it('honors the configured verifier host and requested chain', async () => {
+		vi.stubEnv(
+			'VITE_CONTRACT_VERIFICATION_API_BASE_URL',
+			'https://verifier.example',
+		)
+		vi.resetModules()
+		const { TempoABILoader } = await import('#lib/domain/contracts')
+		const fetch = vi.fn().mockResolvedValue(Response.json({ abi: [] }))
+		vi.stubGlobal('fetch', fetch)
+		await new TempoABILoader({ chainId: 42431 }).loadABI(
+			'0x0000000000000000000000000000000000000001',
+		)
+		expect(fetch).toHaveBeenCalledWith(
+			'https://verifier.example/v2/contract/42431/0x0000000000000000000000000000000000000001?fields=abi',
+		)
+	})
+
+	it('allows inference when the contract is not verified', async () => {
+		vi.stubGlobal(
+			'fetch',
+			vi
+				.fn()
+				.mockResolvedValue(
+					Response.json({ customCode: 'contract_not_found' }, { status: 404 }),
+				),
+		)
+		expect(
+			await new TempoABILoader({ chainId: 4217 }).loadABI(
+				'0x0000000000000000000000000000000000000001',
+			),
+		).toEqual([])
 	})
 })
 


### PR DESCRIPTION
## Problem

On the [bridgedBRLV proxy](https://explore.tempo.xyz/address/0x06D804ADd7208437b10eCe87306cc2aA6914c806?tab=interact), `paused()` incorrectly appears under **Write** with inferred `stateMutability: "nonpayable"` and no return types. The verified implementation declares it as `view`, returning `bool`.

The ABI loader requests `/undefined/v2/contract/...` and falls back to inference. Function classification also applies name heuristics to verified ABIs, incorrectly excluding names such as `paused` from Read.

## Fix

- Use the shared verifier URL/default and honor its Vite override.
- Trust verified mutability and preserve return types; limit name heuristics to inferred ABIs and label their uncertainty.
- Add regression coverage. This fixes shared explorer behavior, not a specific contract.

## Validation

246 explorer tests, workspace lint/type checks, and pre-commit checks pass. The patched UI shows `paused()` under **Read**, with `view`/`bool`, returning `false`; the inference warning was also checked.

Local account-type metadata was seeded; proxy detection, verified ABI fetching, and contract reads were live.

Prompted by: @grandizzy
