### PR TITLE
feat(explorer): show foreign currency holdings estimates

### DIFF
--- a/apps/explorer/src/lib/address-balances.ts
+++ b/apps/explorer/src/lib/address-balances.ts
@@ -4,6 +4,7 @@ import * as React from 'react'
 import { formatUnits } from 'viem'
 
 import { getApiUrl } from '#lib/env.ts'
+import { PriceFormatter } from '#lib/formatting.ts'
 
 export type TokenBalance = {
 	token: Address.Address
@@ -122,4 +123,21 @@ export function getAssetValue(
 		currency: asset.metadata.currency,
 		decimals: asset.metadata.decimals,
 	}
+}
+
+/** Displays an estimate in its denominated currency; does not convert FX. */
+export function formatAssetValue(asset: AssetData): string | undefined {
+	const value = getAssetValue(asset)
+	if (!value?.currency) return undefined
+	if (value.currency === 'USD')
+		return PriceFormatter.format(value.amount, {
+			decimals: value.decimals,
+			format: 'short',
+		})
+	const amount = formatUnits(value.amount, value.decimals)
+	const display =
+		value.amount > 0n && Number(amount) < 0.01
+			? '<0.01'
+			: PriceFormatter.formatAmountShort(amount)
+	return `${display} ${value.currency}`
 }

--- a/apps/explorer/src/routes/_layout/address/$address.tsx
+++ b/apps/explorer/src/routes/_layout/address/$address.tsx
@@ -58,7 +58,7 @@ import {
 	type BalancesResponse,
 	balancesQueryOptions,
 	calculateTotalHoldings,
-	getAssetValue,
+	formatAssetValue,
 	useBalancesData,
 } from '#lib/address-balances'
 import {
@@ -1979,7 +1979,7 @@ function SectionsWrapper(props: {
 									{ label: 'Ticker', align: 'start', width: '0.5fr' },
 									{ label: 'Currency', align: 'start', width: '0.5fr' },
 									{ label: 'Amount', align: 'end', width: '0.5fr' },
-									{ label: 'Value', align: 'end', width: '0.5fr' },
+									{ label: 'Est. value', align: 'end', width: '0.5fr' },
 								],
 							}}
 							items={(mode) =>
@@ -2671,15 +2671,11 @@ function AssetValue(props: { asset: AssetData }) {
 	const { isTokenListed } = useTokenListMembership()
 	if (!isTokenListed(TEMPO_CHAIN_ID, asset.address))
 		return <span className="text-tertiary">—</span>
-	const value = getAssetValue(asset)
-	if (!value) return <span className="text-tertiary">…</span>
-	if (value.currency !== 'USD') return <span className="text-tertiary">—</span>
+	const value = formatAssetValue(asset)
+	if (!value) return <span className="text-tertiary">—</span>
 	return (
-		<span>
-			{PriceFormatter.format(value.amount, {
-				decimals: value.decimals,
-				format: 'short',
-			})}
+		<span title="Estimated value in the denominated currency, assuming the token maintains its peg. No FX conversion applied.">
+			{value}
 		</span>
 	)
 }

--- a/apps/explorer/test/address-balances.node.test.ts
+++ b/apps/explorer/test/address-balances.node.test.ts
@@ -1,8 +1,57 @@
 import { describe, expect, test } from 'vitest'
-import { type AssetData, calculateTotalHoldings } from '#lib/address-balances'
+import {
+	type AssetData,
+	calculateTotalHoldings,
+	formatAssetValue,
+} from '#lib/address-balances'
 import { applyEarnPositionValues } from '#lib/server/address-balances'
 
 const shareToken = '0x20c000000000000000000000baac91f6ca72f768'
+
+describe('foreign currency holdings', () => {
+	const asset: AssetData = {
+		address: shareToken,
+		balance: 123_450_000n,
+		metadata: { symbol: 'euroToken', currency: 'EUR', decimals: 6 },
+		valuation: undefined,
+	}
+
+	test('uses the declared currency instead of the token symbol or USD', () => {
+		expect(formatAssetValue(asset)).toBe('123.45 EUR')
+		expect(calculateTotalHoldings([asset])).toBeUndefined()
+	})
+
+	test('preserves USD formatting and keeps foreign values out of USD totals', () => {
+		const usd = { ...asset, metadata: { currency: 'USD', decimals: 6 } }
+		expect(formatAssetValue(usd)).toBe('$123.45')
+		expect(calculateTotalHoldings([asset, usd])).toBe(123.45)
+	})
+
+	test('uses the currency and decimals of an explicit underlying valuation', () => {
+		expect(
+			formatAssetValue({
+				...asset,
+				valuation: { amount: 24_690n, decimals: 2, currency: 'GBP' },
+			}),
+		).toBe('246.9 GBP')
+	})
+
+	test('handles small, zero, and compact foreign currency values', () => {
+		expect(formatAssetValue({ ...asset, balance: 1n })).toBe('<0.01 EUR')
+		expect(formatAssetValue({ ...asset, balance: 0n })).toBe('0 EUR')
+		expect(formatAssetValue({ ...asset, balance: 1_234_560_000n })).toBe(
+			'1.23K EUR',
+		)
+	})
+
+	test('does not invent a value when metadata or balance is unavailable', () => {
+		expect(formatAssetValue({ ...asset, metadata: undefined })).toBeUndefined()
+		expect(formatAssetValue({ ...asset, balance: undefined })).toBeUndefined()
+		expect(
+			formatAssetValue({ ...asset, metadata: { currency: '', decimals: 6 } }),
+		).toBeUndefined()
+	})
+})
 
 describe('Earn share valuations', () => {
 	test('uses the underlying asset value for holdings totals', () => {


### PR DESCRIPTION
Foreign-currency holdings currently show a dash in the value column even when TIP-20 currency metadata is available. Display the estimated face value with its currency ticker: the linked account's 1,074,782.75 EURC.e now displays `1.07M EUR` alongside the existing `EURC.e` ticker and `EUR` currency columns.

Rename the column to **Est. value** and explain the peg assumption on hover. Preserve USD formatting, verified-token gating, and Earn underlying valuations. Foreign amounts remain excluded from the USD holdings total; this change does not perform FX conversion.

Validation: repository lint and type checks, 278 explorer tests (one environment-gated test skipped), pre-commit checks, and the mainnet production build pass. Generated the missing local contract-verification bindings before rerunning the root type check.

## Screenshots

| Before | After |
| --- | --- |
| [Production holdings: EUR value is absent](https://tempoxyz.enterprise.slack.com/files/U0ANX3AM5RR/F0C0B965WBZ/holdings-before.png) | [Local production build: 1.07M EUR](https://tempoxyz.enterprise.slack.com/files/U0ANX3AM5RR/F0C1M15QEHW/holdings-after.png) |

Screenshots are in Slack and require workspace access. The after capture uses balance and verified-token membership fixtures captured from the linked production account because the local worker could not reach the upstream API (`Network connection lost`). Verified the rendered EUR value and unchanged USD values/total; unrelated account metadata is unavailable in that local preview. This is not deployed.

Prompted by: @0xalpharush
