### PR TITLE
fix(explorer): align transaction social cards with interpreted actions

### DIFF
--- a/apps/explorer/src/lib/og.ts
+++ b/apps/explorer/src/lib/og.ts
@@ -2,7 +2,6 @@ import type * as Address from 'ox/Address'
 import * as Value from 'ox/Value'
 import type { AccountType } from '#lib/account'
 import type { KnownEvent, KnownEventPart } from '#lib/domain/known-events'
-import { DEFAULT_KNOWN_EVENT_AMOUNT_DECIMALS } from '#lib/domain/known-event-totals'
 import { getReceiptEventSideAmount } from '#lib/domain/receipt-presentation'
 import { DateFormatter, HexFormatter } from '#lib/formatting'
 import {
@@ -27,7 +26,15 @@ function truncateOgText(text: string, maxLength: number): string {
 
 // ============ Client-side OG (for $hash.tsx) ============
 
-export function buildOgImageUrl(data: TxDataQuery, hash: string): string {
+export function buildOgImageUrl(
+	data: {
+		block: Pick<TxDataQuery['block'], 'number' | 'timestamp'>
+		receipt: Pick<TxDataQuery['receipt'], 'from'>
+		feeBreakdown: TxDataQuery['feeBreakdown']
+	},
+	hash: string,
+	descriptionEvents: readonly KnownEvent[],
+): string {
 	const timestamp = data.block.timestamp
 	const ogTimestamp = DateFormatter.formatTimestampForOg(timestamp)
 
@@ -44,30 +51,7 @@ export function buildOgImageUrl(data: TxDataQuery, hash: string): string {
 		total = feeDisplay
 	}
 
-	const events: TxOgEvent[] = data.knownEvents.slice(0, 5).map((event) => {
-		const actionPart = event.parts.find((p) => p.type === 'action')
-		const action = actionPart?.type === 'action' ? actionPart.value : event.type
-
-		const details = event.parts
-			.filter((p) => p.type !== 'action')
-			.map((part) => formatPartForOgClient(part))
-			.filter(Boolean)
-			.join(' ')
-
-		const amountPart = event.parts.find((p) => p.type === 'amount')
-		let amount = ''
-		if (amountPart?.type === 'amount') {
-			const val = Number(
-				Value.format(
-					amountPart.value.value,
-					amountPart.value.decimals ?? DEFAULT_KNOWN_EVENT_AMOUNT_DECIMALS,
-				),
-			)
-			amount = val > 0 && val < 0.01 ? '<$0.01' : `$${val.toFixed(0)}`
-		}
-
-		return { action, details, amount: amount || undefined }
-	})
+	const events = descriptionEvents.slice(0, 5).map(formatEventForOg)
 
 	const params: TxOgParams = {
 		hash,
@@ -81,26 +65,6 @@ export function buildOgImageUrl(data: TxDataQuery, hash: string): string {
 	}
 
 	return buildTxOgUrl(OG_BASE_URL, params)
-}
-
-function formatPartForOgClient(part: KnownEventPart): string {
-	switch (part.type) {
-		case 'text':
-			return part.value
-		case 'amount':
-			return `${Value.format(part.value.value, part.value.decimals ?? DEFAULT_KNOWN_EVENT_AMOUNT_DECIMALS)} ${part.value.symbol || ''}`
-		case 'account':
-			return HexFormatter.truncate(part.value)
-		case 'token':
-			return part.value.symbol || HexFormatter.truncate(part.value.address)
-		case 'contractCall': {
-			const selector = part.value.input.slice(0, 10)
-			const target = HexFormatter.truncate(part.value.address)
-			return `${selector} on ${target}`
-		}
-		default:
-			return ''
-	}
 }
 
 function formatAmount(
@@ -167,7 +131,7 @@ function formatEventPart(part: KnownEventPart): string {
 	}
 }
 
-export function formatEventForOgServer(event: KnownEvent): string {
+function formatEventForOg(event: KnownEvent): TxOgEvent {
 	const actionPart = event.parts.find((p) => p.type === 'action')
 	const action = actionPart ? formatEventPart(actionPart) : event.type
 
@@ -182,7 +146,16 @@ export function formatEventForOgServer(event: KnownEvent): string {
 			? `$${formattedSideAmount}`
 			: ''
 
-	return `${truncateOgText(action, 40)}|${truncateOgText(details, 180)}|${truncateOgText(usdAmount, 30)}`
+	return {
+		action: truncateOgText(action, 40),
+		details: truncateOgText(details, 180),
+		amount: truncateOgText(usdAmount, 30),
+	}
+}
+
+export function formatEventForOgServer(event: KnownEvent): string {
+	const { action, details, amount } = formatEventForOg(event)
+	return `${action}|${details}|${amount}`
 }
 
 export function formatDate(timestamp: number): string {

--- a/apps/explorer/src/routes/_layout/tx/$hash.tsx
+++ b/apps/explorer/src/routes/_layout/tx/$hash.tsx
@@ -144,18 +144,21 @@ export const Route = createFileRoute('/_layout/tx/$hash')({
 	}),
 	head: ({ params, loaderData }) => {
 		const title = `Transaction ${params.hash.slice(0, 10)}…${params.hash.slice(-6)} ⋅ Tempo Explorer`
+		const descriptionEvents = loaderData
+			? selectTransactionDescriptionEvents({
+					activityEvents: loaderData.activityEvents,
+					fallbackEvents: loaderData.knownEvents ?? [],
+					knownCall: loaderData.knownCall,
+				})
+			: []
 		const ogImageUrl = loaderData
-			? buildOgImageUrl(loaderData, params.hash)
+			? buildOgImageUrl(loaderData, params.hash, descriptionEvents)
 			: `${OG_BASE_URL}/tx/${params.hash}`
 		const description = loaderData
 			? buildTxDescription({
 					timestamp: Number(loaderData.block.timestamp) * 1000,
 					from: loaderData.receipt.from,
-					events: selectTransactionDescriptionEvents({
-						activityEvents: loaderData.activityEvents,
-						fallbackEvents: loaderData.knownEvents ?? [],
-						knownCall: loaderData.knownCall,
-					}),
+					events: descriptionEvents,
 				})
 			: 'View transaction details on Tempo Explorer.'
 

--- a/apps/explorer/test/og.node.test.ts
+++ b/apps/explorer/test/og.node.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, test } from 'vitest'
+import type { KnownEvent } from '#lib/domain/known-events'
+import { selectTransactionDescriptionEvents } from '#lib/domain/transaction-activities'
+import { buildOgImageUrl, formatEventForOgServer } from '#lib/og'
+
+const hash =
+	'0xd450f9268b6f14ccfea04dfbf57b67cc8a65ec30a3f0ffbaa19b6f70502a49c9'
+const data = {
+	block: { number: 36449187n, timestamp: 1787675820n },
+	receipt: { from: '0xf0d4945f4d9996471bc4d2e7d0cff7a2f9eeb5a4' as const },
+	feeBreakdown: [],
+}
+const amount = {
+	value: 100_000n,
+	decimals: 6,
+	symbol: 'DLUSD',
+	token: '0x20c0000000000000000000000000000000000001' as const,
+}
+
+function event(type: string, action: string): KnownEvent {
+	return {
+		type,
+		parts: [
+			{ type: 'action', value: action },
+			{ type: 'amount', value: amount },
+		],
+	}
+}
+
+function cardEvents(events: KnownEvent[]) {
+	return [...new URL(buildOgImageUrl(data, hash, events)).searchParams]
+		.filter(([key]) => /^ev\d+$/.test(key))
+		.map(([, value]) => value.split('|'))
+}
+
+describe('transaction social card actions', () => {
+	test('uses interpreted actions in order instead of underlying transfers and nonce', () => {
+		const actions = [
+			event('private-shares-redeemed', 'Private Zone Withdrawal'),
+			event('vault-deposit', 'Earn Deposit'),
+			event('private-assets-deposited', 'Private Zone Deposit'),
+		]
+		const selected = selectTransactionDescriptionEvents({
+			activityEvents: actions,
+			fallbackEvents: [
+				event('nonce', 'Increment Nonce'),
+				event('send', 'Send'),
+				event('approval', 'Approve'),
+			],
+			knownCall: null,
+		})
+
+		expect(cardEvents(selected).map(([action]) => action)).toEqual([
+			'Private Zone Withdrawal',
+			'Earn Deposit',
+			'Private Zone Deposit',
+		])
+		expect(cardEvents(selected)[0]?.[2]).toBe('')
+		expect(cardEvents(selected)[2]?.[2]).toBe('')
+		for (const [index, action] of selected.entries()) {
+			expect(cardEvents(selected)[index]?.slice(0, 3).join('|')).toBe(
+				formatEventForOgServer(action),
+			)
+		}
+	})
+
+	test('keeps a decoded call when indexed activities only contain a nonce', () => {
+		const selected = selectTransactionDescriptionEvents({
+			activityEvents: [event('nonce incremented', 'Nonce Incremented')],
+			fallbackEvents: [],
+			knownCall: event('zone batch submission', 'Submit Zone Batch'),
+		})
+		expect(cardEvents(selected).map(([action]) => action)).toEqual([
+			'Submit Zone Batch',
+		])
+	})
+
+	test('retains decoded fallback actions when indexed activities are unavailable', () => {
+		const selected = selectTransactionDescriptionEvents({
+			activityEvents: [],
+			fallbackEvents: [event('send', 'Send')],
+			knownCall: null,
+		})
+		expect(cardEvents(selected)[0]).toEqual(['Send', '0.10 DLUSD', '$0.10', ''])
+	})
+
+	test('keeps numeric and hex details from interpreted actions', () => {
+		const action: KnownEvent = {
+			type: 'zone batch submission',
+			parts: [
+				{ type: 'action', value: 'Submit Zone Batch' },
+				{ type: 'text', value: 'zone' },
+				{ type: 'number', value: 7n },
+				{ type: 'hex', value: hash },
+			],
+		}
+		expect(cardEvents([action])[0]?.[1]).toContain('zone 7 0xd450')
+	})
+
+	test('handles empty actions and caps the selected actions sent to the card', () => {
+		expect(cardEvents([])).toEqual([])
+		expect(
+			cardEvents(Array.from({ length: 7 }, () => event('send', 'Send'))),
+		).toHaveLength(5)
+	})
+})


### PR DESCRIPTION
Transaction social cards used raw decoded events while the explorer description and receipt selected interpreted actions. For [the reported transaction](https://explore.tempo.xyz/tx/0xd450f9268b6f14ccfea04dfbf57b67cc8a65ec30a3f0ffbaa19b6f70502a49c9), the card showed `Increment Nonce` and `Send` instead of `Private Zone Withdrawal`, `Earn Deposit`, and `Private Zone Deposit`.

Select the actions once for both the transaction page's image URL and preview description. Require those selected events as the image builder's input and share the receipt OG formatter, including private-zone side-amount suppression and numeric/hex details.

Validation: root `pnpm check`, `pnpm check:types`, and `pnpm precommit` passed; all 128 Explorer Worker tests and 125 Explorer Node tests passed, including five new regression tests. An HTTP end-to-end check requested the exact transaction from the local mainnet Explorer with a Slackbot user agent, compared all three image action parameters with the local `.txt` receipt, checked Twitter/OpenGraph image parity, and fetched the resulting image through the local OG worker. Inspected the generated 1200×630 WebP and verified its upload to the requesting Slack thread. Local Workers used a test-only transport adapter to reach the sandbox's existing HTTPS proxy; application data came from live services, without mocked transaction responses.

| Before (reported production card) | After (local end-to-end render) |
| --- | --- |
| [View screenshot](https://tempoxyz.enterprise.slack.com/files/U0ANX3AM5RR/F0C06NY3JPR/image.png) | [View rendered card](https://tempoxyz.enterprise.slack.com/files/U0ANX3AM5RR/F0C0Q5SHC5P/tx-card-after.webp) |

Image links require Tempo Slack access. This changes Explorer only; the existing OG renderer accepts the corrected parameters. Production deployment and Slack's cached unfurl have not been changed.

Prompted by: @snario
