### PR TITLE
feat(explorer): add submit batch transaction filter

### DIFF
--- a/apps/explorer/src/comps/TransactionFilters.tsx
+++ b/apps/explorer/src/comps/TransactionFilters.tsx
@@ -29,7 +29,15 @@ const periodSection: FilterSection<'24h' | '7d'> = {
 export function TransactionFilters(
 	props: TransactionFilters.Props,
 ): React.JSX.Element {
-	const { status, period, onStatusChange, onPeriodChange } = props
+	const {
+		status,
+		period,
+		onStatusChange,
+		onPeriodChange,
+		hideSubmitBatches,
+		onHideSubmitBatchesChange,
+		onClearAll,
+	} = props
 
 	const mode = Sections.useSectionsMode()
 	const isStacked = mode === 'stacked'
@@ -38,12 +46,28 @@ export function TransactionFilters(
 	const containerRef = React.useRef<HTMLDivElement>(null)
 
 	const activeCount =
-		(status !== undefined ? 1 : 0) + (period !== undefined ? 1 : 0)
+		(status !== undefined ? 1 : 0) +
+		(period !== undefined ? 1 : 0) +
+		(hideSubmitBatches ? 1 : 0)
 
 	const handleClearAll = React.useCallback(() => {
+		if (onClearAll) return onClearAll()
 		onStatusChange(undefined)
 		onPeriodChange(undefined)
-	}, [onStatusChange, onPeriodChange])
+		onHideSubmitBatchesChange?.(false)
+	}, [onStatusChange, onPeriodChange, onHideSubmitBatchesChange, onClearAll])
+
+	const batchFilter = onHideSubmitBatchesChange && (
+		<label className="flex items-center gap-[8px] text-[12px] text-secondary cursor-pointer">
+			<input
+				type="checkbox"
+				checked={hideSubmitBatches ?? false}
+				onChange={(event) => onHideSubmitBatchesChange(event.target.checked)}
+				className="accent-accent"
+			/>
+			Hide submit batches
+		</label>
+	)
 
 	const toggleOpen = React.useCallback(() => setOpen((v) => !v), [])
 
@@ -68,6 +92,8 @@ export function TransactionFilters(
 					<button
 						type="button"
 						onClick={toggleOpen}
+						aria-label="Filter transactions"
+						aria-expanded={open}
 						className={cx(
 							'flex items-center gap-[6px] border rounded-[6px] px-[8px] py-[4px] text-[12px] cursor-pointer transition-colors',
 							activeCount > 0
@@ -94,6 +120,7 @@ export function TransactionFilters(
 				</div>
 				{open && (
 					<div className="flex flex-col gap-[10px] pt-[6px]">
+						{batchFilter}
 						<SegmentedRow
 							label={statusSection.label}
 							options={statusSection.options}
@@ -117,6 +144,8 @@ export function TransactionFilters(
 			<button
 				type="button"
 				onClick={toggleOpen}
+				aria-label="Filter transactions"
+				aria-expanded={open}
 				className={cx(
 					'flex items-center gap-[6px] border rounded-[6px] px-[8px] py-[4px] text-[12px] cursor-pointer transition-colors',
 					activeCount > 0
@@ -135,6 +164,7 @@ export function TransactionFilters(
 			{open && (
 				<div className="absolute top-full right-0 mt-[6px] z-50 bg-card-header border border-card-border rounded-[10px] shadow-[0_12px_40px_rgba(0,0,0,0.5)] min-w-[260px]">
 					<div className="flex flex-col gap-[10px] p-[14px]">
+						{batchFilter}
 						<SegmentedRow
 							label={statusSection.label}
 							options={statusSection.options}
@@ -200,6 +230,9 @@ export declare namespace TransactionFilters {
 	type Props = {
 		status?: 'success' | 'reverted' | undefined
 		period?: '24h' | '7d' | undefined
+		hideSubmitBatches?: boolean | undefined
+		onHideSubmitBatchesChange?: ((hide: boolean) => void) | undefined
+		onClearAll?: (() => void) | undefined
 		onStatusChange: (status: 'success' | 'reverted' | undefined) => void
 		onPeriodChange: (period: '24h' | '7d' | undefined) => void
 	}

--- a/apps/explorer/src/lib/queries/account.ts
+++ b/apps/explorer/src/lib/queries/account.ts
@@ -28,6 +28,7 @@ export function historyQueryOptions(params: {
 	after?: number | undefined
 	address: Address.Address
 	status?: 'success' | 'reverted' | undefined
+	hideSubmitBatches?: boolean | undefined
 }) {
 	const searchParams = new URLSearchParams({
 		include: params?.include ?? 'all',
@@ -35,6 +36,7 @@ export function historyQueryOptions(params: {
 		sort: params.order ?? 'desc',
 	})
 	if (params.cursor) searchParams.set('cursor', params.cursor)
+	if (params.hideSubmitBatches) searchParams.set('hideSubmitBatches', 'true')
 	if (params.status) {
 		searchParams.set('status', params.status)
 	}
@@ -51,6 +53,7 @@ export function historyQueryOptions(params: {
 			params.include ?? 'all',
 			params.after,
 			params.status ?? 'all',
+			params.hideSubmitBatches ?? false,
 		],
 		queryFn: async ({ signal }): Promise<HistoryResponse> => {
 			const url = getApiUrl(

--- a/apps/explorer/src/lib/server/address-history.ts
+++ b/apps/explorer/src/lib/server/address-history.ts
@@ -1,7 +1,12 @@
 import { type InferResponseType, parseResponse } from 'hono/client'
 import * as Address from 'ox/Address'
 import * as Hex from 'ox/Hex'
-import type { Log, TransactionReceipt } from 'viem'
+import {
+	getAbiItem,
+	toFunctionSelector,
+	type Log,
+	type TransactionReceipt,
+} from 'viem'
 import type { Config } from 'wagmi'
 import { Actions } from 'wagmi/tempo'
 import * as z from 'zod/mini'
@@ -21,10 +26,17 @@ import { api } from '#lib/server/tempo-api'
 import { getTransactionActivities } from '#lib/server/transaction-activities'
 import { parseTimestamp } from '#lib/timestamp'
 import { getWagmiConfig } from '#wagmi.config'
+import { zonePortalAbi } from '#lib/abis'
+import { isZonePortalAddress } from '#lib/domain/zones'
 
 export const [MAX_LIMIT, DEFAULT_LIMIT] = [10, 10]
 const HISTORY_TOTAL_CACHE_TTL = 60_000
 const HISTORY_TOTAL_CACHE_MAX_ENTRIES = 50
+const SUBMIT_BATCH_SELECTOR = toFunctionSelector(
+	getAbiItem({ abi: zonePortalAbi, name: 'submitBatch' }),
+)
+const FILTER_SCAN_PAGE_SIZE = 50
+const FILTER_SCAN_MAX_PAGES = 10
 
 export type EnrichedTransaction = {
 	hash: `0x${string}`
@@ -56,6 +68,7 @@ export const RequestParametersSchema = z.object({
 	include: z.prefault(z.enum(['all', 'sent', 'received']), 'all'),
 	status: z.optional(z.enum(['success', 'reverted'])),
 	after: z.optional(z.coerce.number()),
+	hideSubmitBatches: z.optional(z.enum(['true', 'false'])),
 })
 
 export type HistoryRequestParameters = z.infer<typeof RequestParametersSchema>
@@ -165,6 +178,71 @@ function transactionCursor(row: TransactionRow): string {
 	return btoa(
 		JSON.stringify([Number(row.blockNumber), Number(row.transactionIndex)]),
 	)
+}
+
+function isSubmitBatch(row: TransactionRow, address: Address.Address): boolean {
+	const calls = [
+		{ to: row.recipient, data: row.input },
+		...(row.calls ?? []),
+		...(row.meta?.rpc?.calls ?? []),
+	]
+	return calls.some(
+		(call) =>
+			call.to?.toLowerCase() === address.toLowerCase() &&
+			('input' in call ? (call.input ?? call.data) : call.data)
+				?.toLowerCase()
+				.startsWith(SUBMIT_BATCH_SELECTOR),
+	)
+}
+
+async function fetchFilteredHistoryPage(
+	address: Address.Address,
+	chainId: number,
+	searchParams: HistoryRequestParameters,
+	limit: number,
+): Promise<{
+	data: TransactionRow[]
+	meta?: HistoryTotal | undefined
+	nextCursor: string | null
+	reverseCursor: string | null
+}> {
+	const data: TransactionRow[] = []
+	let cursor = searchParams.cursor
+	let reverseCursor: string | null = null
+	for (let page = 0; page < FILTER_SCAN_MAX_PAGES; page++) {
+		const result = await parseResponse(
+			api.v1.transactions.$get({
+				query: {
+					chainId: String(chainId),
+					...historyFilters(address, searchParams),
+					order: searchParams.sort,
+					limit: String(FILTER_SCAN_PAGE_SIZE),
+					...(cursor ? { cursor } : {}),
+					include: 'receipt',
+				},
+			}),
+		)
+		// Keep the scan boundary even for an empty filtered page, so Previous works.
+		if (reverseCursor === null && result.data[0])
+			reverseCursor = transactionCursor(result.data[0])
+		for (const [index, row] of result.data.entries()) {
+			if (isSubmitBatch(row, address)) continue
+			data.push(row)
+			if (data.length === limit)
+				return {
+					data,
+					reverseCursor,
+					nextCursor:
+						index < result.data.length - 1 || result.nextCursor
+							? transactionCursor(row)
+							: null,
+				}
+		}
+		if (!result.nextCursor) return { data, reverseCursor, nextCursor: null }
+		cursor = result.nextCursor
+	}
+	// Bound Worker work for batch-only stretches; Next continues from this boundary.
+	return { data, reverseCursor, nextCursor: cursor ?? null }
 }
 
 /**
@@ -286,26 +364,31 @@ export async function fetchAddressHistoryData(params: {
 	if (limit < 1) limit = 1
 
 	const filters = historyFilters(address, searchParams)
+	const hideSubmitBatches =
+		searchParams.hideSubmitBatches === 'true' && isZonePortalAddress(address)
 	const totalKey = JSON.stringify([chainId, filters])
 	const cachedTotal = getCachedHistoryTotal(totalKey)
 	// Only the latest edge refreshes the count. The oldest edge is fetched in
 	// parallel with ascending order and reuses the same cached total.
 	const includeTotal =
+		!hideSubmitBatches &&
 		searchParams.cursor === undefined &&
 		searchParams.sort === 'desc' &&
 		cachedTotal === undefined
-	const resultPromise = parseResponse(
-		api.v1.transactions.$get({
-			query: {
-				chainId: String(chainId),
-				...filters,
-				order: searchParams.sort,
-				limit: String(limit),
-				...(searchParams.cursor ? { cursor: searchParams.cursor } : {}),
-				include: includeTotal ? 'receipt,totalCount' : 'receipt',
-			},
-		}),
-	)
+	const resultPromise = hideSubmitBatches
+		? fetchFilteredHistoryPage(address, chainId, searchParams, limit)
+		: parseResponse(
+				api.v1.transactions.$get({
+					query: {
+						chainId: String(chainId),
+						...filters,
+						order: searchParams.sort,
+						limit: String(limit),
+						...(searchParams.cursor ? { cursor: searchParams.cursor } : {}),
+						include: includeTotal ? 'receipt,totalCount' : 'receipt',
+					},
+				}),
+			)
 	const requestedTotal = includeTotal
 		? resultPromise
 				.then((result) =>
@@ -322,7 +405,7 @@ export async function fetchAddressHistoryData(params: {
 
 	const [result, exactTotal] = await Promise.all([
 		resultPromise,
-		cachedTotal ?? requestedTotal,
+		hideSubmitBatches ? undefined : (cachedTotal ?? requestedTotal),
 	])
 
 	const [getTokenMetadata, activities] = await Promise.all([
@@ -350,7 +433,14 @@ export async function fetchAddressHistoryData(params: {
 		total: exactTotal?.totalCount ?? null,
 		limit,
 		nextCursor: result.nextCursor,
-		reverseCursor: result.data[0] ? transactionCursor(result.data[0]) : null,
+		reverseCursor:
+			'reverseCursor' in result &&
+			(typeof result.reverseCursor === 'string' ||
+				result.reverseCursor === null)
+				? result.reverseCursor
+				: result.data[0]
+					? transactionCursor(result.data[0])
+					: null,
 		countCapped: exactTotal?.totalCountCapped ?? false,
 		error: null,
 	}

--- a/apps/explorer/src/lib/server/address-history.ts
+++ b/apps/explorer/src/lib/server/address-history.ts
@@ -192,18 +192,14 @@ async function fetchFilteredHistoryPage(
 	Address.assert(address)
 	const account = address.toLowerCase()
 	const direction = searchParams.sort === 'asc' ? 'ASC' : 'DESC'
+	const callDestination = `"to"[[:space:]]*:[[:space:]]*"${account}"`
+	const callInput = `"(?:input|data)"[[:space:]]*:[[:space:]]*"${SUBMIT_BATCH_SELECTOR}`
 	const filters = [
-		// Native PostgreSQL exposes bytea (\\x), while tiered views expose hex
-		// text (0x). Compare the selector bytes after either two-character prefix.
-		`(t."to" = '${account}' AND lower(substring(t.input::text FROM 3 FOR 8)) = '${SUBMIT_BATCH_SELECTOR.slice(2)}') IS NOT TRUE`,
-		// Use a scalar JSON-path predicate: TIDX does not allow table functions.
-		// Match destination and selector in the same call.
-		`(t.calls::jsonb @? '$[*] ? (
-			@.to like_regex "^${account}$" flag "i" && (
-				@.input like_regex "^${SUBMIT_BATCH_SELECTOR}" flag "i" ||
-				@.data like_regex "^${SUBMIT_BATCH_SELECTOR}" flag "i"
-			)
-		)') IS NOT TRUE`,
+		`NOT (ifNull(t."to", '') = '${account}' AND startsWith(lower(ifNull(t.input, '')), '${SUBMIT_BATCH_SELECTOR}'))`,
+		// Indexed calls are flat JSON objects. TIDX's SQL validator does not
+		// support array lambdas, so match the two fields within one object in
+		// either key order. The brace boundary prevents matching different calls.
+		`empty(extractAll(lower(ifNull(t.calls, '')), '${callDestination}[^{}]*${callInput}|${callInput}[^{}]*${callDestination}'))`,
 	]
 	if (searchParams.cursor) {
 		const cursor: unknown = JSON.parse(atob(searchParams.cursor))
@@ -226,8 +222,6 @@ async function fetchFilteredHistoryPage(
 		filters.push(
 			`t.block_timestamp >= '${new Date(searchParams.after * 1000).toISOString()}'`,
 		)
-	if (searchParams.status)
-		filters.push(`r.status = ${searchParams.status === 'success' ? 1 : 0}`)
 	const sides =
 		searchParams.include === 'sent'
 			? ['from']
@@ -238,13 +232,23 @@ async function fetchFilteredHistoryPage(
 	// pagination and fetch receipts only for the visible page.
 	const results = await Promise.all(
 		sides.map(async (side) => {
+			// Restrict the receipt side before joining, rather than building a
+			// hash table of every receipt in the archive for a status filter.
+			const receiptJoin = searchParams.status
+				? `JOIN (SELECT DISTINCT tx_hash FROM receipts
+					WHERE "${side}" = '${account}' AND status = ${searchParams.status === 'success' ? 1 : 0}
+				) AS r ON r.tx_hash = t.hash`
+				: ''
 			const response = await api.v1.indexer.query.$get({
 				query: {
 					chainId: String(chainId),
+					// Native ClickHouse covers the archive without relying on the
+					// PostgreSQL FDW user mapping used by the default tiered engine.
+					engine: 'clickhouse',
 					sql: `SELECT t.hash, t.block_num, t.idx FROM txs AS t
-			${searchParams.status ? 'JOIN receipts AS r ON r.tx_hash = t.hash' : ''}
+			${receiptJoin}
 			WHERE t."${side}" = '${account}' AND ${filters.join(' AND ')}
-			ORDER BY t.block_num + 0 ${direction}, t.idx ${direction}
+			ORDER BY t.block_num ${direction}, t.idx ${direction}
 			LIMIT ${limit + 1}`,
 				},
 			})

--- a/apps/explorer/src/lib/server/address-history.ts
+++ b/apps/explorer/src/lib/server/address-history.ts
@@ -195,13 +195,14 @@ async function fetchFilteredHistoryPage(
 	const direction = searchParams.sort === 'asc' ? 'ASC' : 'DESC'
 	const filters = [
 		`(t."to" = '${account}' AND lower(left(t.input, 10)) = '${SUBMIT_BATCH_SELECTOR}') IS NOT TRUE`,
-		`NOT EXISTS (
-			SELECT 1 FROM jsonb_array_elements(
-				CASE WHEN jsonb_typeof(t.calls) = 'array' THEN t.calls ELSE '[]'::jsonb END
-			) AS call
-			WHERE lower(call->>'to') = '${account}'
-			AND lower(left(COALESCE(call->>'input', call->>'data'), 10)) = '${SUBMIT_BATCH_SELECTOR}'
-		)`,
+		// Use a scalar JSON-path predicate: TIDX does not allow table functions.
+		// Match destination and selector in the same call.
+		`(t.calls::jsonb @? '$[*] ? (
+			@.to like_regex "^${account}$" flag "i" && (
+				@.input like_regex "^${SUBMIT_BATCH_SELECTOR}" flag "i" ||
+				@.data like_regex "^${SUBMIT_BATCH_SELECTOR}" flag "i"
+			)
+		)') IS NOT TRUE`,
 	]
 	if (searchParams.cursor) {
 		const cursor: unknown = JSON.parse(atob(searchParams.cursor))

--- a/apps/explorer/src/lib/server/address-history.ts
+++ b/apps/explorer/src/lib/server/address-history.ts
@@ -28,7 +28,6 @@ import { parseTimestamp } from '#lib/timestamp'
 import { getWagmiConfig } from '#wagmi.config'
 import { zonePortalAbi } from '#lib/abis'
 import { isZonePortalAddress } from '#lib/domain/zones'
-import { tidx } from '#lib/server/tempo-queries-provider'
 
 export const [MAX_LIMIT, DEFAULT_LIMIT] = [10, 10]
 const HISTORY_TOTAL_CACHE_TTL = 60_000
@@ -194,7 +193,9 @@ async function fetchFilteredHistoryPage(
 	const account = address.toLowerCase()
 	const direction = searchParams.sort === 'asc' ? 'ASC' : 'DESC'
 	const filters = [
-		`(t."to" = '${account}' AND lower(left(t.input, 10)) = '${SUBMIT_BATCH_SELECTOR}') IS NOT TRUE`,
+		// Native PostgreSQL exposes bytea (\\x), while tiered views expose hex
+		// text (0x). Compare the selector bytes after either two-character prefix.
+		`(t."to" = '${account}' AND lower(substring(t.input::text FROM 3 FOR 8)) = '${SUBMIT_BATCH_SELECTOR.slice(2)}') IS NOT TRUE`,
 		// Use a scalar JSON-path predicate: TIDX does not allow table functions.
 		// Match destination and selector in the same call.
 		`(t.calls::jsonb @? '$[*] ? (
@@ -236,16 +237,32 @@ async function fetchFilteredHistoryPage(
 	// Separate address indexes avoid a broad OR scan. Exclude batches before
 	// pagination and fetch receipts only for the visible page.
 	const results = await Promise.all(
-		sides.map((side) =>
-			tidx.fetch({
-				chainId,
-				query: `SELECT t.hash, t.block_num, t.idx FROM txs AS t
+		sides.map(async (side) => {
+			const response = await api.v1.indexer.query.$get({
+				query: {
+					chainId: String(chainId),
+					sql: `SELECT t.hash, t.block_num, t.idx FROM txs AS t
 			${searchParams.status ? 'JOIN receipts AS r ON r.tx_hash = t.hash' : ''}
 			WHERE t."${side}" = '${account}' AND ${filters.join(' AND ')}
 			ORDER BY t.block_num + 0 ${direction}, t.idx ${direction}
-			LIMIT ${limit + 1}` as string,
-			}),
-		),
+			LIMIT ${limit + 1}`,
+				},
+			})
+			// Preserve query-rejection details; tidx.ts 0.1.2 only reads `message`,
+			// while the indexer returns its diagnostic in `error`.
+			if (response.status === 422)
+				throw new Error(
+					`Indexer query rejected: ${(await response.json()).error}`,
+				)
+			const result = await parseResponse(response)
+			return {
+				rows: result.rows.map((values) =>
+					Object.fromEntries(
+						result.columns.map((name, i) => [name, values[i]]),
+					),
+				),
+			}
+		}),
 	)
 	const positions = new Map<
 		string,

--- a/apps/explorer/src/lib/server/address-history.ts
+++ b/apps/explorer/src/lib/server/address-history.ts
@@ -28,6 +28,7 @@ import { parseTimestamp } from '#lib/timestamp'
 import { getWagmiConfig } from '#wagmi.config'
 import { zonePortalAbi } from '#lib/abis'
 import { isZonePortalAddress } from '#lib/domain/zones'
+import { tidx } from '#lib/server/tempo-queries-provider'
 
 export const [MAX_LIMIT, DEFAULT_LIMIT] = [10, 10]
 const HISTORY_TOTAL_CACHE_TTL = 60_000
@@ -35,8 +36,6 @@ const HISTORY_TOTAL_CACHE_MAX_ENTRIES = 50
 const SUBMIT_BATCH_SELECTOR = toFunctionSelector(
 	getAbiItem({ abi: zonePortalAbi, name: 'submitBatch' }),
 )
-const FILTER_SCAN_PAGE_SIZE = 50
-const FILTER_SCAN_MAX_PAGES = 10
 
 export type EnrichedTransaction = {
 	hash: `0x${string}`
@@ -180,21 +179,6 @@ function transactionCursor(row: TransactionRow): string {
 	)
 }
 
-function isSubmitBatch(row: TransactionRow, address: Address.Address): boolean {
-	const calls = [
-		{ to: row.recipient, data: row.input },
-		...(row.calls ?? []),
-		...(row.meta?.rpc?.calls ?? []),
-	]
-	return calls.some(
-		(call) =>
-			call.to?.toLowerCase() === address.toLowerCase() &&
-			('input' in call ? (call.input ?? call.data) : call.data)
-				?.toLowerCase()
-				.startsWith(SUBMIT_BATCH_SELECTOR),
-	)
-}
-
 async function fetchFilteredHistoryPage(
 	address: Address.Address,
 	chainId: number,
@@ -206,43 +190,100 @@ async function fetchFilteredHistoryPage(
 	nextCursor: string | null
 	reverseCursor: string | null
 }> {
-	const data: TransactionRow[] = []
-	let cursor = searchParams.cursor
-	let reverseCursor: string | null = null
-	for (let page = 0; page < FILTER_SCAN_MAX_PAGES; page++) {
-		const result = await parseResponse(
-			api.v1.transactions.$get({
-				query: {
-					chainId: String(chainId),
-					...historyFilters(address, searchParams),
-					order: searchParams.sort,
-					limit: String(FILTER_SCAN_PAGE_SIZE),
-					...(cursor ? { cursor } : {}),
-					include: 'receipt',
-				},
-			}),
+	Address.assert(address)
+	const account = address.toLowerCase()
+	const direction = searchParams.sort === 'asc' ? 'ASC' : 'DESC'
+	const filters = [
+		`(t."to" = '${account}' AND lower(left(t.input, 10)) = '${SUBMIT_BATCH_SELECTOR}') IS NOT TRUE`,
+		`NOT EXISTS (
+			SELECT 1 FROM jsonb_array_elements(
+				CASE WHEN jsonb_typeof(t.calls) = 'array' THEN t.calls ELSE '[]'::jsonb END
+			) AS call
+			WHERE lower(call->>'to') = '${account}'
+			AND lower(left(COALESCE(call->>'input', call->>'data'), 10)) = '${SUBMIT_BATCH_SELECTOR}'
+		)`,
+	]
+	if (searchParams.cursor) {
+		const cursor: unknown = JSON.parse(atob(searchParams.cursor))
+		if (
+			!Array.isArray(cursor) ||
+			cursor.length !== 2 ||
+			!cursor.every(
+				(value) =>
+					typeof value === 'number' &&
+					Number.isSafeInteger(value) &&
+					value >= 0,
+			)
 		)
-		// Keep the scan boundary even for an empty filtered page, so Previous works.
-		if (reverseCursor === null && result.data[0])
-			reverseCursor = transactionCursor(result.data[0])
-		for (const [index, row] of result.data.entries()) {
-			if (isSubmitBatch(row, address)) continue
-			data.push(row)
-			if (data.length === limit)
-				return {
-					data,
-					reverseCursor,
-					nextCursor:
-						index < result.data.length - 1 || result.nextCursor
-							? transactionCursor(row)
-							: null,
-				}
-		}
-		if (!result.nextCursor) return { data, reverseCursor, nextCursor: null }
-		cursor = result.nextCursor
+			throw new Error('Invalid history cursor')
+		filters.push(
+			`(t.block_num, t.idx) ${direction === 'ASC' ? '>' : '<'} (${cursor[0]}, ${cursor[1]})`,
+		)
 	}
-	// Bound Worker work for batch-only stretches; Next continues from this boundary.
-	return { data, reverseCursor, nextCursor: cursor ?? null }
+	if (searchParams.after !== undefined)
+		filters.push(
+			`t.block_timestamp >= '${new Date(searchParams.after * 1000).toISOString()}'`,
+		)
+	if (searchParams.status)
+		filters.push(`r.status = ${searchParams.status === 'success' ? 1 : 0}`)
+	const sides =
+		searchParams.include === 'sent'
+			? ['from']
+			: searchParams.include === 'received'
+				? ['to']
+				: ['from', 'to']
+	// Separate address indexes avoid a broad OR scan. Exclude batches before
+	// pagination and fetch receipts only for the visible page.
+	const results = await Promise.all(
+		sides.map((side) =>
+			tidx.fetch({
+				chainId,
+				query: `SELECT t.hash, t.block_num, t.idx FROM txs AS t
+			${searchParams.status ? 'JOIN receipts AS r ON r.tx_hash = t.hash' : ''}
+			WHERE t."${side}" = '${account}' AND ${filters.join(' AND ')}
+			ORDER BY t.block_num + 0 ${direction}, t.idx ${direction}
+			LIMIT ${limit + 1}` as string,
+			}),
+		),
+	)
+	const positions = new Map<
+		string,
+		{ hash: Hex.Hex; block: number; index: number }
+	>()
+	for (const result of results)
+		for (const row of result.rows) {
+			const hash = String(row.hash)
+			Hex.assert(hash)
+			positions.set(hash.toLowerCase(), {
+				hash,
+				block: Number(row.block_num),
+				index: Number(row.idx),
+			})
+		}
+	const rows = [...positions.values()].sort(
+		(a, b) =>
+			(direction === 'ASC' ? 1 : -1) * (a.block - b.block || a.index - b.index),
+	)
+	const page = rows.slice(0, limit)
+	const data = await Promise.all(
+		page.map(async (row) => {
+			const response = await parseResponse(
+				api.v1.transactions[':transactionHash'].$get({
+					param: { transactionHash: row.hash },
+					query: { chainId: String(chainId), include: 'receipt' },
+				}),
+			)
+			return response
+		}),
+	)
+	const cursorFor = (row: (typeof rows)[number]) =>
+		btoa(JSON.stringify([row.block, row.index]))
+	const last = page.at(-1)
+	return {
+		data,
+		reverseCursor: page[0] ? cursorFor(page[0]) : null,
+		nextCursor: rows.length > limit && last ? cursorFor(last) : null,
+	}
 }
 
 /**

--- a/apps/explorer/src/routes/_layout/address/$address.tsx
+++ b/apps/explorer/src/routes/_layout/address/$address.tsx
@@ -238,6 +238,7 @@ export const Route = createFileRoute('/_layout/address/$address')({
 		status: z.optional(z.enum(['success', 'reverted'])),
 		dir: z.optional(z.enum(['sent', 'received'])),
 		period: z.optional(z.enum(['24h', '7d'])),
+		hideSubmitBatches: z.optional(z.boolean()),
 		voucher: z.optional(
 			z.object({
 				final_voucher: z.optional(z.string()),
@@ -453,8 +454,18 @@ function RouteComponent() {
 	const navigate = useNavigate()
 	const location = useLocation()
 	const { address } = Route.useParams()
-	const { page, cursor, order, tab, live, limit, status, dir, period } =
-		Route.useSearch()
+	const {
+		page,
+		cursor,
+		order,
+		tab,
+		live,
+		limit,
+		status,
+		dir,
+		period,
+		hideSubmitBatches: hideSubmitBatchesSearch,
+	} = Route.useSearch()
 	const {
 		accountType,
 		isToken,
@@ -470,6 +481,7 @@ function RouteComponent() {
 	Address.assert(address)
 	const isMounted = useIsMounted()
 	const isZonePortal = isZonePortalAddress(address)
+	const hideSubmitBatches = isZonePortal && hideSubmitBatchesSearch === true
 	const [portalLive, setPortalLive] = React.useState(true)
 	const { data: zonePortalOverview } = useQuery({
 		...zonePortalOverviewQueryOptions(address),
@@ -590,6 +602,38 @@ function RouteComponent() {
 	const activeSection =
 		visibleTabs.indexOf(tab) !== -1 ? visibleTabs.indexOf(tab) : 0
 
+	const setHideSubmitBatches = React.useCallback(
+		(hide: boolean) => {
+			navigate({
+				to: '.',
+				search: (prev) => ({
+					...prev,
+					page: 1,
+					cursor: undefined,
+					order: 'desc',
+					hideSubmitBatches: hide || undefined,
+				}),
+				resetScroll: false,
+			})
+		},
+		[navigate],
+	)
+	const clearTransactionFilters = React.useCallback(() => {
+		navigate({
+			to: '.',
+			search: (prev) => ({
+				...prev,
+				page: 1,
+				cursor: undefined,
+				order: 'desc',
+				status: undefined,
+				period: undefined,
+				hideSubmitBatches: undefined,
+			}),
+			resetScroll: false,
+		})
+	}, [navigate])
+
 	const { data: assetsData, isLoading: assetsLoading } = useBalancesData(
 		address,
 		balancesData,
@@ -624,6 +668,7 @@ function RouteComponent() {
 							limit: HISTORY_PAGE_SIZE,
 							order,
 							status,
+							hideSubmitBatches,
 							include:
 								dir === 'sent'
 									? 'sent'
@@ -662,6 +707,7 @@ function RouteComponent() {
 		isToken,
 		limit,
 		period,
+		hideSubmitBatches,
 		queryClient,
 		status,
 		tab,
@@ -711,6 +757,11 @@ function RouteComponent() {
 				dir={dir}
 				period={period}
 				onPeriodChange={setPeriod}
+				hideSubmitBatches={hideSubmitBatches}
+				onHideSubmitBatchesChange={
+					isZonePortal ? setHideSubmitBatches : undefined
+				}
+				onClearTransactionFilters={clearTransactionFilters}
 				zonePortalOverview={zonePortalOverview}
 				portalLive={portalLive}
 				onPortalLiveChange={setPortalLive}
@@ -959,6 +1010,9 @@ function SectionsWrapper(props: {
 	dir?: 'sent' | 'received' | undefined
 	period?: '24h' | '7d' | undefined
 	onPeriodChange: (period: '24h' | '7d' | undefined) => void
+	hideSubmitBatches: boolean
+	onHideSubmitBatchesChange?: ((hide: boolean) => void) | undefined
+	onClearTransactionFilters: () => void
 	zonePortalOverview?: ZonePortalOverview | undefined
 	portalLive: boolean
 	onPortalLiveChange: (live: boolean) => void
@@ -987,6 +1041,9 @@ function SectionsWrapper(props: {
 		dir,
 		period,
 		onPeriodChange,
+		hideSubmitBatches,
+		onHideSubmitBatchesChange,
+		onClearTransactionFilters,
 		zonePortalOverview,
 		portalLive,
 		onPortalLiveChange,
@@ -1087,10 +1144,11 @@ function SectionsWrapper(props: {
 				order: position.order,
 				cursor: position.cursor,
 				status,
+				hideSubmitBatches,
 				include,
 				after,
 			}),
-		[address, after, include, status],
+		[address, after, include, status, hideSubmitBatches],
 	)
 
 	const latestHistoryQuery = useQuery({
@@ -1099,6 +1157,7 @@ function SectionsWrapper(props: {
 			limit: HISTORY_PAGE_SIZE,
 			order: 'desc',
 			status,
+			hideSubmitBatches,
 			include,
 			after,
 		}),
@@ -1803,6 +1862,9 @@ function SectionsWrapper(props: {
 							period={period}
 							onStatusChange={onStatusChange}
 							onPeriodChange={onPeriodChange}
+							hideSubmitBatches={hideSubmitBatches}
+							onHideSubmitBatchesChange={onHideSubmitBatchesChange}
+							onClearAll={onClearTransactionFilters}
 						/>
 					),
 					content: transactionsError ?? (
@@ -1878,18 +1940,24 @@ function SectionsWrapper(props: {
 										pageCountCapped={countCapped}
 										onPrefetch={prefetchTransactionPages}
 									/>
-									<Pagination.Count
-										totalItems={totalTrxCount ?? 0}
-										itemsLabel="transactions"
-										loading={totalTrxCount === undefined}
-										capped={countCapped}
-									/>
+									{hideSubmitBatches ? (
+										<span>Submit batches hidden</span>
+									) : (
+										<Pagination.Count
+											totalItems={totalTrxCount ?? 0}
+											itemsLabel="transactions"
+											loading={totalTrxCount === undefined}
+											capped={countCapped}
+										/>
+									)}
 								</div>
 							}
 							emptyState={
-								status || dir || period
-									? 'No matching transactions found.'
-									: 'No transactions found.'
+								hideSubmitBatches && historyData?.nextCursor
+									? 'No matching transactions in this range. Select Next to continue.'
+									: status || dir || period || hideSubmitBatches
+										? 'No matching transactions found.'
+										: 'No transactions found.'
 							}
 						/>
 					),

--- a/apps/explorer/src/routes/_layout/address/$address.tsx
+++ b/apps/explorer/src/routes/_layout/address/$address.tsx
@@ -1953,11 +1953,9 @@ function SectionsWrapper(props: {
 								</div>
 							}
 							emptyState={
-								hideSubmitBatches && historyData?.nextCursor
-									? 'No matching transactions in this range. Select Next to continue.'
-									: status || dir || period || hideSubmitBatches
-										? 'No matching transactions found.'
-										: 'No transactions found.'
+								status || dir || period || hideSubmitBatches
+									? 'No matching transactions found.'
+									: 'No transactions found.'
 							}
 						/>
 					),

--- a/apps/explorer/test/address-history.node.test.ts
+++ b/apps/explorer/test/address-history.node.test.ts
@@ -12,16 +12,34 @@ import {
 	toEnrichedTransaction,
 } from '#lib/server/address-history'
 
-const { getTransactions } = vi.hoisted(() => ({
+const { getTransactions, getTransaction, queryIndex } = vi.hoisted(() => ({
 	getTransactions: vi.fn(),
+	getTransaction: vi.fn(),
+	queryIndex: vi.fn(),
 }))
 
 vi.mock('#lib/server/tempo-api', () => ({
-	api: { v1: { transactions: { $get: getTransactions } } },
+	api: {
+		v1: {
+			transactions: {
+				$get: getTransactions,
+				':transactionHash': { $get: getTransaction },
+			},
+		},
+	},
+}))
+
+vi.mock('#lib/server/tempo-queries-provider', () => ({
+	tidx: { fetch: queryIndex },
 }))
 
 beforeEach(() => {
 	getTransactions.mockReset()
+	queryIndex.mockReset()
+	getTransaction.mockReset()
+	getTransaction.mockImplementation(({ param }) =>
+		Promise.resolve(Response.json(row({ hash: param.transactionHash }))),
+	)
 })
 
 const SENDER = '0x286ad6cfc7279c8a6d86d15dcefcb77a65aa7e92'
@@ -194,132 +212,97 @@ describe('fetchAddressHistoryData', () => {
 		).toBe(false)
 	})
 
-	it('fills a page across batch-only results and resumes after the last visible row', async () => {
-		getTransactions
-			.mockResolvedValueOnce(
-				Response.json({
-					data: [
-						row({ recipient: portal, input: batchInput, blockNumber: 10 }),
-					],
-					nextCursor: 'scan-2',
-				}),
-			)
-			.mockResolvedValueOnce(
-				Response.json({
-					data: [
-						row({ blockNumber: 9 }),
-						row({ blockNumber: 8 }),
-						row({ blockNumber: 7 }),
-					],
-					nextCursor: 'scan-3',
-				}),
-			)
+	it('queries matching hashes before hydrating only the visible page', async () => {
+		const hashes = [1, 2, 3].map((n) => `0x${String(n).repeat(64)}`)
+		queryIndex
+			.mockResolvedValueOnce({
+				rows: [{ hash: hashes[1], block_num: 8, idx: 0 }],
+			})
+			.mockResolvedValueOnce({
+				rows: hashes.map((hash, i) => ({ hash, block_num: 9 - i, idx: 0 })),
+			})
 		const result = await fetchAddressHistoryData(filteredParams)
-		expect(result.transactions.map((tx) => tx.blockNumber)).toEqual([
-			'0x9',
-			'0x8',
-		])
-		expect(result.nextCursor).toBe(btoa(JSON.stringify([8, 17])))
-		expect(result.reverseCursor).toBe(btoa(JSON.stringify([10, 17])))
+		expect(result.transactions.map((tx) => tx.hash)).toEqual(hashes.slice(0, 2))
+		expect(result.nextCursor).toBe(btoa(JSON.stringify([8, 0])))
+		expect(result.reverseCursor).toBe(btoa(JSON.stringify([9, 0])))
 		expect(result.total).toBeNull()
-		expect(getTransactions).toHaveBeenNthCalledWith(2, {
-			query: {
-				address: portal,
-				chainId: '4217',
-				include: 'receipt',
-				limit: '50',
-				order: 'desc',
-				cursor: 'scan-2',
-			},
+		expect(getTransactions).not.toHaveBeenCalled()
+		expect(getTransaction).toHaveBeenCalledTimes(2)
+		expect(getTransaction).toHaveBeenCalledWith({
+			param: { transactionHash: hashes[0] },
+			query: { chainId: '4217', include: 'receipt' },
 		})
+		expect(queryIndex.mock.calls[0]?.[0].query).toContain(
+			`t."from" = '${portal}'`,
+		)
+		expect(queryIndex.mock.calls[1]?.[0].query).toContain(
+			`t."to" = '${portal}'`,
+		)
+		for (const [options] of queryIndex.mock.calls) {
+			expect(options.query).toContain('LIMIT 3')
+			expect(options.query).toContain('jsonb_array_elements')
+			expect(options.query).toContain(batchInput)
+			expect(options.query).toContain('IS NOT TRUE')
+		}
 	})
 
-	it('filters nested and reverted submissions only to the requested portal', async () => {
-		getTransactions.mockResolvedValue(
-			Response.json({
-				data: [
-					row({
-						recipient: portal,
-						input: batchInput,
-						meta: { receipt: receipt({ status: 'reverted' }) },
-					}),
-					row({
-						meta: { rpc: { calls: [{ to: portal, input: batchInput }] } },
-					}),
-					row({ calls: [{ to: portal.toUpperCase(), data: batchInput }] }),
-					row({ recipient: RECIPIENT, input: batchInput, blockNumber: 7 }),
-					row({ recipient: portal, input: '0x', blockNumber: 6 }),
-				],
-				nextCursor: null,
-			}),
-		)
-		const result = await fetchAddressHistoryData(filteredParams)
-		expect(result.transactions.map((tx) => tx.blockNumber)).toEqual([
-			'0x7',
-			'0x6',
-		])
-		expect(result.nextCursor).toBeNull()
-	})
-
-	it('preserves status, direction, period and ascending cursor navigation', async () => {
-		getTransactions.mockResolvedValue(
-			Response.json({
-				data: [
-					row({ recipient: portal, input: batchInput, blockNumber: 1 }),
-					row({ blockNumber: 2 }),
-					row({ blockNumber: 3 }),
-				],
-				nextCursor: null,
-			}),
-		)
+	it('keeps status, direction, period and ascending cursor filters in the indexed query', async () => {
+		const hashes = [1, 2].map((n) => `0x${String(n).repeat(64)}`)
+		queryIndex.mockResolvedValue({
+			rows: hashes.map((hash, i) => ({ hash, block_num: i + 2, idx: 0 })),
+		})
 		const result = await fetchAddressHistoryData({
 			...filteredParams,
 			searchParams: {
 				...filteredParams.searchParams,
 				sort: 'asc',
-				cursor: 'older',
+				cursor: btoa('[1,0]'),
 				include: 'received',
 				status: 'reverted',
 				after: 1,
 			},
 		})
-		expect(result.transactions.map((tx) => tx.blockNumber)).toEqual([
-			'0x3',
-			'0x2',
-		])
-		expect(getTransactions).toHaveBeenCalledWith({
-			query: {
-				recipient: portal,
-				chainId: '4217',
-				include: 'receipt',
-				limit: '50',
-				order: 'asc',
-				cursor: 'older',
-				status: 'reverted',
-				'timestamp.from': '1970-01-01T00:00:01.000Z',
-			},
-		})
+		expect(result.transactions.map((tx) => tx.hash)).toEqual(
+			[...hashes].reverse(),
+		)
+		expect(result.nextCursor).toBeNull()
+		expect(queryIndex).toHaveBeenCalledTimes(1)
+		const query = queryIndex.mock.calls[0]?.[0].query
+		expect(query).toContain('JOIN receipts AS r ON r.tx_hash = t.hash')
+		expect(query).toContain('r.status = 0')
+		expect(query).toContain('(t.block_num, t.idx) > (1, 0)')
+		expect(query).toContain("t.block_timestamp >= '1970-01-01T00:00:01.000Z'")
+		expect(query).toContain('ORDER BY t.block_num + 0 ASC, t.idx ASC')
 	})
 
-	it('keeps both navigation boundaries when the bounded scan finds only batches', async () => {
-		getTransactions.mockImplementation(() =>
-			Promise.resolve(
-				Response.json({
-					data: [
-						row({ recipient: portal, input: batchInput, blockNumber: 10 }),
-					],
-					nextCursor: `scan-${getTransactions.mock.calls.length}`,
-				}),
-			),
-		)
-		const result = await fetchAddressHistoryData(filteredParams)
-		expect(getTransactions).toHaveBeenCalledTimes(10)
-		expect(result).toMatchObject({
+	it('returns an exhausted page without hydrating discarded batches', async () => {
+		queryIndex.mockResolvedValue({ rows: [] })
+		await expect(
+			fetchAddressHistoryData(filteredParams),
+		).resolves.toMatchObject({
 			transactions: [],
-			nextCursor: 'scan-10',
-			reverseCursor: btoa(JSON.stringify([10, 17])),
+			nextCursor: null,
+			reverseCursor: null,
 			total: null,
 		})
+		expect(getTransaction).not.toHaveBeenCalled()
+		expect(getTransactions).not.toHaveBeenCalled()
+	})
+
+	it.each([
+		'invalid',
+		btoa('["1",0]'),
+		btoa('[-1,0]'),
+		btoa('[1.5,0]'),
+		btoa('[9007199254740992,0]'),
+	])('rejects malformed cursors before querying: %s', async (cursor) => {
+		await expect(
+			fetchAddressHistoryData({
+				...filteredParams,
+				searchParams: { ...filteredParams.searchParams, cursor },
+			}),
+		).rejects.toThrow()
+		expect(queryIndex).not.toHaveBeenCalled()
 	})
 
 	it.each([

--- a/apps/explorer/test/address-history.node.test.ts
+++ b/apps/explorer/test/address-history.node.test.ts
@@ -26,11 +26,12 @@ vi.mock('#lib/server/tempo-api', () => ({
 					$get: async ({
 						query,
 					}: {
-						query: { sql: string; chainId: string }
+						query: { sql: string; chainId: string; engine: string }
 					}) => {
 						const result = await queryIndex({
 							query: query.sql,
 							chainId: Number(query.chainId),
+							engine: query.engine,
 						})
 						if (result instanceof Response) return result
 						return Response.json({
@@ -260,10 +261,13 @@ describe('fetchAddressHistoryData', () => {
 		)
 		for (const [options] of queryIndex.mock.calls) {
 			expect(options.query).toContain('LIMIT 3')
-			expect(options.query).toContain("t.calls::jsonb @? '$[*]")
-			expect(options.query).not.toContain('jsonb_array_elements')
+			expect(options.engine).toBe('clickhouse')
+			expect(options.query).toContain("ifNull(t.input, '')")
+			expect(options.query).toContain(
+				"empty(extractAll(lower(ifNull(t.calls, ''))",
+			)
+			expect(options.query).toContain('[^{}]*')
 			expect(options.query).toContain(batchInput)
-			expect(options.query).toContain('IS NOT TRUE')
 		}
 	})
 
@@ -289,11 +293,48 @@ describe('fetchAddressHistoryData', () => {
 		expect(result.nextCursor).toBeNull()
 		expect(queryIndex).toHaveBeenCalledTimes(1)
 		const query = queryIndex.mock.calls[0]?.[0].query
-		expect(query).toContain('JOIN receipts AS r ON r.tx_hash = t.hash')
-		expect(query).toContain('r.status = 0')
+		expect(query).toContain('JOIN (SELECT DISTINCT tx_hash FROM receipts')
+		expect(query).toContain('AS r ON r.tx_hash = t.hash')
+		expect(query).toContain(`WHERE "to" = '${portal}' AND status = 0`)
 		expect(query).toContain('(t.block_num, t.idx) > (1, 0)')
 		expect(query).toContain("t.block_timestamp >= '1970-01-01T00:00:01.000Z'")
-		expect(query).toContain('ORDER BY t.block_num + 0 ASC, t.idx ASC')
+		expect(query).toContain('ORDER BY t.block_num ASC, t.idx ASC')
+	})
+
+	it.each([
+		{ calls: [{ to: portal, input: batchInput }], excluded: true },
+		{ calls: [{ data: `${batchInput}abcd`, to: portal }], excluded: true },
+		{
+			calls: [{ to: portal.toUpperCase(), input: batchInput.toUpperCase() }],
+			excluded: true,
+		},
+		{ calls: [{ to: RECIPIENT, input: batchInput }], excluded: false },
+		{
+			calls: [
+				{ to: portal, input: '0xdeadbeef' },
+				{ to: RECIPIENT, input: batchInput },
+			],
+			excluded: false,
+		},
+		{ calls: null, excluded: false },
+		{ calls: [], excluded: false },
+	])('matches a batch selector and destination within one call: $calls', async ({
+		calls,
+		excluded,
+	}) => {
+		queryIndex.mockResolvedValue({ rows: [] })
+		await fetchAddressHistoryData(filteredParams)
+		const sql = queryIndex.mock.calls[0]?.[0].query as string
+		const pattern = sql.match(
+			/empty\(extractAll\(lower\(ifNull\(t.calls, ''\)\), '([^']+)'\)\)/,
+		)?.[1]
+		expect(pattern).toBeDefined()
+		// JavaScript's equivalent of the POSIX whitespace class used by RE2.
+		const regex = new RegExp(pattern?.replaceAll('[[:space:]]', '\\s'))
+		for (const spacing of [undefined, 2])
+			expect(
+				regex.test(JSON.stringify(calls, null, spacing).toLowerCase()),
+			).toBe(excluded)
 	})
 
 	it('returns an exhausted page without hydrating discarded batches', async () => {

--- a/apps/explorer/test/address-history.node.test.ts
+++ b/apps/explorer/test/address-history.node.test.ts
@@ -1,8 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
-import { encodeFunctionData, zeroHash } from 'viem'
+import {
+	encodeFunctionData,
+	getAbiItem,
+	toFunctionSelector,
+	zeroHash,
+} from 'viem'
 import { zonePortalAbi } from '#lib/abis'
 import {
 	fetchAddressHistoryData,
+	RequestParametersSchema,
 	toEnrichedTransaction,
 } from '#lib/server/address-history'
 
@@ -162,6 +168,186 @@ describe('toEnrichedTransaction', () => {
 })
 
 describe('fetchAddressHistoryData', () => {
+	const portal = '0x5ad0000000000000000000000000000000000001'
+	const batchInput = toFunctionSelector(
+		getAbiItem({ abi: zonePortalAbi, name: 'submitBatch' }),
+	)
+	const filteredParams = {
+		address: portal,
+		chainId: 4217,
+		includeKnownEvents: false,
+		searchParams: {
+			include: 'all',
+			limit: 2,
+			sort: 'desc',
+			hideSubmitBatches: 'true',
+		},
+	} as const
+
+	it('parses explicit filter booleans without treating false as true', () => {
+		expect(
+			RequestParametersSchema.parse({ hideSubmitBatches: 'false' })
+				.hideSubmitBatches,
+		).toBe('false')
+		expect(
+			RequestParametersSchema.safeParse({ hideSubmitBatches: 'yes' }).success,
+		).toBe(false)
+	})
+
+	it('fills a page across batch-only results and resumes after the last visible row', async () => {
+		getTransactions
+			.mockResolvedValueOnce(
+				Response.json({
+					data: [
+						row({ recipient: portal, input: batchInput, blockNumber: 10 }),
+					],
+					nextCursor: 'scan-2',
+				}),
+			)
+			.mockResolvedValueOnce(
+				Response.json({
+					data: [
+						row({ blockNumber: 9 }),
+						row({ blockNumber: 8 }),
+						row({ blockNumber: 7 }),
+					],
+					nextCursor: 'scan-3',
+				}),
+			)
+		const result = await fetchAddressHistoryData(filteredParams)
+		expect(result.transactions.map((tx) => tx.blockNumber)).toEqual([
+			'0x9',
+			'0x8',
+		])
+		expect(result.nextCursor).toBe(btoa(JSON.stringify([8, 17])))
+		expect(result.reverseCursor).toBe(btoa(JSON.stringify([10, 17])))
+		expect(result.total).toBeNull()
+		expect(getTransactions).toHaveBeenNthCalledWith(2, {
+			query: {
+				address: portal,
+				chainId: '4217',
+				include: 'receipt',
+				limit: '50',
+				order: 'desc',
+				cursor: 'scan-2',
+			},
+		})
+	})
+
+	it('filters nested and reverted submissions only to the requested portal', async () => {
+		getTransactions.mockResolvedValue(
+			Response.json({
+				data: [
+					row({
+						recipient: portal,
+						input: batchInput,
+						meta: { receipt: receipt({ status: 'reverted' }) },
+					}),
+					row({
+						meta: { rpc: { calls: [{ to: portal, input: batchInput }] } },
+					}),
+					row({ calls: [{ to: portal.toUpperCase(), data: batchInput }] }),
+					row({ recipient: RECIPIENT, input: batchInput, blockNumber: 7 }),
+					row({ recipient: portal, input: '0x', blockNumber: 6 }),
+				],
+				nextCursor: null,
+			}),
+		)
+		const result = await fetchAddressHistoryData(filteredParams)
+		expect(result.transactions.map((tx) => tx.blockNumber)).toEqual([
+			'0x7',
+			'0x6',
+		])
+		expect(result.nextCursor).toBeNull()
+	})
+
+	it('preserves status, direction, period and ascending cursor navigation', async () => {
+		getTransactions.mockResolvedValue(
+			Response.json({
+				data: [
+					row({ recipient: portal, input: batchInput, blockNumber: 1 }),
+					row({ blockNumber: 2 }),
+					row({ blockNumber: 3 }),
+				],
+				nextCursor: null,
+			}),
+		)
+		const result = await fetchAddressHistoryData({
+			...filteredParams,
+			searchParams: {
+				...filteredParams.searchParams,
+				sort: 'asc',
+				cursor: 'older',
+				include: 'received',
+				status: 'reverted',
+				after: 1,
+			},
+		})
+		expect(result.transactions.map((tx) => tx.blockNumber)).toEqual([
+			'0x3',
+			'0x2',
+		])
+		expect(getTransactions).toHaveBeenCalledWith({
+			query: {
+				recipient: portal,
+				chainId: '4217',
+				include: 'receipt',
+				limit: '50',
+				order: 'asc',
+				cursor: 'older',
+				status: 'reverted',
+				'timestamp.from': '1970-01-01T00:00:01.000Z',
+			},
+		})
+	})
+
+	it('keeps both navigation boundaries when the bounded scan finds only batches', async () => {
+		getTransactions.mockImplementation(() =>
+			Promise.resolve(
+				Response.json({
+					data: [
+						row({ recipient: portal, input: batchInput, blockNumber: 10 }),
+					],
+					nextCursor: `scan-${getTransactions.mock.calls.length}`,
+				}),
+			),
+		)
+		const result = await fetchAddressHistoryData(filteredParams)
+		expect(getTransactions).toHaveBeenCalledTimes(10)
+		expect(result).toMatchObject({
+			transactions: [],
+			nextCursor: 'scan-10',
+			reverseCursor: btoa(JSON.stringify([10, 17])),
+			total: null,
+		})
+	})
+
+	it.each([
+		undefined,
+		'false',
+	] as const)('leaves unfiltered history unchanged for %s', async (hideSubmitBatches) => {
+		getTransactions.mockResolvedValue(
+			Response.json({
+				data: [row({ recipient: portal, input: batchInput })],
+				nextCursor: null,
+			}),
+		)
+		const result = await fetchAddressHistoryData({
+			...filteredParams,
+			searchParams: { ...filteredParams.searchParams, hideSubmitBatches },
+		})
+		expect(result.transactions).toHaveLength(1)
+		expect(getTransactions.mock.calls[0]?.[0].query.limit).toBe('2')
+	})
+
+	it('ignores the portal-specific filter on other addresses', async () => {
+		getTransactions.mockResolvedValue(
+			Response.json({ data: [row()], nextCursor: null }),
+		)
+		await fetchAddressHistoryData({ ...filteredParams, address: RECIPIENT })
+		expect(getTransactions.mock.calls[0]?.[0].query.limit).toBe('2')
+	})
+
 	it('rejects page sizes above 10', async () => {
 		await expect(
 			fetchAddressHistoryData({

--- a/apps/explorer/test/address-history.node.test.ts
+++ b/apps/explorer/test/address-history.node.test.ts
@@ -240,7 +240,8 @@ describe('fetchAddressHistoryData', () => {
 		)
 		for (const [options] of queryIndex.mock.calls) {
 			expect(options.query).toContain('LIMIT 3')
-			expect(options.query).toContain('jsonb_array_elements')
+			expect(options.query).toContain("t.calls::jsonb @? '$[*]")
+			expect(options.query).not.toContain('jsonb_array_elements')
 			expect(options.query).toContain(batchInput)
 			expect(options.query).toContain('IS NOT TRUE')
 		}

--- a/apps/explorer/test/address-history.node.test.ts
+++ b/apps/explorer/test/address-history.node.test.ts
@@ -21,16 +21,36 @@ const { getTransactions, getTransaction, queryIndex } = vi.hoisted(() => ({
 vi.mock('#lib/server/tempo-api', () => ({
 	api: {
 		v1: {
+			indexer: {
+				query: {
+					$get: async ({
+						query,
+					}: {
+						query: { sql: string; chainId: string }
+					}) => {
+						const result = await queryIndex({
+							query: query.sql,
+							chainId: Number(query.chainId),
+						})
+						if (result instanceof Response) return result
+						return Response.json({
+							ok: true,
+							columns: ['hash', 'block_num', 'idx'],
+							rows: result.rows.map((row: Record<string, unknown>) => [
+								row.hash,
+								row.block_num,
+								row.idx,
+							]),
+						})
+					},
+				},
+			},
 			transactions: {
 				$get: getTransactions,
 				':transactionHash': { $get: getTransaction },
 			},
 		},
 	},
-}))
-
-vi.mock('#lib/server/tempo-queries-provider', () => ({
-	tidx: { fetch: queryIndex },
 }))
 
 beforeEach(() => {
@@ -288,6 +308,23 @@ describe('fetchAddressHistoryData', () => {
 		})
 		expect(getTransaction).not.toHaveBeenCalled()
 		expect(getTransactions).not.toHaveBeenCalled()
+	})
+
+	it('preserves the indexer rejection detail without retrying or hydrating', async () => {
+		queryIndex.mockResolvedValue(
+			Response.json(
+				{ ok: false, error: 'Unsupported expression' },
+				{ status: 422 },
+			),
+		)
+		await expect(
+			fetchAddressHistoryData({
+				...filteredParams,
+				searchParams: { ...filteredParams.searchParams, include: 'received' },
+			}),
+		).rejects.toThrow('Indexer query rejected: Unsupported expression')
+		expect(queryIndex).toHaveBeenCalledTimes(1)
+		expect(getTransaction).not.toHaveBeenCalled()
 	})
 
 	it.each([


### PR DESCRIPTION
Adds **Hide submit batches** to the transaction filters on Zone Portal address pages, including [the requested portal](https://explore.tempo.xyz/address/0x5ad0000000000000000000000000000000000001?order=desc). The setting persists as `hideSubmitBatches=true`, resets pagination when changed, and clears alongside status and period.

Filtering happens on the server before returning visible rows. It matches the portal address and `submitBatch` selector in root or available nested calls, including reverted submissions. Existing direction, status, period, and ascending/descending navigation remain supported.

The filter queries matching hashes through the existing authenticated indexer API using its native ClickHouse engine, excludes submissions before pagination, and hydrates receipts only for the visible page. Separate sender/recipient queries preserve address filtering and are merged without self-transaction duplicates. Nested-call matching keeps destination and selector within the same flat call object, supports either key order, and includes reverted submissions. Status joins are restricted to the address's receipts. Filtered views omit the unfiltered total rather than displaying an incorrect count.

The first scanning implementation took 14.72 seconds to scan 500 batch transactions and return zero visible rows. This revision removes that serial scan. Live testing also identified a separate TIDX issue: the default tiered query path reports `user mapping not found for user "tidx_mainnet_api", server "tidx_clickhouse" (42704)`. The native archive engine does not depend on that FDW mapping and retains full-history coverage. No production database permissions are changed here; the underlying mapping still needs an operational repair. Query-rejection details that tidx.ts 0.1.2 otherwise drops are preserved, and this path avoids its automatic query retries.

Validation: root `pnpm check` and `pnpm check:types`; 128 explorer Worker tests and 140 Node tests; `pnpm precommit`. Seven literal-data fixture cases passed against a live native ClickHouse indexer, covering key order, mixed case, null/empty calls, and preventing matches across different call objects. Browser checks cover desktop/mobile controls, URL persistence after reload, and combined-filter clearing. Mainnet preview verification is recorded below; this PR is not merged or deployed to the production explorer.

Live [mainnet-data preview](https://61cec3e5-explorer-mainnet.porto.workers.dev/address/0x5ad0000000000000000000000000000000000001?order=desc&hideSubmitBatches=true) at commit [942f683c](https://github.com/tempoxyz/tempo-apps/commit/942f683c8974f403a890777b97d2f9b1c2f272af):

- First filtered request: HTTP 200, 3.79 seconds, 10 non-batch transactions (2.26 seconds on repeat).
- Next page: HTTP 200, 3.06 seconds, 10 different transactions. Previous: HTTP 200, 1.89 seconds, exactly the original 10 hashes.
- Failed and 24-hour filters returned HTTP 200 with no matching transactions; oldest-first returned HTTP 200 with 10 non-batch transactions.
- All PR CI checks passed.

## Screenshots

Screenshots are attached to the originating Slack thread; links require workspace access. Before is production; after is the deployed preview with real mainnet transactions loaded.

| Before | After |
| --- | --- |
| [Desktop: existing filters](https://tempoxyz.enterprise.slack.com/files/U0ANX3AM5RR/F0C0RVCUEP6/submit-batches-before.png) | [Desktop: Hide submit batches enabled with live results](https://tempoxyz.enterprise.slack.com/files/U0ANX3AM5RR/F0C0SC772KW/submit-batches-indexed-live.png) |

[Mobile filter](https://tempoxyz.enterprise.slack.com/files/U0ANX3AM5RR/F0C0HQK4T1B/submit-batches-mobile.png)

Prompted by: @snario
